### PR TITLE
Add curl --retry to raw-curl release-asset downloads (partial fix for #190)

### DIFF
--- a/tools/osv/install.sh
+++ b/tools/osv/install.sh
@@ -40,20 +40,25 @@ URL="https://github.com/${SOURCE_REPO}/releases/download/v${VERSION}/${BINARY_NA
 
 mkdir -p "$BIN_DIR"
 
-# Download binary to a temporary file
+# Download binary to a temporary file.
+# --retry 5 + --retry-all-errors retries on any failure (including 5xx
+# from GitHub's release CDN). Default exponential backoff (1s, 2s, 4s,
+# 8s, 16s) is curl's built-in. --retry-max-time caps total retry
+# duration so a sustained outage fails the install promptly. See #190.
 TMP_BINARY="$(mktemp "${BIN_DIR}/wrangle-dl-XXXXX")"
-if ! curl -fsSL -o "$TMP_BINARY" "$URL"; then
+if ! curl -fsSL --retry 5 --retry-all-errors --retry-max-time 60 -o "$TMP_BINARY" "$URL"; then
     printf 'wrangle: FATAL: failed to download %s %s\n' "$TOOL_NAME" "$VERSION" >&2
     rm -f "$TMP_BINARY"
     exit 1
 fi
 
-# Download SLSA provenance attestation
+# Download SLSA provenance attestation.
 # Note: raw curl is used (not wrangle_download_verify) because verifying
 # the provenance file's own integrity would be circular — it IS the trust anchor.
+# Same retry flags as above for the same reason.
 PROVENANCE_URL="https://github.com/${SOURCE_REPO}/releases/download/v${VERSION}/multiple.intoto.jsonl"
 PROVENANCE_PATH="${TMP_BINARY}.intoto.jsonl"
-if ! curl -fsSL -o "$PROVENANCE_PATH" "$PROVENANCE_URL"; then
+if ! curl -fsSL --retry 5 --retry-all-errors --retry-max-time 60 -o "$PROVENANCE_PATH" "$PROVENANCE_URL"; then
     printf 'wrangle: FATAL: failed to download SLSA provenance for %s %s\n' "$TOOL_NAME" "$VERSION" >&2
     rm -f "$TMP_BINARY" "$PROVENANCE_PATH"
     exit 1

--- a/tools/syft/install.sh
+++ b/tools/syft/install.sh
@@ -54,6 +54,12 @@ PEM_PATH="${CHECKSUMS_PATH}.pem"
 # Download checksums.txt + cosign signature + cert.
 # Raw curl is intentional here: integrity is established by cosign
 # verify-blob in the next step, not by a checksum.
+#
+# --retry 5 + --retry-all-errors retries on any failure (including 5xx
+# responses from GitHub's release CDN, which periodically returns 502).
+# Default exponential backoff (1s, 2s, 4s, 8s, 16s) is curl's built-in.
+# --retry-max-time caps total retry duration so a sustained outage fails
+# the install promptly rather than hanging the runner. See issue #190.
 for spec in "checksums:${CHECKSUMS_URL}:${CHECKSUMS_PATH}" \
             "signature:${CHECKSUMS_URL}.sig:${SIG_PATH}" \
             "certificate:${CHECKSUMS_URL}.pem:${PEM_PATH}"; do
@@ -61,7 +67,7 @@ for spec in "checksums:${CHECKSUMS_URL}:${CHECKSUMS_PATH}" \
     rest="${spec#*:}"
     url="${rest%:*}"
     out="${rest##*:}"
-    if ! curl -fsSL -o "$out" "$url"; then
+    if ! curl -fsSL --retry 5 --retry-all-errors --retry-max-time 60 -o "$out" "$url"; then
         printf 'wrangle: FATAL: failed to download %s for syft %s\n' "$label" "$VERSION" >&2
         exit 1
     fi


### PR DESCRIPTION
## Summary

Partial fix for #190. Adds `--retry 5 --retry-all-errors --retry-max-time 60` to every raw-curl release-asset download in wrangle's tool installers:

- `tools/syft/install.sh` — checksums.txt + cosign signature + cert (3 calls)
- `tools/osv/install.sh` — binary + SLSA provenance attestation (2 calls)

Default exponential backoff (1s, 2s, 4s, 8s, 16s) is curl's built-in. `--retry-max-time 60` caps total retry time so a sustained outage fails the install promptly rather than hanging the runner. `--retry-all-errors` (curl 7.71+, comfortably present on every GitHub-hosted runner) covers edge cases beyond curl's default retry set — DNS hiccups, mid-stream resets, TLS handshake errors. The bug we hit was a default-set 502, but the broader flag closes adjacent flake vectors at zero extra cost.

## Why partial

The curl-in-shell-scripts case was the easy half of #190. The harder half is the `slsa-framework/slsa-verifier/actions/installer` GitHub Action used in three reusable workflows' verify jobs (and `actions/scan/action.yml`). That's a third-party JS action — there's no flag to add from outside, so making it retry-aware requires either:

1. Replacing it wholesale with a wrangle-owned curl-based installer + cosign verify (similar shape to `tools/syft/install.sh`), or
2. Wrapping with `nick-fields/retry`'s `command:` mode, which means re-implementing the installer's setup-tool-cache logic.

Either is a separate change with its own design call (which trust anchor, what version pin, how to handle the tool cache). Tracking under #190 still — this PR doesn't close it.

The same flake class also affects `sigstore/cosign-installer` (used in `actions/scan/action.yml` and the container verify job). Same story, same follow-up.

## Why not also bump `lib/download_verify.sh`

That helper already has bash-level retry (3 attempts, 1s/2s/4s exponential backoff). Could be simplified by switching to curl's native `--retry`, but that changes behavior the existing test suite (`test/lib/test_download_verify.bats`) was written against. Not worth the test churn for this PR — file as a clean-up follow-up if anyone cares.

## Test plan

- [ ] `bats tools/syft/test.bats tools/osv/test.bats` — should still pass; existing mock curl uses arg-parser with wildcard fallback (`*) shift ;;`) so the new flags pass through harmlessly.
- [ ] `actionlint` / `shellcheck` — clean.
- [ ] CI on this PR. Note: `dispatch` will keep being flaky on installer-action 502s until the slsa-verifier follow-up lands; pass-fail signal here is unit tests + your review.

https://claude.ai/code/session_01AqkojrFQsx5CgHGndN96E2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqkojrFQsx5CgHGndN96E2)_