### PR TITLE
dep-review: invert change_type filter to fail safe against schema drift

### DIFF
--- a/tools/dependency-review/SPEC.md
+++ b/tools/dependency-review/SPEC.md
@@ -38,7 +38,9 @@ Severity mapping:
 
 With the default `fail-on-severity: high`, the upstream action only emits `high` / `critical` advisories, so in practice only the `error`-level rows occur; the `moderate` / `low` rows apply when an adopter lowers `fail-on-severity`. Either way, every advisory that reaches the converter blocks the PR — the SARIF `level` affects only how the GitHub Security tab renders a finding, not the `check_results.sh` gate.
 
-Only `change_type: "added"` entries are converted. A `"removed"` entry means the PR drops a vulnerable dependency, which must not block the PR.
+Every change except `change_type: "removed"` is converted — a `"removed"` entry means the PR drops a vulnerable dependency, which must not block the PR. The filter tests `!= "removed"` rather than `== "added"` so it fails safe: `change_type` is currently a two-value enum (`added`, `removed`), but if the upstream schema ever gains a new value, a vulnerable change of that type is still surfaced rather than silently dropped.
+
+A vulnerable change is converted regardless of its `scope` — a vulnerable `development`/build-time dependency is flagged exactly like a `runtime` one. That is deliberate and matches the default policy of blocking on any introduced vulnerability; scope-aware policy (à la dependency-review-action's `fail-on-scopes`) would belong with the per-tool configuration design in [#221](https://github.com/TomHennen/wrangle/issues/221).
 
 ## Known limitations
 

--- a/tools/dependency-review/test.bats
+++ b/tools/dependency-review/test.bats
@@ -282,6 +282,25 @@ EOF
     printf '%s' "$output" | jq -e '[.runs[].results[]] | length == 1' >/dev/null
 }
 
+@test "converter: unrecognized change_type is surfaced (fail-safe vs schema drift)" {
+    # change_type is currently enum(added, removed). The filter tests
+    # `!= "removed"` rather than `== "added"`, so a vulnerable change
+    # carrying a value the upstream schema might add later is still
+    # flagged rather than silently dropped.
+    cat > "$TMP_DIR/in.json" <<'EOF'
+[
+  { "change_type": "future-unknown-type", "manifest": "package.json", "ecosystem": "npm", "name": "p", "version": "1",
+    "vulnerabilities": [
+      { "severity": "high", "advisory_ghsa_id": "GHSA-drift", "advisory_summary": "s", "advisory_url": "u" }
+    ]
+  }
+]
+EOF
+    run "$TOOL_DIR/vulnerable_changes_to_sarif.sh" "$TMP_DIR/in.json"
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | jq -e '[.runs[].results[]] | length == 1' >/dev/null
+}
+
 @test "collect_outputs: empty env -> output.sarif + output.md, zero results" {
     META="$TMP_DIR/meta-empty"
     VULNERABLE_CHANGES='' run "$TOOL_DIR/collect_outputs.sh" "$META"

--- a/tools/dependency-review/vulnerable_changes_to_sarif.sh
+++ b/tools/dependency-review/vulnerable_changes_to_sarif.sh
@@ -14,6 +14,7 @@ set -f  # disable globbing — processes external tool output
 #       "ecosystem": "<eco>",
 #       "name": "<pkg>",
 #       "version": "<ver>",
+#       "scope": "runtime" | "development" | "unknown",
 #       "package_url": "<purl>",
 #       "vulnerabilities": [
 #         {
@@ -26,6 +27,14 @@ set -f  # disable globbing — processes external tool output
 #     },
 #     ...
 #   ]
+#
+# Scope policy: a vulnerable change is converted regardless of its
+# `scope` — a vulnerable development/build-time dependency is flagged
+# exactly like a runtime one. This is deliberate: the default policy is
+# to block on any introduced vulnerability, and "flag, don't guess" is
+# the conservative choice. If wrangle later wants scope-aware policy
+# (e.g. don't block on dev-only deps, like dependency-review-action's
+# `fail-on-scopes`), `scope` is the field to branch on.
 #
 # Usage: vulnerable_changes_to_sarif.sh <json_file>
 # Output: SARIF 2.1.0 JSON to stdout.
@@ -64,9 +73,13 @@ fi
 #     output is surfaced rather than silently mapped to a high level.
 #   - rules: one per unique GHSA id
 #   - results: one per (change, vulnerability)
-#   - only change_type "added" entries are converted. A "removed"
-#     entry means the PR drops a vulnerable dependency — that must not
-#     block the PR. A missing change_type defaults to "added".
+#   - every change EXCEPT change_type "removed" is converted. A
+#     "removed" entry means the PR drops a vulnerable dependency —
+#     that must not block the PR. The test is `!= "removed"` rather
+#     than `== "added"` so it fails safe: change_type is currently
+#     enum(added, removed), but should the upstream schema gain a new
+#     value, a vulnerable change of that type is still surfaced rather
+#     than silently dropped. A missing change_type defaults to "added".
 # Empty advisory_url / advisory_summary are omitted (SARIF requires
 # helpUri to be a valid URI when present; empty strings fail strict
 # validators).
@@ -89,7 +102,7 @@ SARIF_FILTER='
     end;
 
   [ .[]
-    | select((.change_type // "added") == "added") as $c
+    | select((.change_type // "added") != "removed") as $c
     | ($c.vulnerabilities // [])[]
     | {change: $c, vuln: .}
   ] as $pairs

--- a/tools/dependency-review/vulnerable_changes_to_sarif.sh
+++ b/tools/dependency-review/vulnerable_changes_to_sarif.sh
@@ -79,7 +79,8 @@ fi
 #     than `== "added"` so it fails safe: change_type is currently
 #     enum(added, removed), but should the upstream schema gain a new
 #     value, a vulnerable change of that type is still surfaced rather
-#     than silently dropped. A missing change_type defaults to "added".
+#     than silently dropped. A missing or null change_type is likewise
+#     not "removed", so it too is surfaced.
 # Empty advisory_url / advisory_summary are omitted (SARIF requires
 # helpUri to be a valid URI when present; empty strings fail strict
 # validators).
@@ -102,7 +103,7 @@ SARIF_FILTER='
     end;
 
   [ .[]
-    | select((.change_type // "added") != "removed") as $c
+    | select(.change_type != "removed") as $c
     | ($c.vulnerabilities // [])[]
     | {change: $c, vuln: .}
   ] as $pairs


### PR DESCRIPTION
## What

`tools/dependency-review/vulnerable_changes_to_sarif.sh` filtered changes with `select((.change_type // "added") == "added")`. This switches it to `!= "removed"`.

## Why

Reviewing the change_type handling raised the question: the filter keeps `added` and drops `removed` — is there an `updated` (or other) case being missed?

**There isn't.** `actions/dependency-review-action`'s `ChangeSchema` defines `change_type: z.enum(['added', 'removed'])` — exactly two values. A dependency *version bump* is not a third type; it's emitted as a `removed` (old version) + `added` (new version) pair, so `added` already catches every introduced version.

But `== "added"` is an allowlist that **fails silent**: if the upstream enum ever gains a value, a vulnerable change of that new type would be dropped rather than flagged — the wrong direction for a security gate.

The question the converter actually answers is *"is this vulnerable package present at the PR's head?"* — true for every change except a `removed`. So `!= "removed"` is both the semantically precise test and fails **safe**: an unknown future `change_type` is still surfaced.

Behavior is **identical today** (only `added`/`removed` exist). A new test (`converter: unrecognized change_type is surfaced`) locks in the fail-safe behavior; the existing `removed` and missing-`change_type` tests still pass unchanged.

## Also: documented the `scope` choice (no behavior change)

While here, documented something the converter does silently: it converts vulnerable changes **regardless of `scope`** (`runtime` / `development` / `unknown`) — a vulnerable dev/build-time dependency is flagged exactly like a runtime one. That's the conservative default (block on any introduced vuln); a comment in the script and a note in `SPEC.md` now make it an explicit, intentional choice. Scope-aware policy (à la `fail-on-scopes`) would belong with the per-tool config design in #221. No code change — just documentation, per review preference.

## Testing

`bats tools/dependency-review/test.bats` — 31/31 pass (was 30; +1 new). `shellcheck` clean.

## Origin

Review discussion on #220.