### PR TITLE
Add quick-start to README, prep for v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,31 @@ users without them needing to know all the details.
 NOTE: I've never really used GitHub for professional development
 before, so this is a bit of a learning process too.
 
+## Quick Start
+
+Add source scanning to any GitHub repo — create `.github/workflows/check_source_change.yml`:
+
+```yaml
+name: Check Source Change
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  check-change:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.1.0
+```
+
+This runs OSV-Scanner, Zizmor, and OSSF Scorecard on every PR. Results appear in the Actions step summary and the Security tab.
+
+For shell and container build types, see the [workflow examples](gh_workflow_examples/README.md).
+
 ## Goals
 
 ### Project Owners
@@ -29,12 +54,8 @@ next version of Wrangle.
 Wrangle is composed of a few pieces:
 
 
-- [GitHub Workflow Examples](gh_workflow_examples/README.md)
-  - GitHub workflow examples that GitHub users can copy, paste, and tweak in their own repos to adopt wrangle.
-- [build](build/README.md)
-  - Integrations for managing building artifacts and any metadata related to those artifacts.
-- [source](source/README.md)
-  - Integrations for managing source code.  Currently limited to 'scans' which look for problems.
-    Could be expanded to linting, formatting, etc in the future.
-- [worfkflows](.github/workflows/README.md)
-  - Reusable workflows that allow project owners to easily adopt best practices for managing their project.
+- [Workflow examples](gh_workflow_examples/README.md) — starter workflows for adopting wrangle
+- [Reusable workflows](.github/workflows/README.md) — the workflows adopters call via `uses:`
+- [Composite actions](actions/) — scan orchestration and tool wrappers
+- [Build actions](build/) — build types (shell, container)
+- [Spec](docs/SPEC.md) — architecture, contracts, and security model

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -852,19 +852,19 @@ Layers:
 2. Adjust the branch name if your default branch isn't `main`
 3. Push. Done.
 
-### For AI agents
+### For AI agents and new adopters
 
-`AGENTS.md` in the repo root provides adoption instructions for AI coding agents. It MUST contain:
+The README's quick-start section and the workflow examples in `gh_workflow_examples/` provide adoption instructions. Together they MUST cover:
 
 1. A single-command adoption instruction (e.g., "create this file at this path")
-2. The exact workflow YAML to generate, parameterized by default branch name
+2. The exact workflow YAML to use, parameterized by project type
 3. The required GitHub permissions
 4. How to detect project type (check for Dockerfile, language files, etc.)
 5. Expected output after adoption (what the user should see on their next PR)
 
-If the agent cannot determine the project type (no Dockerfile, no recognized language files), it should add only the source scanning workflow — this is always applicable regardless of project type. The agent should note to the user that build/publish workflows can be added once the project type is identified.
+If the project type is unknown (no Dockerfile, no recognized language files), adopt only the source scanning workflow — this is always applicable regardless of project type.
 
-The goal: any AI agent that reads `AGENTS.md` can adopt wrangle on a new repo without additional context or web searches.
+`AGENTS.md` in the repo root may additionally provide AI-agent-specific instructions. It is not required; the README and examples are the primary adoption surface.
 
 ### Long-term: OpenSSF contribution
 


### PR DESCRIPTION
## Summary

- Add quick-start section to README with source scanning workflow example
- Update README layout: remove stale `source/` link, add links to spec and actions
- Update SPEC.md: adoption docs live in README + workflow examples; AGENTS.md is optional, not required
- Resolves the adoption-doc question from #125

## Test plan

- [x] `./test.sh` passes (145 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)