### PR TITLE
Replace all cross-repo @main refs with ./ local paths

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
     - name: "build and publish"
       id: build    
-      uses: tomhennen/wrangle/build/actions/container@main
+      uses: ./build/actions/container
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -23,8 +23,9 @@ jobs:
 
       # The scan action runs adapter-pattern tools (via run.sh) and
       # action-pattern tools (zizmor, scorecard) via uses: internally.
-      # TODO(PR 14): Pin to release tag @v0.1.0 — @main is temporary
+      # ./actions/scan resolves to this repo at the called ref (the
+      # adopter's pinned tag or the PR branch for local CI).
       - name: Source scan
-        uses: tomhennen/wrangle/actions/scan@main
+        uses: ./actions/scan
         with:
           tools: ${{ inputs.tools }}

--- a/.github/workflows/local_check_change.yml
+++ b/.github/workflows/local_check_change.yml
@@ -13,5 +13,6 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    # TODO(PR 14): Pin to release tag @v0.1.0
-    uses: tomhennen/wrangle/.github/workflows/check_source_change.yml@main
+    # ./ resolves to this repo at the PR branch ref, so PR CI tests
+    # the actual code in the PR (not main).
+    uses: ./.github/workflows/check_source_change.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    # TODO: Pin to release tag (e.g., @v0.1.0) once available
-    uses: tomhennen/wrangle/.github/workflows/check_source_change.yml@main
+    uses: tomhennen/wrangle/.github/workflows/check_source_change.yml@v0.1.0
 ```
 
 Replace `DEFAULT_BRANCH` with the repository's default branch name.
@@ -84,6 +83,6 @@ and publish workflows can be added once the project type is identified.
 ## Do NOT
 
 - Do not add secrets to the workflow — wrangle doesn't need them
-- Do not use `@main` in production — use the latest release tag (e.g., `@v0.1.0`) once available
+- Do not use `@main` in production — always use a release tag (e.g., `@v0.1.0`)
 - Do not add extra permissions beyond the three listed above
 - Do not modify the reusable workflow call — wrangle handles tool selection internally

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -44,17 +44,17 @@ runs:
           -o "$WRANGLE_METADATA_DIR" \
           $WRANGLE_TOOLS
 
-    # Action-pattern tools: invoked via cross-repo uses: reference.
-    # ./tools/<name> won't work cross-repo (resolves to caller's repo).
-    # TODO(PR 14): Pin to release tag @v0.1.0 — @main is temporary
+    # Action-pattern tools: invoked via local path. Inside a reusable
+    # workflow, ./ resolves to this repo at the called ref (the adopter's
+    # pinned tag or the PR branch for local CI).
     - name: Zizmor
       if: always()
-      uses: tomhennen/wrangle/tools/zizmor@main
+      uses: ./tools/zizmor
 
     - name: Scorecard
       if: always()
       continue-on-error: true
-      uses: tomhennen/wrangle/tools/scorecard@main
+      uses: ./tools/scorecard
 
     - name: Generate step summary
       if: always()

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -8,15 +8,12 @@ inputs:
   path:
     description: "Relative path within the repo to the folder containing a Dockerfile."
     required: true
-    type: string
   imagename:
     description: "Full image name (e.g., ghcr.io/owner/repo/image)"
     required: true
-    type: string
   registry:
     description: "Container registry (e.g., ghcr.io)"
     required: true
-    type: string
   github_token:
     description: "GitHub token with packages:write access"
     required: true

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -422,7 +422,7 @@ inputs:
 5. Uploads SARIF to GitHub Code Scanning
 6. Uploads all results as an artifact
 
-**Portability:** All internal paths use `${{ github.action_path }}` so the action works when called from any repo.
+**Portability:** Shell script paths use `${{ github.action_path }}` for resolution relative to the composite action's own directory. Action-pattern tool steps use `./` paths (e.g., `uses: ./tools/zizmor`), which resolve to the same repo at the called ref — so when an adopter pins `@v0.1.0`, all internal actions resolve at that tag, and when wrangle's own CI runs on a PR branch, they resolve at the PR's code.
 
 **Path constraint:** The composite action resolves the orchestrator via `${{ github.action_path }}/../../run.sh`, which means the scan action MUST remain at exactly `actions/scan/` (two directories below the repo root). This is a hard structural constraint — moving the action to a different depth breaks the relative path. If the directory layout changes, these paths must be updated in the same commit.
 
@@ -445,6 +445,8 @@ Note: `$WRANGLE_TOOLS` is intentionally unquoted so it word-splits into multiple
 ## Reusable Workflow Interface
 
 The reusable workflow (`.github/workflows/check_source_change.yml`) wraps the composite action for `workflow_call` consumers.
+
+**Internal path resolution:** All `uses:` steps inside the reusable workflow use `./` paths (e.g., `uses: ./actions/scan`). When a caller invokes the workflow at a specific ref (e.g., `@v0.1.0`), GitHub fetches the workflow at that ref, and all `./` references resolve to the same repo at that ref. This means adopters automatically get version-locked internal actions matching their pinned tag, and wrangle's own PR CI tests the PR branch's code (not main).
 
 ```yaml
 on:
@@ -685,9 +687,10 @@ All `uses:` references in wrangle's own workflows and examples MUST be pinned:
 |---------------|---------------------|
 | Third-party actions | Full commit SHA |
 | Wrangle's own actions (in examples) | Release tag (e.g., `@v0.1.0`) |
-| Wrangle's internal cross-references | Relative path (`./`) or full SHA |
+| Wrangle internal refs in reusable workflows | Relative path (`./`) — resolves to the workflow's own repo at the called ref |
+| Wrangle internal refs in composite actions | Relative path (`./`) — resolves to the same repo at the called ref |
 
-Adopters are advised to pin to a release tag. The `@main` ref MUST NOT appear in any example or documentation.
+Adopters are advised to pin to a release tag. The `@main` ref MUST NOT appear in any `uses:` line in the repo, including examples and documentation.
 
 ### Output Sanitization
 

--- a/gh_workflow_examples/build_and_publish_containers.yml
+++ b/gh_workflow_examples/build_and_publish_containers.yml
@@ -21,8 +21,7 @@ jobs:
       actions: read # for detecting the Github Actions environment.
       id-token: write # for creating OIDC tokens for signing.
       packages: write # for uploading attestations.
-    # TODO(v0.1.0): Pin to release tag @v0.1.0 before release
-    uses: tomhennen/wrangle/.github/workflows/build_and_publish_container.yml@main
+    uses: tomhennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.1.0
     with:
       path: PATH/TO/FOLDER/WITH/Dockerfile
       imagename: ghcr.io/${{ github.repository }}/YOUR_IMAGE_NAME

--- a/gh_workflow_examples/check_source_change.yml
+++ b/gh_workflow_examples/check_source_change.yml
@@ -14,5 +14,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    # TODO(v0.1.0): Update to @v0.1.0 before release
-    uses: tomhennen/wrangle/.github/workflows/check_source_change.yml@main
+    uses: tomhennen/wrangle/.github/workflows/check_source_change.yml@v0.1.0


### PR DESCRIPTION
## Summary

Fixes #117.

- Replace all `tomhennen/wrangle/...@main` `uses:` references in wrangle's own workflows and composite actions with `./` local paths, which resolve to the same repo at the called ref
- Pin `gh_workflow_examples/` and `AGENTS.md` to `@v0.1.0` (adopter-facing refs)
- Update SPEC.md pinning table and document `./` resolution semantics in the Reusable Workflow and Composite Action Interface sections
- Fix invalid `type: string` fields in `build/actions/container/action.yml` composite action inputs (exposed by actionlint now resolving `./` locally)

**Why this matters:** `./` paths inside a reusable workflow resolve to the workflow's own repo at the called ref. So adopters pinning `@v0.1.0` get version-locked internal actions, and wrangle's own PR CI now tests the PR branch's code instead of main's.

## Test plan

- [x] All 73 tests pass (`./test.sh`)
- [x] Zero `@main` refs remain in any `uses:` line (`grep -r 'uses:.*@main'` returns nothing)
- [x] All `TODO(PR 14)` and `TODO(v0.1.0)` comments removed
- [ ] CI on this PR should show the PR's commit SHA in the action download logs (not main's), confirming `./` paths resolve to the PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)