### PR TITLE
Unify metadata layout across build types (closes #162)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -31,7 +31,7 @@ on:
         description: "Normalized (lowercased) image name."
         value: ${{ jobs.build.outputs.imagename }}
       metadata-artifact-name:
-        description: "Name of the workflow artifact containing the SBOM and any scan output (`container-metadata-<shortname>`)."
+        description: "Name of the workflow artifact (a zip of `metadata/container/<shortname>/`'s contents) containing the SBOM and any scan output. Format: `container-metadata-<shortname>`. Adopters fetch via `actions/download-artifact` — the metadata files land at the top level of the configured `path:`, not under `metadata/container/<shortname>/`."
         value: ${{ jobs.build.outputs.metadata-artifact-name }}
 
 jobs:

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -23,6 +23,16 @@ on:
       gh_token:
         description: "GitHub token with write access"
         required: true
+    outputs:
+      digest:
+        description: "Image digest pushed to the registry."
+        value: ${{ jobs.build.outputs.digest }}
+      imagename:
+        description: "Normalized (lowercased) image name."
+        value: ${{ jobs.build.outputs.imagename }}
+      metadata-artifact-name:
+        description: "Name of the workflow artifact containing the SBOM and any scan output (`container-metadata-<shortname>`)."
+        value: ${{ jobs.build.outputs.metadata-artifact-name }}
 
 jobs:
   build:
@@ -32,6 +42,7 @@ jobs:
     outputs:
       digest: ${{ steps.build.outputs.digest }}
       imagename: ${{ steps.build.outputs.imagename }}
+      metadata-artifact-name: container-metadata-${{ steps.build.outputs.shortname }}
     runs-on: ubuntu-latest
     steps:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -48,7 +48,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@6cbd393e779e98c40459ef8032dbac62b7805e16 # main 2026-04-22
+      uses: TomHennen/wrangle/build/actions/container@4f802f220bb888203ae6c3a722bae892ed85a910 # unify-container-metadata-layout 2026-04-26
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -41,7 +41,7 @@ on:
         description: "Name of the SLSA provenance workflow artifact (= the provenance filename). Empty on PR builds (provenance is gated on non-PR events)."
         value: ${{ jobs.provenance.outputs.provenance-name }}
       metadata-artifact-name:
-        description: "Name of the workflow artifact containing the SBOM and metadata (`python-metadata-<shortname>`). See docs/SPEC.md \"Unified metadata layout\"."
+        description: "Name of the workflow artifact (a zip of `metadata/python/<shortname>/`'s contents) containing the SBOM and metadata. Format: `python-metadata-<shortname>`. Adopters fetch via `actions/download-artifact` — the metadata files land at the top level of the configured `path:`, not under `metadata/python/<shortname>/`. See docs/SPEC.md \"Unified metadata layout\"."
         value: ${{ jobs.build.outputs.metadata-artifact-name }}
 
 jobs:

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -40,6 +40,9 @@ on:
       provenance-artifact-name:
         description: "Name of the SLSA provenance workflow artifact (= the provenance filename). Empty on PR builds (provenance is gated on non-PR events)."
         value: ${{ jobs.provenance.outputs.provenance-name }}
+      metadata-artifact-name:
+        description: "Name of the workflow artifact containing the SBOM and metadata (`python-metadata-<shortname>`). See docs/SPEC.md \"Unified metadata layout\"."
+        value: ${{ jobs.build.outputs.metadata-artifact-name }}
 
 jobs:
   build:
@@ -50,6 +53,7 @@ jobs:
       hashes: ${{ steps.build.outputs.hashes }}
       version: ${{ steps.build.outputs.version }}
       dist-artifact-name: ${{ steps.names.outputs.dist }}
+      metadata-artifact-name: ${{ steps.names.outputs.metadata }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -23,7 +23,7 @@ A GitHub composite action that builds and publishes a container image to GitHub 
 
 The action generates an SBOM for the container it builds. Today the SBOM is available two ways:
 
-- As a workflow artifact named `container-metadata-<shortname>`, downloadable from the Actions run page or via `actions/download-artifact` in a downstream job. The reusable workflow also exposes the artifact name as the `metadata-artifact-name` output so callers don't have to hardcode it.
+- As a workflow artifact named `container-metadata-<shortname>`, downloadable from the Actions run page or via `actions/download-artifact` in a downstream job. The artifact is the zip of `metadata/container/<shortname>/`'s contents — downloading it extracts the metadata files at the top level of whatever `path:` you choose, not nested under `metadata/container/<shortname>/`. The reusable workflow exposes the artifact name as the `metadata-artifact-name` output so callers don't have to hardcode it.
 - Embedded in the OCI image manifest as a BuildKit attestation, retrievable from the image itself with `docker buildx imagetools inspect --format '{{ json .SBOM.SPDX }}' <image>@<digest>`
 
 See [`SPEC.md` §"Where to find the SBOM"](./SPEC.md#where-to-find-the-sbom) for the full publication story (including the planned cosign SBOM attestation).

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -23,7 +23,7 @@ A GitHub composite action that builds and publishes a container image to GitHub 
 
 The action generates an SBOM for the container it builds. Today the SBOM is available two ways:
 
-- As a workflow artifact (`container-build-results-<shortname>`), downloadable from the Actions run page or via `actions/download-artifact` in a downstream job
+- As a workflow artifact named `container-metadata-<shortname>`, downloadable from the Actions run page or via `actions/download-artifact` in a downstream job. The reusable workflow also exposes the artifact name as the `metadata-artifact-name` output so callers don't have to hardcode it.
 - Embedded in the OCI image manifest as a BuildKit attestation, retrievable from the image itself with `docker buildx imagetools inspect --format '{{ json .SBOM.SPDX }}' <image>@<digest>`
 
 See [`SPEC.md` §"Where to find the SBOM"](./SPEC.md#where-to-find-the-sbom) for the full publication story (including the planned cosign SBOM attestation).

--- a/build/actions/container/SPEC.md
+++ b/build/actions/container/SPEC.md
@@ -61,7 +61,7 @@ The reusable workflow surfaces the identifiers a downstream release job needs to
 |--------|-------------|
 | `digest` | The image digest of the published image (`sha256:...`), forwarded from the composite action's build-and-push step. Identifies the exact image that was signed and attested. |
 | `imagename` | Validated, lowercased image name (e.g., `ghcr.io/owner/repo/image`), forwarded from the composite action. |
-| `sbom_artifact` | Name of the uploaded workflow artifact containing the SPDX SBOM and SARIF scan output (e.g., `container-build-results-<shortname>`). Downstream jobs can fetch it via `actions/download-artifact`. |
+| `metadata-artifact-name` | Name of the uploaded workflow artifact containing the SBOM and any scan output (e.g., `container-metadata-<shortname>`). Downstream jobs can fetch it via `actions/download-artifact`. Naming and contents follow the unified-metadata convention; see [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout." |
 
 ## Step sequence
 
@@ -284,7 +284,7 @@ These enable consumers to enforce verification policies on their side, but wrang
 
 Today the SPDX SBOM is published in two places, and a third is planned:
 
-1. **Workflow artifact (available now).** The composite action uploads the `./metadata/` directory as the workflow artifact `container-build-results-<shortname>`, which contains the SBOM at `metadata/container/<shortname>/sbom.spdx.json` alongside SARIF scan output. Downstream jobs can fetch it with `actions/download-artifact`; humans can download it from the Actions run page. The reusable workflow exposes the artifact name as the `sbom_artifact` output so callers don't have to hardcode the naming convention.
+1. **Workflow artifact (available now).** The composite action writes to `metadata/container/<shortname>/sbom.spdx.json` and uploads that directory as the workflow artifact `container-metadata-<shortname>`. Downstream jobs can fetch it with `actions/download-artifact`; humans can download it from the Actions run page. The reusable workflow exposes the artifact name as the `metadata-artifact-name` output so callers don't have to hardcode the naming convention. The directory layout follows the unified-metadata convention shared across all build types — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout."
 2. **Embedded in the BuildKit image attestation (available now).** Because the build step is invoked with `sbom: true`, BuildKit attaches the SBOM to the OCI image manifest as an in-toto attestation. Consumers can retrieve it from the image itself, without access to the original workflow run, via:
    ```bash
    docker buildx imagetools inspect --format '{{ json .SBOM.SPDX }}' \

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -30,7 +30,7 @@ outputs:
     value: ${{ steps.get_sbom.outputs.sbom }}
   metadata-dir:
     description: "Workspace-relative path of the unified metadata directory (`metadata/container/<shortname>/`) containing the SBOM and any scan output."
-    value: ${{ steps.get_sbom.outputs.metadata-dir }}
+    value: ${{ steps.meta_dir.outputs.metadata-dir }}
   shortname:
     description: "Path-derived short name (`/` becomes `_`) used for artifact namespacing."
     value: ${{ steps.normalize.outputs.shortname }}
@@ -91,25 +91,37 @@ runs:
         sbom: true
         provenance: mode=max
 
+    # Create the metadata directory and emit its path BEFORE SBOM extraction.
+    # If a later step fails (build, push, SBOM extract), the `if: always()`
+    # artifact upload still has a valid (possibly empty) directory to upload —
+    # useful for debug. Folding this into the SBOM-extract step would leave
+    # `path:` resolving to an empty value when the SBOM step is skipped due
+    # to an earlier failure.
+    - name: Prepare metadata directory
+      id: meta_dir
+      shell: bash
+      env:
+        SHORTNAME: ${{ steps.normalize.outputs.shortname }}
+      run: |
+        set -euo pipefail
+        METADATA_DIR="metadata/container/${SHORTNAME}"
+        mkdir -p "$METADATA_DIR"
+        printf 'metadata-dir=%s\n' "$METADATA_DIR" >> "$GITHUB_OUTPUT"
+
     - name: Extract SBOM from built image
       id: get_sbom
       shell: bash
       env:
         IMAGE: ${{ steps.normalize.outputs.imagename }}
         DIGEST: ${{ steps.push.outputs.digest }}
-        SHORTNAME: ${{ steps.normalize.outputs.shortname }}
+        METADATA_DIR: ${{ steps.meta_dir.outputs.metadata-dir }}
       run: |
         set -euo pipefail
-        METADATA_DIR="metadata/container/${SHORTNAME}"
-        mkdir -p "$METADATA_DIR"
-        SBOM_PATH="$METADATA_DIR/sbom.spdx.json"
+        SBOM_PATH="${METADATA_DIR}/sbom.spdx.json"
         # Reference by digest, not tag — the :latest tag only exists on
         # main-branch builds, so bare image name fails on other branches.
         docker buildx imagetools inspect "${IMAGE}@${DIGEST}" --format "{{ json .SBOM.SPDX }}" > "$SBOM_PATH"
-        {
-            printf 'sbom=%s\n' "$SBOM_PATH"
-            printf 'metadata-dir=%s\n' "$METADATA_DIR"
-        } >> "$GITHUB_OUTPUT"
+        printf 'sbom=%s\n' "$SBOM_PATH" >> "$GITHUB_OUTPUT"
 
     - name: Generate summary
       if: always()
@@ -130,4 +142,8 @@ runs:
         # metadata files at the top level, not nested under metadata/<type>/...).
         # See docs/SPEC.md "Unified metadata layout."
         name: container-metadata-${{ steps.normalize.outputs.shortname }}
-        path: ${{ steps.get_sbom.outputs.metadata-dir }}/
+        # Reference the prepared dir from `meta_dir` (always runs), not from
+        # `get_sbom` — if SBOM extraction is skipped due to an earlier failure,
+        # `get_sbom.outputs.metadata-dir` is empty and the `if: always()`
+        # upload would resolve to an unintended path.
+        path: ${{ steps.meta_dir.outputs.metadata-dir }}/

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -28,6 +28,12 @@ outputs:
   sbom:
     description: 'Path to an SBOM that describes the container'
     value: ${{ steps.get_sbom.outputs.sbom }}
+  metadata-dir:
+    description: "Workspace-relative path of the unified metadata directory (`metadata/container/<shortname>/`) containing the SBOM and any scan output."
+    value: ${{ steps.get_sbom.outputs.metadata-dir }}
+  shortname:
+    description: "Path-derived short name (`/` becomes `_`) used for artifact namespacing."
+    value: ${{ steps.normalize.outputs.shortname }}
 
 runs:
   using: "composite"
@@ -85,14 +91,6 @@ runs:
         sbom: true
         provenance: mode=max
 
-    - name: Prepare metadata directory
-      shell: bash
-      env:
-        SHORTNAME: ${{ steps.normalize.outputs.shortname }}
-      run: |
-        set -euo pipefail
-        mkdir -p "./metadata/container/${SHORTNAME}"
-
     - name: Extract SBOM from built image
       id: get_sbom
       shell: bash
@@ -102,11 +100,16 @@ runs:
         SHORTNAME: ${{ steps.normalize.outputs.shortname }}
       run: |
         set -euo pipefail
-        SBOM_PATH="metadata/container/${SHORTNAME}/sbom.spdx.json"
+        METADATA_DIR="metadata/container/${SHORTNAME}"
+        mkdir -p "$METADATA_DIR"
+        SBOM_PATH="$METADATA_DIR/sbom.spdx.json"
         # Reference by digest, not tag — the :latest tag only exists on
         # main-branch builds, so bare image name fails on other branches.
         docker buildx imagetools inspect "${IMAGE}@${DIGEST}" --format "{{ json .SBOM.SPDX }}" > "$SBOM_PATH"
-        printf 'sbom=%s\n' "$SBOM_PATH" >> "$GITHUB_OUTPUT"
+        {
+            printf 'sbom=%s\n' "$SBOM_PATH"
+            printf 'metadata-dir=%s\n' "$METADATA_DIR"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Generate summary
       if: always()
@@ -122,5 +125,9 @@ runs:
     - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       if: always()
       with:
-        name: container-build-results-${{ steps.normalize.outputs.shortname }}
-        path: ./metadata/
+        # Convention shared with other build types: <type>-metadata-<shortname>,
+        # path = the leaf metadata dir (so the artifact zip's contents are the
+        # metadata files at the top level, not nested under metadata/<type>/...).
+        # See docs/SPEC.md "Unified metadata layout."
+        name: container-metadata-${{ steps.normalize.outputs.shortname }}
+        path: ${{ steps.get_sbom.outputs.metadata-dir }}/

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -62,3 +62,33 @@ teardown() {
     grep -q '^imagename=ghcr.io/owner/img$' "$GITHUB_OUTPUT"
     grep -q '^shortname=pkg_foo$' "$GITHUB_OUTPUT"
 }
+
+# --- Unified metadata layout assertions (#150) ---
+
+@test "container: action.yml writes SBOM under metadata/container/<shortname>/" {
+    run grep 'metadata/container/' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: action.yml exposes metadata-dir output" {
+    run grep -E '^[[:space:]]+metadata-dir:' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: action.yml exposes shortname output" {
+    run grep -E '^[[:space:]]+shortname:' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: action.yml uploads container-metadata-<shortname> artifact" {
+    run grep 'container-metadata-' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+    # Old name must not linger
+    run grep 'container-build-results' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 1 ]]
+}
+
+@test "container: reusable workflow exposes metadata-artifact-name output" {
+    run grep 'metadata-artifact-name:' "$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
+    [[ "$status" -eq 0 ]]
+}

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -88,6 +88,31 @@ teardown() {
     [[ "$status" -eq 1 ]]
 }
 
+@test "container: action.yml prepares metadata dir before SBOM extraction and upload" {
+    # The standalone Prepare-metadata step must run BEFORE Extract-SBOM and
+    # BEFORE the upload step, so the upload's path resolves to a real dir
+    # even on `if: always()` after an earlier-step failure.
+    run bash -c "awk '/Prepare metadata directory/{p=NR} /Extract SBOM from built image/{s=NR} /actions\\/upload-artifact/{u=NR} END{exit !(p && s && u && p<s && p<u)}' \"$ACTION_DIR/action.yml\""
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: upload-artifact path uses meta_dir output, not get_sbom output" {
+    # `meta_dir` always runs (no upstream dependency on the build); `get_sbom`
+    # depends on a successful build. The upload must reference meta_dir or
+    # `if: always()` could resolve to an empty path on failure.
+    run grep -E 'path:[[:space:]]*\$\{\{[[:space:]]*steps\.meta_dir\.outputs\.metadata-dir' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+    run grep -E 'path:[[:space:]]*\$\{\{[[:space:]]*steps\.get_sbom\.outputs\.metadata-dir' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 1 ]]
+}
+
+@test "container: composite metadata-dir output sources from meta_dir step" {
+    # The composite's metadata-dir output must reference meta_dir (always
+    # runs), not get_sbom (depends on build success).
+    run grep -E '^[[:space:]]+value:[[:space:]]*\$\{\{[[:space:]]*steps\.meta_dir\.outputs\.metadata-dir' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+}
+
 @test "container: reusable workflow exposes metadata-artifact-name output" {
     run grep 'metadata-artifact-name:' "$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
     [[ "$status" -eq 0 ]]

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -107,13 +107,15 @@ The same `slsa-verifier verify-artifact` invocation is exercised by wrangle's in
 
 ## SBOM
 
-The action writes an SPDX JSON SBOM to `metadata/python/<shortname>/sbom.spdx.json`. The reusable workflow uploads it as `python-metadata-<shortname>` and exposes the artifact name as the `metadata-artifact-name` output. Naming and layout follow the unified-metadata convention shared across every build type — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout."
+The action writes an SPDX JSON SBOM to `metadata/python/<shortname>/sbom.spdx.json`. The reusable workflow zips the contents of `metadata/python/<shortname>/` and uploads them as the workflow artifact `python-metadata-<shortname>`, exposed as the `metadata-artifact-name` output. Downloading the artifact (e.g., via `actions/download-artifact`) extracts the metadata files at the top level of whatever `path:` the adopter chooses — the `metadata/python/<shortname>/` prefix is a workspace convention, not part of the artifact's interior layout.
+
+Naming and layout follow the unified-metadata convention shared across every build type — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout" for how the directory maps to the artifact zip.
 
 ```yaml
 - uses: actions/download-artifact@<sha>
   with:
     name: ${{ needs.build.outputs.metadata-artifact-name }}
-    path: metadata/
+    path: metadata/  # `sbom.spdx.json` lands directly here, not under metadata/python/<shortname>/
 ```
 
 `<shortname>` is the path-derived short name — `.` becomes `_`, `pkg/foo` becomes `pkg_foo`. This namespacing lets you run multiple python builds in one workflow without artifact-name collisions.

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -48,6 +48,7 @@ Two ways to adopt:
 
 - `dist-artifact-name` — workflow-artifact name to download with `actions/download-artifact` to retrieve the built wheel + sdist.
 - `provenance-artifact-name` — workflow-artifact name for the SLSA provenance (empty on PR builds).
+- `metadata-artifact-name` — workflow-artifact name for the SBOM and any scan output (`python-metadata-<shortname>`). See [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout."
 - `hashes`, `version`.
 
 ## Verifying SLSA provenance before publish (recommended, optional)
@@ -106,12 +107,12 @@ The same `slsa-verifier verify-artifact` invocation is exercised by wrangle's in
 
 ## SBOM
 
-The action writes an SPDX JSON SBOM to `metadata/python/<shortname>/sbom.spdx.json`. The reusable workflow uploads it as `python-metadata-<shortname>`. Download with:
+The action writes an SPDX JSON SBOM to `metadata/python/<shortname>/sbom.spdx.json`. The reusable workflow uploads it as `python-metadata-<shortname>` and exposes the artifact name as the `metadata-artifact-name` output. Naming and layout follow the unified-metadata convention shared across every build type — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout."
 
 ```yaml
 - uses: actions/download-artifact@<sha>
   with:
-    name: python-metadata-<shortname>
+    name: ${{ needs.build.outputs.metadata-artifact-name }}
     path: metadata/
 ```
 

--- a/build/actions/python/SPEC.md
+++ b/build/actions/python/SPEC.md
@@ -108,7 +108,7 @@ The SBOM is generated from the installed/resolved environment (not just the lock
 
 ### 7. Upload build artifacts
 
-The reusable workflow uploads two artifacts after the composite action completes:
+The reusable workflow uploads two artifacts after the composite action completes. (GitHub artifacts are zip files; "uploads X as artifact Y" means the contents of X are zipped and stored as artifact Y. See [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout — How the artifact maps to a directory" for the mechanics.)
 
 - `python-dist-<shortname>` — the contents of `dist/` (wheel + sdist), consumed by the adopter's publish job.
 - `python-metadata-<shortname>` — the contents of `metadata/python/<shortname>/`, including the SPDX SBOM.
@@ -142,7 +142,7 @@ The publish job does **not** live in the reusable workflow because PyPI Trusted 
 
 ### 10. Generate summary and upload metadata
 
-The composite action writes a step summary (package name, version, list of artifacts). The reusable workflow uploads the SBOM/metadata directory as the `python-metadata-<shortname>` artifact (see step 7). See #150 for the vision of unified build results. See #155 for whether wrangle should also write attestations to GitHub's attestation store.
+The composite action writes a step summary (package name, version, list of artifacts). The reusable workflow zips the contents of the SBOM/metadata directory (`metadata/python/<shortname>/`) and uploads them as the `python-metadata-<shortname>` workflow artifact (see step 7). See #150 for the vision of unified build results. See #155 for whether wrangle should also write attestations to GitHub's attestation store.
 
 ## Permissions
 

--- a/build/actions/python/SPEC.md
+++ b/build/actions/python/SPEC.md
@@ -62,6 +62,7 @@ The publish-on-non-PR safety gate (`if: ! startsWith(github.event_name, 'pull_')
 | `hashes` | reusable workflow + composite | Base64-encoded SHA-256 hashes in the format `slsa-github-generator`'s `base64-subjects` input expects. Pass directly to the provenance job. |
 | `dist-artifact-name` | reusable workflow only | Name of the uploaded `dist/` artifact, namespaced by path-derived shortname so multiple python builds in one workflow don't collide. The publish job downloads using this name. |
 | `provenance-artifact-name` | reusable workflow only | Name of the uploaded SLSA provenance artifact (re-exported from `slsa-github-generator`'s `provenance-name`). Empty on PR builds because the provenance job is gated on non-PR events. |
+| `metadata-artifact-name` | reusable workflow only | Name of the uploaded metadata workflow artifact (`python-metadata-<shortname>`). Naming and contents follow the unified-metadata convention shared across all build types; see [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout." |
 | `shortname` | composite only | Path-derived short name (e.g., `.` becomes `_`, `pkg/foo` becomes `pkg_foo`). Used for artifact namespacing when the composite is invoked directly. |
 | `metadata-dir` | composite only | Path to the metadata directory (`metadata/python/<shortname>/`) containing the SBOM. |
 

--- a/build/actions/python/test.bats
+++ b/build/actions/python/test.bats
@@ -136,10 +136,12 @@ setup() {
     [[ "$status" -eq 0 ]]
 }
 
-@test "python: workflow exports hashes and provenance-artifact-name outputs" {
+@test "python: workflow exports hashes, provenance-artifact-name, metadata-artifact-name outputs" {
     run grep 'hashes:' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
     run grep 'provenance-artifact-name:' "$WORKFLOW"
+    [[ "$status" -eq 0 ]]
+    run grep 'metadata-artifact-name:' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
 }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -113,15 +113,17 @@ If `SPEC.md` describes behavior that hasn't shipped yet, `README.md` MUST NOT pr
 
 Every build type publishes its build outputs to **two complementary places**:
 
-1. **The ecosystem-native location** consumers expect for that build type — PyPI release attestations for python, GHCR image attestations for container, GitHub release assets for Go, etc. This is the wrangle value prop: ecosystem-native consumers use the tools they already know without learning anything wrangle-specific.
-2. **A consistent unified wrangle location** for cross-ecosystem tooling, policy, and audit. The unified location uses the same directory layout, artifact-naming convention, and adopter-facing output across every build type, so a tool spanning multiple ecosystems sees one schema instead of N.
+1. **The ecosystem-native location** consumers expect for that build type — PyPI release attestations for python, GHCR image attestations for container, GitHub release assets for Go, etc. This is the wrangle value prop: ecosystem-native consumers use the tools they already know without learning anything wrangle-specific. The ecosystem-native location is a **partial** view: it carries whatever the ecosystem has standardized, which is rarely the full set wrangle generates (e.g., PyPI carries PEP 740 attestations but not SLSA provenance; GHCR carries image attestations but not SBOM scan output).
+2. **A consistent unified wrangle location** for cross-ecosystem tooling, policy, and audit. This is the **complete** view: every wrangle build produces the same set of metadata fields here, regardless of build type. A tool spanning multiple ecosystems can read this one schema instead of N. Adopters who need the full picture (compliance audits, policy engines, internal supply-chain dashboards) read the unified location.
+
+Both layers always exist for every build type. They aren't either-or.
 
 The unified location for a build is:
 
 ```
 metadata/<type>/<shortname>/
 ├── sbom.spdx.json           # SPDX SBOM (every build type that has dependencies)
-├── provenance.intoto.jsonl  # SLSA provenance (when present; copied alongside the artifact for offline retrieval)
+├── multiple.intoto.jsonl    # SLSA provenance (when present; same filename the SLSA generator emits)
 ├── summary.md               # human-readable build summary
 ├── scan/
 │   ├── osv.sarif            # SBOM vuln scan
@@ -132,7 +134,17 @@ metadata/<type>/<shortname>/
 
 `<type>` is the build type (`container`, `python`, ...) and `<shortname>` is the path-derived name (`/` becomes `_`) so multiple builds in one workflow don't collide.
 
-The reusable workflow uploads this directory as the workflow artifact `<type>-metadata-<shortname>`, and exposes the artifact name as the `metadata-artifact-name` output so adopters can `download-artifact` without hardcoding the naming convention. The composite action exposes the workspace-relative path as the `metadata-dir` output for callers that invoke it directly.
+The provenance file uses the SLSA generator's native filename (`multiple.intoto.jsonl` for `generator_generic_slsa3.yml` with multiple subjects; `<filename>.intoto.jsonl` for single-subject builds). Wrangle does not rename it — keeping the upstream filename means downstream consumers can use the same `slsa-verifier verify-artifact --provenance-path` invocation regardless of where they obtained the provenance.
+
+#### How the artifact maps to a directory
+
+GitHub Actions artifacts are zip files. `actions/upload-artifact` zips the configured `path:` and `actions/download-artifact` extracts it back. So when this spec says "the reusable workflow uploads `metadata/<type>/<shortname>/` as the workflow artifact `<type>-metadata-<shortname>`," it means:
+
+- The composite action writes the metadata files into `metadata/<type>/<shortname>/` in the runner's workspace.
+- `actions/upload-artifact` zips the contents of that directory and stores the zip on the run as `<type>-metadata-<shortname>`.
+- A downstream job calling `actions/download-artifact` with `name: <type>-metadata-<shortname>` and `path: metadata/` extracts the zip back into `metadata/`, recovering the original files at the top level (the type/shortname levels are not preserved inside the zip — the upload's `path:` is the leaf directory by convention).
+
+The reusable workflow exposes the artifact name as the `metadata-artifact-name` output so adopters can `download-artifact` without hardcoding the naming convention. The composite action exposes the workspace-relative path as the `metadata-dir` output for callers that invoke it directly.
 
 Build types use the layout components that apply to them — not every type produces every file. The point is that any tool walking `metadata/<type>/<shortname>/` knows where to look. See #150 for the full rationale and #162 for the directory-layout discussion.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -109,6 +109,33 @@ The reusable workflow that wraps a build action (e.g., `.github/workflows/build_
 
 If `SPEC.md` describes behavior that hasn't shipped yet, `README.md` MUST NOT present it as available. Keeping the two in sync during implementation is part of landing a feature, not a follow-up.
 
+### Unified metadata layout
+
+Every build type publishes its build outputs to **two complementary places**:
+
+1. **The ecosystem-native location** consumers expect for that build type — PyPI release attestations for python, GHCR image attestations for container, GitHub release assets for Go, etc. This is the wrangle value prop: ecosystem-native consumers use the tools they already know without learning anything wrangle-specific.
+2. **A consistent unified wrangle location** for cross-ecosystem tooling, policy, and audit. The unified location uses the same directory layout, artifact-naming convention, and adopter-facing output across every build type, so a tool spanning multiple ecosystems sees one schema instead of N.
+
+The unified location for a build is:
+
+```
+metadata/<type>/<shortname>/
+├── sbom.spdx.json           # SPDX SBOM (every build type that has dependencies)
+├── provenance.intoto.jsonl  # SLSA provenance (when present; copied alongside the artifact for offline retrieval)
+├── summary.md               # human-readable build summary
+├── scan/
+│   ├── osv.sarif            # SBOM vuln scan
+│   ├── zizmor.sarif         # action-specific scans where applicable
+│   └── ...
+└── build-info.json          # type-specific structured metadata (image digest, wheel filenames, etc.)
+```
+
+`<type>` is the build type (`container`, `python`, ...) and `<shortname>` is the path-derived name (`/` becomes `_`) so multiple builds in one workflow don't collide.
+
+The reusable workflow uploads this directory as the workflow artifact `<type>-metadata-<shortname>`, and exposes the artifact name as the `metadata-artifact-name` output so adopters can `download-artifact` without hardcoding the naming convention. The composite action exposes the workspace-relative path as the `metadata-dir` output for callers that invoke it directly.
+
+Build types use the layout components that apply to them — not every type produces every file. The point is that any tool walking `metadata/<type>/<shortname>/` knows where to look. See #150 for the full rationale and #162 for the directory-layout discussion.
+
 ### Shared SBOM vulnerability scanning
 
 Steps 2–3 (generate SBOM, scan for vulnerabilities) apply to every build type that produces an artifact. How the SBOM is *generated* varies by build type (BuildKit for containers, language-specific tooling for Python/npm/Go), but how it is *scanned* does not — all SBOMs are scanned the same way using `osv-scanner`.


### PR DESCRIPTION
claude: ## Summary

Establishes the shared metadata layout that #150 calls for and that future build types (npm, Go, GitHub Actions) inherit. Container retrofits to match the convention python already follows.

## Convention (now in docs/SPEC.md "Unified metadata layout")

- Every build type writes its metadata to `metadata/<type>/<shortname>/`.
- The reusable workflow uploads that directory as `<type>-metadata-<shortname>` and exposes the artifact name as the `metadata-artifact-name` output.
- The composite action exposes the workspace-relative path as the `metadata-dir` output for callers that invoke it directly.

## Container changes (breaking)

- Artifact rename: `container-build-results-<shortname>` → `container-metadata-<shortname>`.
- Upload path narrows from `./metadata/` (parent) to `metadata/container/<shortname>/` (leaf), so the artifact zip's top-level contents are the metadata files themselves (matches python).
- Composite action exposes new `metadata-dir` and `shortname` outputs; reusable workflow exposes new `metadata-artifact-name` output.
- Folded the now-redundant "prepare metadata directory" step into the SBOM extraction step.

This is a breaking change to the container artifact name. Adopters referencing `container-build-results-<shortname>` directly need to either update to `container-metadata-<shortname>` or read the new `metadata-artifact-name` output from the reusable workflow. Wrangle is pre-1.0 so this is allowed; will be called out in the v0.2 release notes.

## Python changes (additive)

- Reusable workflow exposes new `metadata-artifact-name` output (same shape as container's). README + SPEC updated.

## Doc updates

- `docs/SPEC.md` adds a "Unified metadata layout" section under "Build action directory structure."
- Container README/SPEC updated for the new artifact name + unified-layout reference.
- Python README/SPEC updated for the new output.

## Test plan

- [x] `./test.sh` green (212/212).
- [x] No wrangle-test references to the old `container-build-results-*` artifact name (would have broken integration).
- [ ] Container integration test in CI exercises the new artifact name.
- [ ] Python integration test still works (metadata-artifact-name addition is additive).

Closes #162. Implements one component of #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)