### PR TITLE
Cancel outstanding workflows

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -24,6 +24,12 @@ on:
         description: "GitHub token with write access"
         required: true
 
+# Make sure we cancel any outstanding workflows that are outdated.
+# This should save time & money.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     permissions:


### PR DESCRIPTION
As we're debugging these workflows we often wind up committing multiple times, which winds up causing lots of duplicate runs.