### PR TITLE
Use the image from the push

### DIFF
--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -28,7 +28,7 @@ jobs:
     uses: tomhennen/wrangle/.github/workflows/build_and_publish_container.yml@main
     with:
       path: ${{ matrix.tool }}
-      imagename: ghcr.io/tomhennen/wrangle/${{ matrix.tool }}
+      imagename: ghcr.io/${{ github.repository }}/${{ matrix.tool }}
       registry: 'ghcr.io'
       publish_provenance_for_private_repo: true
     secrets:

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -31,6 +31,7 @@ jobs:
       packages: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
+      image: ${{ steps.build.outputs.image }}
     runs-on: ubuntu-latest
     steps:
     - name: "build and publish"
@@ -52,7 +53,7 @@ jobs:
       packages: write # for uploading attestations.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
     with:
-      image: ${{ inputs.imagename }}
+      image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}
       registry-username: ${{ github.actor }}
       private-repository: ${{ inputs.publish_provenance_for_private_repo }}

--- a/publish/actions/container/action.yml
+++ b/publish/actions/container/action.yml
@@ -20,10 +20,14 @@ inputs:
     description: "Publish provenance to Sigstore for a private repo"
     required: false
     default: false
+
 outputs:
   digest:
     description: 'Image digest'
     value: ${{ steps.push.outputs.digest }}
+  image:
+    description: 'The image name'
+    value: ${{ steps.push.outputs.image }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
You might think we can just use the same image name we passed to docker/metadata-action but we need the path to be lowercase.

The push action may do that for us.