### PR TITLE
docs: shared source-scan companion doc + short pointers in build-type READMEs

### DIFF
--- a/actions/scan/README.md
+++ b/actions/scan/README.md
@@ -1,0 +1,70 @@
+# Wrangle Source Scan
+
+Run wrangle's bundled source-stage security scanners (OSV-Scanner, Zizmor, Scorecard) against your repo on every PR and on push to main. The companion to wrangle's build/publish reusable workflows: build/publish hardens *how* your artifact is produced; source scan covers *what was checked into the repo you're building from*.
+
+> **Note:** This README documents currently-shipped behavior. For the design and adoption philosophy, see [`../../docs/SPEC.md`](../../docs/SPEC.md).
+
+## Why pair this with a build/publish workflow
+
+Wrangle's build/publish workflows produce signed SLSA L3 provenance over the bytes they ship. That provenance attests *how* the build happened — but it does not attest that the source was trustworthy. The May 2026 Mini Shai-Hulud compromise of TanStack/router illustrates the gap: a `pull_request_target` workflow with checkout of PR-head SHA let attacker code execute in the privileged base context, poison the GitHub Actions cache, and pollute legitimate downstream builds with malicious modules. The build was honest; the attestation was honest; the source side was the gap.
+
+This scan composite closes that gap on every PR and push to main:
+
+- **[OSV-Scanner](https://github.com/google/osv-scanner)** against your lockfiles. Catches known-vulnerable dependencies before they ship.
+- **[Zizmor](https://github.com/woodruffw/zizmor)** static analysis over `.github/workflows/`. Flags dangerous-trigger patterns like the `pull_request_target` + fork-head checkout combination that initiated Mini Shai-Hulud, plus expression injection, unpinned actions, and other known workflow footguns.
+- **[Scorecard](https://github.com/ossf/scorecard)** against your repo configuration. Surfaces missing branch protection, code-review requirements, signed-commits, and similar repo-config gaps.
+
+Without source scan, an attacker who lands a malicious dep in your lockfile or introduces a dangerous workflow trigger can route around wrangle's build-side hardening — wrangle will then faithfully L3-sign the malicious output, because the build itself *was* legitimate.
+
+## Quick-start (one workflow file)
+
+Copy [`../../gh_workflow_examples/check_source_change.yml`](../../gh_workflow_examples/check_source_change.yml) into your repo at `.github/workflows/check_source_change.yml`:
+
+```yaml
+name: Check Source Change
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+jobs:
+  check-change:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write   # SARIF upload to the Security tab
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@<version>
+```
+
+That's it. Findings appear in the Security tab; the workflow run's step summary shows a quick overview. Pair this with whichever build/publish workflow your project uses (npm, python, container, shell) for end-to-end coverage.
+
+## Customizing which tools run
+
+The `tools` input is a space-separated list. Default: `"osv zizmor scorecard:info"`. Suffix a tool with `:info` to make its findings informational (non-blocking).
+
+```yaml
+uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@<version>
+with:
+  tools: "osv zizmor"   # skip Scorecard (e.g., on forks where it doesn't apply)
+```
+
+## What this composite does NOT do (yet)
+
+- **Build-time vulnerability scanning of compiled dependencies.** OSV reads lockfiles, not installed `node_modules/`, installed wheels, or extracted container layers. Layered binary scanners (Trivy, Grype) against installed artifacts complement this and are out of wrangle's scope today.
+- **Active remediation.** Findings are reported, not fixed. Dependabot-style auto-remediation is roadmap.
+- **Source provenance attestations.** Coming via [#201](https://github.com/TomHennen/wrangle/issues/201) — integrating [slsa-framework/source-tool](https://github.com/slsa-framework/source-tool) into this same `check_source_change.yml` workflow so adopters keep their one workflow file and gain per-commit source provenance + SLSA Source Track conformance assessment.
+
+## Roadmap
+
+- **[#201](https://github.com/TomHennen/wrangle/issues/201)** — SLSA Source Track integration via `source-tool`. Per-commit source provenance attestations + level-aware status reporting in this same workflow.
+- **[#194](https://github.com/TomHennen/wrangle/issues/194)** — npm-specific source-scan tools (ESLint, `tsc --noEmit`, dep-review).
+- **[#203](https://github.com/TomHennen/wrangle/issues/203)** — Surface Scorecard findings as actionable remediations rather than informational warnings.
+- **[#202](https://github.com/TomHennen/wrangle/issues/202)** — Refuse `pull_request_target` invocations in wrangle's reusable workflows as defense-in-depth alongside Zizmor's static check.
+
+## Further reading
+
+- [`../../docs/SPEC.md`](../../docs/SPEC.md) — wrangle's overall architecture.
+- [`../../gh_workflow_examples/check_source_change.yml`](../../gh_workflow_examples/check_source_change.yml) — copy-paste starting point.
+- [`./action.yml`](./action.yml) — the composite action this README documents.

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -4,6 +4,10 @@ A GitHub composite action that builds and publishes a container image to GitHub 
 
 > **Note:** This README documents *currently-shipped* behavior. For the full design — including Cosign signing, SLSA L3 provenance, the release gate, failure contract, and trust model — see [`SPEC.md`](./SPEC.md). The spec is forward-looking; features described there but not yet implemented in `action.yml` will land in follow-up PRs, and this README will be updated in the same commit. The full structure this README must eventually cover (quick-start example, verification commands, failure runbook) is defined in [`SPEC.md` §"Required contents of `build/actions/container/README.md`"](./SPEC.md#required-contents-of-buildactionscontainerreadmemd).
 
+## Recommended companion: source scan
+
+This action hardens *how* your container image is produced. It does NOT scan your source — vulnerable deps in your Dockerfile's base image or pinned packages, dangerous workflow triggers, or missing branch protection still slip through and would be faithfully L3-attested by wrangle as legitimately built. Pair this with wrangle's source-scan workflow ([`actions/scan/README.md`](../../../actions/scan/README.md)) to close that gap on every PR and push. Without it, an attacker who lands a malicious dep or workflow misconfiguration routes around the build-side hardening — the May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical recent example of why this matters.
+
 ## What this action does today
 
 - Builds a Docker image from a Dockerfile at a caller-provided path
@@ -79,3 +83,4 @@ Per the failure contract in [`SPEC.md`](./SPEC.md#failure-contract), SBOM vulner
 - [`SPEC.md`](./SPEC.md) — this action's full specification
 - [`../../../docs/SPEC.md`](../../../docs/SPEC.md) — wrangle's overall architecture and build-type model
 - [`../../README.md`](../../README.md) — the build/ directory overview
+- [`../../../actions/scan/README.md`](../../../actions/scan/README.md) — recommended source-scan companion

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -4,6 +4,10 @@ Build an npm package (tarball via `npm pack`), run tests, generate an SBOM, and 
 
 > **Note:** This README documents *currently-shipped* behavior. For the full design — architecture, attestation model, full step sequence — see [`SPEC.md`](./SPEC.md).
 
+## Recommended companion: source scan
+
+This action hardens *how* your artifact is produced. It does NOT scan your source — vulnerable deps in `package-lock.json`, dangerous workflow triggers, or missing branch protection still slip through and would be faithfully L3-attested by wrangle as legitimately built. Pair this with wrangle's source-scan workflow ([`actions/scan/README.md`](../../../actions/scan/README.md)) to close that gap on every PR and push. The May 2026 Mini Shai-Hulud compromise of TanStack/router is the most recent example of why this matters — the build side wasn't the vulnerability; the source side was.
+
 ## Before first use
 
 **Bootstrap the package's first version manually.** npm Trusted Publishing cannot publish a package's *first* version ([npm/cli#8544](https://github.com/npm/cli/issues/8544)). For a brand-new package, run `npm publish` once from a maintainer's terminal with an `NPM_TOKEN` to mint v0.0.1 (or whatever the initial version is). After that, every subsequent version goes through the automated path. Skip this step and your first run of the workflow will fail with a non-obvious "package not found" error from the registry.

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -4,6 +4,10 @@ Build a Python package (wheel + sdist), run tests, generate an SBOM, and produce
 
 > **Note:** This README documents *currently-shipped* behavior. For the full design — architecture, security model, full step sequence — see [`SPEC.md`](./SPEC.md).
 
+## Recommended companion: source scan
+
+This action hardens *how* your artifact is produced. It does NOT scan your source — vulnerable deps in your lockfile, dangerous workflow triggers, or missing branch protection still slip through and would be faithfully L3-attested by wrangle as legitimately built. Pair this with wrangle's source-scan workflow ([`actions/scan/README.md`](../../../actions/scan/README.md)) to close that gap on every PR and push. Without it, an attacker who lands a malicious dep or workflow misconfiguration routes around the build-side hardening — the May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical recent example.
+
 ## Quick-start
 
 Two ways to adopt:
@@ -150,5 +154,6 @@ Before the first publish:
 - [`SPEC.md`](./SPEC.md) — this action's full specification
 - [`../../../docs/SPEC.md`](../../../docs/SPEC.md) — wrangle's overall architecture
 - [`../../README.md`](../../README.md) — the build/ directory overview
+- [`../../../actions/scan/README.md`](../../../actions/scan/README.md) — recommended source-scan companion
 - [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) — the underlying PyPI feature
 - [SLSA generic generator](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md)

--- a/gh_workflow_examples/README.md
+++ b/gh_workflow_examples/README.md
@@ -2,9 +2,11 @@
 
 Starting points for adopting wrangle. Copy to `.github/workflows/` in your repo and customize the inputs (paths, image names, etc.) for your project.
 
+**Recommended pattern:** pair *any* build/publish workflow below with `check_source_change.yml`. Build/publish hardens *how* your artifact is produced; the source-scan workflow covers *what was checked into the repo you're building from*. Without both, an attacker who lands a malicious dep or workflow misconfiguration routes around the build-side hardening — wrangle will still faithfully attest the result. See [`../actions/scan/README.md`](../actions/scan/README.md) for the full rationale.
+
 ## check_source_change.yml
 
-Run OSV, Zizmor, and Scorecard source scanning on every PR and push.
+Run OSV-Scanner, Zizmor, and Scorecard source scanning on every PR and push to main. **Adopt alongside whichever build/publish workflow below matches your project.** Roadmap: [#201](https://github.com/TomHennen/wrangle/issues/201) extends this with per-commit SLSA Source Track attestations via [slsa-framework/source-tool](https://github.com/slsa-framework/source-tool) — adoption stays a single workflow file.
 
 ## build_shell.yml
 
@@ -13,6 +15,10 @@ Run shellcheck and bats tests on shell projects.
 ## build_and_publish_containers.yml
 
 Build, sign, and publish a container image with SBOM and SLSA L3 provenance.
+
+## build_npm.yml
+
+Build an npm package (`npm pack`), run tests, generate an SPDX SBOM, and produce SLSA L3 build provenance. Publishes to npmjs.org via Trusted Publishing (no `NPM_TOKEN`) — the publish job lives in the caller workflow because npm's Trusted Publishing OIDC token must come from the caller's workflow filename, not a reusable workflow. Adopters must bootstrap-publish v0.0.1 once manually and configure a [Trusted Publisher on npmjs.com](https://docs.npmjs.com/trusted-publishers/) before the first automated publish — see [`build/actions/npm/README.md`](/build/actions/npm/README.md) for the onboarding checklist.
 
 ## build_python.yml
 


### PR DESCRIPTION
## Summary

Adopters of any build/publish workflow today don't get pointed at wrangle's source-scan composite, which means they miss the half that would have caught attacks like TanStack/Mini Shai-Hulud (May 2026). This PR fixes that with one shared doc and short pointers — no duplication across build-type READMEs.

## What changes

- **NEW: `actions/scan/README.md`** — single source of truth for the source-scan companion pattern. Covers what the scan runs (OSV + Zizmor + Scorecard), how to adopt with one workflow file, why pair it with build/publish, what it doesn't cover yet, and roadmap pointers (#201 SLSA Source Track, #194 npm scan tools, #202 PR-target guard, #203 Scorecard remediations).

- **`build/actions/npm/README.md`** — short "Recommended companion: source scan" section near the top pointing at the shared doc.

- **`build/actions/python/README.md`** — same shape, plus added the shared doc to "Further reading."

- **`build/actions/container/README.md`** — same shape, plus added the shared doc to "Further reading."

- **`gh_workflow_examples/README.md`** — adds `build_npm.yml` (which was missing) and prepends a "pair build with source-scan" recommendation at the top of the file.

## Why short pointers rather than duplicating the section

The companion-scan story is identical for npm, python, and container — same scan composite, same rationale, same workflow shape. Duplicating across three READMEs costs maintenance and means updates can drift. Single shared doc + short pointers is the canonical pattern.

## What this PR does NOT do (filed as follow-ups)

- **#201** — SLSA Source Track integration via [slsa-framework/source-tool](https://github.com/slsa-framework/source-tool). Per-commit source provenance attestations in the same `check_source_change.yml` workflow so adopters keep their one-file pattern.
- **#202** — refuse `pull_request_target` invocations in wrangle's reusable workflows as defense-in-depth alongside Zizmor's static check.
- **#203** — surface Scorecard findings as actionable remediations.
- (existing) **#194** — npm-specific source-scan tools (ESLint, `tsc --noEmit`, dep-review).

## Test plan

- [ ] CI: actionlint + zizmor + bats — no changes that should affect them (docs-only).
- [ ] Manual: read all four updated READMEs front-to-back, confirm the new section reads naturally and the link to `actions/scan/README.md` resolves.
- [ ] Manual: read the new `actions/scan/README.md` end-to-end.

https://claude.ai/code/session_01AqkojrFQsx5CgHGndN96E2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqkojrFQsx5CgHGndN96E2)_