### PR TITLE
TEST ONLY — trigger zizmor and OSV findings for step summary verification

### DIFF
--- a/.github/workflows/test_insecure.yml
+++ b/.github/workflows/test_insecure.yml
@@ -1,0 +1,20 @@
+# DELIBERATELY INSECURE — test fixture to verify wrangle step summary.
+# DO NOT MERGE. Delete this file after verifying findings display.
+name: Test Insecure Workflow
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  insecure:
+    runs-on: ubuntu-latest
+    steps:
+      # Unpinned action reference — triggers zizmor unpinned-uses
+      - uses: actions/checkout@v4
+
+      # Expression injection — triggers zizmor injection
+      - name: Greet
+        run: echo "Hello ${{ github.event.pull_request.title }}"

--- a/test_vuln/package-lock.json
+++ b/test_vuln/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "test-vuln-fixture",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-vuln-fixture",
+      "version": "0.0.0",
+      "dependencies": {
+        "lodash": "4.17.20"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "license": "MIT"
+    }
+  }
+}

--- a/test_vuln/package.json
+++ b/test_vuln/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-vuln-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "description": "DELIBERATELY VULNERABLE — test fixture for OSV findings. DO NOT MERGE.",
+  "dependencies": {
+    "lodash": "4.17.20"
+  }
+}


### PR DESCRIPTION
## DO NOT MERGE

Test PR to verify the step summary displays findings details correctly after #126 and #127.

**What this adds (intentionally insecure):**
- `.github/workflows/test_insecure.yml` — unpinned action (`actions/checkout@v4`) and expression injection (`${{ github.event.pull_request.title }}` in `run:`) to trigger zizmor
- `test_vuln/package.json` — lodash 4.17.20 with known CVEs to trigger OSV

**What to check:**
- [ ] Step summary shows a markdown table with zizmor findings (unpinned-uses, injection)
- [ ] Step summary shows OSV findings for lodash CVEs
- [ ] Each tool has a Details section with severity, rule, location, message
- [ ] Banners visible in raw logs

Close without merging after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)