### PR TITLE
Add new composite actions at actions/scan/ and tools/scorecard/ (PR 7)

### DIFF
--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -39,14 +39,16 @@ runs:
           -o "$WRANGLE_METADATA_DIR" \
           $WRANGLE_TOOLS
 
-    # Action-pattern tools: invoked directly via uses:
+    # Action-pattern tools: invoked via cross-repo uses: reference.
+    # ./tools/<name> won't work cross-repo (resolves to caller's repo).
+    # TODO(PR 14): Pin to release tag @v0.1.0 — @main is temporary
     - name: Zizmor
       if: always()
-      uses: ./tools/zizmor
+      uses: tomhennen/wrangle/tools/zizmor@main
 
     - name: Scorecard
       if: always()
-      uses: ./tools/scorecard
+      uses: tomhennen/wrangle/tools/scorecard@main
 
     - name: Generate step summary
       if: always()
@@ -59,12 +61,10 @@ runs:
         fi
 
     # SARIF upload: one step per tool for per-tool attribution in the
-    # Security tab (wrangle/osv, wrangle/zizmor). This is intentionally
-    # not generic — adding a new tool requires adding an upload step here.
-    # A dynamic approach (loop over metadata dirs) is not possible in
-    # composite actions since each uses: step must be statically defined.
-    # This is a known limitation accepted for v0.1; a future version could
-    # use a wrapper action or post-run script to enumerate tools.
+    # Security tab. This is intentionally not generic — adding a new
+    # tool requires adding an upload step here. Composite actions
+    # require static uses: steps; dynamic enumeration is not possible.
+    # Known limitation accepted for v0.1.
     - name: Upload OSV SARIF
       if: always()
       uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
@@ -80,6 +80,14 @@ runs:
       with:
         sarif_file: ${{ runner.temp }}/.wrangle/metadata/zizmor/output.sarif
         category: wrangle/zizmor
+
+    - name: Upload Scorecard SARIF
+      if: always()
+      uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+      continue-on-error: true
+      with:
+        sarif_file: ${{ runner.temp }}/.wrangle/metadata/scorecard/output.sarif
+        category: wrangle/scorecard
 
     - name: Upload scan results artifact
       if: always()

--- a/tools/scorecard/action.yml
+++ b/tools/scorecard/action.yml
@@ -23,9 +23,11 @@ runs:
     - name: Format results
       if: always()
       shell: bash
+      env:
+        SCORECARD_DIR: ${{ github.action_path }}
       run: |
         SARIF_FILE="$RUNNER_TEMP/.wrangle/metadata/scorecard/output.sarif"
         MD_FILE="$RUNNER_TEMP/.wrangle/metadata/scorecard/output.md"
         if [[ -f "$SARIF_FILE" ]]; then
-          "${{ github.action_path }}/sarif_to_markdown.sh" "$SARIF_FILE" > "$MD_FILE"
+          "$SCORECARD_DIR/sarif_to_markdown.sh" "$SARIF_FILE" > "$MD_FILE"
         fi

--- a/tools/scorecard/sarif_to_markdown.sh
+++ b/tools/scorecard/sarif_to_markdown.sh
@@ -9,10 +9,10 @@ set -euo pipefail
 # GitHub Actions context (repository metadata, API access) which makes
 # it incompatible with the adapter's environment isolation.
 #
-# Usage: format_sarif.sh <sarif_file>
+# Usage: sarif_to_markdown.sh <sarif_file>
 
 if [[ $# -ne 1 ]]; then
-    printf 'Usage: format_sarif.sh <sarif_file>\n' >&2
+    printf 'Usage: sarif_to_markdown.sh <sarif_file>\n' >&2
     exit 1
 fi
 
@@ -32,8 +32,9 @@ fi
 printf 'Rule Name | Location | Message\n'
 printf '--------- | -------- | -------\n'
 
-# Extract results and strip HTML tags for output sanitization
-if ! jq -r '[.runs[].results[] | {rule: .ruleId, message: .message.text, locations: .locations[].physicalLocation.artifactLocation.uri}] | .[] | "\(.rule) | \(.locations) | \(.message)"' "$SARIF_FILE" 2>/dev/null | sed 's/<[^>]*>//g'; then
+# Extract results, strip HTML tags, and truncate to prevent summary flooding
+MAX_OUTPUT="${WRANGLE_MAX_SUMMARY:-65536}"
+if ! jq -r '[.runs[].results[] | {rule: .ruleId, message: .message.text, locations: .locations[].physicalLocation.artifactLocation.uri}] | .[] | "\(.rule) | \(.locations) | \(.message)"' "$SARIF_FILE" 2>/dev/null | sed 's/<[^>]*>//g' | head -c "$MAX_OUTPUT"; then
     printf 'Error: failed to parse SARIF results\n' >&2
     exit 2
 fi


### PR DESCRIPTION
Replaces #95 (closed when base branch was deleted during squash merge).

## Summary
- Adds `actions/scan/action.yml` composite action orchestrating both tool patterns:
  - Adapter-pattern tools (OSV) via `run.sh` orchestrator
  - Action-pattern tools (Zizmor, Scorecard) via `uses: ./tools/<name>`
- Adds `tools/scorecard/action.yml` wrapping `ossf/scorecard-action`
- Adds `tools/scorecard/sarif_to_markdown.sh` with output sanitization

## Test plan
- [ ] Verify action YAML passes actionlint
- [ ] Verify all third-party actions pinned to full SHAs
- [ ] Verify `sarif_to_markdown.sh` passes shellcheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)