### PR TITLE
Bump self-ref pins to main HEAD (post-#213/#220 cleanup)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -80,7 +80,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@2baa1821b4dea1c93faeb6b2b8adad8f5be50f9f # claude/202-refuse-pull-request-target 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
 
   gate:
     needs: [guard]
@@ -91,7 +91,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@2baa1821b4dea1c93faeb6b2b8adad8f5be50f9f # claude/202-refuse-pull-request-target 2026-05-17
+      - uses: TomHennen/wrangle/actions/release_gate@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -110,7 +110,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@2baa1821b4dea1c93faeb6b2b8adad8f5be50f9f # claude/202-refuse-pull-request-target 2026-05-17
+      uses: TomHennen/wrangle/build/actions/container@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -125,7 +125,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@2baa1821b4dea1c93faeb6b2b8adad8f5be50f9f # claude/202-refuse-pull-request-target 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
 
   gate:
     needs: [guard]
@@ -136,7 +136,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@2baa1821b4dea1c93faeb6b2b8adad8f5be50f9f # claude/202-refuse-pull-request-target 2026-05-17
+      - uses: TomHennen/wrangle/actions/release_gate@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -160,7 +160,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@2baa1821b4dea1c93faeb6b2b8adad8f5be50f9f # claude/202-refuse-pull-request-target 2026-05-17
+      - uses: TomHennen/wrangle/build/actions/npm@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -104,7 +104,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@2baa1821b4dea1c93faeb6b2b8adad8f5be50f9f # claude/202-refuse-pull-request-target 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -119,7 +119,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@2baa1821b4dea1c93faeb6b2b8adad8f5be50f9f # claude/202-refuse-pull-request-target 2026-05-17
+      - uses: TomHennen/wrangle/actions/release_gate@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -142,7 +142,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@2baa1821b4dea1c93faeb6b2b8adad8f5be50f9f # claude/202-refuse-pull-request-target 2026-05-17
+      - uses: TomHennen/wrangle/build/actions/python@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -29,7 +29,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@2baa1821b4dea1c93faeb6b2b8adad8f5be50f9f # claude/202-refuse-pull-request-target 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
 
   shell-build:
     needs: [guard]
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@2baa1821b4dea1c93faeb6b2b8adad8f5be50f9f # claude/202-refuse-pull-request-target 2026-05-17
+        uses: TomHennen/wrangle/build/actions/shell@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -20,7 +20,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@2baa1821b4dea1c93faeb6b2b8adad8f5be50f9f # claude/202-refuse-pull-request-target 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
 
   check-change:
     needs: [guard]
@@ -38,6 +38,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@2baa1821b4dea1c93faeb6b2b8adad8f5be50f9f # claude/202-refuse-pull-request-target 2026-05-17
+        uses: TomHennen/wrangle/actions/scan@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
         with:
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -55,7 +55,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@e858013837afec2c18c61d0d67249dca39efd225 # main 2026-04-22
+      uses: TomHennen/wrangle/tools/zizmor@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -63,7 +63,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@e858013837afec2c18c61d0d67249dca39efd225 # main 2026-04-22
+      uses: TomHennen/wrangle/tools/scorecard@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -75,7 +75,7 @@ runs:
     # (fail-on-severity: high, comment-summary-in-pr: never) apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@075238e9d9dc8b1548912e4b387d243674f47abf # claude/address-issue-209-X3JeP 2026-05-15
+      uses: TomHennen/wrangle/tools/dependency-review@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
 
     - name: Generate step summary
       if: always()


### PR DESCRIPTION
claude: standard post-merge pin refresh.

#213 left the `.github/workflows/` self-ref pins at its branch SHA
(`2baa182`); #220 left `actions/scan/action.yml`'s `tools/dependency-review`
ref at its branch SHA (`075238e`). This bumps every
`TomHennen/wrangle/...@<sha>` self-reference to `main` HEAD (`68b1cae`)
so the reusable workflows and the scan composite resolve internal
actions at a `main` commit rather than a feature branch.

Mechanical: produced by `tools/bump_action_pins.sh`. 16 pins across 6
files; pin SHAs/comments only, no logic changes. `./test.sh` green (406).

🤖 Generated with [Claude Code](https://claude.com/claude-code)