### PR TITLE
Update spec: provenance-only verification is sufficient

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,13 +83,13 @@ Adapters take exactly two positional arguments: `<src_dir>` (read-only) and `<ou
 
 Install scripts MUST:
 - Use `lib/download_verify.sh` for all downloads (never raw `curl | sh`)
-- Verify integrity using the strongest method the upstream tool supports: SLSA provenance > Sigstore signature > hardcoded SHA-256 checksum
-- **NEVER fall back to a weaker verification method if a stronger one fails.** If a tool is configured for SLSA provenance verification and it fails, the install MUST abort — do not silently continue with only checksum verification. A verification failure may be a supply chain attack.
+- Verify integrity using the strongest method the upstream tool supports: SLSA provenance > Sigstore signature > hardcoded SHA-256 checksum. Provenance or signature verification is sufficient on its own — tools with SLSA/Sigstore do not need additional checksums.
+- **NEVER fall back to a weaker verification method if a stronger one fails.** If a tool is configured for SLSA provenance verification and it fails, the install MUST abort. A verification failure may be a supply chain attack.
 - Install to `$WRANGLE_BIN_DIR` (default: `$RUNNER_TEMP/.wrangle/bin`), never `/usr/local/bin`
 - Be idempotent (skip if correct version already installed)
 - Use atomic `mv` (not `cp`) to prevent TOCTOU races
 
-Checksums are hardcoded in the install script, not downloaded alongside the binary. A version bump and its checksum update MUST be in the same commit.
+For tools without SLSA provenance or Sigstore signatures, checksums are hardcoded in the install script (not downloaded alongside the binary). A version bump and its checksum update MUST be in the same commit.
 
 ## Path Resolution
 
@@ -160,8 +160,7 @@ Before writing tool output to `$GITHUB_STEP_SUMMARY`:
 
 - **No auto-merge of dependency updates.** New upstream tool versions are adopted after a delay (aim for 7 days) to let the community discover supply chain attacks before wrangle amplifies them.
 - **No `curl | sh` anywhere.** All binary downloads go through `lib/download_verify.sh`.
-- **No downloading checksums from the same source as binaries.** Checksums are hardcoded.
-- Tool version + checksum updates are always a single atomic commit.
+- **No downloading checksums from the same source as binaries.** When checksums are used (tools without provenance/signatures), they are hardcoded. Tool version + checksum updates are always a single atomic commit.
 
 ## Dogfooding
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -326,9 +326,10 @@ INTEGRITY VERIFICATION (mandatory):
     1. SLSA provenance verification — if the tool publishes SLSA
        attestations, the install script verifies them via slsa-verifier.
        This proves the binary was built from specific source by a specific
-       builder. Provenance verification is sufficient on its own — no
-       additional checksum is needed because the provenance attestation
-       covers the artifact's identity and integrity.
+       builder. Provenance verification is sufficient on its own — the
+       provenance attestation covers the artifact's identity and integrity,
+       so an additional checksum is not required. This simplifies wrangle
+       integration for tools with SLSA support.
     2. Sigstore signature verification — if the tool signs releases with
        Cosign/Sigstore but does not publish full SLSA attestations, the
        install script verifies the signature. If signature verification
@@ -692,11 +693,11 @@ All downloaded binaries are verified before execution:
 | Layer | Mechanism | Status |
 |-------|-----------|--------|
 | Transport | HTTPS only | Always required |
-| Content | SHA-256 checksum (pinned in install script) | Always required (baseline integrity) |
-| Provenance | SLSA attestation via slsa-verifier | Required for tools that publish it; failure = hard stop |
-| Signature | Sigstore/Cosign signature verification | Required for tools that publish it; failure = hard stop |
+| Content | SHA-256 checksum (pinned in install script) | Required for tools without provenance or signatures |
+| Provenance | SLSA attestation via slsa-verifier | Required for tools that publish it; sufficient on its own; failure = hard stop |
+| Signature | Sigstore/Cosign signature verification | Required for tools that publish it; sufficient on its own; failure = hard stop |
 
-Checksums are hardcoded in each install script, not downloaded from the same source as the binary. Updating a tool version requires updating the checksum in the same commit.
+For tools verified via SLSA provenance or Sigstore signatures, hardcoded checksums are not required — the cryptographic verification already covers artifact integrity. Checksums are only needed for tools that lack both provenance and signatures, in which case they are hardcoded in each install script (not downloaded alongside the binary) and updated in the same commit as a version bump.
 
 **No fallback between verification methods.** Each tool's verification method is chosen at development time. If provenance verification fails for a tool configured to use it, the install MUST fail — even if the checksum passed. A verification failure may indicate a supply chain attack; silently downgrading to a weaker method would mask the attack.
 


### PR DESCRIPTION
## Summary

- Update SPEC.md and CLAUDE.md to say SLSA provenance (or Sigstore signatures) is sufficient on its own — tools with provenance don't need additional checksums
- Aligns the spec with the current code (`osv/install.sh` has been provenance-only since #93)
- Updates the integrity verification table: checksums are "required for tools without provenance or signatures" instead of "always required"

Closes #98.

## Test plan

- [x] `./test.sh` passes (145 tests)
- Spec-only change, no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)