### PR TITLE
Fix SBOM extraction failing on non-main branches

### DIFF
--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -128,11 +128,14 @@ runs:
       shell: bash
       env:
         IMAGE: ${{ steps.normalize.outputs.imagename }}
+        DIGEST: ${{ steps.push.outputs.digest }}
         SHORTNAME: ${{ steps.normalize.outputs.shortname }}
       run: |
         set -euo pipefail
         SBOM_PATH="metadata/container/${SHORTNAME}/sbom.spdx.json"
-        docker buildx imagetools inspect "$IMAGE" --format "{{ json .SBOM.SPDX }}" > "$SBOM_PATH"
+        # Reference by digest, not tag — the :latest tag only exists on
+        # main-branch builds, so bare image name fails on other branches.
+        docker buildx imagetools inspect "${IMAGE}@${DIGEST}" --format "{{ json .SBOM.SPDX }}" > "$SBOM_PATH"
         printf 'sbom=%s\n' "$SBOM_PATH" >> "$GITHUB_OUTPUT"
 
     - name: Generate summary


### PR DESCRIPTION
## Summary

- Fix container builder SBOM extraction step defaulting to `:latest` tag (which only exists on main-branch builds)
- Use image digest from the push step output instead, which is always available
- This unblocks green integration tests — the container job was the last failing companion job

Closes #138.

## Test plan

- [x] `./test.sh` passes (145 tests)
- [ ] Integration test — will verify when CI runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)