### PR TITLE
Bump action pins post-#188 + fix BSD-sed portability in bump script

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@72f1040fab83a7c8faaf21888eb16a1b70fa4b93 # claude/implement-npm-build-type-draft 2026-05-11
+      - uses: TomHennen/wrangle/actions/release_gate@21dc3e6d965ea45a933c1173c86b1db2c649d460 # main 2026-05-12
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -94,7 +94,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@72f1040fab83a7c8faaf21888eb16a1b70fa4b93 # claude/implement-npm-build-type-draft 2026-05-11
+      uses: TomHennen/wrangle/build/actions/container@21dc3e6d965ea45a933c1173c86b1db2c649d460 # main 2026-05-12
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -123,7 +123,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@72f1040fab83a7c8faaf21888eb16a1b70fa4b93 # claude/implement-npm-build-type-draft 2026-05-11
+      - uses: TomHennen/wrangle/actions/release_gate@21dc3e6d965ea45a933c1173c86b1db2c649d460 # main 2026-05-12
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -146,7 +146,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@72f1040fab83a7c8faaf21888eb16a1b70fa4b93 # claude/implement-npm-build-type-draft 2026-05-11
+      - uses: TomHennen/wrangle/build/actions/npm@21dc3e6d965ea45a933c1173c86b1db2c649d460 # main 2026-05-12
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@72f1040fab83a7c8faaf21888eb16a1b70fa4b93 # claude/implement-npm-build-type-draft 2026-05-11
+      - uses: TomHennen/wrangle/actions/release_gate@21dc3e6d965ea45a933c1173c86b1db2c649d460 # main 2026-05-12
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -128,7 +128,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@72f1040fab83a7c8faaf21888eb16a1b70fa4b93 # claude/implement-npm-build-type-draft 2026-05-11
+      - uses: TomHennen/wrangle/build/actions/python@21dc3e6d965ea45a933c1173c86b1db2c649d460 # main 2026-05-12
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@72f1040fab83a7c8faaf21888eb16a1b70fa4b93 # claude/implement-npm-build-type-draft 2026-05-11
+        uses: TomHennen/wrangle/build/actions/shell@21dc3e6d965ea45a933c1173c86b1db2c649d460 # main 2026-05-12
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -25,6 +25,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@72f1040fab83a7c8faaf21888eb16a1b70fa4b93 # claude/implement-npm-build-type-draft 2026-05-11
+        uses: TomHennen/wrangle/actions/scan@21dc3e6d965ea45a933c1173c86b1db2c649d460 # main 2026-05-12
         with:
           tools: ${{ inputs.tools }}

--- a/test/test_bump_action_pins.bats
+++ b/test/test_bump_action_pins.bats
@@ -43,6 +43,29 @@ EOF
     ! grep -q "@aaaa" .github/workflows/a.yml
 }
 
+@test "bump_action_pins: replaces entire trailing comment when branch name contains 'n'/'r'/'\\\\'" {
+    # Regression test. Earlier drafts used `[^\\r\\n]*` to match the
+    # trailing comment, which BSD sed (macOS) reads as `[^\\rn]*` —
+    # the character class stops at the first literal 'r', 'n', or '\\'.
+    # On a branch like `claude/implement-npm-build-type-draft` the
+    # script would replace `claude/impleme` and leave
+    # `nt-npm-build-type-draft <date>` behind in the line. `.*` is
+    # portable because sed's pattern space is one line at a time,
+    # so `.` is naturally bounded.
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # claude/implement-npm-build-type-draft 2026-05-11
+EOF
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    grep -q "@${NEW_SHA} # test-branch 2099-12-31" .github/workflows/a.yml
+    # No fragment of the old comment may survive — these substrings
+    # are what leaked through under BSD sed before the fix.
+    ! grep -q "implement-npm-build-type-draft" .github/workflows/a.yml
+    ! grep -q "2026-05-11" .github/workflows/a.yml
+}
+
 @test "bump_action_pins: adds comment when pin lacks one" {
     cat > .github/workflows/a.yml <<EOF
 jobs:

--- a/tools/bump_action_pins.sh
+++ b/tools/bump_action_pins.sh
@@ -92,6 +92,15 @@ date_label="${WRANGLE_PINS_DATE:-$(date -u +%Y-%m-%d)}"
 # `# uses: ...@<sha>` would match — wrong, since the comment is supposed
 # to neutralize the line.
 #
+# Trailing comment uses `.*` to match the rest of the line. `.` does not
+# match newline in sed (which processes one line at a time by default),
+# so `.*` is bounded. Earlier drafts used `[^\r\n]*` to be explicit, but
+# BSD sed (macOS) does NOT interpret \r/\n as escape sequences inside a
+# bracket expression — it reads them as the literal characters '\', 'r',
+# 'n', so any branch name containing those letters (e.g.,
+# `claude/implement-npm-build-type-draft`) was truncated at the first
+# such letter on macOS, leaving a corrupted trailing comment.
+#
 # The branch and date labels flow into the sed REPLACEMENT string. Three
 # characters need escaping there: `\` (sed escape), `&` (matched-text
 # backreference), and `|` (our chosen delimiter — legal in git refs per
@@ -111,7 +120,7 @@ escaped_date="$(escape_for_sed_replace "$date_label")"
 escaped_repo="${PINS_REPO//\//\\/}"
 new_suffix="@${target_sha} # ${escaped_branch} ${escaped_date}"
 
-match='\(^[[:space:]]*-\{0,1\}[[:space:]]*uses:[[:space:]]*'"$escaped_repo"'/[^@[:space:]]*\)@[0-9a-f]\{40\}\([[:space:]]*#[^\r\n]*\)\{0,1\}'
+match='\(^[[:space:]]*-\{0,1\}[[:space:]]*uses:[[:space:]]*'"$escaped_repo"'/[^@[:space:]]*\)@[0-9a-f]\{40\}\([[:space:]]*#.*\)\{0,1\}'
 replace='\1'"$new_suffix"
 
 # Walk every YAML file in the target dir and rewrite in place. We write


### PR DESCRIPTION
## Summary

- **Bump action pins** to the post-#188 merge SHA (21dc3e6). Mechanical `make bump-action-pins` output covering all five sibling workflows. Standard post-merge cleanup, same shape as #172 / #192.

- **Fix a portability bug in `tools/bump_action_pins.sh`** surfaced while running the bump on macOS. The trailing-comment match used `[^\\r\\n]*` to bound the rewrite. BSD sed (macOS) does NOT interpret `\\r`/`\\n` as escape sequences inside a bracket expression — it reads them as the literal characters `\\`, `r`, `n`. On a branch like `claude/implement-npm-build-type-draft` the match stopped at the first `n` in `implement`, producing corrupted output:

  ```
  # main 2026-05-12nt-npm-build-type-draft 2026-05-11
  ```

  Switched to `.*`. Sed processes one line at a time so `.` does not match newline; the match remains bounded. GNU sed (Linux/CI) was happy with the old regex, which is why previous bump runs went out fine. Added a regression test using the exact branch name that surfaced the bug — the existing "rewrites pin with existing comment" test passed even under the bug because it only checked that the new comment appears and the old SHA is gone.

## Test plan

- [x] `./test.sh` — 344/344 (existing 343 + 1 new bump regression test)
- [x] BSD-sed reproduction on macOS: before the fix produced corrupted comments; after the fix produces clean ones
- [ ] CI checks on the bumped self-references (the bump targets the merge of #188 which is already on `main`)