### PR TITLE
Add shell build example, prep for v0.1.0

### DIFF
--- a/gh_workflow_examples/README.md
+++ b/gh_workflow_examples/README.md
@@ -1,6 +1,6 @@
 # Wrangle Workflow Examples
 
-Copy these files to `.github/workflows/` in your repo to adopt wrangle.
+Starting points for adopting wrangle. Copy to `.github/workflows/` in your repo and customize the inputs (paths, image names, etc.) for your project.
 
 ## check_source_change.yml
 

--- a/gh_workflow_examples/README.md
+++ b/gh_workflow_examples/README.md
@@ -1,13 +1,15 @@
-# Wrangle Workflows Examples
+# Wrangle Workflow Examples
 
-GitHub users can use these examples to see how to easily adopt Wrangle within their GitHub repositories.
-
-## build_and_publish_containers.yml
-
-This example workflow will build and publish a container image for any changes to the main branch,
-any tags, and for any PRs.
+Copy these files to `.github/workflows/` in your repo to adopt wrangle.
 
 ## check_source_change.yml
 
-This example workflow will run all wrangle checks for changes to source and create a summary
-of the results.
+Run OSV, Zizmor, and Scorecard source scanning on every PR and push.
+
+## build_shell.yml
+
+Run shellcheck and bats tests on shell projects.
+
+## build_and_publish_containers.yml
+
+Build, sign, and publish a container image with SBOM and SLSA L3 provenance.

--- a/gh_workflow_examples/build_and_publish_containers.yml
+++ b/gh_workflow_examples/build_and_publish_containers.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   build-and-publish:
     permissions:
-      contents: read
-      actions: read # for detecting the Github Actions environment.
-      id-token: write # for creating OIDC tokens for signing.
-      packages: write # for uploading attestations.
+      contents: read       # checkout
+      actions: read        # SLSA provenance generator
+      id-token: write      # OIDC for keyless Cosign signing
+      packages: write      # push image + provenance to GHCR
     uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.1.0
     with:
       path: PATH/TO/FOLDER/WITH/Dockerfile

--- a/gh_workflow_examples/build_and_publish_containers.yml
+++ b/gh_workflow_examples/build_and_publish_containers.yml
@@ -21,7 +21,7 @@ jobs:
       actions: read # for detecting the Github Actions environment.
       id-token: write # for creating OIDC tokens for signing.
       packages: write # for uploading attestations.
-    uses: tomhennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.1.0
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.1.0
     with:
       path: PATH/TO/FOLDER/WITH/Dockerfile
       imagename: ghcr.io/${{ github.repository }}/YOUR_IMAGE_NAME

--- a/gh_workflow_examples/build_shell.yml
+++ b/gh_workflow_examples/build_shell.yml
@@ -1,0 +1,19 @@
+# Copy this file to your repo at .github/workflows/build_shell.yml
+# Adjust the branch name if your default branch isn't "main".
+name: Shell Build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+jobs:
+  shell-build:
+    permissions:
+      contents: read
+    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.1.0
+    # with:
+    #   scan-path: "."       # optional: subdirectory to scan (default: repo root)
+    #   bats-path: ""        # optional: path to bats tests (default: auto-detect)

--- a/gh_workflow_examples/check_source_change.yml
+++ b/gh_workflow_examples/check_source_change.yml
@@ -14,4 +14,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: tomhennen/wrangle/.github/workflows/check_source_change.yml@v0.1.0
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.1.0


### PR DESCRIPTION
## Summary

- Add missing `build_shell.yml` workflow example for shell project adopters
- Fix owner casing (`tomhennen` → `TomHennen`) in existing examples
- Update examples README with concise descriptions

Part of v0.1.0 prep (#72). After this, the remaining v0.1.0 blocker is resolving the AGENTS.md approach (#125).

## Test plan

- [x] `./test.sh` passes (145 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)