### PR TITLE
Add make bump-action-pins (closes #165)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test lint shellcheck bats
+.PHONY: all test lint shellcheck bats bump-action-pins
 
 # Default target
 all: test
@@ -25,6 +25,13 @@ shellcheck:
 bats:
 	@echo "=== bats ==="
 	@bats test/ test/lib/ test/integration/ tools/*/test.bats actions/*/test.bats build/actions/*/test.bats
+
+# Bump every TomHennen/wrangle/...@<sha> ref in .github/workflows/ to current HEAD.
+# Idempotent. See tools/bump_action_pins.sh and #165.
+# Usage: make bump-action-pins             # bump to HEAD
+#        make bump-action-pins SHA=<sha>   # bump to a specific SHA
+bump-action-pins:
+	@./tools/bump_action_pins.sh $(SHA)
 
 # Update a tool version and its checksum
 # Usage: make update-tool TOOL=osv VERSION=1.2.3

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update -q && \
     apt-get install -y -q --no-install-recommends \
         bats \
         curl \
+        git \
         jq \
         shellcheck \
         ca-certificates \

--- a/test/test_bump_action_pins.bats
+++ b/test/test_bump_action_pins.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+
+# Tests for tools/bump_action_pins.sh.
+#
+# Each test runs the script in a temporary git repo with a fabricated
+# .github/workflows/ tree so we exercise the rewrite logic against
+# representative inputs without touching the real wrangle repo.
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    SCRIPT="$REPO_ROOT/tools/bump_action_pins.sh"
+    TEST_DIR="$(mktemp -d)"
+    ORIG_DIR="$(pwd)"
+
+    cd "$TEST_DIR"
+    git init -q
+    git config user.email "t@t"
+    git config user.name "t"
+    git commit --allow-empty -q -m init
+    mkdir -p .github/workflows
+
+    # Stable comment env so test assertions don't drift with date.
+    export WRANGLE_PINS_BRANCH=test-branch
+    export WRANGLE_PINS_DATE=2099-12-31
+
+    NEW_SHA="cccccccccccccccccccccccccccccccccccccccc"
+}
+
+teardown() {
+    cd "$ORIG_DIR"
+    rm -rf "$TEST_DIR"
+}
+
+@test "bump_action_pins: rewrites pin with existing comment" {
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # main 2026-01-01
+EOF
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    grep -q "@${NEW_SHA} # test-branch 2099-12-31" .github/workflows/a.yml
+    ! grep -q "@aaaa" .github/workflows/a.yml
+}
+
+@test "bump_action_pins: adds comment when pin lacks one" {
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/actions/scan@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    grep -q "@${NEW_SHA} # test-branch 2099-12-31" .github/workflows/a.yml
+}
+
+@test "bump_action_pins: leaves unrelated action refs alone" {
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    grep -q "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2" .github/workflows/a.yml
+    grep -q "TomHennen/wrangle/build/actions/python@${NEW_SHA}" .github/workflows/a.yml
+}
+
+@test "bump_action_pins: leaves third-party SLSA generator tag refs alone" {
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  provenance:
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+EOF
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    grep -q "slsa-framework/slsa-github-generator.*@v2.1.0" .github/workflows/a.yml
+}
+
+@test "bump_action_pins: handles multiple pins in one file" {
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  a:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # main 2026-01-01
+  b:
+    uses: TomHennen/wrangle/actions/scan@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb # main 2026-02-01
+EOF
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    [[ "$(grep -c "@${NEW_SHA}" .github/workflows/a.yml)" -eq 2 ]]
+}
+
+@test "bump_action_pins: handles multiple files" {
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    cat > .github/workflows/b.yml <<EOF
+jobs:
+  scan:
+    uses: TomHennen/wrangle/actions/scan@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+EOF
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    grep -q "@${NEW_SHA}" .github/workflows/a.yml
+    grep -q "@${NEW_SHA}" .github/workflows/b.yml
+}
+
+@test "bump_action_pins: idempotent on second run" {
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    "$SCRIPT" "$NEW_SHA" >/dev/null
+    BEFORE="$(cat .github/workflows/a.yml)"
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"0 file(s) changed"* ]]
+    AFTER="$(cat .github/workflows/a.yml)"
+    [[ "$BEFORE" == "$AFTER" ]]
+}
+
+@test "bump_action_pins: defaults to current HEAD when no SHA given" {
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    git add . && git commit -q -m fixture
+    HEAD_SHA="$(git rev-parse HEAD)"
+    run "$SCRIPT"
+    [[ "$status" -eq 0 ]]
+    grep -q "@${HEAD_SHA}" .github/workflows/a.yml
+}
+
+@test "bump_action_pins: rejects non-SHA argument" {
+    run "$SCRIPT" "not-a-sha"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"40-char hex"* ]]
+}
+
+@test "bump_action_pins: rejects too many arguments" {
+    run "$SCRIPT" "$NEW_SHA" extra
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "bump_action_pins: errors when not in a git working tree" {
+    NON_GIT="$(mktemp -d)"
+    cd "$NON_GIT"
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"git working tree"* ]]
+    rm -rf "$NON_GIT"
+}
+
+@test "bump_action_pins: WRANGLE_PINS_REPO override targets a different prefix" {
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: example/repo/path@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    other:
+    uses: TomHennen/wrangle/build/actions/python@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+EOF
+    WRANGLE_PINS_REPO=example/repo run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    grep -q "example/repo/path@${NEW_SHA}" .github/workflows/a.yml
+    # Default prefix should NOT be touched when override is set
+    grep -q "TomHennen/wrangle/build/actions/python@bbbb" .github/workflows/a.yml
+}
+
+@test "bump_action_pins: matches both .yml and .yaml extensions" {
+    cat > .github/workflows/a.yaml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    grep -q "@${NEW_SHA}" .github/workflows/a.yaml
+}

--- a/test/test_bump_action_pins.bats
+++ b/test/test_bump_action_pins.bats
@@ -242,6 +242,35 @@ EOF
     [[ "$leftover_count" -eq 0 ]]
 }
 
+@test "bump_action_pins: handles branch names with sed-special characters" {
+    # Branch names can legally contain `|`, `&`, and `\` per
+    # git-check-ref-format(1). They flow into the sed REPLACEMENT string
+    # for the trailing comment, where each has special meaning. The
+    # script must escape them so the rewrite produces a literal label.
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+
+    # `|` (the sed delimiter) — must not break the rewrite.
+    WRANGLE_PINS_BRANCH='feat|x' run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    grep -qF "@${NEW_SHA} # feat|x" .github/workflows/a.yml
+
+    # `&` (sed's matched-text backreference) — must not be expanded.
+    "$SCRIPT" "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" >/dev/null  # reset to unique pre-state
+    WRANGLE_PINS_BRANCH='foo&bar' run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    grep -qF "@${NEW_SHA} # foo&bar" .github/workflows/a.yml
+
+    # `\` (sed's escape character) — must round-trip as a literal backslash.
+    "$SCRIPT" "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" >/dev/null  # reset
+    WRANGLE_PINS_BRANCH='back\slash' run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    grep -qF "@${NEW_SHA} # back\\slash" .github/workflows/a.yml
+}
+
 @test "bump_action_pins: only mixed-SHA files are rewritten when some pins already match target" {
     # File with a mix of SHAs — must be rewritten so all pins reach target.
     cat > .github/workflows/mixed.yml <<EOF

--- a/test/test_bump_action_pins.bats
+++ b/test/test_bump_action_pins.bats
@@ -183,3 +183,82 @@ EOF
     [[ "$status" -eq 0 ]]
     grep -q "@${NEW_SHA}" .github/workflows/a.yaml
 }
+
+@test "bump_action_pins: ignores commented-out uses: lines" {
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    # uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    uses: TomHennen/wrangle/actions/scan@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+EOF
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    # Commented line untouched
+    grep -q "# uses: TomHennen/wrangle/build/actions/python@aaaa" .github/workflows/a.yml
+    # Real pin updated
+    grep -q "uses: TomHennen/wrangle/actions/scan@${NEW_SHA}" .github/workflows/a.yml
+}
+
+@test "bump_action_pins: rejects CRLF line endings" {
+    printf 'jobs:\r\n  build:\r\n    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\n' > .github/workflows/a.yml
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CRLF"* ]]
+}
+
+@test "bump_action_pins: idempotent when SHA matches even with different env date/branch" {
+    # Initial bump with date X, branch Y.
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    "$SCRIPT" "$NEW_SHA" >/dev/null
+    BEFORE="$(cat .github/workflows/a.yml)"
+
+    # Re-run with the same SHA but a different date/branch — file must
+    # remain byte-identical because the SHA hasn't changed.
+    WRANGLE_PINS_DATE=2100-01-01 WRANGLE_PINS_BRANCH=other-branch run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"0 file(s) changed"* ]]
+    AFTER="$(cat .github/workflows/a.yml)"
+    [[ "$BEFORE" == "$AFTER" ]]
+}
+
+@test "bump_action_pins: cleans up temp files on sed failure" {
+    # Simulate a permission-denied write to make sed fail. Pre-create
+    # a target file, then make the workflows dir non-writable.
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    chmod -w .github/workflows
+    run "$SCRIPT" "$NEW_SHA"
+    chmod +w .github/workflows
+    # Either it errored, or it succeeded but no temp files leaked.
+    # Crucial assertion: no leftover .yml.* temp files in the workflows dir.
+    leftover_count="$(find .github/workflows -maxdepth 1 -name 'a.yml.*' | wc -l)"
+    [[ "$leftover_count" -eq 0 ]]
+}
+
+@test "bump_action_pins: only mixed-SHA files are rewritten when some pins already match target" {
+    # File with a mix of SHAs — must be rewritten so all pins reach target.
+    cat > .github/workflows/mixed.yml <<EOF
+jobs:
+  a:
+    uses: TomHennen/wrangle/build/actions/python@${NEW_SHA}
+  b:
+    uses: TomHennen/wrangle/actions/scan@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    # File with all pins already at target — must NOT be rewritten.
+    cat > .github/workflows/all-match.yml <<EOF
+jobs:
+  a:
+    uses: TomHennen/wrangle/build/actions/python@${NEW_SHA}
+EOF
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"bumped: .github/workflows/mixed.yml"* ]]
+    [[ "$output" != *"bumped: .github/workflows/all-match.yml"* ]]
+}

--- a/tools/bump_action_pins.sh
+++ b/tools/bump_action_pins.sh
@@ -77,8 +77,25 @@ date_label="${WRANGLE_PINS_DATE:-$(date -u +%Y-%m-%d)}"
 # YAML list-item dash. Without the anchor, comment lines like
 # `# uses: ...@<sha>` would match — wrong, since the comment is supposed
 # to neutralize the line.
+#
+# The branch and date labels flow into the sed REPLACEMENT string. Three
+# characters need escaping there: `\` (sed escape), `&` (matched-text
+# backreference), and `|` (our chosen delimiter — legal in git refs per
+# git-check-ref-format(1)). Order matters: backslash first so the others
+# don't double-escape. The SHA is `[0-9a-f]{40}` and PINS_REPO is operator-
+# supplied (already vetted), so they don't need this treatment.
+escape_for_sed_replace() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//&/\\&}"
+    s="${s//|/\\|}"
+    printf '%s' "$s"
+}
+escaped_branch="$(escape_for_sed_replace "$branch_label")"
+escaped_date="$(escape_for_sed_replace "$date_label")"
+
 escaped_repo="${PINS_REPO//\//\\/}"
-new_suffix="@${target_sha} # ${branch_label} ${date_label}"
+new_suffix="@${target_sha} # ${escaped_branch} ${escaped_date}"
 
 match='\(^[[:space:]]*-\{0,1\}[[:space:]]*uses:[[:space:]]*'"$escaped_repo"'/[^@[:space:]]*\)@[0-9a-f]\{40\}\([[:space:]]*#[^\r\n]*\)\{0,1\}'
 replace='\1'"$new_suffix"

--- a/tools/bump_action_pins.sh
+++ b/tools/bump_action_pins.sh
@@ -11,6 +11,15 @@
 # No per-action change tracking — bump everything to HEAD on each run.
 # That matches how `$/` syntax (#136) would behave once it ships.
 #
+# Idempotency: if every matching pin in a file already points at the
+# target SHA, the file is left untouched (the comment date/branch is
+# only refreshed when the SHA actually changes). This means running
+# the script on different days produces no spurious diff.
+#
+# Portability: works with GNU and BSD sed. Workflow files are required
+# to use LF line endings — CRLF causes the script to error out so the
+# rewrite doesn't silently mangle line endings.
+#
 # Usage:
 #   tools/bump_action_pins.sh             # bump every pin to current HEAD
 #   tools/bump_action_pins.sh <sha>       # bump every pin to a specific SHA
@@ -60,39 +69,67 @@ else
 fi
 date_label="${WRANGLE_PINS_DATE:-$(date -u +%Y-%m-%d)}"
 
-# Build the sed expression. Escape the slashes in the repo prefix so
-# they survive the s|||g delimiter choice. We use | as the delimiter
-# because the matched text contains /, which would otherwise need
-# escaping.
+# Build the sed expression. We use | as the delimiter because the matched
+# text contains /, which would otherwise need escaping. The `\{0,1\}`
+# quantifier is POSIX BRE and works on both GNU and BSD sed (\? is GNU-only).
+#
+# Anchor: the line must start with optional whitespace and an optional
+# YAML list-item dash. Without the anchor, comment lines like
+# `# uses: ...@<sha>` would match — wrong, since the comment is supposed
+# to neutralize the line.
 escaped_repo="${PINS_REPO//\//\\/}"
 new_suffix="@${target_sha} # ${branch_label} ${date_label}"
 
-# Match group 1: the path between the repo prefix and the @ separator.
-# The whole tail (sha + optional " # ..." comment) is replaced.
-match='\(uses:[[:space:]]*'"$escaped_repo"'/[^@[:space:]]*\)@[0-9a-f]\{40\}\([[:space:]]*#[^\n]*\)\?'
+match='\(^[[:space:]]*-\{0,1\}[[:space:]]*uses:[[:space:]]*'"$escaped_repo"'/[^@[:space:]]*\)@[0-9a-f]\{40\}\([[:space:]]*#[^\r\n]*\)\{0,1\}'
 replace='\1'"$new_suffix"
 
-# Walk every YAML file in the target dir and rewrite in place. POSIX sed
-# (BSD on macOS, GNU on Linux) differ on -i; sed's -i'' form works on GNU
-# but not BSD. To stay portable, write to a temp file and atomically replace.
+# Walk every YAML file in the target dir and rewrite in place. We write
+# to a sibling temp file (mktemp on the same filesystem) and atomically
+# rename — `mktemp` defaults to $TMPDIR, often a different mount, where
+# `mv` falls back to copy+unlink (not atomic).
+tmp_file=""
+cleanup() { [[ -n "$tmp_file" && -f "$tmp_file" ]] && rm -f "$tmp_file"; tmp_file=""; }
+trap cleanup EXIT INT TERM
+
 shopt -s nullglob
 changed=0
 total=0
 for f in "$REPO_ROOT/$PINS_DIR"/*.yml "$REPO_ROOT/$PINS_DIR"/*.yaml; do
     [[ -f "$f" ]] || continue
+
+    # Filter to files that even contain a matching pin.
     if ! grep -q -E "uses:[[:space:]]*${PINS_REPO}/[^@[:space:]]+@[0-9a-f]{40}" "$f"; then
         continue
     fi
     total=$((total + 1))
-    tmp="$(mktemp)"
-    sed "s|$match|$replace|g" "$f" > "$tmp"
-    if ! cmp -s "$f" "$tmp"; then
-        mv "$tmp" "$f"
-        changed=$((changed + 1))
-        printf 'bumped: %s\n' "${f#"$REPO_ROOT"/}"
-    else
-        rm -f "$tmp"
+
+    # Reject CRLF — silently dropping \r would produce mixed line endings.
+    if grep -q $'\r' "$f"; then
+        # shellcheck disable=SC2016 # the backticks are part of the human-readable message, not an attempt at command substitution
+        printf 'Error: %s has CRLF line endings; convert to LF first (see dos2unix(1) or `tr -d "\\r" < file > tmp && mv tmp file`).\n' "${f#"$REPO_ROOT"/}" >&2
+        exit 1
     fi
+
+    # Idempotency: if every existing pin already matches the target SHA,
+    # leave the file alone (preserves the existing comment, so re-runs
+    # on different days don't produce spurious diffs).
+    needs_update=false
+    while IFS= read -r existing_sha; do
+        if [[ "$existing_sha" != "$target_sha" ]]; then
+            needs_update=true
+            break
+        fi
+    done < <(grep -oE "${PINS_REPO}/[^@[:space:]]+@[0-9a-f]{40}" "$f" | grep -oE '[0-9a-f]{40}$')
+    if [[ "$needs_update" == "false" ]]; then
+        continue
+    fi
+
+    tmp_file="$(mktemp "$f.XXXXXX")"
+    sed "s|$match|$replace|g" "$f" > "$tmp_file"
+    mv "$tmp_file" "$f"
+    tmp_file=""
+    changed=$((changed + 1))
+    printf 'bumped: %s\n' "${f#"$REPO_ROOT"/}"
 done
 
 printf '\nSummary: %d file(s) had pins, %d file(s) changed.\n' "$total" "$changed"

--- a/tools/bump_action_pins.sh
+++ b/tools/bump_action_pins.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# tools/bump_action_pins.sh — Rewrite TomHennen/wrangle/...@<sha> action refs
+# in .github/workflows/ to a target SHA (default: current HEAD).
+#
+# Wrangle's reusable workflows pin to local composite actions via
+# fully-qualified SHA refs because GitHub resolves `uses: ./` relative
+# to the *caller's* workspace, not the action's own repo. Whenever a
+# composite changes, the matching reusable workflow's pin needs a bump
+# in the same PR. This script automates the bump.
+#
+# No per-action change tracking — bump everything to HEAD on each run.
+# That matches how `$/` syntax (#136) would behave once it ships.
+#
+# Usage:
+#   tools/bump_action_pins.sh             # bump every pin to current HEAD
+#   tools/bump_action_pins.sh <sha>       # bump every pin to a specific SHA
+#
+# Env overrides (escape hatch for forks / testing):
+#   WRANGLE_PINS_REPO   — repo prefix to match (default: TomHennen/wrangle)
+#   WRANGLE_PINS_DIR    — directory to walk (default: .github/workflows)
+#   WRANGLE_PINS_BRANCH — branch label to write into the comment
+#                         (default: `git symbolic-ref --short HEAD`,
+#                         falling back to "main" if detached)
+#   WRANGLE_PINS_DATE   — date label to write into the comment
+#                         (default: today's date in YYYY-MM-DD UTC)
+
+set -euo pipefail
+
+# Resolve the repo to operate on from the current git working directory,
+# NOT from the script's own location. This makes the script safe to run
+# from any clone (forks, integration tests, ad-hoc checkouts) and keeps
+# tests honest — they can target a temporary fixture repo.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$REPO_ROOT" ]]; then
+    printf 'Error: must be run inside a git working tree\n' >&2
+    exit 1
+fi
+
+PINS_REPO="${WRANGLE_PINS_REPO:-TomHennen/wrangle}"
+PINS_DIR="${WRANGLE_PINS_DIR:-.github/workflows}"
+
+if [[ $# -gt 1 ]]; then
+    printf 'Usage: %s [<sha>]\n' "$0" >&2
+    exit 1
+fi
+
+target_sha="${1:-}"
+if [[ -z "$target_sha" ]]; then
+    target_sha="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+fi
+if [[ ! "$target_sha" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'Error: target SHA must be a 40-char hex string, got: %s\n' "$target_sha" >&2
+    exit 1
+fi
+
+if [[ -n "${WRANGLE_PINS_BRANCH:-}" ]]; then
+    branch_label="$WRANGLE_PINS_BRANCH"
+else
+    branch_label="$(git -C "$REPO_ROOT" symbolic-ref --short HEAD 2>/dev/null || echo main)"
+fi
+date_label="${WRANGLE_PINS_DATE:-$(date -u +%Y-%m-%d)}"
+
+# Build the sed expression. Escape the slashes in the repo prefix so
+# they survive the s|||g delimiter choice. We use | as the delimiter
+# because the matched text contains /, which would otherwise need
+# escaping.
+escaped_repo="${PINS_REPO//\//\\/}"
+new_suffix="@${target_sha} # ${branch_label} ${date_label}"
+
+# Match group 1: the path between the repo prefix and the @ separator.
+# The whole tail (sha + optional " # ..." comment) is replaced.
+match='\(uses:[[:space:]]*'"$escaped_repo"'/[^@[:space:]]*\)@[0-9a-f]\{40\}\([[:space:]]*#[^\n]*\)\?'
+replace='\1'"$new_suffix"
+
+# Walk every YAML file in the target dir and rewrite in place. POSIX sed
+# (BSD on macOS, GNU on Linux) differ on -i; sed's -i'' form works on GNU
+# but not BSD. To stay portable, write to a temp file and atomically replace.
+shopt -s nullglob
+changed=0
+total=0
+for f in "$REPO_ROOT/$PINS_DIR"/*.yml "$REPO_ROOT/$PINS_DIR"/*.yaml; do
+    [[ -f "$f" ]] || continue
+    if ! grep -q -E "uses:[[:space:]]*${PINS_REPO}/[^@[:space:]]+@[0-9a-f]{40}" "$f"; then
+        continue
+    fi
+    total=$((total + 1))
+    tmp="$(mktemp)"
+    sed "s|$match|$replace|g" "$f" > "$tmp"
+    if ! cmp -s "$f" "$tmp"; then
+        mv "$tmp" "$f"
+        changed=$((changed + 1))
+        printf 'bumped: %s\n' "${f#"$REPO_ROOT"/}"
+    else
+        rm -f "$tmp"
+    fi
+done
+
+printf '\nSummary: %d file(s) had pins, %d file(s) changed.\n' "$total" "$changed"
+printf 'Target SHA: %s\n' "$target_sha"
+printf 'Comment:    # %s %s\n' "$branch_label" "$date_label"


### PR DESCRIPTION
## Summary

- Adds `tools/bump_action_pins.sh` and a `make bump-action-pins` wrapper that rewrites every `TomHennen/wrangle/...@<sha>` reference under `.github/workflows/` to current HEAD (or a specified SHA), updating the trailing `# <branch> <date>` comment in place.
- Idempotent. Operates on the current git working tree (not the script's own location). Errors on bad SHA / bad args / non-git working dir.
- 12 bats tests covering the rewrite logic, what it leaves alone (`actions/checkout`, SLSA generator tag pins), idempotency, .yaml extension, multiple files, and the `WRANGLE_PINS_REPO` escape hatch.
- Test Docker image learned `git`.

Why: PR #156 hit the manual-SHA-bump dance three times (`8485af3`, `830540e`, `049fb5d`). Every future build-type PR has the same pattern. This automates it.

This addresses the day-to-day pain in #137. Fork compatibility still depends on `$/` syntax (#136).

Closes #165.

## Test plan

- [x] `./test.sh` green (220/220).
- [ ] Manually run `make bump-action-pins` after merge to update the existing stale pin in `build_and_publish_python.yml` (which still references `c65a939`).
- [ ] Confirm CI on this PR is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)