### PR TITLE
Bump action pins to #193 merge SHA (post-merge cleanup for #191 + #193)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@f0c17ea8da4d868940717e77739df5dc0a045896 # main 2026-05-04
+      - uses: TomHennen/wrangle/actions/release_gate@282387b20f24d06476e50acf2f195512b3d3c72b # main 2026-05-04
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -94,7 +94,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@f0c17ea8da4d868940717e77739df5dc0a045896 # main 2026-05-04
+      uses: TomHennen/wrangle/build/actions/container@282387b20f24d06476e50acf2f195512b3d3c72b # main 2026-05-04
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e768aaca4b7f794cc0d1c0cbb729c3bd98adcbc5 # add-release-verify 2026-04-26
+      - uses: TomHennen/wrangle/actions/release_gate@f0c17ea8da4d868940717e77739df5dc0a045896 # main 2026-05-04
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -94,7 +94,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@e768aaca4b7f794cc0d1c0cbb729c3bd98adcbc5 # add-release-verify 2026-04-26
+      uses: TomHennen/wrangle/build/actions/container@f0c17ea8da4d868940717e77739df5dc0a045896 # main 2026-05-04
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -91,7 +91,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e768aaca4b7f794cc0d1c0cbb729c3bd98adcbc5 # add-release-verify 2026-04-26
+      - uses: TomHennen/wrangle/actions/release_gate@f0c17ea8da4d868940717e77739df5dc0a045896 # main 2026-05-04
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -112,7 +112,7 @@ jobs:
           persist-credentials: false
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@e768aaca4b7f794cc0d1c0cbb729c3bd98adcbc5 # add-release-verify 2026-04-26
+      - uses: TomHennen/wrangle/build/actions/python@f0c17ea8da4d868940717e77739df5dc0a045896 # main 2026-05-04
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -91,7 +91,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@f0c17ea8da4d868940717e77739df5dc0a045896 # main 2026-05-04
+      - uses: TomHennen/wrangle/actions/release_gate@282387b20f24d06476e50acf2f195512b3d3c72b # main 2026-05-04
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -112,7 +112,7 @@ jobs:
           persist-credentials: false
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@f0c17ea8da4d868940717e77739df5dc0a045896 # main 2026-05-04
+      - uses: TomHennen/wrangle/build/actions/python@282387b20f24d06476e50acf2f195512b3d3c72b # main 2026-05-04
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@e768aaca4b7f794cc0d1c0cbb729c3bd98adcbc5 # add-release-verify 2026-04-26
+        uses: TomHennen/wrangle/build/actions/shell@f0c17ea8da4d868940717e77739df5dc0a045896 # main 2026-05-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@f0c17ea8da4d868940717e77739df5dc0a045896 # main 2026-05-04
+        uses: TomHennen/wrangle/build/actions/shell@282387b20f24d06476e50acf2f195512b3d3c72b # main 2026-05-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -25,6 +25,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@6b181145f459b30f3afc931835e0596d183061cc # claude/setup-npm-fixture-1h6Sv 2026-05-04
+        uses: TomHennen/wrangle/actions/scan@f0c17ea8da4d868940717e77739df5dc0a045896 # main 2026-05-04
         with:
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -25,6 +25,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@f0c17ea8da4d868940717e77739df5dc0a045896 # main 2026-05-04
+        uses: TomHennen/wrangle/actions/scan@282387b20f24d06476e50acf2f195512b3d3c72b # main 2026-05-04
         with:
           tools: ${{ inputs.tools }}


### PR DESCRIPTION
## Summary

Standard post-merge bump after #191 and #193. Rewrites every `TomHennen/wrangle/...@<sha>` ref under `.github/workflows/` to `282387b2` (the merge commit of #193, the most recent main HEAD).

Generated mechanically — ran `tools/bump_action_pins.sh 282387b20f24d06476e50acf2f195512b3d3c72b` against a clean clone of main with `WRANGLE_PINS_BRANCH=main`. Same shape as past post-merge bumps (e.g., PR #172).

## Why batched

This PR was originally opened against #191's merge SHA. Per discussion in [comment](https://github.com/TomHennen/wrangle/pull/192#issuecomment-4374565928) it was parked while #193 went through review — otherwise we'd have merged this, then merged #193, then immediately needed a third bump PR. With #193 now merged, the branch was refreshed to the new merge SHA in a single pass.

## Files changed

| File | Pins updated |
|------|--------------|
| `build_and_publish_container.yml` | `release_gate`, `build/actions/container` |
| `build_and_publish_python.yml` | `release_gate`, `build/actions/python` |
| `build_shell.yml` | `build/actions/shell` |
| `check_source_change.yml` | `actions/scan` |

`build_and_publish_npm.yml` is intentionally excluded — that workflow lives on PR #188's branch, not main, so it isn't picked up by `tools/bump_action_pins.sh` walking `.github/workflows/`. It'll get rolled into the next bump pass after #188 merges.

## Test plan

- [ ] CI on this PR — `dispatch` integration check should now pick up #193's curl-retry hardening (the scan action's syft install runs at the bumped SHA, which has the retry flags).
- [ ] After merge, no further action needed; this is the post-#191/#193 cleanup.

https://claude.ai/code/session_01AqkojrFQsx5CgHGndN96E2