### PR TITLE
Add scorecards when scanning source

### DIFF
--- a/.github/workflows/scan-source-callable.yml
+++ b/.github/workflows/scan-source-callable.yml
@@ -20,6 +20,12 @@ jobs:
     - name: Generate summary
       if: always()
       run: cat ./metadata/summary.md >> $GITHUB_STEP_SUMMARY
+    - name: Scorecard
+      uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46
+      with:
+        results_file: ./metadata/scorecard/scorecard.sarif
+        results_format: sarif
+        publish_results: false
     - name: Upload SARIFs
       if: ${{ false }} # We're still a private repo so we can't enable code scanning. :(
       uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Instead of adding it as a tool (container that runs independently) it's added as a GitHub action directly in our callable.

That lets us use the GitHub integration, but does limit its use elsewhere.  Still maybe that's not so bad?

It demonstrates that we can add GitHub specific actions if needed.