### PR TITLE
Skip integration test dispatch for Dependabot PRs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,10 +10,13 @@ concurrency:
 
 jobs:
   dispatch:
-    # Only run for internal PRs — fork PRs do not get secrets, so the
-    # dispatch would fail. This is the security model's fork-PR guard.
+    # Only run for internal PRs from human contributors. Skip for:
+    # - Fork PRs: no secret access (GitHub's baseline security model)
+    # - Dependabot PRs: GitHub strips secrets from the dependabot actor
     # See test/integration/SPEC.md for the full rationale.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     environment: integration-test
     permissions:


### PR DESCRIPTION
## Summary

GitHub strips secrets from the `dependabot[bot]` actor on `pull_request` events, causing the integration test dispatch to fail with "GH_TOKEN not set." This is noisy — every Dependabot PR shows a failing check even though the version bump itself is fine.

Add `github.actor != 'dependabot[bot]'` to the dispatch job guard. Dependabot PRs will show "skipped" instead of "failed."

## Test plan

- [x] `./test.sh` passes (145 tests)
- Dependabot PRs will show dispatch as skipped after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)