### PR TITLE
claude: Gate build caches on release status for SLSA Build L3 (closes #224)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -97,7 +97,10 @@ jobs:
           events: ${{ inputs.release-events }}
 
   build:
-    needs: [guard]
+    # needs `gate` so the build can read should-release and disable the
+    # BuildKit cache for release builds (SLSA L3 isolation — see the
+    # `cache:` input below and docs/SLSA_L3_AUDIT.md Finding 2).
+    needs: [guard, gate]
     permissions:
       contents: read
       packages: write
@@ -116,6 +119,13 @@ jobs:
         imagename: ${{ inputs.imagename }}
         registry: ${{ inputs.registry }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        # Disable the BuildKit GHA cache on release builds. should-release
+        # == 'true' means this event produces L3 provenance, so the build
+        # must not consume a shared, cross-build, unverified-on-hit cache —
+        # see docs/SLSA_L3_AUDIT.md Finding 2. PR builds keep the cache for
+        # fast iteration; they produce no provenance, so cache poisoning is
+        # not an L3 concern at that layer.
+        cache: ${{ needs.gate.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
 
   provenance:
     # Gated on release-events (default: non-pull-request) so adopters can

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -125,7 +125,10 @@ jobs:
           events: ${{ inputs.release-events }}
 
   build:
-    needs: [guard]
+    # needs `gate` so the build can read should-release and disable the
+    # uv cache for release builds (SLSA L3 isolation — see the `cache:`
+    # input below and docs/SLSA_L3_AUDIT.md Finding 1).
+    needs: [guard, gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read    # minimal — no OIDC, no publish
@@ -148,6 +151,13 @@ jobs:
           path: ${{ inputs.path }}
           python-version: ${{ inputs.python-version }}
           run-tests: ${{ inputs.run-tests }}
+          # Disable the uv cache on release builds. should-release == 'true'
+          # means this event produces L3 provenance, so the build must not
+          # consume a shared, cross-build, unverified-on-hit cache — see
+          # docs/SLSA_L3_AUDIT.md Finding 1. PR builds keep the cache for
+          # fast iteration; they produce no provenance, so cache poisoning
+          # is not an L3 concern at that layer.
+          cache: ${{ needs.gate.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
 
       # Namespace artifact names by the path-derived shortname so multiple
       # python builds in one workflow don't collide.

--- a/actions/scan/README.md
+++ b/actions/scan/README.md
@@ -6,7 +6,7 @@ Run wrangle's bundled source-stage security scanners (OSV-Scanner, Zizmor, Score
 
 ## Why pair this with a build/publish workflow
 
-Wrangle's build/publish workflows produce signed SLSA L3 provenance over the bytes they ship. That provenance attests *how* the build happened — but it does not attest that the source was trustworthy. The May 2026 Mini Shai-Hulud compromise of TanStack/router illustrates the gap: a `pull_request_target` workflow with checkout of PR-head SHA let attacker code execute in the privileged base context, poison the GitHub Actions cache, and pollute legitimate downstream builds with malicious modules. The build was honest; the attestation was honest; the source side was the gap.
+Wrangle's build/publish workflows produce signed SLSA provenance (Build L3) over the bytes they ship. That provenance attests *how* the build happened — but it does not attest that the source was trustworthy. The May 2026 Mini Shai-Hulud compromise of TanStack/router illustrates the gap: a `pull_request_target` workflow with checkout of PR-head SHA let attacker code execute in the privileged base context, poison the GitHub Actions cache, and pollute legitimate downstream builds with malicious modules. The build was honest; the attestation was honest; the source side was the gap.
 
 This scan composite closes that gap on every PR and push to main:
 

--- a/build/README.md
+++ b/build/README.md
@@ -27,7 +27,7 @@ Example vulnerability scan results:
 
 ## Python with GitHub Actions
 
-Build Python wheels and sdists, run pytest, generate an SPDX SBOM, and produce SLSA L3 provenance via `slsa-github-generator`. Publish to PyPI via Trusted Publishing (no API tokens required) with PEP 740 attestations.
+Build Python wheels and sdists, run pytest, generate an SPDX SBOM, and produce SLSA provenance (Build L3) via `slsa-github-generator`. Publish to PyPI via Trusted Publishing (no API tokens required) with PEP 740 attestations.
 
 * A reusable workflow that runs build + test + SBOM + SLSA provenance. [Example](/gh_workflow_examples/build_python.yml)
 * The composite [action](/build/actions/python/action.yml) for plugging into existing workflows (build + test + SBOM only).

--- a/build/README.md
+++ b/build/README.md
@@ -9,6 +9,10 @@ Currently supported build types:
 - **Python** — see [`actions/python/README.md`](actions/python/README.md).
 - **Shell** — see the [example workflow](/gh_workflow_examples/build_shell.yml).
 
+## Build Track level
+
+Every wrangle build-type reusable workflow that produces provenance — npm, pnpm, pip, uv, and container — meets **SLSA v1.2 Build L3** when consumed through wrangle's reusable workflow on GitHub-hosted runners. Shell produces no artifact and no provenance, so no Build Track level applies to it. Each build type's README states its level and the conditions that narrow it; the source-of-truth discussion is [`docs/SPEC.md` §"Build Track level"](../docs/SPEC.md) and the full per-builder analysis is [`docs/SLSA_L3_AUDIT.md`](../docs/SLSA_L3_AUDIT.md).
+
 ## Containers with GitHub Actions
 
 ### User Instructions

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -1,6 +1,6 @@
 # Wrangle Build Container
 
-A GitHub composite action that builds and publishes a container image to GitHub Container Registry (ghcr.io), generates and extracts an SBOM, and (when wired into the reusable workflow) signs the image with Cosign and attaches SLSA L3 provenance.
+A GitHub composite action that builds and publishes a container image to GitHub Container Registry (ghcr.io), generates and extracts an SBOM, and (when wired into the reusable workflow) signs the image with Cosign and attaches SLSA provenance (Build L3).
 
 > **Note:** This README documents *currently-shipped* behavior. For the full design — including Cosign signing, SLSA L3 provenance, the release gate, failure contract, and trust model — see [`SPEC.md`](./SPEC.md). The spec is forward-looking; features described there but not yet implemented in `action.yml` will land in follow-up PRs, and this README will be updated in the same commit. The full structure this README must eventually cover (quick-start example, verification commands, failure runbook) is defined in [`SPEC.md` §"Required contents of `build/actions/container/README.md`"](./SPEC.md#required-contents-of-buildactionscontainerreadmemd).
 

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -8,6 +8,15 @@ A GitHub composite action that builds and publishes a container image to GitHub 
 
 This action hardens *how* your container image is produced. It does NOT scan your source — vulnerable deps in your Dockerfile's base image or pinned packages, dangerous workflow triggers, or missing branch protection still slip through and would be faithfully L3-attested by wrangle as legitimately built. Pair this with wrangle's source-scan workflow ([`actions/scan/README.md`](../../../actions/scan/README.md)) to close that gap on every PR and push. Without it, an attacker who lands a malicious dep or workflow misconfiguration routes around the build-side hardening — the May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical recent example of why this matters.
 
+## Build Track level
+
+Consumed through wrangle's reusable workflow (`build_and_publish_container.yml`), the container build meets **SLSA v1.2 Build L3**. You do not need to reason about individual SLSA L3 requirements to use this — the single Build Track level is the claim. Two conditions narrow it:
+
+- **Reusable consumption only.** Calling the `build/actions/container` composite directly from a workflow you author yourself forfeits the build-vs-sign job separation and is **not** a supported L3 path.
+- **GitHub-hosted runners only.** Self-hosted runners invalidate the build-environment isolation the L3 verdict assumes.
+
+Release builds run with the BuildKit `type=gha` cache disabled, so the attested image cannot be influenced by a shared, cross-build cache that BuildKit does not re-verify on cache hits (SLSA's "Isolated" requirement). PR builds keep the cache for fast iteration — they produce no attested artifact. The full per-builder analysis is [`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md) (Finding 2).
+
 ## What this action does today
 
 - Builds a Docker image from a Dockerfile at a caller-provided path

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -17,6 +17,27 @@ inputs:
   github_token:
     description: "GitHub token with packages:write access"
     required: true
+  cache:
+    description: |
+      Whether the BuildKit GitHub Actions cache (cache-from / cache-to
+      type=gha) is used. "enabled" (default) restores and writes the
+      shared cross-build cache; "disabled" builds with no BuildKit cache
+      at all. Validated against the enabled|disabled allowlist by
+      validate_inputs.sh — any other value fails the build.
+
+      The reusable workflow (build_and_publish_container.yml) sets this to
+      "disabled" for release builds and "enabled" for PR builds. A release
+      build MUST NOT consume the shared cache: BuildKit's type=gha cache is
+      not re-verified on cache hits and is shared cross-build via GitHub's
+      branch-scoped cache service, so a poisoned entry could alter the
+      bytes the SLSA generator signs over. Skipping the cache for release
+      builds keeps the container path at SLSA v1.2 Build L3 — see
+      docs/SLSA_L3_AUDIT.md Finding 2.
+
+      Direct callers of this composite (not a supported L3 path) get
+      caching by default; they are not claiming L3 provenance.
+    required: false
+    default: "enabled"
 
 outputs:
   digest:
@@ -45,9 +66,10 @@ runs:
         INPUT_IMAGENAME: ${{ inputs.imagename }}
         INPUT_PATH: ${{ inputs.path }}
         INPUT_REGISTRY: ${{ inputs.registry }}
+        INPUT_CACHE: ${{ inputs.cache }}
       run: |
         set -euo pipefail
-        "${{ github.action_path }}/validate_inputs.sh" "$INPUT_PATH" "$INPUT_REGISTRY" "$INPUT_IMAGENAME"
+        "${{ github.action_path }}/validate_inputs.sh" "$INPUT_PATH" "$INPUT_REGISTRY" "$INPUT_IMAGENAME" "$INPUT_CACHE"
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -86,8 +108,20 @@ runs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        # BuildKit GHA cache, gated on the `cache` input. When cache is not
+        # 'enabled' both keys resolve to empty strings, which docker/
+        # build-push-action treats as "no cache" — release builds consume no
+        # shared cross-build state, so a poisoned cache entry cannot influence
+        # the bytes the SLSA generator signs over (SLSA v1.2 Build L3
+        # isolation — docs/SLSA_L3_AUDIT.md Finding 2). `inputs.cache` is
+        # validated to enabled|disabled by validate_inputs.sh and is only
+        # compared against a literal here (never expanded into a shell or
+        # into the image), so it carries no injection surface.
+        #
+        # The truthy branch MUST be on the `&&` side: GHA treats '' as
+        # falsy, so `cond && '' || 'type=gha'` would always yield 'type=gha'.
+        cache-from: ${{ inputs.cache == 'enabled' && 'type=gha' || '' }}
+        cache-to: ${{ inputs.cache == 'enabled' && 'type=gha,mode=max' || '' }}
         sbom: true
         provenance: mode=max
 

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -97,11 +97,13 @@ teardown() {
 }
 
 @test "container: action.yml gates cache-from/cache-to on the cache input" {
-    # Both BuildKit cache keys must be conditional on inputs.cache so a
-    # release build (cache: disabled) emits no type=gha cache.
-    run grep -E 'cache-from:.*inputs\.cache' "$ACTION_DIR/action.yml"
+    # Pin the full expression — operator and operands. A loose
+    # 'mentions inputs.cache' regex would still pass if the condition
+    # were inverted (!= instead of ==), which turns caching ON for
+    # release builds: the exact Build L3 downgrade this gating prevents.
+    run grep -F "cache-from: \${{ inputs.cache == 'enabled' && 'type=gha' || '' }}" "$ACTION_DIR/action.yml"
     [[ "$status" -eq 0 ]]
-    run grep -E 'cache-to:.*inputs\.cache' "$ACTION_DIR/action.yml"
+    run grep -F "cache-to: \${{ inputs.cache == 'enabled' && 'type=gha,mode=max' || '' }}" "$ACTION_DIR/action.yml"
     [[ "$status" -eq 0 ]]
     # The unconditional type=gha cache config must be gone.
     run grep -E '^[[:space:]]+cache-from:[[:space:]]*type=gha[[:space:]]*$' "$ACTION_DIR/action.yml"

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -32,35 +32,94 @@ teardown() {
 }
 
 @test "container: validate_inputs.sh rejects absolute path" {
-    run "$ACTION_DIR/validate_inputs.sh" "/etc" "ghcr.io" "ghcr.io/owner/img"
+    run "$ACTION_DIR/validate_inputs.sh" "/etc" "ghcr.io" "ghcr.io/owner/img" "enabled"
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"path must be relative"* ]]
 }
 
 @test "container: validate_inputs.sh rejects traversal" {
-    run "$ACTION_DIR/validate_inputs.sh" "../etc" "ghcr.io" "ghcr.io/owner/img"
+    run "$ACTION_DIR/validate_inputs.sh" "../etc" "ghcr.io" "ghcr.io/owner/img" "enabled"
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"traversal"* ]]
 }
 
 @test "container: validate_inputs.sh rejects bad registry" {
-    run "$ACTION_DIR/validate_inputs.sh" "src" "BAD;REGISTRY" "ghcr.io/owner/img"
+    run "$ACTION_DIR/validate_inputs.sh" "src" "BAD;REGISTRY" "ghcr.io/owner/img" "enabled"
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"invalid registry"* ]]
 }
 
 @test "container: validate_inputs.sh rejects bad imagename" {
-    run "$ACTION_DIR/validate_inputs.sh" "src" "ghcr.io" "BAD IMAGE"
+    run "$ACTION_DIR/validate_inputs.sh" "src" "ghcr.io" "BAD IMAGE" "enabled"
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"invalid image name"* ]]
 }
 
 @test "container: validate_inputs.sh writes path/imagename/shortname to GITHUB_OUTPUT" {
-    run "$ACTION_DIR/validate_inputs.sh" "pkg/foo" "ghcr.io" "ghcr.io/owner/img"
+    run "$ACTION_DIR/validate_inputs.sh" "pkg/foo" "ghcr.io" "ghcr.io/owner/img" "enabled"
     [[ "$status" -eq 0 ]]
     grep -q '^path=pkg/foo$' "$GITHUB_OUTPUT"
     grep -q '^imagename=ghcr.io/owner/img$' "$GITHUB_OUTPUT"
     grep -q '^shortname=pkg_foo$' "$GITHUB_OUTPUT"
+}
+
+# --- Cache gating (SLSA L3 isolation, #224 / SLSA_L3_AUDIT.md Finding 2) ---
+
+@test "container: validate_inputs.sh accepts cache=enabled and cache=disabled" {
+    run "$ACTION_DIR/validate_inputs.sh" "src" "ghcr.io" "ghcr.io/owner/img" "enabled"
+    [[ "$status" -eq 0 ]]
+    run "$ACTION_DIR/validate_inputs.sh" "src" "ghcr.io" "ghcr.io/owner/img" "disabled"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: validate_inputs.sh rejects an invalid cache value" {
+    # A typo must fail loudly — silently leaving the cache on would
+    # downgrade a release build from Build L3 to Build L2.
+    run "$ACTION_DIR/validate_inputs.sh" "src" "ghcr.io" "ghcr.io/owner/img" "disabeld"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"invalid cache value"* ]]
+}
+
+@test "container: validate_inputs.sh rejects a missing cache argument" {
+    run "$ACTION_DIR/validate_inputs.sh" "src" "ghcr.io" "ghcr.io/owner/img"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "container: action.yml exposes a cache input" {
+    run grep -E '^  cache:' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: action.yml passes cache to validate_inputs.sh" {
+    run grep -E 'validate_inputs.sh.*INPUT_CACHE' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: action.yml gates cache-from/cache-to on the cache input" {
+    # Both BuildKit cache keys must be conditional on inputs.cache so a
+    # release build (cache: disabled) emits no type=gha cache.
+    run grep -E 'cache-from:.*inputs\.cache' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+    run grep -E 'cache-to:.*inputs\.cache' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+    # The unconditional type=gha cache config must be gone.
+    run grep -E '^[[:space:]]+cache-from:[[:space:]]*type=gha[[:space:]]*$' "$ACTION_DIR/action.yml"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "container: build job needs gate so it can read should-release" {
+    local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
+    run bash -c "sed -n '/^  build:/,/^  [a-z]/p' \"$wf\" | grep -E 'needs:.*gate'"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: reusable workflow disables cache for release builds" {
+    # The composite's cache input must be driven by should-release:
+    # 'disabled' on release, 'enabled' otherwise.
+    local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
+    run bash -c "grep -E \"cache:.*should-release.*'disabled'.*'enabled'\" \"$wf\""
+    [[ "$status" -eq 0 ]]
 }
 
 # --- Unified metadata layout assertions (#150) ---

--- a/build/actions/container/validate_inputs.sh
+++ b/build/actions/container/validate_inputs.sh
@@ -7,20 +7,32 @@
 # imagename are checked here against narrow allowlists because they
 # are container-specific.
 #
-# Usage: build/actions/container/validate_inputs.sh <path> <registry> <imagename>
+# Usage: build/actions/container/validate_inputs.sh <path> <registry> <imagename> <cache>
 
 set -euo pipefail
 set -f  # disable globbing — processes external input
 
-if [[ $# -ne 3 ]]; then
-    printf 'Usage: %s <path> <registry> <imagename>\n' "$0" >&2
+if [[ $# -ne 4 ]]; then
+    printf 'Usage: %s <path> <registry> <imagename> <cache>\n' "$0" >&2
     exit 1
 fi
 
 INPUT_PATH="$1"
 INPUT_REGISTRY="$2"
 INPUT_IMAGENAME="$3"
+INPUT_CACHE="$4"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Reject any cache value that is not the exact enabled|disabled allowlist.
+# This is load-bearing for SLSA L3: the reusable workflow passes
+# cache=disabled for release builds, and a typo there must fail the build
+# loudly rather than silently leave the BuildKit cache on (which would
+# downgrade the release build from Build L3 to Build L2). See
+# docs/SLSA_L3_AUDIT.md Finding 2.
+if [[ ! "$INPUT_CACHE" =~ ^(enabled|disabled)$ ]]; then
+    printf 'Error: invalid cache value: %s (expected "enabled" or "disabled")\n' "$INPUT_CACHE" >&2
+    exit 1
+fi
 
 "$SCRIPT_DIR/../../../lib/validate_path.sh" "$INPUT_PATH"
 

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -8,6 +8,17 @@ Build an npm or pnpm package (tarball via `npm pack` or `pnpm pack`), run tests,
 
 This action hardens *how* your artifact is produced. It does NOT scan your source — vulnerable deps in your lockfile, dangerous workflow triggers, or missing branch protection still slip through and would be faithfully L3-attested by wrangle as legitimately built. Pair this with wrangle's source-scan workflow ([`actions/scan/README.md`](../../../actions/scan/README.md)) to close that gap on every PR and push. The May 2026 Mini Shai-Hulud compromise of TanStack/router is the most recent example of why this matters — the build side wasn't the vulnerability; the source side was.
 
+## Build Track level
+
+Consumed through wrangle's reusable workflow (`build_and_publish_npm.yml`), the npm build meets **SLSA v1.2 Build L3** — for both the npm and the pnpm sub-path. You do not need to reason about individual SLSA L3 requirements to use this — the single Build Track level is the claim. Two conditions narrow it:
+
+- **Reusable consumption only.** Calling the `build/actions/npm` composite directly from a workflow you author yourself forfeits the build-vs-sign job separation and is **not** a supported L3 path.
+- **GitHub-hosted runners only.** Self-hosted runners invalidate the build-environment isolation the L3 verdict assumes.
+
+The npm sub-path keeps dependency caching on in both PR and release builds: `npm ci` re-verifies every cached tarball against `package-lock.json` on install, so the cache cannot poison the attested output (SLSA's "Isolated" requirement). The pnpm sub-path uses no cross-build cache at all (see [#205](https://github.com/TomHennen/wrangle/issues/205)). The full per-builder analysis is [`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md).
+
+This Build Track level is wrangle's build-platform claim. It is distinct from — and additional to — the SLSA L2 in-CLI attestation that `npm publish --provenance` writes into the npm registry slot from your publish job; see ["SLSA provenance verification"](#slsa-provenance-verification-default-on-opt-out) below for how the two attestations relate.
+
 ## Before first use
 
 Complete these in order — step 1's bootstrap publish requires an `NPM_TOKEN`, which step 3 disallows.

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -1,6 +1,6 @@
 # Wrangle Build npm
 
-Build an npm or pnpm package (tarball via `npm pack` or `pnpm pack`), run tests, generate an SBOM, and produce SLSA L3 build provenance via `slsa-github-generator`. Package manager is detected from the lockfile (`package-lock.json` / `npm-shrinkwrap.json` → npm; `pnpm-lock.yaml` → pnpm). The publish step itself runs in the adopter's own workflow because npm Trusted Publishing's OIDC token must come from the caller's workflow filename, not a reusable workflow ([npm/documentation#1755](https://github.com/npm/documentation/issues/1755)).
+Build an npm or pnpm package (tarball via `npm pack` or `pnpm pack`), run tests, generate an SBOM, and produce SLSA provenance (Build L3) via `slsa-github-generator`. Package manager is detected from the lockfile (`package-lock.json` / `npm-shrinkwrap.json` → npm; `pnpm-lock.yaml` → pnpm). The publish step itself runs in the adopter's own workflow because npm Trusted Publishing's OIDC token must come from the caller's workflow filename, not a reusable workflow ([npm/documentation#1755](https://github.com/npm/documentation/issues/1755)).
 
 > **Note:** This README documents *currently-shipped* behavior. For the full design — architecture, attestation model, full step sequence — see [`SPEC.md`](./SPEC.md). For npm workspaces support (multi-package monorepos), see [`WORKSPACES_PHASE_1.md`](./WORKSPACES_PHASE_1.md) — design only; not yet implemented.
 

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -8,6 +8,15 @@ Build a Python package (wheel + sdist), run tests, generate an SBOM, and produce
 
 This action hardens *how* your artifact is produced. It does NOT scan your source — vulnerable deps in your lockfile, dangerous workflow triggers, or missing branch protection still slip through and would be faithfully L3-attested by wrangle as legitimately built. Pair this with wrangle's source-scan workflow ([`actions/scan/README.md`](../../../actions/scan/README.md)) to close that gap on every PR and push. Without it, an attacker who lands a malicious dep or workflow misconfiguration routes around the build-side hardening — the May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical recent example.
 
+## Build Track level
+
+Consumed through wrangle's reusable workflow (`build_and_publish_python.yml`), the python build meets **SLSA v1.2 Build L3** — for both the pip and the uv sub-path. You do not need to reason about individual SLSA L3 requirements to use this — the single Build Track level is the claim. Two conditions narrow it:
+
+- **Reusable consumption only.** Calling the `build/actions/python` composite directly from a workflow you author yourself forfeits the build-vs-sign job separation and is **not** a supported L3 path.
+- **GitHub-hosted runners only.** Self-hosted runners invalidate the build-environment isolation the L3 verdict assumes.
+
+On the uv sub-path, release builds run with the uv cache disabled (`setup-uv`'s `enable-cache: false`), so the attested artifact cannot be influenced by a shared, cross-build cache that uv does not re-verify on cache hits (SLSA's "Isolated" requirement). PR builds keep the cache for fast iteration — they produce no attested artifact. The pip sub-path consumes no cross-build cache in either case. The full per-builder analysis is [`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md) (Finding 1).
+
 ## Before first use
 
 1. **Configure a Trusted Publisher on PyPI.** Project → Publishing → Add a trusted publisher. Specify your GitHub repository, workflow filename (`build_python.yml`), and optionally an environment name.

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -1,6 +1,6 @@
 # Wrangle Build Python
 
-Build a Python package (wheel + sdist), run tests, generate an SBOM, and produce SLSA L3 build provenance — composing PyPI Trusted Publishing (PEP 740 attestations) with `slsa-github-generator`. The publish step itself runs in the adopter's own workflow because PyPI Trusted Publishing's OIDC token must come from the caller, not a reusable workflow ([pypi/warehouse#11096](https://github.com/pypi/warehouse/issues/11096)).
+Build a Python package (wheel + sdist), run tests, generate an SBOM, and produce SLSA provenance (Build L3) — composing PyPI Trusted Publishing (PEP 740 attestations) with `slsa-github-generator`. The publish step itself runs in the adopter's own workflow because PyPI Trusted Publishing's OIDC token must come from the caller, not a reusable workflow ([pypi/warehouse#11096](https://github.com/pypi/warehouse/issues/11096)).
 
 > **Note:** This README documents *currently-shipped* behavior. For the full design — architecture, security model, full step sequence — see [`SPEC.md`](./SPEC.md).
 

--- a/build/actions/python/action.yml
+++ b/build/actions/python/action.yml
@@ -19,6 +19,31 @@ inputs:
     description: "Whether to run pytest before building"
     required: false
     default: "true"
+  cache:
+    description: |
+      Whether the uv dependency cache (astral-sh/setup-uv's enable-cache)
+      is used on the uv sub-path. "enabled" (default) lets setup-uv restore
+      and save the shared uv cache; "disabled" passes enable-cache: false
+      so uv downloads every dependency fresh. Validated against the
+      enabled|disabled allowlist by validate_inputs.sh — any other value
+      fails the build.
+
+      This input only affects the uv sub-path (a project with uv.lock).
+      The pip sub-path never opts into actions/setup-python's cache, so
+      this input is a no-op there.
+
+      The reusable workflow (build_and_publish_python.yml) sets this to
+      "disabled" for release builds and "enabled" for PR builds. uv does
+      not re-verify cached files against the lockfile on cache hits, and
+      the uv cache is shared cross-build via GitHub's cache service, so a
+      release build that consumed it could attest poisoned bytes.
+      Disabling the cache for release builds keeps the uv path at SLSA
+      v1.2 Build L3 — see docs/SLSA_L3_AUDIT.md Finding 1.
+
+      Direct callers of this composite (not a supported L3 path) get
+      caching by default; they are not claiming L3 provenance.
+    required: false
+    default: "enabled"
 
 outputs:
   version:
@@ -41,9 +66,10 @@ runs:
       shell: bash
       env:
         INPUT_PATH: ${{ inputs.path }}
+        INPUT_CACHE: ${{ inputs.cache }}
       run: |
         set -euo pipefail
-        "${{ github.action_path }}/validate_inputs.sh" "$INPUT_PATH"
+        "${{ github.action_path }}/validate_inputs.sh" "$INPUT_PATH" "$INPUT_CACHE"
 
     - name: Setup Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -69,6 +95,14 @@ runs:
     - name: Install uv
       if: steps.tooling.outputs.use_uv == 'true'
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        # Release builds (cache: disabled) pass enable-cache: false so the
+        # build consumes no shared uv cache — uv does not re-hash cached
+        # files on cache hits, so a poisoned entry could be attested.
+        # See docs/SLSA_L3_AUDIT.md Finding 1. validate_inputs.sh constrains
+        # `cache` to enabled|disabled, so this resolves to exactly
+        # true or false.
+        enable-cache: ${{ inputs.cache != 'disabled' }}
 
     - name: Install dependencies
       shell: bash

--- a/build/actions/python/test.bats
+++ b/build/actions/python/test.bats
@@ -102,6 +102,54 @@ setup() {
     [[ "$status" -eq 0 ]]
 }
 
+# --- Cache gating (SLSA L3 isolation, #224 / SLSA_L3_AUDIT.md Finding 1) ---
+
+@test "python: validate_inputs.sh accepts cache=enabled and cache=disabled" {
+    # validate_path.sh rejects absolute paths, so use a relative project
+    # dir: cd into a temp dir and pass the relative subdir name.
+    local tmp
+    tmp="$(mktemp -d)"
+    mkdir -p "$tmp/proj"
+    printf '[project]\nname = "x"\nversion = "0"\n' > "$tmp/proj/pyproject.toml"
+    cd "$tmp"
+    run "$ACTION_DIR/validate_inputs.sh" "proj" "enabled"
+    [[ "$status" -eq 0 ]]
+    run "$ACTION_DIR/validate_inputs.sh" "proj" "disabled"
+    [[ "$status" -eq 0 ]]
+    rm -rf "$tmp"
+}
+
+@test "python: validate_inputs.sh rejects an invalid cache value" {
+    # A typo must fail loudly — silently leaving the uv cache on would
+    # downgrade a release build from Build L3 to Build L2.
+    run "$ACTION_DIR/validate_inputs.sh" "." "enabledd"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"invalid cache value"* ]]
+}
+
+@test "python: validate_inputs.sh rejects a missing cache argument" {
+    run "$ACTION_DIR/validate_inputs.sh" "."
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "python: action.yml exposes a cache input" {
+    run grep -E '^  cache:' "$ACTION"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "python: action.yml passes cache to validate_inputs.sh" {
+    run grep -E 'validate_inputs.sh.*INPUT_CACHE' "$ACTION"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "python: action.yml gates setup-uv enable-cache on the cache input" {
+    # setup-uv's enable-cache must be conditional on inputs.cache so a
+    # release build (cache: disabled) passes enable-cache: false.
+    run grep -E 'enable-cache:.*inputs\.cache' "$ACTION"
+    [[ "$status" -eq 0 ]]
+}
+
 # --- Reusable workflow structural tests ---
 
 @test "python: workflow exists" {
@@ -141,6 +189,18 @@ setup() {
     run grep -E '^  gate:' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
     run grep -E 'TomHennen/wrangle/actions/release_gate' "$WORKFLOW"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "python: build job needs gate so it can read should-release" {
+    run bash -c "sed -n '/^  build:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E 'needs:.*gate'"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "python: reusable workflow disables the uv cache for release builds" {
+    # The composite's cache input must be driven by should-release:
+    # 'disabled' on release, 'enabled' otherwise (SLSA_L3_AUDIT Finding 1).
+    run bash -c "grep -E \"cache:.*should-release.*'disabled'.*'enabled'\" \"$WORKFLOW\""
     [[ "$status" -eq 0 ]]
 }
 

--- a/build/actions/python/test.bats
+++ b/build/actions/python/test.bats
@@ -96,8 +96,11 @@ setup() {
     [[ "$status" -eq 1 ]]
 }
 
-@test "python: validate_inputs.sh disables globbing via lib/validate_path.sh" {
-    # External input flows through validate_path.sh; CLAUDE.md requires set -f there.
+@test "python: validate_inputs.sh and validate_path.sh disable globbing with set -f" {
+    # Both process external input (validate_inputs.sh now also takes the
+    # cache arg); CLAUDE.md requires set -f in scripts that do.
+    run grep '^set -f' "$ACTION_DIR/validate_inputs.sh"
+    [[ "$status" -eq 0 ]]
     run grep '^set -f' "$REPO_ROOT/lib/validate_path.sh"
     [[ "$status" -eq 0 ]]
 }
@@ -144,9 +147,11 @@ setup() {
 }
 
 @test "python: action.yml gates setup-uv enable-cache on the cache input" {
-    # setup-uv's enable-cache must be conditional on inputs.cache so a
-    # release build (cache: disabled) passes enable-cache: false.
-    run grep -E 'enable-cache:.*inputs\.cache' "$ACTION"
+    # Pin the full expression — operator and operand. A loose
+    # 'mentions inputs.cache' regex would still pass if the condition
+    # were inverted (== instead of !=), which turns the uv cache ON for
+    # release builds: the exact Build L3 downgrade this gating prevents.
+    run grep -F "enable-cache: \${{ inputs.cache != 'disabled' }}" "$ACTION"
     [[ "$status" -eq 0 ]]
 }
 

--- a/build/actions/python/validate_inputs.sh
+++ b/build/actions/python/validate_inputs.sh
@@ -5,17 +5,29 @@
 # the action reads python-version from it via actions/setup-python's
 # python-version-file, so legacy setup.py-only projects aren't supported.
 #
-# Usage: build/actions/python/validate_inputs.sh <path>
+# Usage: build/actions/python/validate_inputs.sh <path> <cache>
 
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-    printf 'Usage: %s <path>\n' "$0" >&2
+if [[ $# -ne 2 ]]; then
+    printf 'Usage: %s <path> <cache>\n' "$0" >&2
     exit 1
 fi
 
 INPUT_PATH="$1"
+INPUT_CACHE="$2"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Reject any cache value that is not the exact enabled|disabled allowlist.
+# This is load-bearing for SLSA L3: the reusable workflow passes
+# cache=disabled for release builds, and a typo there must fail the build
+# loudly rather than silently leave the uv cache on (which would downgrade
+# the release build from Build L3 to Build L2). See docs/SLSA_L3_AUDIT.md
+# Finding 1.
+if [[ ! "$INPUT_CACHE" =~ ^(enabled|disabled)$ ]]; then
+    printf 'Error: invalid cache value: %s (expected "enabled" or "disabled")\n' "$INPUT_CACHE" >&2
+    exit 1
+fi
 
 "$SCRIPT_DIR/../../../lib/validate_path.sh" "$INPUT_PATH"
 

--- a/build/actions/python/validate_inputs.sh
+++ b/build/actions/python/validate_inputs.sh
@@ -8,6 +8,7 @@
 # Usage: build/actions/python/validate_inputs.sh <path> <cache>
 
 set -euo pipefail
+set -f  # disable globbing — processes external input
 
 if [[ $# -ne 2 ]]; then
     printf 'Usage: %s <path> <cache>\n' "$0" >&2

--- a/docs/SLSA_L3_AUDIT.md
+++ b/docs/SLSA_L3_AUDIT.md
@@ -36,6 +36,15 @@ adopter consuming wrangle through one of wrangle's **reusable workflows**:
     `npm ci` is the command wrangle invokes, so the precondition holds
     by-construction; full detail at [npm path (npm sub-path)](#npm-path-npm-sub-path).
 
+> **Update — 2026-05-17.** Findings 1 and 2 are now **resolved** by
+> [PR #226](https://github.com/TomHennen/wrangle/pull/226) (issue
+> [#224](https://github.com/TomHennen/wrangle/issues/224)): the python-uv and
+> container reusable workflows disable their shared caches for release builds,
+> so **both paths now meet Build L3**. The "Build L2 today" rows above are the
+> point-in-time verdict at the audit date (commit `a84c855`); the "After
+> follow-up fix" column is now the live state. The per-builder analysis below
+> is kept as the historical record of why the fix was needed.
+
 Two caveats narrow every Build L3 row above:
 
 - **Direct composite consumption is not a supported L3 path.** Calling the
@@ -1385,6 +1394,12 @@ contract of #216.
 
 ### Finding 1: uv cache integrity gap on the python uv sub-path
 
+> **Resolved by [PR #226](https://github.com/TomHennen/wrangle/pull/226).**
+> The python reusable workflow now passes `cache=disabled` to the build
+> composite on release builds, which sets `astral-sh/setup-uv`'s
+> `enable-cache: false` — the preferred option (1) below. The analysis that
+> follows is retained as the historical record of the gap.
+
 **Summary.** `astral-sh/setup-uv@v8.1.0` is invoked at
 [`build/actions/python/action.yml:69–71`](../build/actions/python/action.yml)
 without `enable-cache: false`, so the uv cache is enabled by default on
@@ -1434,6 +1449,12 @@ builds; protection is conditional on `$RUNNER_TEMP` ephemerality. Spawn a
 follow-up issue tracking whichever path is chosen.
 
 ### Finding 2: BuildKit GHA cache integrity gap on the container path
+
+> **Resolved by [PR #226](https://github.com/TomHennen/wrangle/pull/226).**
+> The container reusable workflow now passes `cache=disabled` to the build
+> composite on release builds, which drops `cache-from`/`cache-to` from the
+> `docker/build-push-action` step — the preferred recommendation below. The
+> analysis that follows is retained as the historical record of the gap.
 
 **Summary.** [`build/actions/container/action.yml:89–90`](../build/actions/container/action.yml)
 sets `cache-from: type=gha` and `cache-to: type=gha,mode=max`. BuildKit

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -218,6 +218,19 @@ Why default-on. Verification belongs in wrangle as a default-on guarantee, not i
 
 Why opt-out exists. Some adopters run custom verification policies (different `--source-uri` constraints, custom cert identities, ratchet-style multi-tag-tolerance). For those cases the opt-out lets them keep wrangle's build/provenance/attestation while replacing the verify step. The contract becomes: wrangle still pushes/builds/attests, but the integrity-between-build-and-publish guarantee shifts to the adopter.
 
+### Build Track level
+
+Every wrangle build-type reusable workflow that produces provenance — `build_and_publish_npm.yml` (npm and pnpm), `build_and_publish_python.yml` (pip and uv), and `build_and_publish_container.yml` — meets **SLSA v1.2 Build L3**. `build_shell.yml` produces no artifact and no provenance, so no Build Track level applies to it.
+
+Wrangle's user-facing docs claim exactly **one** Build Track level per workflow — Build L2 or Build L3 — and never a finer-grained, requirement-by-requirement breakdown. An adopter should not have to reason about individual SLSA L3 requirements ("Provenance is Unforgeable" versus "Isolated") to know what a workflow delivers; the single Build Track level is the claim. The full per-builder analysis behind the L3 verdicts is [`docs/SLSA_L3_AUDIT.md`](SLSA_L3_AUDIT.md).
+
+Two conditions narrow every Build L3 claim:
+
+- **Reusable consumption only.** The verdict assumes the adopter consumes wrangle through one of wrangle's reusable workflows. Calling a `build/actions/<type>` composite directly from an adopter-authored job forfeits the build-vs-sign job separation and is **not** a supported L3 path.
+- **GitHub-hosted runners only.** Self-hosted runners invalidate the ephemeral-build-environment assumption the L3 verdicts depend on.
+
+**Cache isolation is part of the L3 claim.** SLSA v1.2's "Isolated" requirement states the output of a build MUST be identical whether or not a cache is used. Two of wrangle's cache surfaces — the container path's BuildKit `type=gha` cache and the python-uv sub-path's uv cache — are shared cross-build via GitHub's cache service and are not re-verified on cache hits, so a release build must not consume them. Each of those two workflows gates its build cache on the same `should-release` signal that gates provenance: release builds (`should-release == 'true'`) build cache-free; PR builds keep caching for fast iteration, since they produce no attested artifact. The npm sub-path keeps its cache in both contexts because `npm ci` re-verifies every cached tarball against the lockfile on install; the pnpm sub-path and the python-pip sub-path consume no cross-build cache at all. See [`docs/SLSA_L3_AUDIT.md`](SLSA_L3_AUDIT.md) Findings 1 and 2 and its "Release-vs-PR build asymmetry" section.
+
 ## Architecture
 
 ### Layers

--- a/gh_workflow_examples/README.md
+++ b/gh_workflow_examples/README.md
@@ -14,12 +14,12 @@ Run shellcheck and bats tests on shell projects.
 
 ## build_and_publish_containers.yml
 
-Build, sign, and publish a container image with SBOM and SLSA L3 provenance.
+Build, sign, and publish a container image with SBOM and SLSA provenance (Build L3).
 
 ## build_npm.yml
 
-Build an npm package (`npm pack`), run tests, generate an SPDX SBOM, and produce SLSA L3 build provenance. Publishes to npmjs.org via Trusted Publishing (no `NPM_TOKEN`) — the publish job lives in the caller workflow because npm's Trusted Publishing OIDC token must come from the caller's workflow filename, not a reusable workflow. Adopters must bootstrap-publish v0.0.1 once manually and configure a [Trusted Publisher on npmjs.com](https://docs.npmjs.com/trusted-publishers/) before the first automated publish — see [`build/actions/npm/README.md`](/build/actions/npm/README.md) for the onboarding checklist.
+Build an npm package (`npm pack`), run tests, generate an SPDX SBOM, and produce SLSA provenance (Build L3). Publishes to npmjs.org via Trusted Publishing (no `NPM_TOKEN`) — the publish job lives in the caller workflow because npm's Trusted Publishing OIDC token must come from the caller's workflow filename, not a reusable workflow. Adopters must bootstrap-publish v0.0.1 once manually and configure a [Trusted Publisher on npmjs.com](https://docs.npmjs.com/trusted-publishers/) before the first automated publish — see [`build/actions/npm/README.md`](/build/actions/npm/README.md) for the onboarding checklist.
 
 ## build_python.yml
 
-Build a Python package (wheel + sdist), run pytest, generate an SPDX SBOM, and produce SLSA L3 build provenance. Optionally verify the provenance with `slsa-verifier` before publishing to PyPI via Trusted Publishing (no API tokens). Adopters must configure a [Trusted Publisher on PyPI](https://docs.pypi.org/trusted-publishers/) before the first publish — see [`build/actions/python/README.md`](/build/actions/python/README.md) for the onboarding checklist.
+Build a Python package (wheel + sdist), run pytest, generate an SPDX SBOM, and produce SLSA provenance (Build L3). Optionally verify the provenance with `slsa-verifier` before publishing to PyPI via Trusted Publishing (no API tokens). Adopters must configure a [Trusted Publisher on PyPI](https://docs.pypi.org/trusted-publishers/) before the first publish — see [`build/actions/python/README.md`](/build/actions/python/README.md) for the onboarding checklist.

--- a/gh_workflow_examples/build_npm.yml
+++ b/gh_workflow_examples/build_npm.yml
@@ -18,7 +18,7 @@
 # https://docs.npmjs.com/trusted-publishers/ (Troubleshooting)
 # https://github.com/npm/documentation/issues/1755
 #
-# Wrangle's reusable workflow generates SLSA L3 provenance AND verifies
+# Wrangle's reusable workflow generates SLSA provenance (Build L3) AND verifies
 # the just-built tarball against it before declaring success. If
 # verification fails, the workflow fails and `needs: [build]` blocks
 # publish — so adopters don't need to wire `slsa-verifier` into their

--- a/gh_workflow_examples/build_python.yml
+++ b/gh_workflow_examples/build_python.yml
@@ -13,7 +13,7 @@
 # from your workflow, not a reusable workflow. See:
 # https://github.com/pypi/warehouse/issues/11096
 #
-# Wrangle's reusable workflow generates SLSA L3 provenance AND verifies
+# Wrangle's reusable workflow generates SLSA provenance (Build L3) AND verifies
 # the just-built dist against it before declaring success. If verification
 # fails, the workflow fails and `needs: [build]` blocks publish — so
 # adopters don't need to wire `slsa-verifier` into their own publish job.


### PR DESCRIPTION
claude: Closes #224.

## What this does

The SLSA v1.2 Build L3 isolation audit (`docs/SLSA_L3_AUDIT.md`, #216) found the **container** and **python-uv** build paths meet only **Build L2**: both consume a GitHub-Actions–backed cache that is shared cross-build and not re-verified on cache hits, so a poisoned entry could alter the bytes the SLSA generator signs over — violating SLSA v1.2's "Isolated" requirement (*"the output of the build MUST be identical whether or not the cache is used"*).

This PR closes both gaps using the **release-vs-PR cache asymmetry** the audit recommends: release builds (which produce L3 provenance) build cache-free; PR builds (no provenance) keep caching for fast iteration.

## Changes

**Finding 2 — container (`build/actions/container/`)**
- New `cache` composite input. `cache-from` / `cache-to` `type=gha` are emitted only when `cache == 'enabled'`.
- `build_and_publish_container.yml` plumbs `cache` from the `gate` job: `disabled` when `should-release == 'true'`, `enabled` otherwise. The `build` job now `needs: gate`.

**Finding 1 — python-uv (`build/actions/python/`)**
- New `cache` composite input. `setup-uv`'s `enable-cache` is `false` on release builds — audit Finding 1, **Option 1** (not the `UV_CACHE_DIR` fallback), per the #217 review. Affects the uv sub-path only; the pip sub-path uses no cross-build cache either way.
- `build_and_publish_python.yml` plumbs `cache` the same way.

**Hardening.** Both `cache` inputs are validated against a strict `enabled|disabled` allowlist in `validate_inputs.sh`. A typo would otherwise *silently* leave the cache on for a release build — downgrading it from Build L3 to L2 with no error. The validator makes that fail loudly.

**Expression correctness.** `cache-from`/`cache-to` use `${{ inputs.cache == 'enabled' && 'type=gha' || '' }}` — the truthy value is deliberately on the `&&` side, because GHA treats `''` as falsy and `cond && '' || 'type=gha'` would always yield `type=gha`.

**Docs (item 3 of #224).** With both gaps closed, every wrangle build workflow that produces provenance is **Build L3**. `docs/SPEC.md` gains a "Build Track level" subsection; `build/README.md` and the container/python/npm build-type READMEs each make a single Build Track claim with the two narrowing caveats (reusable consumption only; GitHub-hosted runners only). `actions/scan/` (a source workflow — no Build Track level) and `gh_workflow_examples/` (already accurate post-fix, no requirement-split framing) were reviewed and need no change.

## Tests

`test.bats` updates for both composites, both `validate_inputs.sh` scripts, and both reusable workflows — cache input present, validator accepts `enabled`/`disabled` and rejects typos/missing args, `cache-from`/`cache-to` and `enable-cache` gated on the input, `build` job `needs: gate`, reusable workflow keys `cache` on `should-release`. All 162 affected bats tests pass locally; `shellcheck` clean.

## ⚠️ Follow-up required: self-ref pin bump

The reusable workflows still pin the composites at the pre-change SHA (`68b1caea…`) — a not-yet-merged commit cannot be referenced. So **integration CI on this PR exercises the reusable workflows against the *old* composites** (which silently ignore the new `cache` input); the new cache-gating behavior is covered here by unit tests. A routine **post-merge self-ref pin bump** — the same pattern as b5106b2 / #136 — is required for the reusable workflows to exercise the new gating end-to-end. Flagging so it isn't lost.

## Out of scope

Defense-in-depth items (the `::stop-commands::` guard and adopter-tunable PR-to-PR cache knobs) are tracked separately in #225 — splitting keeps this PR reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
