### PR TITLE
Fix scorecard printf error and adapter fallback output.md

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -213,6 +213,11 @@ OUTPUT FILES (written to output_dir):
   output.md      OPTIONAL  Human-readable markdown summary
   output.txt     OPTIONAL  Human-readable plain text (fallback if no .md)
 
+  If the adapter does not produce output.md or output.txt, the
+  orchestrator generates output.md from output.sarif via
+  lib/sarif_to_md.sh. Adapters that produce richer tool-specific
+  output should write their own output.md to prevent this fallback.
+
 EXIT CODES:
   0  Scan completed, no findings
   1  Scan completed, findings detected

--- a/run.sh
+++ b/run.sh
@@ -170,8 +170,10 @@ for tool in "${adapter_tools[@]}"; do
     esac
 
     # Generate human-readable output if the adapter didn't produce one.
-    # This ensures all tools have details in the step summary.
-    if [[ -f "${tool_output_dir}/output.sarif" ]] \
+    # Only on successful runs — on error the SARIF may be missing or
+    # incomplete, and showing "No findings" would be misleading.
+    if [[ "$tool_status" != "error" ]] \
+        && [[ -f "${tool_output_dir}/output.sarif" ]] \
         && [[ ! -s "${tool_output_dir}/output.md" ]] \
         && [[ ! -s "${tool_output_dir}/output.txt" ]]; then
         "$SCRIPT_DIR/lib/sarif_to_md.sh" "${tool_output_dir}/output.sarif" \

--- a/run.sh
+++ b/run.sh
@@ -169,6 +169,15 @@ for tool in "${adapter_tools[@]}"; do
             ;;
     esac
 
+    # Generate human-readable output if the adapter didn't produce one.
+    # This ensures all tools have details in the step summary.
+    if [[ -f "${tool_output_dir}/output.sarif" ]] \
+        && [[ ! -s "${tool_output_dir}/output.md" ]] \
+        && [[ ! -s "${tool_output_dir}/output.txt" ]]; then
+        "$SCRIPT_DIR/lib/sarif_to_md.sh" "${tool_output_dir}/output.sarif" \
+            > "${tool_output_dir}/output.md" 2>/dev/null || true
+    fi
+
     summary_tools+=("$tool")
     summary_statuses+=("$tool_status")
     printf '::endgroup::\n'

--- a/tools/scorecard/sarif_to_markdown.sh
+++ b/tools/scorecard/sarif_to_markdown.sh
@@ -29,8 +29,8 @@ if ! jq empty "$SARIF_FILE" 2>/dev/null; then
     exit 2
 fi
 
-printf 'Rule Name | Location | Message\n'
-printf '--------- | -------- | -------\n'
+printf '%s\n' 'Rule Name | Location | Message'
+printf '%s\n' '--------- | -------- | -------'
 
 # Extract results, strip HTML tags, and truncate to prevent summary flooding
 MAX_OUTPUT="${WRANGLE_MAX_SUMMARY:-65536}"


### PR DESCRIPTION
## Summary

Two fixes from post-merge CI run of #126:

- **scorecard/sarif_to_markdown.sh**: `printf '--------- | ...'` treated leading dashes as an option flag (`--: invalid option`). Changed to `printf '%s\n' '...'` to treat as data.
- **run.sh**: Adapter-pattern tools that don't produce `output.md` or `output.txt` (e.g., OSV when no package sources found) now get a fallback `output.md` generated from their SARIF via `lib/sarif_to_md.sh`. This ensures all tools show details in the step summary.

## Test plan

- [x] All 114 tests pass via `./test.sh`
- [ ] CI passes — scorecard step no longer errors on printf
- [ ] Step summary shows details for all tools including OSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)