### PR TITLE
Add release_gate composite to make provenance/release events configurable (closes #161)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@606728787cbc5b1672f0944277c988ab66cd8cf6 # add-release-gate 2026-04-26
+      - uses: TomHennen/wrangle/actions/release_gate@391c46e2dc5d3bc17ce183ad2094380b04c041c1 # add-release-gate 2026-04-26
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -82,7 +82,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@606728787cbc5b1672f0944277c988ab66cd8cf6 # add-release-gate 2026-04-26
+      uses: TomHennen/wrangle/build/actions/container@391c46e2dc5d3bc17ce183ad2094380b04c041c1 # add-release-gate 2026-04-26
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -19,6 +19,21 @@ on:
         required: false
         default: false
         type: boolean
+      release-events:
+        description: |
+          Which events should trigger SLSA provenance generation. One of:
+            - non-pull-request (default): every event except pull_request*.
+            - tag-only: push to refs/tags/* only.
+            - main-and-tags: push to refs/heads/main or refs/tags/*.
+            - <comma-separated event_name list>: matches if github.event_name
+              is in the list. See actions/release_gate for full vocabulary.
+          Note: this gate currently controls only provenance generation, not
+          the docker push (which happens mid-composite in build/actions/container
+          and is gated by the workflow's own trigger conditions). See
+          docs/SPEC.md for the asymmetry rationale.
+        required: false
+        type: string
+        default: non-pull-request
     secrets:
       gh_token:
         description: "GitHub token with write access"
@@ -33,8 +48,27 @@ on:
       metadata-artifact-name:
         description: "Name of the workflow artifact (a zip of `metadata/container/<shortname>/`'s contents) containing the SBOM and any scan output. Format: `container-metadata-<shortname>`. Adopters fetch via `actions/download-artifact` — the metadata files land at the top level of the configured `path:`, not under `metadata/container/<shortname>/`."
         value: ${{ jobs.build.outputs.metadata-artifact-name }}
+      should-release:
+        description: |
+          "true" if the current event matches release-events; "false" otherwise.
+          Wrangle gates the provenance job on this internally; callers can
+          gate downstream release-time jobs on it too.
+        value: ${{ jobs.gate.outputs.should-release }}
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions: {}    # release_gate reads only env; no workspace, no API
+    outputs:
+      should-release: ${{ steps.gate.outputs.should-release }}
+    steps:
+      # No checkout: release_gate resolves via ${{ github.action_path }}.
+      # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
+      - uses: TomHennen/wrangle/actions/release_gate@606728787cbc5b1672f0944277c988ab66cd8cf6 # add-release-gate 2026-04-26
+        id: gate
+        with:
+          events: ${{ inputs.release-events }}
+
   build:
     permissions:
       contents: read
@@ -48,7 +82,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@80bb7cbd8ff4f346a237ea0d4b5aaf4a78c9d546 # main 2026-04-26
+      uses: TomHennen/wrangle/build/actions/container@606728787cbc5b1672f0944277c988ab66cd8cf6 # add-release-gate 2026-04-26
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -56,10 +90,10 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
   provenance:
-    # Generate provenance for anything that's not a PR
-    # We should probably be more restrictive in the future?
-    if: ${{ ! startsWith(github.event_name, 'pull_') }}
-    needs: [build]
+    # Gated on release-events (default: non-pull-request) so adopters can
+    # tighten when provenance is produced without forking the workflow.
+    if: ${{ needs.gate.outputs.should-release == 'true' }}
+    needs: [gate, build]
     permissions:
       actions: read # for detecting the Github Actions environment.
       id-token: write # for creating OIDC tokens for signing.

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@606728787cbc5b1672f0944277c988ab66cd8cf6 # add-release-gate 2026-04-26
+      - uses: TomHennen/wrangle/actions/release_gate@391c46e2dc5d3bc17ce183ad2094380b04c041c1 # add-release-gate 2026-04-26
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -96,7 +96,7 @@ jobs:
           persist-credentials: false
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@606728787cbc5b1672f0944277c988ab66cd8cf6 # add-release-gate 2026-04-26
+      - uses: TomHennen/wrangle/build/actions/python@391c46e2dc5d3bc17ce183ad2094380b04c041c1 # add-release-gate 2026-04-26
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -27,6 +27,18 @@ on:
         required: false
         type: boolean
         default: true
+      release-events:
+        description: |
+          Which events should trigger release-time actions (SLSA provenance,
+          and — in the caller's publish job — package publish). One of:
+            - non-pull-request (default): every event except pull_request*.
+            - tag-only: push to refs/tags/* only.
+            - main-and-tags: push to refs/heads/main or refs/tags/*.
+            - <comma-separated event_name list>: matches if github.event_name
+              is in the list. See actions/release_gate for full vocabulary.
+        required: false
+        type: string
+        default: non-pull-request
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -38,13 +50,37 @@ on:
         description: "Name of the uploaded dist/ artifact (download with this name to publish)"
         value: ${{ jobs.build.outputs.dist-artifact-name }}
       provenance-artifact-name:
-        description: "Name of the SLSA provenance workflow artifact (= the provenance filename). Empty on PR builds (provenance is gated on non-PR events)."
+        description: "Name of the SLSA provenance workflow artifact (= the provenance filename). Empty when should-release is false."
         value: ${{ jobs.provenance.outputs.provenance-name }}
       metadata-artifact-name:
         description: "Name of the workflow artifact (a zip of `metadata/python/<shortname>/`'s contents) containing the SBOM and metadata. Format: `python-metadata-<shortname>`. Adopters fetch via `actions/download-artifact` — the metadata files land at the top level of the configured `path:`, not under `metadata/python/<shortname>/`. See docs/SPEC.md \"Unified metadata layout\"."
         value: ${{ jobs.build.outputs.metadata-artifact-name }}
+      should-release:
+        description: |
+          "true" if the current event matches release-events and the caller
+          should perform release-time actions (publish, attestation upload,
+          etc.); "false" otherwise. Wrangle gates the provenance job on
+          this internally; the caller's publish job should gate on it too.
+        value: ${{ jobs.gate.outputs.should-release }}
 
 jobs:
+  # Decide whether release-time actions (provenance, publish) should run
+  # for this event. Cheap separate job so the result is available to
+  # both the provenance job below and the caller's publish job via
+  # outputs.should-release.
+  gate:
+    runs-on: ubuntu-latest
+    permissions: {}    # release_gate reads only env; no workspace, no API
+    outputs:
+      should-release: ${{ steps.gate.outputs.should-release }}
+    steps:
+      # No checkout: release_gate resolves via ${{ github.action_path }}.
+      # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
+      - uses: TomHennen/wrangle/actions/release_gate@606728787cbc5b1672f0944277c988ab66cd8cf6 # add-release-gate 2026-04-26
+        id: gate
+        with:
+          events: ${{ inputs.release-events }}
+
   build:
     runs-on: ubuntu-latest
     permissions:
@@ -60,7 +96,7 @@ jobs:
           persist-credentials: false
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@80bb7cbd8ff4f346a237ea0d4b5aaf4a78c9d546 # main 2026-04-26
+      - uses: TomHennen/wrangle/build/actions/python@606728787cbc5b1672f0944277c988ab66cd8cf6 # add-release-gate 2026-04-26
         id: build
         with:
           path: ${{ inputs.path }}
@@ -91,9 +127,9 @@ jobs:
 
   # Generate SLSA L3 provenance for the built artifacts. The generator
   # runs in an isolated reusable workflow that the caller cannot tamper
-  # with — this is what makes the provenance non-falsifiable. Skipped
-  # on PRs because publishing is also skipped, so provenance there
-  # would be wasted compute.
+  # with — this is what makes the provenance non-falsifiable. Gated on
+  # the release-events input so adopters can tighten when provenance is
+  # produced (e.g., tag-only) without forking the workflow.
   #
   # contents: write is required because the generator's upload-assets
   # job declares it. GitHub validates every called job's permissions
@@ -104,8 +140,8 @@ jobs:
   # release assets (permanent, discoverable). Off-tag the generator
   # only uploads provenance as a workflow artifact (90-day retention).
   provenance:
-    if: ${{ ! startsWith(github.event_name, 'pull_') }}
-    needs: [build]
+    if: ${{ needs.gate.outputs.should-release == 'true' }}
+    needs: [gate, build]
     permissions:
       actions: read    # detect the GitHub Actions environment
       id-token: write  # OIDC for Sigstore signing

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@80bb7cbd8ff4f346a237ea0d4b5aaf4a78c9d546 # main 2026-04-26
+        uses: TomHennen/wrangle/build/actions/shell@391c46e2dc5d3bc17ce183ad2094380b04c041c1 # add-release-gate 2026-04-26
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -25,6 +25,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@80bb7cbd8ff4f346a237ea0d4b5aaf4a78c9d546 # main 2026-04-26
+        uses: TomHennen/wrangle/actions/scan@391c46e2dc5d3bc17ce183ad2094380b04c041c1 # add-release-gate 2026-04-26
         with:
           tools: ${{ inputs.tools }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 metadata/
 .wrangle/
+.claude/

--- a/actions/release_gate/action.yml
+++ b/actions/release_gate/action.yml
@@ -1,0 +1,35 @@
+name: Wrangle Release Gate
+description: >
+  Decide whether the current GitHub Actions run should perform release-time
+  side effects — SLSA provenance generation, publishing, attestation upload,
+  etc. Exposes a single `should-release` output that callers gate on.
+
+inputs:
+  events:
+    description: |
+      Which events should trigger release-time actions. One of:
+        - non-pull-request (default): every event except pull_request*.
+        - tag-only: push to refs/tags/* only.
+        - main-and-tags: push to refs/heads/main or refs/tags/*.
+        - <comma-separated event_name list>: matches if github.event_name
+          is in the list (e.g., "push,workflow_dispatch"). Lowercase
+          letters/digits/underscore only; tokens are matched literally
+          against github.event_name with no ref filtering.
+    required: false
+    default: non-pull-request
+
+outputs:
+  should-release:
+    description: "true if release-time actions should run, false otherwise"
+    value: ${{ steps.gate.outputs.should-release }}
+
+runs:
+  using: composite
+  steps:
+    - id: gate
+      shell: bash
+      env:
+        EVENTS_INPUT: ${{ inputs.events }}
+        EVENT_NAME: ${{ github.event_name }}
+        REF: ${{ github.ref }}
+      run: "${{ github.action_path }}/release_gate.sh"

--- a/actions/release_gate/release_gate.sh
+++ b/actions/release_gate/release_gate.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# release_gate.sh — decide whether release-time side effects (provenance,
+# publish, etc.) should run for the current event.
+#
+# Required env (set by the composite action wrapper):
+#   EVENTS_INPUT  — caller's release-events value
+#   EVENT_NAME    — github.event_name
+#   REF           — github.ref
+#   GITHUB_OUTPUT — set by GitHub Actions for action outputs
+#
+# Writes `should-release=true|false` to $GITHUB_OUTPUT.
+# Exits 0 on a successful decision, 2 on invalid input.
+
+set -euo pipefail
+# Disable globbing — events input is external and case-pattern matching
+# in this script must not perform pathname expansion.
+set -f
+
+# Use ${var?} (no colon) for EVENTS_INPUT so an empty string falls through
+# to the case statement and exits 2 with an "events input is empty" message
+# rather than the generic shell parameter-expansion error.
+: "${EVENTS_INPUT?EVENTS_INPUT not set}"
+: "${EVENT_NAME:?EVENT_NAME not set}"
+: "${REF:?REF not set}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT not set}"
+
+# Reject CR/LF (caller workflows are authored as YAML and CR sneaks into
+# windows-edited files; treat it as invalid input rather than silently
+# mismatching tokens).
+case "$EVENTS_INPUT" in
+  *$'\r'*|*$'\n'*)
+    printf 'release_gate: events input contains CR/LF; reject\n' >&2
+    exit 2
+    ;;
+esac
+
+# Strip leading/trailing whitespace so " tag-only " still matches the
+# literal-shorthand cases below. Without this, a YAML formatting accident
+# (e.g., a stray space after the colon) bypasses the shorthand match,
+# falls through to the comma-list path, and fails the event_name regex
+# with a confusing "invalid token" error — even though the token IS a
+# known shorthand.
+EVENTS_INPUT="${EVENTS_INPUT#"${EVENTS_INPUT%%[![:space:]]*}"}"
+EVENTS_INPUT="${EVENTS_INPUT%"${EVENTS_INPUT##*[![:space:]]}"}"
+
+# Allowed event-name regex: lowercase letter, lowercase letters / digits /
+# underscore. Covers every documented github.event_name (push,
+# pull_request, workflow_dispatch, schedule, merge_group, release,
+# repository_dispatch, etc.). Reject anything else — typos shouldn't
+# silently match nothing.
+event_name_re='^[a-z][a-z0-9_]*$'
+
+decide() {
+  case "$EVENTS_INPUT" in
+    non-pull-request)
+      [[ "$EVENT_NAME" != pull_* ]]
+      ;;
+    tag-only)
+      [[ "$EVENT_NAME" == "push" && "$REF" == refs/tags/* ]]
+      ;;
+    main-and-tags)
+      [[ "$EVENT_NAME" == "push" && ( "$REF" == "refs/heads/main" || "$REF" == refs/tags/* ) ]]
+      ;;
+    "")
+      printf 'release_gate: events input is empty\n' >&2
+      exit 2
+      ;;
+    *)
+      # Treat as comma-separated event_name list. Validate each token,
+      # then match github.event_name against the set.
+      local tokens
+      read -ra tokens <<< "${EVENTS_INPUT//,/ }"
+      if (( ${#tokens[@]} == 0 )); then
+        printf 'release_gate: events input %q resolved to no tokens\n' "$EVENTS_INPUT" >&2
+        exit 2
+      fi
+      local matched=false
+      for tok in "${tokens[@]}"; do
+        if [[ ! "$tok" =~ $event_name_re ]]; then
+          printf 'release_gate: invalid token %q in events input (expected lowercase event name or known shorthand)\n' "$tok" >&2
+          exit 2
+        fi
+        if [[ "$tok" == "$EVENT_NAME" ]]; then
+          matched=true
+        fi
+      done
+      $matched
+      ;;
+  esac
+}
+
+if decide; then
+  result=true
+else
+  result=false
+fi
+
+printf 'should-release=%s\n' "$result" >> "$GITHUB_OUTPUT"
+printf 'release_gate: events=%q event_name=%q ref=%q -> should-release=%s\n' \
+  "$EVENTS_INPUT" "$EVENT_NAME" "$REF" "$result"

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -19,6 +19,21 @@ A GitHub composite action that builds and publishes a container image to GitHub 
 - SBOM vulnerability scanning with `osv-scanner` (non-blocking)
 - The release gate job that enforces "image is signed AND attested before any downstream release job runs"
 
+## Controlling when provenance is generated
+
+The reusable workflow's `release-events` input controls which events trigger SLSA provenance generation. Default: `non-pull-request`. Other shorthands: `tag-only`, `main-and-tags`. A comma-separated `github.event_name` list is also accepted. See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full vocabulary.
+
+```yaml
+uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.2.0
+with:
+  path: .
+  imagename: ghcr.io/<owner>/<repo>
+  registry: ghcr.io
+  release-events: tag-only   # only tag pushes mint provenance
+```
+
+Note: `release-events` currently scopes only the SLSA provenance job. The docker push happens mid-composite and is gated by your workflow's own trigger configuration (see [`SPEC.md` §"Trigger restriction"](./SPEC.md#trigger-restriction)).
+
 ## SBOM
 
 The action generates an SBOM for the container it builds. Today the SBOM is available two ways:

--- a/build/actions/container/SPEC.md
+++ b/build/actions/container/SPEC.md
@@ -199,13 +199,15 @@ The SLSA generator is a reusable workflow, not an action. It must run as a separ
 
 ### Trigger restriction
 
-Neither Cosign signing nor SLSA provenance runs on `pull_request` triggers. Both are gated on `if: ${{ ! startsWith(github.event_name, 'pull_') }}`. This is a deliberate design rule, not just a workaround for an upstream limitation:
+Neither Cosign signing nor SLSA provenance runs on `pull_request` triggers. SLSA provenance is gated on the `release-events` input (default `non-pull-request`); see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full vocabulary. The trigger restriction is a deliberate design rule, not just a workaround for an upstream limitation:
 
 - **PRs must not produce artifacts that look production-ready.** A Cosign-signed image from a PR branch is binary-indistinguishable from a signed release image at the consumer's verification step, and its signing identity would be tied to the PR branch (or worse, a fork) rather than the release branch. Consumers whose verification policy accepts "any signature from this repo" would treat a PR-built image as a release — exactly the shape of a release-confusion supply chain attack. The safe default is that PR builds *cannot* produce a signed or attested image, period.
 - **SBOM generation and vulnerability scanning do run on PRs.** Those steps surface actionable information to the PR author (new CVEs, new dependencies pulled in by the change) without producing anything a consumer could mistake for a release. SBOM scan findings are uploaded as SARIF so they appear on the PR's Security tab.
 - **SLSA provenance is additionally blocked by upstream.** `slsa-github-generator`'s container reusable workflow does not support `pull_request` events, so even if wrangle wanted to produce provenance on PRs, it couldn't. But wrangle would skip it on PRs regardless, for the same reason signing is skipped.
 
 In practice a PR-triggered run executes: validate → build → push → SBOM extract → SBOM scan, and then exits without invoking signing, provenance, or the release gate. The gate job's success condition encodes the full release contract (build + SBOM + sign + provenance), which is only achievable on non-PR events — so PR runs never produce a successful gate, and adopters should not configure release tagging or deployment workflows to react to PR-triggered container builds.
+
+`release-events` currently scopes only the SLSA provenance job in the container reusable workflow. The docker push happens mid-composite inside `build/actions/container` and is gated by the workflow's own trigger configuration; tightening `release-events` (e.g., to `tag-only`) prevents provenance from being produced on non-tag events but does not stop the push itself. This asymmetry is documented in [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" and is expected to be resolved when the container build is restructured to separate build from push (or when an explicit publish gate is added).
 
 ### Private repos
 

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -117,3 +117,25 @@ teardown() {
     run grep 'metadata-artifact-name:' "$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
     [[ "$status" -eq 0 ]]
 }
+
+@test "container: reusable workflow has gate job calling release_gate" {
+    local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
+    run grep -E '^  gate:' "$wf"
+    [[ "$status" -eq 0 ]]
+    run grep -E 'TomHennen/wrangle/actions/release_gate' "$wf"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: provenance job is gated on release-gate output" {
+    local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
+    run bash -c "sed -n '/^  provenance:/,/^[a-z]/p' \"$wf\" | grep -E \"if:.*should-release\""
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: reusable workflow exposes release-events input and should-release output" {
+    local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
+    run grep -E '^      release-events:' "$wf"
+    [[ "$status" -eq 0 ]]
+    run grep -E '^      should-release:' "$wf"
+    [[ "$status" -eq 0 ]]
+}

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -47,9 +47,21 @@ Two ways to adopt:
 ## Outputs from the reusable workflow
 
 - `dist-artifact-name` — workflow-artifact name to download with `actions/download-artifact` to retrieve the built wheel + sdist.
-- `provenance-artifact-name` — workflow-artifact name for the SLSA provenance (empty on PR builds).
+- `provenance-artifact-name` — workflow-artifact name for the SLSA provenance (empty when `should-release` is false).
 - `metadata-artifact-name` — workflow-artifact name for the SBOM and any scan output (`python-metadata-<shortname>`). See [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout."
+- `should-release` — `"true"` if the current event matches `release-events`. Use this to gate your publish job so wrangle's internal provenance gating and your publish gating stay in lockstep.
 - `hashes`, `version`.
+
+## Controlling when releases happen
+
+The `release-events` input controls which events produce SLSA provenance and (in your publish job, if you gate on `should-release`) trigger publish. Default: `non-pull-request`. Other shorthands: `tag-only`, `main-and-tags`. A comma-separated `github.event_name` list (e.g., `push,workflow_dispatch`) is also accepted. See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full vocabulary.
+
+```yaml
+uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.0
+with:
+  path: "."
+  release-events: tag-only   # only tag pushes mint provenance and publish
+```
 
 ## Verifying SLSA provenance before publish (recommended, optional)
 

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -49,12 +49,24 @@ Two ways to adopt:
 - `dist-artifact-name` — workflow-artifact name to download with `actions/download-artifact` to retrieve the built wheel + sdist.
 - `provenance-artifact-name` — workflow-artifact name for the SLSA provenance (empty when `should-release` is false).
 - `metadata-artifact-name` — workflow-artifact name for the SBOM and any scan output (`python-metadata-<shortname>`). See [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout."
-- `should-release` — `"true"` if the current event matches `release-events`. Use this to gate your publish job so wrangle's internal provenance gating and your publish gating stay in lockstep.
+- `should-release` — `"true"` if the current event matches `release-events`. Your publish job MUST gate on this (see below).
 - `hashes`, `version`.
 
 ## Controlling when releases happen
 
-The `release-events` input controls which events produce SLSA provenance and (in your publish job, if you gate on `should-release`) trigger publish. Default: `non-pull-request`. Other shorthands: `tag-only`, `main-and-tags`. A comma-separated `github.event_name` list (e.g., `push,workflow_dispatch`) is also accepted. See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full vocabulary.
+The `release-events` input controls which events produce SLSA provenance. Your publish job MUST also gate on `should-release` so wrangle's provenance gating and your publish gating stay in lockstep.
+
+> **Required wiring.** Without the gate, your publish job runs on every non-PR event regardless of what you pass as `release-events`. The example workflow at [`gh_workflow_examples/build_python.yml`](../../../gh_workflow_examples/build_python.yml) shows the canonical shape:
+>
+> ```yaml
+> publish:
+>   if: ${{ needs.build.outputs.should-release == 'true' }}
+>   needs: [build]
+> ```
+>
+> Wrangle cannot enforce this from inside its reusable workflow — publish lives in your workflow due to PyPI Trusted Publishing's OIDC `workflow_ref` constraint ([pypi/warehouse#11096](https://github.com/pypi/warehouse/issues/11096)). If you forget the gate, builds still succeed, provenance still respects `release-events`, but your publish runs more often than you intended. ([#176](https://github.com/TomHennen/wrangle/issues/176) tracks moving verification — and possibly more of this gating responsibility — into wrangle itself.)
+
+`release-events` accepts: `non-pull-request` (default), `tag-only`, `main-and-tags`, or a comma-separated `github.event_name` list (e.g., `push,workflow_dispatch`). See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full vocabulary.
 
 ```yaml
 uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.0

--- a/build/actions/python/SPEC.md
+++ b/build/actions/python/SPEC.md
@@ -49,10 +49,11 @@ Before the first publish, the adopter must:
 | `path` | No | `.` | Relative path to the directory containing `pyproject.toml` |
 | `python-version` | No | (auto-detect) | Python version override. If empty, detected from `pyproject.toml` via `actions/setup-python`'s `python-version-file` feature. |
 | `run-tests` | No | `true` | Whether to run pytest before building |
+| `release-events` | No | `non-pull-request` | Which events trigger release-time actions (provenance, publish). See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full vocabulary. |
 
 Wrangle's reusable workflow has no `repository-url` input — publishing lives in the adopter's own workflow because PyPI Trusted Publishing requires the OIDC token's `workflow_ref` to point at the adopter, not at a reusable workflow ([pypi/warehouse#11096](https://github.com/pypi/warehouse/issues/11096)). The adopter's publish job sets `repository-url` directly on `pypa/gh-action-pypi-publish`.
 
-The publish-on-non-PR safety gate (`if: ! startsWith(github.event_name, 'pull_')`) lives on the adopter side too. Adopters control WHEN to publish via their calling workflow's trigger configuration — e.g., `on: push: tags: ['v*']` for tag-only publishing, or `on: push: branches: ['main']` for every-merge publishing. The example workflow in `gh_workflow_examples/build_python.yml` shows the canonical wiring.
+Adopters' publish jobs MUST gate on `needs.build.outputs.should-release == 'true'` — that mirrors the gate the reusable workflow applies internally to provenance, so a single `release-events` value controls both sides. The example workflow in `gh_workflow_examples/build_python.yml` shows the canonical wiring.
 
 ## Outputs
 
@@ -61,8 +62,9 @@ The publish-on-non-PR safety gate (`if: ! startsWith(github.event_name, 'pull_')
 | `version` | reusable workflow + composite | The package version (read from the built wheel filename; the build backend reads it from `pyproject.toml`'s `[project].version` or a dynamic version plugin like `hatch-vcs` / `setuptools-scm`). |
 | `hashes` | reusable workflow + composite | Base64-encoded SHA-256 hashes in the format `slsa-github-generator`'s `base64-subjects` input expects. Pass directly to the provenance job. |
 | `dist-artifact-name` | reusable workflow only | Name of the uploaded `dist/` artifact, namespaced by path-derived shortname so multiple python builds in one workflow don't collide. The publish job downloads using this name. |
-| `provenance-artifact-name` | reusable workflow only | Name of the uploaded SLSA provenance artifact (re-exported from `slsa-github-generator`'s `provenance-name`). Empty on PR builds because the provenance job is gated on non-PR events. |
+| `provenance-artifact-name` | reusable workflow only | Name of the uploaded SLSA provenance artifact (re-exported from `slsa-github-generator`'s `provenance-name`). Empty when `should-release` is false. |
 | `metadata-artifact-name` | reusable workflow only | Name of the uploaded metadata workflow artifact (`python-metadata-<shortname>`). Naming and contents follow the unified-metadata convention shared across all build types; see [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout." |
+| `should-release` | reusable workflow only | `"true"` if the current event matches `release-events`. The caller's publish job MUST gate on this; the reusable workflow gates its provenance job on it internally. |
 | `shortname` | composite only | Path-derived short name (e.g., `.` becomes `_`, `pkg/foo` becomes `pkg_foo`). Used for artifact namespacing when the composite is invoked directly. |
 | `metadata-dir` | composite only | Path to the metadata directory (`metadata/python/<shortname>/`) containing the SBOM. |
 
@@ -115,7 +117,7 @@ The reusable workflow uploads two artifacts after the composite action completes
 
 Both names are namespaced by the path-derived `shortname` so that multiple python builds in one workflow do not collide. The reusable workflow exports `dist-artifact-name` so adopters can `download-artifact` without hardcoding the namespacing scheme.
 
-### 8. Generate SLSA provenance (reusable workflow, gated on non-PR events)
+### 8. Generate SLSA provenance (reusable workflow, gated on release-events)
 
 The reusable workflow invokes `slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml` with the `hashes` output from the build job. The generator runs in an isolated environment and produces non-falsifiable provenance. Referenced by tag (`@vX.Y.Z`) per the generator's OIDC verification requirement (#147). The generator uploads the provenance file as a workflow artifact; the reusable workflow re-exports its `provenance-name` as `provenance-artifact-name` so the adopter can locate it.
 
@@ -123,9 +125,9 @@ The provenance job declares `contents: write` because the SLSA generator's `uplo
 
 Callers of this reusable workflow must therefore grant `contents: write` themselves. This matches the SLSA generic generator's [reference example](https://github.com/slsa-framework/slsa-github-generator/blob/v2.1.0/internal/builders/generic/README.md).
 
-Provenance is gated on non-PR events (`if: ! startsWith(github.event_name, 'pull_')`). On PR builds, only the build + test + SBOM steps run.
+Provenance is gated on the `release-events` input (default `non-pull-request`). The reusable workflow runs a small `gate` job that calls `actions/release_gate` and exposes a `should-release` output; the provenance job runs only when `should-release == 'true'`. On gated-out runs (e.g., PRs, or non-tag events when `release-events: tag-only`), only the build + test + SBOM steps run. See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full predicate vocabulary.
 
-### 9. Verify provenance and publish (adopter workflow, gated on non-PR events)
+### 9. Verify provenance and publish (adopter workflow, gated on should-release)
 
 The adopter's calling workflow runs a `publish` job with `id-token: write`. The job:
 
@@ -227,9 +229,20 @@ jobs:
           name: ${{ steps.names.outputs.metadata }}
           path: ${{ steps.build.outputs.metadata-dir }}/
 
+  gate:
+    runs-on: ubuntu-latest
+    outputs: { should-release: ${{ steps.gate.outputs.should-release }} }
+    steps:
+      - uses: actions/checkout@<sha>
+        with: { persist-credentials: false }
+      - uses: TomHennen/wrangle/actions/release_gate@<sha>
+        id: gate
+        with:
+          events: ${{ inputs.release-events }}
+
   provenance:
-    if: ${{ ! startsWith(github.event_name, 'pull_') }}
-    needs: [build]
+    if: ${{ needs.gate.outputs.should-release == 'true' }}
+    needs: [gate, build]
     permissions:
       actions: read
       id-token: write
@@ -240,7 +253,7 @@ jobs:
       upload-assets: ${{ startsWith(github.ref, 'refs/tags/') }}
 ```
 
-The publish job lives in the adopter's calling workflow (see `gh_workflow_examples/build_python.yml`), which depends on this reusable workflow's `dist-artifact-name`, `provenance-artifact-name`, and `hashes` outputs.
+The publish job lives in the adopter's calling workflow (see `gh_workflow_examples/build_python.yml`), which depends on this reusable workflow's `dist-artifact-name`, `provenance-artifact-name`, `hashes`, and `should-release` outputs.
 
 ## Security model
 

--- a/build/actions/python/test.bats
+++ b/build/actions/python/test.bats
@@ -130,9 +130,27 @@ setup() {
     [[ "$status" -eq 0 ]]
 }
 
-@test "python: provenance job is gated on non-PR events" {
-    # On PRs, publish doesn't run, so provenance is wasted compute.
-    run bash -c "sed -n '/^  provenance:/,/^[a-z]/p' \"$WORKFLOW\" | grep -E \"if:.*startsWith.*pull_\""
+@test "python: provenance job is gated on release-gate output" {
+    # Provenance gates on the gate job's should-release output so adopters
+    # can tighten the predicate via release-events without forking the workflow.
+    run bash -c "sed -n '/^  provenance:/,/^[a-z]/p' \"$WORKFLOW\" | grep -E \"if:.*should-release\""
+    [[ "$status" -eq 0 ]]
+}
+
+@test "python: workflow has gate job calling release_gate" {
+    run grep -E '^  gate:' "$WORKFLOW"
+    [[ "$status" -eq 0 ]]
+    run grep -E 'TomHennen/wrangle/actions/release_gate' "$WORKFLOW"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "python: workflow exposes release-events input" {
+    run grep -E '^      release-events:' "$WORKFLOW"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "python: workflow exposes should-release output" {
+    run grep -E '^      should-release:' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
 }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -183,6 +183,26 @@ The build stage has multiple failure points with different behaviors:
 
 This "fail on anything that weakens security guarantees" approach is stricter than the typical "warn on infra" pattern, but wrangle is a security tool — its releases must model the behavior it advocates. If Sigstore/Fulcio is down, the correct response is to wait and retry, not to ship without signing.
 
+### Release-events gating
+
+Every wrangle build-type reusable workflow MUST expose a `release-events` input that controls whether release-time side effects (SLSA provenance generation; in some build types, publish) run for a given event. The default is `non-pull-request`. Internally the workflow MUST delegate the decision to the shared composite action `actions/release_gate/`, which exposes a `should-release` output. The reusable workflow then:
+
+1. Gates its own provenance job on `needs.gate.outputs.should-release == 'true'`.
+2. Re-exports `should-release` as a workflow output so the caller's publish job (when one exists) can gate on the same value — keeping wrangle's internal gating and the caller's downstream gating in lockstep.
+
+Supported `release-events` shorthands:
+
+- `non-pull-request` (default) — every event except `pull_request*`.
+- `tag-only` — push to `refs/tags/*` only.
+- `main-and-tags` — push to `refs/heads/main` or `refs/tags/*`.
+- A comma-separated list of `github.event_name` values (e.g., `push,workflow_dispatch`) for adopters who need exact control. The list matches purely on event name; ref filtering is only available through the shorthands above.
+
+Why a shared composite. Centralizing the predicate means adopters get a single vocabulary across every build type, and refining the gate (adding a shorthand, supporting environments, applying ref filters to event lists) is a single-PR change rather than a sweep across every reusable workflow.
+
+Why over-generation is acceptable for the default. SLSA L3 provenance is non-falsifiable: a verifier checks `--source-uri` and (where the consumer specifies it) `--source-tag` against the provenance's recorded `workflow_ref`. A `schedule`-cron run that nobody downstream consumes is harmless because no consumer references that `workflow_ref`. The cost of over-generation is generator-job runtime; the cost of under-generation is "the consumer expected provenance and didn't get it." Asymmetric — over-generate by default, let adopters tighten when they have a stronger threat model (e.g., `tag-only` to ensure unauthorized `workflow_dispatch` cannot mint provenance for a release that downstream verifiers might trust under a default policy).
+
+Asymmetry: container vs. python. The container reusable workflow's docker push happens mid-composite inside `build/actions/container`; `release-events` currently gates only the provenance job in that workflow, not the push. The python reusable workflow has no publish step (PyPI Trusted Publishing's OIDC constraint means publish lives in the caller), so `release-events` gates provenance and `should-release` flows out to the caller's publish job. Build types MUST document this scope when their publish path differs from the python pattern.
+
 ## Architecture
 
 ### Layers

--- a/gh_workflow_examples/build_python.yml
+++ b/gh_workflow_examples/build_python.yml
@@ -18,11 +18,12 @@
 # recommended pattern, but you may remove the verify step if you don't
 # need it. See build/actions/python/README.md for details.
 #
-# Trigger note: this workflow publishes whenever `github.event_name` is not
-# `pull_*`. With the default triggers below, only tag pushes (`push: tags:
+# Trigger note: this workflow publishes when `should-release` is true. By
+# default, the wrangle reusable workflow's `release-events` input is
+# `non-pull-request`, so with the triggers below tag pushes (`push: tags:
 # ["v*"]`) and manual `workflow_dispatch` runs publish; PRs do not.
-# `workflow_dispatch` from any branch will publish, so tighten the trigger
-# (or add a branch/ref guard) if that is undesirable.
+# `workflow_dispatch` from any branch will publish under the default —
+# pass `release-events: tag-only` (or `main-and-tags`) to tighten that.
 name: Python Build
 
 on:
@@ -42,12 +43,14 @@ jobs:
     uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.0
     with:
       path: "."
-      # python-version: ""    # optional: auto-detected from pyproject.toml
-      # run-tests: true       # optional: skip with false
+      # python-version: ""              # optional: auto-detected from pyproject.toml
+      # run-tests: true                 # optional: skip with false
+      # release-events: non-pull-request  # optional: tag-only | main-and-tags | <event_name list>
 
   publish:
-    # Only publish on non-PR events.
-    if: ${{ ! startsWith(github.event_name, 'pull_') }}
+    # Gate on the should-release output so wrangle's reusable workflow
+    # and this publish job agree on which events trigger a release.
+    if: ${{ needs.build.outputs.should-release == 'true' }}
     needs: [build]
     runs-on: ubuntu-latest
     permissions:

--- a/gh_workflow_examples/build_python.yml
+++ b/gh_workflow_examples/build_python.yml
@@ -18,12 +18,14 @@
 # recommended pattern, but you may remove the verify step if you don't
 # need it. See build/actions/python/README.md for details.
 #
-# Trigger note: this workflow publishes when `should-release` is true. By
-# default, the wrangle reusable workflow's `release-events` input is
-# `non-pull-request`, so with the triggers below tag pushes (`push: tags:
-# ["v*"]`) and manual `workflow_dispatch` runs publish; PRs do not.
-# `workflow_dispatch` from any branch will publish under the default —
-# pass `release-events: tag-only` (or `main-and-tags`) to tighten that.
+# Trigger note: this workflow publishes when `should-release` is true.
+# This template sets `release-events: tag-only` so only tag pushes
+# publish — `workflow_dispatch` runs build + test + provenance but does
+# NOT publish, even from main. That is the safer default for a
+# canonical security-tool template: a stolen workflow_dispatch invocation
+# from any branch cannot mint a release. Switch to `non-pull-request`
+# (publish on every non-PR event) or `main-and-tags` (push to main or
+# tags) if your release model needs that.
 name: Python Build
 
 on:
@@ -43,9 +45,9 @@ jobs:
     uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.0
     with:
       path: "."
+      release-events: tag-only          # only tag pushes publish (recommended default)
       # python-version: ""              # optional: auto-detected from pyproject.toml
       # run-tests: true                 # optional: skip with false
-      # release-events: non-pull-request  # optional: tag-only | main-and-tags | <event_name list>
 
   publish:
     # Gate on the should-release output so wrangle's reusable workflow

--- a/test/test_release_gate.bats
+++ b/test/test_release_gate.bats
@@ -1,0 +1,245 @@
+#!/usr/bin/env bats
+
+# Tests for actions/release_gate/release_gate.sh
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../actions/release_gate/release_gate.sh"
+    export TEST_DIR="$(mktemp -d)"
+    export GITHUB_OUTPUT="$TEST_DIR/output"
+    : > "$GITHUB_OUTPUT"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# Helper: run the gate with given env, return its output via $output and
+# expose what was written to $GITHUB_OUTPUT via $gate_output.
+run_gate() {
+    : > "$GITHUB_OUTPUT"
+    run env \
+        EVENTS_INPUT="$1" \
+        EVENT_NAME="$2" \
+        REF="$3" \
+        GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+        "$SCRIPT"
+    gate_output="$(cat "$GITHUB_OUTPUT" 2>/dev/null || true)"
+}
+
+# --- non-pull-request shorthand ---
+
+@test "non-pull-request: push event releases" {
+    run_gate "non-pull-request" "push" "refs/heads/main"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+@test "non-pull-request: workflow_dispatch releases" {
+    run_gate "non-pull-request" "workflow_dispatch" "refs/heads/feature"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+@test "non-pull-request: schedule releases" {
+    run_gate "non-pull-request" "schedule" "refs/heads/main"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+@test "non-pull-request: pull_request does NOT release" {
+    run_gate "non-pull-request" "pull_request" "refs/pull/1/merge"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=false"* ]]
+}
+
+@test "non-pull-request: pull_request_target does NOT release" {
+    run_gate "non-pull-request" "pull_request_target" "refs/pull/1/merge"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=false"* ]]
+}
+
+@test "non-pull-request: merge_group releases" {
+    run_gate "non-pull-request" "merge_group" "refs/heads/gh-readonly-queue/main/pr-1-abc"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+@test "non-pull-request: release event releases" {
+    run_gate "non-pull-request" "release" "refs/tags/v1.0.0"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+@test "non-pull-request: repository_dispatch releases" {
+    run_gate "non-pull-request" "repository_dispatch" "refs/heads/main"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+# --- tag-only shorthand ---
+
+@test "tag-only: push to tag releases" {
+    run_gate "tag-only" "push" "refs/tags/v1.0.0"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+@test "tag-only: push to main does NOT release" {
+    run_gate "tag-only" "push" "refs/heads/main"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=false"* ]]
+}
+
+@test "tag-only: workflow_dispatch does NOT release" {
+    run_gate "tag-only" "workflow_dispatch" "refs/tags/v1.0.0"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=false"* ]]
+}
+
+@test "tag-only: pull_request does NOT release" {
+    run_gate "tag-only" "pull_request" "refs/pull/1/merge"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=false"* ]]
+}
+
+@test "tag-only: release event does NOT release (event_name != push)" {
+    # The github.event_name for a release publish is "release", not "push" —
+    # so even though the ref is a tag, tag-only requires push specifically.
+    run_gate "tag-only" "release" "refs/tags/v1.0.0"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=false"* ]]
+}
+
+# --- main-and-tags shorthand ---
+
+@test "main-and-tags: push to main releases" {
+    run_gate "main-and-tags" "push" "refs/heads/main"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+@test "main-and-tags: push to tag releases" {
+    run_gate "main-and-tags" "push" "refs/tags/v1.0.0"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+@test "main-and-tags: push to feature branch does NOT release" {
+    run_gate "main-and-tags" "push" "refs/heads/feature"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=false"* ]]
+}
+
+@test "main-and-tags: workflow_dispatch on main does NOT release" {
+    run_gate "main-and-tags" "workflow_dispatch" "refs/heads/main"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=false"* ]]
+}
+
+# --- comma-separated event list ---
+
+@test "event-list: single matching event releases" {
+    run_gate "workflow_dispatch" "workflow_dispatch" "refs/heads/main"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+@test "event-list: multiple events, one matches" {
+    run_gate "push,workflow_dispatch" "workflow_dispatch" "refs/heads/main"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+@test "event-list: no match returns false" {
+    run_gate "push,workflow_dispatch" "schedule" "refs/heads/main"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=false"* ]]
+}
+
+@test "event-list: tolerates spaces around commas" {
+    run_gate "push , workflow_dispatch" "push" "refs/heads/main"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+@test "event-list: list with merge_group matches" {
+    run_gate "push,merge_group" "merge_group" "refs/heads/gh-readonly-queue/main/pr-1-abc"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+# --- whitespace handling on shorthands ---
+
+@test "shorthand: leading/trailing space tolerated on tag-only" {
+    run_gate " tag-only " "push" "refs/tags/v1"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+@test "shorthand: leading/trailing space tolerated on non-pull-request" {
+    run_gate "  non-pull-request" "push" "refs/heads/main"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=true"* ]]
+}
+
+# --- invalid input ---
+
+@test "invalid: empty input fails with exit 2" {
+    run_gate "" "push" "refs/heads/main"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"empty"* ]]
+}
+
+@test "invalid: token with uppercase fails" {
+    run_gate "Push" "push" "refs/heads/main"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"invalid token"* ]]
+}
+
+@test "invalid: token with shell metachar fails" {
+    run_gate "push;rm" "push" "refs/heads/main"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"invalid token"* ]]
+}
+
+@test "invalid: CR in input fails" {
+    run_gate $'tag-only\r' "push" "refs/tags/v1"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"CR/LF"* ]]
+}
+
+@test "invalid: unknown shorthand falls through to event-list and fails" {
+    # 'main_only' has an underscore so passes the token regex; it just
+    # doesn't match the event_name 'push', so it's not an *error* — it
+    # returns false. This documents that shorthand-style typos with
+    # valid characters silently return false.
+    run_gate "main_only" "push" "refs/heads/main"
+    [ "$status" -eq 0 ]
+    [[ "$gate_output" == *"should-release=false"* ]]
+}
+
+@test "invalid: shorthand-like typo with hyphen fails (hyphen not in event_name regex)" {
+    run_gate "tag-onyl" "push" "refs/tags/v1"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"invalid token"* ]]
+}
+
+# --- env var validation ---
+
+@test "missing EVENTS_INPUT fails" {
+    run env -u EVENTS_INPUT \
+        EVENT_NAME="push" \
+        REF="refs/heads/main" \
+        GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+        "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "missing GITHUB_OUTPUT fails" {
+    run env -u GITHUB_OUTPUT \
+        EVENTS_INPUT="non-pull-request" \
+        EVENT_NAME="push" \
+        REF="refs/heads/main" \
+        "$SCRIPT"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

claude: Factor the hardcoded `if: ! startsWith(github.event_name, 'pull_')` predicate out of both reusable workflows into a shared composite at `actions/release_gate/`. Adopters now pass `release-events: tag-only` (or `main-and-tags`, or a comma-separated event_name list) to tighten when SLSA provenance and (in the python example) publish run, without forking the workflow.

- Reusable workflows expose `should-release` as a workflow output. The python example workflow gates its publish job on `needs.build.outputs.should-release == 'true'`, so wrangle's internal provenance gate and the caller's publish gate read from the same source of truth.
- Container's docker push happens mid-composite and is **not yet** gated by `release-events` — `release-events` currently scopes only the SLSA provenance job in that workflow. The asymmetry is documented in `docs/SPEC.md` "Release-events gating" and `build/actions/container/SPEC.md`. Will be resolved when the container build is restructured (or when an explicit publish gate is added).
- Strict input validation: tokens must match `^[a-z][a-z0-9_]*$`. A typo with a hyphen (`tag-onyl`) fails loud (exit 2). A typo with valid characters (`tag_only`) silently returns false — intentional, because with valid characters it's indistinguishable from a list of one event_name that doesn't match.
- The `gate` job has no `actions/checkout` step: `release_gate` resolves its script via `${{ github.action_path }}` (action cache), not the workspace.

## Test plan

- [x] `./test.sh` — 265 bats tests pass (added `test_release_gate.bats` covering shorthands, event lists, validation, env preconditions; updated python/container `test.bats` with structural assertions for the gate job + new input/output)
- [ ] CI green on this PR
- [ ] Integration test (wrangle-test companion repo) under default `release-events: non-pull-request` produces unchanged outputs from current behavior
- [ ] Smoke-check `release-events: tag-only` on a non-tag dispatch to verify provenance is gated out (and `should-release == 'false'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)