### PR TITLE
Bump composite-action pins to main HEAD

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -48,7 +48,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@4f802f220bb888203ae6c3a722bae892ed85a910 # unify-container-metadata-layout 2026-04-26
+      uses: TomHennen/wrangle/build/actions/container@80bb7cbd8ff4f346a237ea0d4b5aaf4a78c9d546 # main 2026-04-26
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -60,7 +60,7 @@ jobs:
           persist-credentials: false
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@c65a939677cbe9e1622933f6c16729677ce16c90 # implement-python-build 2026-04-25
+      - uses: TomHennen/wrangle/build/actions/python@80bb7cbd8ff4f346a237ea0d4b5aaf4a78c9d546 # main 2026-04-26
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@6cbd393e779e98c40459ef8032dbac62b7805e16 # main 2026-04-22
+        uses: TomHennen/wrangle/build/actions/shell@80bb7cbd8ff4f346a237ea0d4b5aaf4a78c9d546 # main 2026-04-26
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -25,6 +25,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@6cbd393e779e98c40459ef8032dbac62b7805e16 # main 2026-04-22
+        uses: TomHennen/wrangle/actions/scan@80bb7cbd8ff4f346a237ea0d4b5aaf4a78c9d546 # main 2026-04-26
         with:
           tools: ${{ inputs.tools }}

--- a/test/test_bump_action_pins.bats
+++ b/test/test_bump_action_pins.bats
@@ -271,6 +271,75 @@ EOF
     grep -qF "@${NEW_SHA} # back\\slash" .github/workflows/a.yml
 }
 
+# --- Default branch-label detection (issue #173) ---
+
+@test "bump_action_pins: labels as 'main' when target SHA is on main, even from a feature branch" {
+    # Setup: a real main branch with a real commit (so target_sha is reachable
+    # from main), then a feature branch we run the script from.
+    git checkout -q -b main 2>/dev/null || git checkout -q main
+    target_sha="$(git rev-parse HEAD)"
+    git checkout -q -b cleanup-branch
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    # Don't pass WRANGLE_PINS_BRANCH — exercise default detection.
+    unset WRANGLE_PINS_BRANCH
+    run "$SCRIPT" "$target_sha"
+    [[ "$status" -eq 0 ]]
+    grep -qF "# main 2099-12-31" .github/workflows/a.yml
+}
+
+@test "bump_action_pins: labels as current branch when target SHA is NOT on main" {
+    # Setup: main with one commit, feature branch with an additional commit.
+    # Run the script targeting the feature-branch-only commit.
+    git checkout -q -b main 2>/dev/null || git checkout -q main
+    git checkout -q -b feature
+    git commit --allow-empty -q -m "feature work"
+    target_sha="$(git rev-parse HEAD)"
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    unset WRANGLE_PINS_BRANCH
+    run "$SCRIPT" "$target_sha"
+    [[ "$status" -eq 0 ]]
+    grep -qF "# feature 2099-12-31" .github/workflows/a.yml
+}
+
+@test "bump_action_pins: WRANGLE_PINS_BRANCH overrides auto-detection" {
+    # Even when target IS on main, an explicit override wins.
+    git checkout -q -b main 2>/dev/null || git checkout -q main
+    target_sha="$(git rev-parse HEAD)"
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    WRANGLE_PINS_BRANCH="explicit-label" run "$SCRIPT" "$target_sha"
+    [[ "$status" -eq 0 ]]
+    grep -qF "# explicit-label 2099-12-31" .github/workflows/a.yml
+}
+
+@test "bump_action_pins: WRANGLE_PINS_DEFAULT_BRANCH redirects ancestry check" {
+    # If the operator's repo uses `master`, point the merge-base check there.
+    # Rename whatever the initial branch is (depends on init.defaultBranch).
+    git branch -m master
+    target_sha="$(git rev-parse HEAD)"
+    git checkout -q -b cleanup-branch
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    unset WRANGLE_PINS_BRANCH
+    WRANGLE_PINS_DEFAULT_BRANCH="master" run "$SCRIPT" "$target_sha"
+    [[ "$status" -eq 0 ]]
+    grep -qF "# master 2099-12-31" .github/workflows/a.yml
+}
+
 @test "bump_action_pins: only mixed-SHA files are rewritten when some pins already match target" {
     # File with a mix of SHAs — must be rewritten so all pins reach target.
     cat > .github/workflows/mixed.yml <<EOF

--- a/tools/bump_action_pins.sh
+++ b/tools/bump_action_pins.sh
@@ -27,9 +27,17 @@
 # Env overrides (escape hatch for forks / testing):
 #   WRANGLE_PINS_REPO   — repo prefix to match (default: TomHennen/wrangle)
 #   WRANGLE_PINS_DIR    — directory to walk (default: .github/workflows)
-#   WRANGLE_PINS_BRANCH — branch label to write into the comment
-#                         (default: `git symbolic-ref --short HEAD`,
-#                         falling back to "main" if detached)
+#   WRANGLE_PINS_BRANCH — branch label to write into the comment.
+#                         Default detection (in order):
+#                           1. If target_sha is reachable from `main` (i.e.,
+#                              already merged), use `main`. This makes
+#                              post-merge cleanup runs label correctly even
+#                              when the cleanup happens on a temporary branch.
+#                           2. Else use the current branch
+#                              (`git symbolic-ref --short HEAD`).
+#                           3. Else (detached HEAD) fall back to "main".
+#                         WRANGLE_PINS_DEFAULT_BRANCH overrides which branch
+#                         the merge-base check considers (default: main).
 #   WRANGLE_PINS_DATE   — date label to write into the comment
 #                         (default: today's date in YYYY-MM-DD UTC)
 
@@ -62,10 +70,16 @@ if [[ ! "$target_sha" =~ ^[0-9a-f]{40}$ ]]; then
     exit 1
 fi
 
+default_branch="${WRANGLE_PINS_DEFAULT_BRANCH:-main}"
 if [[ -n "${WRANGLE_PINS_BRANCH:-}" ]]; then
     branch_label="$WRANGLE_PINS_BRANCH"
+elif git -C "$REPO_ROOT" merge-base --is-ancestor "$target_sha" "$default_branch" >/dev/null 2>&1; then
+    # Target is already on the default branch — e.g., the operator branched
+    # off main to refresh pins after a merge. Label as the default branch
+    # rather than the cleanup branch's name, which would be misleading.
+    branch_label="$default_branch"
 else
-    branch_label="$(git -C "$REPO_ROOT" symbolic-ref --short HEAD 2>/dev/null || echo main)"
+    branch_label="$(git -C "$REPO_ROOT" symbolic-ref --short HEAD 2>/dev/null || echo "$default_branch")"
 fi
 date_label="${WRANGLE_PINS_DATE:-$(date -u +%Y-%m-%d)}"
 


### PR DESCRIPTION
claude: ## Summary

First real use of `make bump-action-pins` (just merged in #166): brings all four `TomHennen/wrangle/...@<sha>` pins under `.github/workflows/` forward to main HEAD (`80bb7cb`).

Before:
- container @ `4f802f2` (unify-container-metadata-layout — branch deleted)
- python @ `c65a939` (implement-python-build — branch deleted)
- shell, scan @ `6cbd393` (main, but stale)

After: all four at `80bb7cb` with `# main 2026-04-26` comments.

The old pins still resolved correctly via reachability through merge ancestry, but the trailing comments referenced gone branches — confusing context for anyone reading the pin later.

## UX wart noticed

The script's default branch-label (`git symbolic-ref --short HEAD`) is right for feature-branch PR work but wrong for post-merge main-cleanup. I had to use `WRANGLE_PINS_BRANCH=main` explicitly. Probably worth a follow-up: either auto-detect "this SHA is on main" → label "main", or add a `make bump-action-pins-to-main` convenience target. Filing as a small enhancement issue.

## Test plan

- [x] `./test.sh` green (234/234, including the 19 bump-action-pins tests).
- [ ] Confirm CI on this PR is green — this is also the first time wrangle's reusable workflows pull composite actions from a SHA reachable only through a squash-merge ancestor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)