### PR TITLE
Bump self-ref pins to current main to clear zizmor impostor-commit

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@dad131c0f4faf6348952ad21b037750cb568834a # claude/v0.2-pnpm-support 2026-05-14
+      - uses: TomHennen/wrangle/actions/release_gate@184105530fd123a7e93eaa7c39f03dc2758a07d9 # main 2026-05-15
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -94,7 +94,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@dad131c0f4faf6348952ad21b037750cb568834a # claude/v0.2-pnpm-support 2026-05-14
+      uses: TomHennen/wrangle/build/actions/container@184105530fd123a7e93eaa7c39f03dc2758a07d9 # main 2026-05-15
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -123,7 +123,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@dad131c0f4faf6348952ad21b037750cb568834a # claude/v0.2-pnpm-support 2026-05-14
+      - uses: TomHennen/wrangle/actions/release_gate@184105530fd123a7e93eaa7c39f03dc2758a07d9 # main 2026-05-15
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -146,7 +146,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@dad131c0f4faf6348952ad21b037750cb568834a # claude/v0.2-pnpm-support 2026-05-14
+      - uses: TomHennen/wrangle/build/actions/npm@184105530fd123a7e93eaa7c39f03dc2758a07d9 # main 2026-05-15
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@dad131c0f4faf6348952ad21b037750cb568834a # claude/v0.2-pnpm-support 2026-05-14
+      - uses: TomHennen/wrangle/actions/release_gate@184105530fd123a7e93eaa7c39f03dc2758a07d9 # main 2026-05-15
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -128,7 +128,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@dad131c0f4faf6348952ad21b037750cb568834a # claude/v0.2-pnpm-support 2026-05-14
+      - uses: TomHennen/wrangle/build/actions/python@184105530fd123a7e93eaa7c39f03dc2758a07d9 # main 2026-05-15
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@dad131c0f4faf6348952ad21b037750cb568834a # claude/v0.2-pnpm-support 2026-05-14
+        uses: TomHennen/wrangle/build/actions/shell@184105530fd123a7e93eaa7c39f03dc2758a07d9 # main 2026-05-15
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -25,6 +25,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@dad131c0f4faf6348952ad21b037750cb568834a # claude/v0.2-pnpm-support 2026-05-14
+        uses: TomHennen/wrangle/actions/scan@184105530fd123a7e93eaa7c39f03dc2758a07d9 # main 2026-05-15
         with:
           tools: ${{ inputs.tools }}


### PR DESCRIPTION
## Summary

- Stopgap for the 8 HIGH `zizmor/impostor-commit` findings on `main`'s check-change. The self-refs in our reusable workflows point at `dad131c0...` on the unmerged `claude/v0.2-pnpm-support` branch; zizmor can't see that SHA from the default branch and flags it. Bump all 8 to the current main HEAD so the SHA is reachable.
- Behaviorally identical: the only diff between `dad131c0` and current `main` inside `actions/` + `build/` is a research-only doc (`WORKSPACES_PHASE_1.md`), no action.yml or script changes.
- Generated via `tools/bump_action_pins.sh` with `WRANGLE_PINS_BRANCH=main` override. (The script's auto-label check needs a local `main` ref to detect "SHA is on main" — worth fixing the script later to also accept `origin/main`, but not in this PR.)
- This is a *stopgap* until #218 lands a real fix.

## Test plan

- [x] `./test.sh` — 352/352 pass
- [ ] PR check-change should now pass (the whole point)
- [ ] After merge, main's check-change should be green

🤖 Generated with [Claude Code](https://claude.com/claude-code)