### PR TITLE
claude: Bump self-ref pins to main HEAD (post-#226 cleanup)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -80,7 +80,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
 
   gate:
     needs: [guard]
@@ -91,7 +91,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/release_gate@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -113,7 +113,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+      uses: TomHennen/wrangle/build/actions/container@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -125,7 +125,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
 
   gate:
     needs: [guard]
@@ -136,7 +136,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/release_gate@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -160,7 +160,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+      - uses: TomHennen/wrangle/build/actions/npm@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -104,7 +104,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -119,7 +119,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/release_gate@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+      - uses: TomHennen/wrangle/build/actions/python@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -29,7 +29,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
 
   shell-build:
     needs: [guard]
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+        uses: TomHennen/wrangle/build/actions/shell@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -20,7 +20,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
 
   check-change:
     needs: [guard]
@@ -38,6 +38,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+        uses: TomHennen/wrangle/actions/scan@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
         with:
           tools: ${{ inputs.tools }}


### PR DESCRIPTION
claude: routine post-merge self-reference pin bump, flagged in #226.

#226 added the `cache` input to the container and python build composites for SLSA Build L3 cache gating. Per wrangle's self-reference pattern (#136), the reusable workflows could not be pinned at #226's own not-yet-merged merge commit, so they still pointed at the pre-change SHA `68b1caea`. **Until this lands, the merged cache-gating composites are not actually invoked by the reusable workflows.**

This bumps all 13 self-references in `.github/workflows/` to current main HEAD (`204995d`, the #226 squash merge) via `tools/bump_action_pins.sh`. Mechanical SHA-only change, no logic. Same pattern as b5106b2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)