### PR TITLE
Add PR template and testing guidance (#118)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## What does this PR do?
+
+<!-- Brief description of the change and its motivation. -->
+
+## Checklist
+
+- [ ] Spec updated if contracts changed (`docs/SPEC.md` or `tools/<name>/SPEC.md`)
+- [ ] `make test` passes locally (or `./test.sh` for Docker)
+- [ ] CI passes on this PR
+- [ ] No new `continue-on-error` without justification in a comment
+- [ ] No `@main` refs in `uses:` lines
+- [ ] Tool `SPEC.md` exists/updated for any tool changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,18 @@ If you cannot determine the project type, add only the source scanning
 workflow above. It is always applicable. Note to the user that build
 and publish workflows can be added once the project type is identified.
 
+## Verifying Your Work (CI Testing)
+
+PR CI tests the actual code in the PR branch, not `main`, because wrangle's own actions use `./` relative paths. This means your changes are exercised in CI before merge.
+
+**After pushing a PR:**
+1. Check the Actions tab — confirm CI passes (don't rely only on local tests)
+2. For tool changes: inspect the step summary and the `scan-metadata` artifact to verify SARIF output and metadata are correct
+3. If CI fails, investigate before re-pushing — it may reveal a real environment difference
+
+**What CI does not cover:**
+- Cross-repo consumption (`uses: tomhennen/wrangle/...@v0.1.0`) is only testable after tagging a release. If your change affects the reusable workflow interface, note this in the PR description.
+
 ## Do NOT
 
 - Do not add secrets to the workflow — wrangle doesn't need them

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ PR CI tests the actual code in the PR branch, not `main`, because wrangle's own 
 
 **After pushing a PR:**
 1. Check the Actions tab — confirm CI passes (don't rely only on local tests)
-2. For tool changes: inspect the step summary and the `scan-metadata` artifact to verify SARIF output and metadata are correct
+2. For tool changes: inspect the step summary and the `wrangle-scan-results` artifact to verify SARIF output and metadata are correct
 3. If CI fails, investigate before re-pushing — it may reveal a real environment difference
 
 **What CI does not cover:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,18 @@ Always run `./test.sh` before pushing. CI runs the same checks.
 
 Write the `test.bats` before (or alongside) the implementation. If a bug is found, add a regression test before fixing it.
 
+### CI testing workflow
+
+PR CI tests the actual code in the PR branch, not `main`. Wrangle's own actions are referenced via `./` relative paths, so the CI run exercises the exact code under review.
+
+**Before requesting review:**
+- Confirm CI passes on the PR — check the Actions tab, not just local tests
+- For tool changes: inspect the step summary (markdown table) and the `scan-metadata` artifact in the CI logs to verify correct SARIF output and metadata
+- If CI fails on something local tests don't catch, investigate — it may reveal a real environment difference
+
+**What CI does not cover:**
+- Cross-repo consumption (e.g., another repo calling `uses: tomhennen/wrangle/.github/workflows/...@v0.1.0`) is only testable after tagging a release. If your change affects the reusable workflow interface, note this in the PR description.
+
 ## SARIF Output
 
 All tools produce SARIF 2.1.0. Each tool uploads its SARIF separately with category `wrangle/<tool>` (not merged into one file). This preserves per-tool attribution in GitHub's Security tab.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ PR CI tests the actual code in the PR branch, not `main`. Wrangle's own actions 
 
 **Before requesting review:**
 - Confirm CI passes on the PR — check the Actions tab, not just local tests
-- For tool changes: inspect the step summary (markdown table) and the `scan-metadata` artifact in the CI logs to verify correct SARIF output and metadata
+- For tool changes: inspect the step summary (markdown table) and the `wrangle-scan-results` artifact in the CI logs to verify correct SARIF output and metadata
 - If CI fails on something local tests don't catch, investigate — it may reveal a real environment difference
 
 **What CI does not cover:**


### PR DESCRIPTION
## Summary

- Add `.github/PULL_REQUEST_TEMPLATE.md` with checklist (spec updated, tests pass, no `@main` refs, no unjustified `continue-on-error`, tool SPEC.md exists)
- Add "CI testing workflow" section to `CLAUDE.md` explaining how PR CI exercises branch code via `./` paths, how to verify tool changes, and what CI doesn't cover
- Add matching "Verifying Your Work" section to `AGENTS.md` for AI agents

Closes #118 (remaining items — sub-specs, `./` paths, and PR CI already landed in earlier PRs).

## Test plan

- [ ] Verify PR template renders on new PRs
- [ ] Confirm CLAUDE.md and AGENTS.md read clearly
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)