### PR TITLE
Disable old check-change workflow on PRs

### DIFF
--- a/.github/workflows/local_check_change.yml
+++ b/.github/workflows/local_check_change.yml
@@ -1,13 +1,15 @@
 name: Check Change
+
+# DISABLED: This workflow uses the old Docker-based scan pipeline which
+# requires private container images and fails on repos without package
+# sources (#71). It will be replaced by the new binary-download pipeline
+# in the v0.1 cutover (PR 8 of #72).
+#
+# The `test` workflow (.github/workflows/test.yml) is the active CI gate.
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "**" ]
   workflow_dispatch:
 
 jobs:
-  # Whenever new source is pushed or a PR is received, scan it for any issues
   check-change:
     permissions:
       actions: read
@@ -15,7 +17,7 @@ jobs:
       packages: read
       issues: read
       pull-requests: read
-      security-events: write # So we can upload sarif
+      security-events: write
       statuses: read
     uses: tomhennen/wrangle/.github/workflows/check_source_change.yml@main
     secrets:


### PR DESCRIPTION
## Summary

- Remove push/PR triggers from `local_check_change.yml` (keep `workflow_dispatch` for manual testing)
- The old Docker-based scan pipeline fails on every PR due to private images (#64) and no package sources (#71)
- The `test` workflow is now the active CI gate
- The old pipeline will be replaced by the new binary-download pipeline in PR 8 of #72

## Test plan

- [x] No more failing `check-change` status on PRs
- [x] `test` workflow remains the CI gate

Part of #72 (v0.1 Implementation Plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)