### PR TITLE
claude: stop-commands guard around build/test invocations (#225, Finding 3)

### DIFF
--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -97,6 +97,27 @@ runs:
         username: ${{ github.actor }}
         password: ${{ inputs.github_token }}
 
+    # Suspend GitHub Actions workflow-command processing for the docker
+    # build below. docker/build-push-action streams BuildKit's build
+    # output (every `RUN` layer's stdout) to the step log; a malicious
+    # Dockerfile could otherwise print a `::add-mask::` / `::add-path::` /
+    # `::set-output::` line and hijack the build job. `begin` emits
+    # `::stop-commands::<token>` with a per-run random token the docker
+    # build cannot read (it is never exported into the build environment),
+    # so the build cannot re-enable commands itself. The re-enable step
+    # below closes the guard. See docs/SLSA_L3_AUDIT.md Finding 3.
+    #
+    # The guard spans two steps (not one `run:` wrapper) because the
+    # docker build is a `uses:` step. This is sound: the runner's
+    # stop-commands state is job-scoped, so `::stop-commands::` emitted
+    # here stays in effect through the build step until the re-enable.
+    - name: Suspend workflow commands for the docker build
+      id: stopcmd
+      shell: bash
+      run: |
+        set -euo pipefail
+        "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" begin
+
     # TODO(#123): Investigate whether docker/build-push-action can accept
     # context via env, or whether zizmor will support marking validated step
     # outputs as safe, to eliminate the need for this suppression.
@@ -124,6 +145,21 @@ runs:
         cache-to: ${{ inputs.cache == 'enabled' && 'type=gha,mode=max' || '' }}
         sbom: true
         provenance: mode=max
+
+    # Re-enable workflow-command processing suspended by the `stopcmd`
+    # step. `if: always()` is mandatory: stop-commands is job-scoped in
+    # the runner, so a failed docker build that left commands suspended
+    # would silently disable `::add-mask::` secret redaction for every
+    # later step in the job. `end` is a no-op when the token is empty
+    # (the `stopcmd` step was skipped by an earlier-step failure).
+    - name: Re-enable workflow commands after the docker build
+      if: always()
+      shell: bash
+      env:
+        STOP_COMMANDS_TOKEN: ${{ steps.stopcmd.outputs.stop-commands-token }}
+      run: |
+        set -euo pipefail
+        "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" end "$STOP_COMMANDS_TOKEN"
 
     # Create the metadata directory and emit its path BEFORE SBOM extraction.
     # If a later step fails (build, push, SBOM extract), the `if: always()`

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -253,3 +253,48 @@ teardown() {
     run grep 'github.repository' "$wf"
     [[ "$status" -eq 0 ]]
 }
+
+# --- Workflow-command-injection guard (#225 / SLSA_L3_AUDIT.md Finding 3) ---
+
+@test "container: stop-commands guard helper exists and is executable" {
+    [[ -x "$REPO_ROOT/lib/stop_commands_guard.sh" ]]
+}
+
+@test "container: docker build is bracketed by the stop-commands guard" {
+    # docker/build-push-action streams BuildKit's per-RUN-layer output to
+    # the step log; a malicious Dockerfile could otherwise inject a
+    # `::add-mask::` / `::set-output::` workflow command via stdout. The
+    # guard's begin/end subcommands bracket the build step.
+    # See docs/SLSA_L3_AUDIT.md Finding 3.
+    run grep -E 'stop_commands_guard\.sh" begin' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+    run grep -E 'stop_commands_guard\.sh" end' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+    # The begin step must carry id: stopcmd — the end step reads the token
+    # from steps.stopcmd.outputs to close the same guard.
+    run bash -c "sed -n '/name: Suspend workflow commands/,/run:/p' \"$ACTION_DIR/action.yml\" | grep -F 'id: stopcmd'"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: stop-commands begin precedes the build and end follows it" {
+    # begin → docker build → end ordering is what makes the guard cover
+    # the build. A reordering would silently leave the build unguarded.
+    run bash -c "awk '/stop_commands_guard.sh\" begin/{b=NR} /uses: docker\\/build-push-action/{d=NR} /stop_commands_guard.sh\" end/{e=NR} END{exit !(b && d && e && b<d && d<e)}' \"$ACTION_DIR/action.yml\""
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: the stop-commands re-enable step runs with if: always()" {
+    # stop-commands is job-scoped in the runner: a failed docker build
+    # that left commands suspended would disable ::add-mask:: secret
+    # redaction for every later step. The re-enable MUST be unconditional.
+    run bash -c "sed -n '/name: Re-enable workflow commands/,/run:/p' \"$ACTION_DIR/action.yml\" | grep -F 'if: always()'"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: re-enable step passes the token through env, not run interpolation" {
+    # The token is a step output; interpolating it directly into a run:
+    # block would trip zizmor's template-injection audit. It must flow
+    # through env: per CLAUDE.md's expression-injection rule.
+    run grep -F 'STOP_COMMANDS_TOKEN: ${{ steps.stopcmd.outputs.stop-commands-token }}' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+}

--- a/build/actions/npm/action.yml
+++ b/build/actions/npm/action.yml
@@ -109,21 +109,24 @@ runs:
         pnpm --version
 
     # Run install (npm ci or pnpm install --frozen-lockfile), optional
-    # build, optional test, pack into dist/. The script does not emit
-    # the tarball name on stdout — instead this step globs dist/*.tgz
-    # after the script returns and asserts exactly one match. Channel-
-    # free output prevents a future stray stdout-bound printf from
-    # silently breaking the capture, and the explicit count check turns
-    # "unexpected multiple tarballs" (e.g., from a workspace change)
-    # into a clear error rather than a non-deterministic pick.
+    # build, optional test, pack into dist/, and discover the produced
+    # tarball. Everything — including the dist/ glob, the count check,
+    # and the tarball=<name> emit to $GITHUB_OUTPUT — runs inside
+    # build_and_pack.sh so it all happens under stop_commands_guard.sh.
+    # The script does not emit the tarball name on stdout; it writes
+    # to $GITHUB_OUTPUT (a file the runner reads), which is unaffected
+    # by the stop-commands suspension. Keeping discovery inside the
+    # guard closes the "malicious hook plants dist/::add-mask::evil.tgz,
+    # the post-script error printf echoes the filename, runner
+    # interprets it as a workflow command" path that an unguarded
+    # post-script discovery in this run: block would leave open.
     #
     # build_and_pack.sh runs ecosystem build tooling (npm/pnpm install,
-    # build, test, pack) that executes arbitrary package.json scripts and
-    # transitive dependency lifecycle hooks. stop_commands_guard.sh wraps
-    # it so a malicious hook printing a `::add-mask::` / `::set-output::`
-    # workflow command to stdout cannot hijack the build job — see
-    # docs/SLSA_L3_AUDIT.md Finding 3. The guard re-enables command
-    # processing before this step's tarball-capture logic runs.
+    # build, test, pack) that executes arbitrary package.json scripts
+    # and transitive dependency lifecycle hooks. stop_commands_guard.sh
+    # wraps the whole thing so a malicious hook printing a `::add-mask::`
+    # / `::set-output::` workflow command cannot hijack the build job —
+    # see docs/SLSA_L3_AUDIT.md Finding 3.
     - name: Build and pack
       id: build
       shell: bash
@@ -135,15 +138,6 @@ runs:
         set -euo pipefail
         "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run \
           "${{ github.action_path }}/build_and_pack.sh" "$INPUT_PATH" "$RUN_TESTS" "$IGNORE_SCRIPTS"
-        cd "$INPUT_PATH/dist"
-        shopt -s nullglob
-        tarballs=(*.tgz)
-        if (( ${#tarballs[@]} != 1 )); then
-            printf 'Error: expected exactly 1 tarball in dist/, found %d:\n' "${#tarballs[@]}" >&2
-            printf '  %s\n' "${tarballs[@]}" >&2
-            exit 1
-        fi
-        printf 'tarball=%s\n' "${tarballs[0]}" >> "$GITHUB_OUTPUT"
 
     - name: Extract package metadata
       id: metadata

--- a/build/actions/npm/action.yml
+++ b/build/actions/npm/action.yml
@@ -116,6 +116,14 @@ runs:
     # silently breaking the capture, and the explicit count check turns
     # "unexpected multiple tarballs" (e.g., from a workspace change)
     # into a clear error rather than a non-deterministic pick.
+    #
+    # build_and_pack.sh runs ecosystem build tooling (npm/pnpm install,
+    # build, test, pack) that executes arbitrary package.json scripts and
+    # transitive dependency lifecycle hooks. stop_commands_guard.sh wraps
+    # it so a malicious hook printing a `::add-mask::` / `::set-output::`
+    # workflow command to stdout cannot hijack the build job — see
+    # docs/SLSA_L3_AUDIT.md Finding 3. The guard re-enables command
+    # processing before this step's tarball-capture logic runs.
     - name: Build and pack
       id: build
       shell: bash
@@ -125,7 +133,8 @@ runs:
         IGNORE_SCRIPTS: ${{ inputs.ignore-scripts }}
       run: |
         set -euo pipefail
-        "${{ github.action_path }}/build_and_pack.sh" "$INPUT_PATH" "$RUN_TESTS" "$IGNORE_SCRIPTS"
+        "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run \
+          "${{ github.action_path }}/build_and_pack.sh" "$INPUT_PATH" "$RUN_TESTS" "$IGNORE_SCRIPTS"
         cd "$INPUT_PATH/dist"
         shopt -s nullglob
         tarballs=(*.tgz)

--- a/build/actions/npm/build_and_pack.sh
+++ b/build/actions/npm/build_and_pack.sh
@@ -37,10 +37,17 @@
 #
 # Tarball lands in dist/ (matching python's layout) so the reusable
 # workflow can upload `${path}/dist/` symmetrically with python and
-# slsa-verifier matches subjects against bare filenames. The action.yml
-# locates the produced tarball via a glob over dist/*.tgz after this
-# script returns — keeping the tarball name out of stdout means a stray
-# stdout-bound printf elsewhere can't silently break the capture.
+# slsa-verifier matches subjects against bare filenames. This script
+# also handles tarball discovery — globs dist/*.tgz, asserts exactly
+# one match, and writes `tarball=<filename>` to $GITHUB_OUTPUT — so
+# that every step that touches the (possibly attacker-influenced)
+# filename runs inside the caller's stop_commands_guard.sh wrap. A
+# malicious package.json hook could otherwise plant a file named
+# `::add-mask::evil.tgz` in dist/, and an unguarded post-script printf
+# of that name would let the runner interpret the workflow command. By
+# keeping discovery inside the script, the action.yml's run: block
+# emits nothing after the guard returns. Tarball name still does not
+# reach stdout (it goes to $GITHUB_OUTPUT, a file the runner reads).
 #
 # Usage: build/actions/npm/build_and_pack.sh <path> <run_tests> <ignore_scripts>
 #   path:            project directory (already validated)
@@ -124,8 +131,32 @@ fi
 printf 'Packing tarball into dist/ (%s pack)...\n' "$PM"
 mkdir -p dist
 # `<pm> pack --pack-destination dist` writes the tarball to dist/.
-# Output parsing is the action.yml's job (glob over dist/*.tgz); this
-# script only needs to exit 0 on success. --ignore-scripts (when set)
-# suppresses prepack/postpack/prepare on the pack side too for both
-# npm and pnpm.
+# --ignore-scripts (when set) suppresses prepack/postpack/prepare on
+# the pack side too for both npm and pnpm.
 "$PM" pack --pack-destination dist "${ignore_scripts_args[@]}"
+
+# Discover the tarball. Done in this script (inside the caller's
+# stop_commands_guard.sh wrap) rather than in action.yml so the count-
+# check error path's stderr printf cannot leak a malicious filename
+# (e.g., `dist/::add-mask::SECRET.tgz` planted by a hostile postinstall
+# hook) past the guard and into the runner's workflow-command parser.
+# nullglob expands `*.tgz` to nothing rather than the literal pattern
+# when dist/ is empty, so the count check works cleanly in both cases.
+shopt -s nullglob
+tarballs=(dist/*.tgz)
+if (( ${#tarballs[@]} != 1 )); then
+    printf 'Error: expected exactly 1 tarball in dist/, found %d:\n' "${#tarballs[@]}" >&2
+    printf '  %s\n' "${tarballs[@]}" >&2
+    exit 1
+fi
+
+# Strip the dist/ prefix so the output matches the action.yml's previous
+# `cd "$INPUT_PATH/dist"; tarball=*.tgz` contract — downstream steps
+# (hash, SBOM, attach) expect a bare filename relative to dist/.
+TARBALL="${tarballs[0]#dist/}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    # File-based output (not the ::set-output:: stdout command), so this
+    # write is unaffected by the stop-commands suspension.
+    printf 'tarball=%s\n' "$TARBALL" >> "$GITHUB_OUTPUT"
+fi

--- a/build/actions/npm/test.bats
+++ b/build/actions/npm/test.bats
@@ -168,15 +168,38 @@ setup() {
     [[ "$status" -eq 0 ]]
 }
 
-@test "npm: build step asserts exactly one tarball in dist/ (not tail-n1)" {
+@test "npm: build_and_pack.sh asserts exactly one tarball in dist/ (not tail-n1)" {
     # Channel-free output: derives the tarball name from a glob over
     # dist/*.tgz and asserts the count is exactly 1 — catches surprise
     # multi-build scenarios (e.g., a future workspace change) explicitly,
     # instead of non-deterministically picking via `tail -n1`.
-    run grep -E 'expected exactly 1 tarball' "$ACTION"
+    #
+    # Discovery lives in build_and_pack.sh (not in the action.yml run:
+    # block) so that the count-check error printf — which echoes
+    # filenames — runs INSIDE stop_commands_guard.sh. An unguarded
+    # post-script discovery would let a hostile postinstall plant
+    # `dist/::add-mask::evil.tgz` and inject a workflow command via the
+    # error path's stderr.
+    run grep -E 'expected exactly 1 tarball' "$ACTION_DIR/build_and_pack.sh"
     [[ "$status" -eq 0 ]]
     # And verify we are not relying on tail -n1 for the tarball capture.
-    run grep -E 'tarball=.*tail' "$ACTION"
+    run grep -E 'tarball=.*tail' "$ACTION_DIR/build_and_pack.sh"
+    [[ "$status" -ne 0 ]]
+    # The action.yml MUST NOT do its own post-script discovery — that
+    # would put the filename-echoing error printf outside the guard.
+    run grep -E 'expected exactly 1 tarball' "$ACTION"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "npm: build_and_pack.sh writes tarball=<name> to GITHUB_OUTPUT" {
+    # The tarball-name output is consumed by the workflow's metadata-
+    # artifact-name output and by the step summary. Discovery moved into
+    # the script (see test above) means the GITHUB_OUTPUT write moves
+    # too — both happen inside the guard.
+    run grep -E 'tarball=.*GITHUB_OUTPUT' "$ACTION_DIR/build_and_pack.sh"
+    [[ "$status" -eq 0 ]]
+    # The action.yml's run: block must NOT also write tarball=...
+    run bash -c "sed -n '/name: Build and pack/,/name: /p' \"$ACTION\" | grep -E 'tarball=.*GITHUB_OUTPUT'"
     [[ "$status" -ne 0 ]]
 }
 

--- a/build/actions/npm/test.bats
+++ b/build/actions/npm/test.bats
@@ -453,3 +453,22 @@ setup() {
     run bash -c "sed -n '/^  publish:/,/^[a-z]/p' \"$EXAMPLE\" | grep 'id-token: write'"
     [[ "$status" -eq 0 ]]
 }
+
+# --- Workflow-command-injection guard (#225 / SLSA_L3_AUDIT.md Finding 3) ---
+
+@test "npm: stop-commands guard helper exists and is executable" {
+    [[ -x "$REPO_ROOT/lib/stop_commands_guard.sh" ]]
+}
+
+@test "npm: build_and_pack.sh runs under the stop-commands guard" {
+    # build_and_pack.sh runs ecosystem build tooling and arbitrary
+    # package.json / transitive-dependency lifecycle scripts. The
+    # ::stop-commands:: guard neutralizes workflow-command injection via
+    # their stdout (a hook printing `::add-mask::` / `::set-output::`).
+    # See docs/SLSA_L3_AUDIT.md Finding 3.
+    run grep -E 'lib/stop_commands_guard\.sh" run' "$ACTION"
+    [[ "$status" -eq 0 ]]
+    # The guarded command (on the line after `... run`) must be build_and_pack.sh.
+    run bash -c "grep -A1 'stop_commands_guard.sh\" run' \"$ACTION\" | grep -F build_and_pack.sh"
+    [[ "$status" -eq 0 ]]
+}

--- a/build/actions/python/action.yml
+++ b/build/actions/python/action.yml
@@ -104,6 +104,12 @@ runs:
         # true or false.
         enable-cache: ${{ inputs.cache != 'disabled' }}
 
+    # install_deps.sh and run_tests.sh run ecosystem build tooling
+    # (uv sync / pip install, pytest) that executes arbitrary build
+    # backends, dependency hooks, and project test code. stop_commands_guard.sh
+    # wraps each invocation so a malicious dependency or test printing a
+    # `::add-mask::` / `::set-output::` workflow command to stdout cannot
+    # hijack the build job — see docs/SLSA_L3_AUDIT.md Finding 3.
     - name: Install dependencies
       shell: bash
       env:
@@ -111,7 +117,8 @@ runs:
         USE_UV: ${{ steps.tooling.outputs.use_uv }}
       run: |
         set -euo pipefail
-        "${{ github.action_path }}/install_deps.sh" "$INPUT_PATH" "$USE_UV"
+        "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run \
+          "${{ github.action_path }}/install_deps.sh" "$INPUT_PATH" "$USE_UV"
 
     - name: Run tests
       if: inputs.run-tests == 'true'
@@ -121,7 +128,8 @@ runs:
         USE_UV: ${{ steps.tooling.outputs.use_uv }}
       run: |
         set -euo pipefail
-        "${{ github.action_path }}/run_tests.sh" "$INPUT_PATH" "$USE_UV"
+        "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run \
+          "${{ github.action_path }}/run_tests.sh" "$INPUT_PATH" "$USE_UV"
 
     - name: Build package
       shell: bash

--- a/build/actions/python/test.bats
+++ b/build/actions/python/test.bats
@@ -348,3 +348,27 @@ setup() {
     run grep -E 'contents: write' "$REPO_ROOT/build/actions/python/README.md"
     [[ "$status" -eq 0 ]]
 }
+
+# --- Workflow-command-injection guard (#225 / SLSA_L3_AUDIT.md Finding 3) ---
+
+@test "python: stop-commands guard helper exists and is executable" {
+    [[ -x "$REPO_ROOT/lib/stop_commands_guard.sh" ]]
+}
+
+@test "python: install_deps.sh runs under the stop-commands guard" {
+    # install_deps.sh runs ecosystem build tooling (uv sync / pip install)
+    # that executes build backends and dependency hooks. The
+    # ::stop-commands:: guard neutralizes workflow-command injection via
+    # their stdout. See docs/SLSA_L3_AUDIT.md Finding 3.
+    run grep -E 'lib/stop_commands_guard\.sh" run' "$ACTION"
+    [[ "$status" -eq 0 ]]
+    run bash -c "grep -A1 'stop_commands_guard.sh\" run' \"$ACTION\" | grep -F install_deps.sh"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "python: run_tests.sh runs under the stop-commands guard" {
+    # pytest executes arbitrary project test code; the guard neutralizes
+    # workflow-command injection via its stdout.
+    run bash -c "grep -A1 'stop_commands_guard.sh\" run' \"$ACTION\" | grep -F run_tests.sh"
+    [[ "$status" -eq 0 ]]
+}

--- a/build/actions/shell/action.yml
+++ b/build/actions/shell/action.yml
@@ -46,6 +46,14 @@ runs:
         fi
         printf 'bats version: %s\n' "$(bats --version)"
 
+    # shellcheck echoes excerpts of the source lines it diagnoses, and
+    # the source files under scan-path are caller-controlled. A `.sh`
+    # file containing a line that starts with `::add-mask::` or
+    # `::set-output::` could therefore reach the step log via shellcheck's
+    # output. stop_commands_guard.sh wraps the shellcheck invocation so a
+    # workflow command on stdout is neutralized — see
+    # docs/SLSA_L3_AUDIT.md Finding 3. The guard re-enables command
+    # processing on exit, before the final "scripts passed" line.
     - name: Run shellcheck
       shell: bash
       env:
@@ -74,13 +82,20 @@ runs:
         fi
 
         # Use find -print0 + xargs -0 for safe filename handling.
-        # shellcheck also supports .bats files (bash syntax).
+        # shellcheck also supports .bats files (bash syntax). Each xargs
+        # batch is one guarded invocation; the guard preserves shellcheck's
+        # exit status so findings still fail the step.
         find "$SCAN_PATH" \( -name '*.sh' -o -name '*.bats' \) \
           -not -path '*/.git/*' \
           -not -path '*/node_modules/*' \
-          -print0 | xargs -0 -r shellcheck
+          -print0 | xargs -0 -r "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run shellcheck
         printf 'shellcheck: all scripts under %s passed\n' "$SCAN_PATH"
 
+    # bats EXECUTES caller-supplied .bats files (arbitrary bash), which
+    # is a direct workflow-command-injection path: a test that printfs
+    # `::add-mask::SECRET` would hijack the build job. Both invocation
+    # paths (explicit BATS_PATH and auto-detected .bats files) run under
+    # stop_commands_guard.sh — see docs/SLSA_L3_AUDIT.md Finding 3.
     - name: Run bats tests
       shell: bash
       env:
@@ -105,7 +120,7 @@ runs:
             printf 'bats: invalid characters in bats-path: %s\n' "$BATS_PATH" >&2
             exit 1
           fi
-          bats "$BATS_PATH"
+          "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run bats "$BATS_PATH"
         else
           # Auto-detect: find all .bats files under scan-path.
           # scan-path was validated by the shellcheck step above.
@@ -115,7 +130,7 @@ runs:
           done < <(find "$SCAN_PATH" -name '*.bats' -not -path '*/.git/*' -print0 2>/dev/null)
 
           if [[ ${#bats_files[@]} -gt 0 ]]; then
-            bats "${bats_files[@]}"
+            "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run bats "${bats_files[@]}"
           else
             printf 'bats: no .bats files found under %s, skipping\n' "$SCAN_PATH"
           fi

--- a/build/actions/shell/test.bats
+++ b/build/actions/shell/test.bats
@@ -8,6 +8,7 @@
 
 setup() {
     ACTION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    REPO_ROOT="$(cd "$ACTION_DIR/../../.." && pwd)"
 }
 
 @test "shell: has Run shellcheck step" {
@@ -23,4 +24,38 @@ setup() {
 @test "shell: accepts scan-path input" {
     run grep 'scan-path:' "$ACTION_DIR/action.yml"
     [ "$status" -eq 0 ]
+}
+
+# --- Workflow-command-injection guard (#225 / SLSA_L3_AUDIT.md Finding 3) ---
+
+@test "shell: stop-commands guard helper exists and is executable" {
+    [[ -x "$REPO_ROOT/lib/stop_commands_guard.sh" ]]
+}
+
+@test "shell: shellcheck runs under the stop-commands guard" {
+    # shellcheck echoes excerpts of source lines in its diagnostics, and
+    # the source files come from the caller's repo. A `.sh` file with a
+    # line starting `::add-mask::` could reach the step log unguarded.
+    # The xargs invocation must spawn the guard, not bare shellcheck.
+    run grep -F 'xargs -0 -r "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run shellcheck' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+    # The unguarded `xargs -0 -r shellcheck` form must not creep back.
+    run grep -E '^[[:space:]]*-print0[[:space:]]*\|[[:space:]]*xargs -0 -r shellcheck[[:space:]]*$' "$ACTION_DIR/action.yml"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "shell: both bats invocation paths run under the stop-commands guard" {
+    # bats executes arbitrary user .bats files — a direct injection path
+    # via printf '::add-mask::...'. BOTH branches (explicit bats-path
+    # and auto-detected file list) must run under the guard.
+    run grep -F '"${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run bats "$BATS_PATH"' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+    run grep -F '"${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run bats "${bats_files[@]}"' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+    # Bare `bats "$BATS_PATH"` / `bats "${bats_files[@]}"` (no guard)
+    # must not creep back.
+    run bash -c "grep -E '^[[:space:]]+bats[[:space:]]+\"\\\$BATS_PATH\"[[:space:]]*\$' \"$ACTION_DIR/action.yml\""
+    [[ "$status" -ne 0 ]]
+    run bash -c "grep -E '^[[:space:]]+bats[[:space:]]+\"\\\${bats_files\\[@\\]}\"[[:space:]]*\$' \"$ACTION_DIR/action.yml\""
+    [[ "$status" -ne 0 ]]
 }

--- a/docs/SLSA_L3_AUDIT.md
+++ b/docs/SLSA_L3_AUDIT.md
@@ -1496,8 +1496,14 @@ executes in base-repo context.
 > build/test invocation in a `::stop-commands::` guard
 > (`lib/stop_commands_guard.sh`, a per-run random token): the npm
 > `build_and_pack.sh` call, the python `install_deps.sh` and `run_tests.sh`
-> calls, and the container `docker/build-push-action` step. The analysis
-> that follows is retained as the historical record.
+> calls, the container `docker/build-push-action` step, and the shell
+> composite's `shellcheck` and `bats` invocations. New build composites
+> are kept honest by `test/test_build_guard_coverage.bats`, which
+> enumerates `build/actions/*/action.yml` and fails if a composite
+> ships without the guard (or without a written allowlist entry). The
+> SPEC requirement is in `docs/SPEC.md` "Workflow-command-injection
+> guard for build composites". The analysis that follows is retained
+> as the historical record.
 
 **Summary.** The SLSA ecosystem-specific Go builder shadows the `::`
 workflow-command prefix with a per-run token before invoking the compile,

--- a/docs/SLSA_L3_AUDIT.md
+++ b/docs/SLSA_L3_AUDIT.md
@@ -1490,6 +1490,15 @@ executes in base-repo context.
 
 ### Finding 3 (highly recommended): `::stop-commands::` guard around build/test invocations
 
+> **Resolved by [PR #230](https://github.com/TomHennen/wrangle/pull/230)**
+> (issue [#225](https://github.com/TomHennen/wrangle/issues/225)). Every
+> wrangle build composite that runs ecosystem build tooling now wraps the
+> build/test invocation in a `::stop-commands::` guard
+> (`lib/stop_commands_guard.sh`, a per-run random token): the npm
+> `build_and_pack.sh` call, the python `install_deps.sh` and `run_tests.sh`
+> calls, and the container `docker/build-push-action` step. The analysis
+> that follows is retained as the historical record.
+
 **Summary.** The SLSA ecosystem-specific Go builder shadows the `::`
 workflow-command prefix with a per-run token before invoking the compile,
 neutralizing any attempt by the build tool (or a dependency's lifecycle hook)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -109,6 +109,12 @@ The reusable workflow that wraps a build action (e.g., `.github/workflows/build_
 
 If `SPEC.md` describes behavior that hasn't shipped yet, `README.md` MUST NOT present it as available. Keeping the two in sync during implementation is part of landing a feature, not a follow-up.
 
+### Workflow-command-injection guard for build composites
+
+Every build composite MUST wrap its ecosystem invocations (compile, install, test, lint — anything that runs caller-controlled code or echoes caller-controlled content to the step log) in `lib/stop_commands_guard.sh`. GitHub Actions interprets any line on a step's output stream beginning with `::` as a workflow command (`::add-mask::`, `::add-path::`, `::set-output::`); without the guard a malicious dependency lifecycle hook, test, build backend, or `Dockerfile RUN` can hijack the build job just by printing such a line. See `docs/SLSA_L3_AUDIT.md` Finding 3 for the threat model and `lib/stop_commands_guard.sh` for the two supported wrap shapes (`run` for inline `run:` blocks, `begin` / `end` for `uses:` build steps).
+
+This requirement is enforced by `test/test_build_guard_coverage.bats`, which enumerates every `build/actions/*/action.yml` and fails if a composite has no reference to the guard. A new build type cannot be added without either wiring in the guard or adding the composite to the explicit allowlist in that test (which requires a written rationale — today the list is empty).
+
 ### Unified metadata layout
 
 Every build type publishes its build outputs to **two complementary places**:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -115,6 +115,10 @@ Every build composite MUST wrap its ecosystem invocations (compile, install, tes
 
 This requirement is enforced by `test/test_build_guard_coverage.bats`, which enumerates every `build/actions/*/action.yml` and fails if a composite has no reference to the guard. A new build type cannot be added without either wiring in the guard or adding the composite to the explicit allowlist in that test (which requires a written rationale — today the list is empty).
 
+The guarded window MUST also cover any post-script logic in the composite's `run:` block that echoes content derived from the build's output (a glob of build artifacts, an error message including filenames, etc.). The pattern is to push that logic INTO the guarded script (writing results to `$GITHUB_OUTPUT`, a file-based channel that stop-commands does not affect) rather than running it in the composite's `run:` block after the guard returns. An unguarded post-script `printf '%s\n' "${tarballs[@]}"` over attacker-influenced filenames is a workflow-command injection path that the guard around the build itself does NOT close.
+
+**Adopter-visible side effect.** GitHub workflow commands intentionally emitted by wrapped build tools — e.g., `printf '::warning::version mismatch\n'` from an npm script, an `::error::` line from a pytest test, an `::notice::` from a `Dockerfile RUN` — are suppressed under the guard: they appear in the step log as plain text rather than surfacing as PR-level annotations. The trade is deliberate (an attacker cannot use a malicious dependency to call `::add-mask::` / `::add-path::` / `::set-output::`); adopters who want PR-level annotations from their build should emit them from a wrangle-controlled step (e.g., the source-scan workflow's SARIF upload) rather than from within their build script.
+
 ### Unified metadata layout
 
 Every build type publishes its build outputs to **two complementary places**:

--- a/lib/stop_commands_guard.sh
+++ b/lib/stop_commands_guard.sh
@@ -78,7 +78,7 @@ case "${1:-}" in
             exit 1
         fi
         if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
-            printf 'Error: begin requires $GITHUB_OUTPUT to be set\n' >&2
+            printf 'Error: begin requires GITHUB_OUTPUT to be set\n' >&2
             exit 1
         fi
         token="$(generate_token)"

--- a/lib/stop_commands_guard.sh
+++ b/lib/stop_commands_guard.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Runs a build/test invocation with GitHub Actions workflow-command
+# processing suspended, neutralizing workflow-command injection via
+# build-tool stdout.
+#
+# GitHub Actions interprets any line on a step's output stream that
+# begins with `::` as a workflow command (`::add-path::`, `::add-mask::`,
+# `::set-output::`, `::error::`, ...). A build tool — or a malicious
+# dependency lifecycle hook (npm `postinstall`, a hostile test, a build
+# backend, a Dockerfile `RUN`) — can therefore hijack the build job just
+# by printing such a line. `::stop-commands::<token>` tells the runner to
+# treat every subsequent line as plain text until it sees a matching
+# `::<token>::` line; with a per-run unguessable token the build tool
+# cannot re-enable command processing on its own.
+#
+# This mirrors the SLSA ecosystem-specific Go builder
+# (builder_go_slsa3.yml). See docs/SLSA_L3_AUDIT.md Finding 3.
+#
+# The stop-commands state is job-scoped: the GitHub Actions runner's
+# ActionCommandManager is a per-job singleton with no per-step reset, so
+# `::stop-commands::` emitted in one step stays in effect for every later
+# step until the matching token is emitted. The guard therefore MUST
+# always re-enable command processing — leaving it suspended would
+# silently disable `::add-mask::` secret redaction for the rest of the
+# job. Subcommands:
+#
+#   run <command> [args...]
+#       Suspend commands, run <command>, then ALWAYS re-enable (even when
+#       the command exits non-zero), preserving the command's exit
+#       status. Use this to wrap a single build/test script invocation
+#       inside one `run:` step.
+#
+#   begin
+#       Generate a token, write `stop-commands-token=<token>` to
+#       $GITHUB_OUTPUT, and emit `::stop-commands::<token>`. Use this in
+#       a step that precedes a `uses:` build step which cannot be wrapped
+#       in-process (e.g. docker/build-push-action). The matching `end`
+#       MUST run in a later step.
+#
+#   end <token>
+#       Emit `::<token>::` to re-enable command processing. A no-op when
+#       <token> is empty, so an `if: always()` cleanup step is safe even
+#       when the `begin` step was skipped by an earlier failure.
+#
+# Usage: lib/stop_commands_guard.sh <run|begin|end> [args...]
+
+set -euo pipefail
+set -f  # disable globbing — processes externally-supplied arguments
+
+# 32 bytes of kernel CSPRNG output, hex-encoded (a 256-bit token). `od`
+# reads an exact byte count and exits 0, so there is no SIGPIPE/pipefail
+# hazard (unlike `tr -dc < /dev/urandom | head`, where head closing the
+# pipe early would trip pipefail).
+generate_token() {
+    od -vN32 -An -tx1 /dev/urandom | tr -d '[:space:]'
+}
+
+case "${1:-}" in
+    run)
+        shift
+        if [[ $# -eq 0 ]]; then
+            printf 'Usage: %s run <command> [args...]\n' "$0" >&2
+            exit 1
+        fi
+        token="$(generate_token)"
+        printf '::stop-commands::%s\n' "$token"
+        # `|| status=$?` makes the wrapped command a tested command, so
+        # `set -e` does not abort here on a non-zero exit — the re-enable
+        # line below MUST be reached on every code path.
+        status=0
+        "$@" || status=$?
+        printf '::%s::\n' "$token"
+        exit "$status"
+        ;;
+    begin)
+        if [[ $# -ne 1 ]]; then
+            printf 'Usage: %s begin\n' "$0" >&2
+            exit 1
+        fi
+        if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
+            printf 'Error: begin requires $GITHUB_OUTPUT to be set\n' >&2
+            exit 1
+        fi
+        token="$(generate_token)"
+        # $GITHUB_OUTPUT is a file the runner reads after the step; it is
+        # not the `::set-output::` stdout command, so this write is
+        # unaffected by stop-commands. The docker build cannot read step
+        # outputs, so the token stays unguessable to the guarded build.
+        printf 'stop-commands-token=%s\n' "$token" >> "$GITHUB_OUTPUT"
+        printf '::stop-commands::%s\n' "$token"
+        ;;
+    end)
+        if [[ $# -ne 2 ]]; then
+            printf 'Usage: %s end <token>\n' "$0" >&2
+            exit 1
+        fi
+        token="$2"
+        # No-op on an empty token: the `end` step runs with `if: always()`
+        # so it still fires when an earlier failure skipped `begin`, in
+        # which case there is no suspended state to re-enable.
+        if [[ -n "$token" ]]; then
+            printf '::%s::\n' "$token"
+        fi
+        ;;
+    *)
+        printf 'Usage: %s <run|begin|end> [args...]\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/lib/stop_commands_guard.sh
+++ b/lib/stop_commands_guard.sh
@@ -62,14 +62,26 @@ case "${1:-}" in
             printf 'Usage: %s run <command> [args...]\n' "$0" >&2
             exit 1
         fi
+        # An EXIT trap re-emits the re-enable line on every code path:
+        # explicit exit, set -e abort, or an unexpected signal. The
+        # explicit `printf '::%s::\n' "$token"` after `"$@"` could fail
+        # (closed stdout — rare on GHA but possible) and set -e would
+        # then exit before the line was emitted; the trap closes that
+        # window. `[[ -n "$token" ]]` skips the trap body when
+        # generate_token failed before we suspended anything (no
+        # suspension to close), and `|| true` keeps a trap-time printf
+        # failure from masking the exit status the wrapped command
+        # already established. Initializing `token=""` BEFORE setting
+        # the trap prevents a `set -u` reference-time error if the trap
+        # fires before the token assignment runs.
+        token=""
+        trap '[[ -n "$token" ]] && printf "::%s::\n" "$token" 2>/dev/null || true' EXIT
         token="$(generate_token)"
         printf '::stop-commands::%s\n' "$token"
         # `|| status=$?` makes the wrapped command a tested command, so
-        # `set -e` does not abort here on a non-zero exit — the re-enable
-        # line below MUST be reached on every code path.
+        # `set -e` does not abort here on a non-zero exit.
         status=0
         "$@" || status=$?
-        printf '::%s::\n' "$token"
         exit "$status"
         ;;
     begin)

--- a/test/lib/test_stop_commands_guard.bats
+++ b/test/lib/test_stop_commands_guard.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+
+# Tests for lib/stop_commands_guard.sh — the ::stop-commands:: guard that
+# neutralizes GitHub Actions workflow-command injection via build-tool
+# stdout. See docs/SLSA_L3_AUDIT.md Finding 3.
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/lib/stop_commands_guard.sh"
+    GITHUB_OUTPUT="$(mktemp)"
+    export GITHUB_OUTPUT
+}
+
+teardown() {
+    rm -f "$GITHUB_OUTPUT"
+}
+
+@test "stop_commands_guard: exists and is executable" {
+    [[ -x "$SCRIPT" ]]
+}
+
+@test "stop_commands_guard: starts with set -euo pipefail and set -f" {
+    # set -f is required by CLAUDE.md for scripts processing external args.
+    run grep -E '^set -euo pipefail$' "$SCRIPT"
+    [[ "$status" -eq 0 ]]
+    run grep -E '^set -f' "$SCRIPT"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "stop_commands_guard: rejects an unknown subcommand" {
+    run "$SCRIPT" bogus
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "stop_commands_guard: rejects no subcommand" {
+    run "$SCRIPT"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+# --- run ---
+
+@test "stop_commands_guard: run rejects a missing command" {
+    run "$SCRIPT" run
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "stop_commands_guard: run emits stop-commands, the output, then a matching re-enable" {
+    run "$SCRIPT" run printf 'BUILD-OUTPUT\n'
+    [[ "$status" -eq 0 ]]
+    # Line 1: ::stop-commands::<token>
+    [[ "${lines[0]}" == ::stop-commands::* ]]
+    local token="${lines[0]#::stop-commands::}"
+    # Line 2: the wrapped command's output, verbatim.
+    [[ "${lines[1]}" == "BUILD-OUTPUT" ]]
+    # Line 3: the re-enable line, using the SAME token.
+    [[ "${lines[2]}" == "::${token}::" ]]
+}
+
+@test "stop_commands_guard: run token is 64 hex characters (256-bit)" {
+    run "$SCRIPT" run true
+    [[ "$status" -eq 0 ]]
+    local token="${lines[0]#::stop-commands::}"
+    [[ "$token" =~ ^[0-9a-f]{64}$ ]]
+}
+
+@test "stop_commands_guard: run token is freshly random on every invocation" {
+    run "$SCRIPT" run true
+    local token1="${lines[0]#::stop-commands::}"
+    run "$SCRIPT" run true
+    local token2="${lines[0]#::stop-commands::}"
+    [[ -n "$token1" ]]
+    [[ "$token1" != "$token2" ]]
+}
+
+@test "stop_commands_guard: run preserves the wrapped command's exit status" {
+    run "$SCRIPT" run bash -c 'exit 7'
+    [[ "$status" -eq 7 ]]
+}
+
+@test "stop_commands_guard: run re-enables commands even when the wrapped command fails" {
+    # The re-enable line is load-bearing: stop-commands is job-scoped, so
+    # a failed build that left commands suspended would disable
+    # ::add-mask:: secret redaction for the rest of the job.
+    run "$SCRIPT" run bash -c 'exit 1'
+    [[ "$status" -eq 1 ]]
+    local token="${lines[0]#::stop-commands::}"
+    [[ "${lines[${#lines[@]}-1]}" == "::${token}::" ]]
+}
+
+@test "stop_commands_guard: run passes every argument through to the wrapped command" {
+    run "$SCRIPT" run bash -c 'printf "[%s]" "$@"' _ one "two three" four
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"[one][two three][four]"* ]]
+}
+
+@test "stop_commands_guard: run does not export the token into the wrapped command's environment" {
+    # The guarded build must not be able to read the token — otherwise it
+    # could emit a matching ::<token>:: and re-enable commands itself.
+    # The guard keeps `token` as a plain (unexported) shell variable.
+    run "$SCRIPT" run bash -c 'printf "token=[%s]\n" "${token:-UNSET}"'
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"token=[UNSET]"* ]]
+}
+
+# --- begin ---
+
+@test "stop_commands_guard: begin writes the token to GITHUB_OUTPUT and emits stop-commands" {
+    run "$SCRIPT" begin
+    [[ "$status" -eq 0 ]]
+    [[ "${lines[0]}" == ::stop-commands::* ]]
+    local emitted="${lines[0]#::stop-commands::}"
+    # The step-output token must match the emitted stop-commands token.
+    run grep -E "^stop-commands-token=${emitted}\$" "$GITHUB_OUTPUT"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "stop_commands_guard: begin token is 64 hex characters" {
+    run "$SCRIPT" begin
+    [[ "$status" -eq 0 ]]
+    run bash -c "grep -oE '^stop-commands-token=.*' \"$GITHUB_OUTPUT\" | cut -d= -f2"
+    [[ "$output" =~ ^[0-9a-f]{64}$ ]]
+}
+
+@test "stop_commands_guard: begin fails when GITHUB_OUTPUT is unset" {
+    run env -u GITHUB_OUTPUT "$SCRIPT" begin
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"GITHUB_OUTPUT"* ]]
+}
+
+@test "stop_commands_guard: begin rejects extra arguments" {
+    run "$SCRIPT" begin extra
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+# --- end ---
+
+@test "stop_commands_guard: end emits the re-enable line for the given token" {
+    run "$SCRIPT" end abcdef0123
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "::abcdef0123::" ]]
+}
+
+@test "stop_commands_guard: end is a no-op for an empty token" {
+    # The end step runs with if: always(); when an earlier failure skipped
+    # begin, the token is empty and end must emit nothing.
+    run "$SCRIPT" end ""
+    [[ "$status" -eq 0 ]]
+    [[ -z "$output" ]]
+}
+
+@test "stop_commands_guard: end requires exactly one token argument" {
+    run "$SCRIPT" end
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* ]]
+    run "$SCRIPT" end tok1 tok2
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "stop_commands_guard: begin/end round-trip uses one consistent token" {
+    run "$SCRIPT" begin
+    local token="${lines[0]#::stop-commands::}"
+    run "$SCRIPT" end "$token"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "::${token}::" ]]
+}

--- a/test/lib/test_stop_commands_guard.bats
+++ b/test/lib/test_stop_commands_guard.bats
@@ -105,6 +105,30 @@ teardown() {
     [[ "$output" == *"token=[UNSET]"* ]]
 }
 
+@test "stop_commands_guard: run uses an EXIT trap so re-enable runs even on script abort" {
+    # Stop-commands is job-scoped — leaving it suspended would disable
+    # ::add-mask:: secret redaction for the rest of the job. The explicit
+    # re-enable printf could in principle fail (closed stdout) and set -e
+    # would then exit before the line was emitted. An EXIT trap closes
+    # that window. Structural assertion: a trap on EXIT must exist in the
+    # `run` path, and the trap body must reference the token variable.
+    run grep -E '^[[:space:]]*trap.*EXIT' "$SCRIPT"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *'"$token"'* ]]
+}
+
+@test "stop_commands_guard: run trap re-enables even when generate_token has not yet run" {
+    # Belt-and-suspenders: if anything aborted the script BEFORE the
+    # token was generated, the trap must not itself fail (and must not
+    # emit a malformed `::::` re-enable). Verified indirectly: the trap
+    # guards on [[ -n "$token" ]], and token is initialized to "" before
+    # the trap is installed.
+    run grep -F 'token=""' "$SCRIPT"
+    [[ "$status" -eq 0 ]]
+    run grep -F '[[ -n "$token" ]] && printf' "$SCRIPT"
+    [[ "$status" -eq 0 ]]
+}
+
 # --- begin ---
 
 @test "stop_commands_guard: begin writes the token to GITHUB_OUTPUT and emits stop-commands" {

--- a/test/test_build_guard_coverage.bats
+++ b/test/test_build_guard_coverage.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+
+# Meta-test: every wrangle build composite MUST run its ecosystem build
+# tooling (compile, install, test, lint) under lib/stop_commands_guard.sh.
+#
+# Why this lives at the top of test/ and not inside one of the per-tool
+# build/actions/*/test.bats files: those per-tool tests only catch
+# regressions in the composites that EXIST today. A new build composite
+# added in a future PR (build/actions/go/, build/actions/rust/, ...)
+# could ship without ever referencing the guard and every per-tool test
+# would still pass — the workflow-command-injection hole would slip
+# through silently. This meta-test enumerates the directory and fails
+# if a new composite is added without wiring in the guard.
+#
+# See docs/SLSA_L3_AUDIT.md Finding 3 and docs/SPEC.md "Workflow-command-
+# injection guard for build composites".
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    GUARD="lib/stop_commands_guard.sh"
+
+    # Explicit allowlist of composites that intentionally do NOT need to
+    # invoke the guard. Composites belong here only if they run NO
+    # caller-controlled code, NO ecosystem tooling against caller-
+    # controlled inputs, AND echo nothing derived from caller inputs to
+    # the step log. Today the list is empty — every existing build
+    # composite runs adversarially-influenceable output through the step
+    # log (Dockerfiles, package.json hooks, pytest, shellcheck source
+    # excerpts, bats test code). Add a composite here ONLY with a
+    # written rationale in the comment justifying the exemption.
+    EXEMPT_COMPOSITES=()
+}
+
+is_exempt() {
+    local name="$1"
+    for exempt in "${EXEMPT_COMPOSITES[@]}"; do
+        [[ "$name" == "$exempt" ]] && return 0
+    done
+    return 1
+}
+
+@test "build-guard-coverage: at least one build composite exists" {
+    # Sanity check — if this fails the enumeration below is meaningless.
+    local count
+    count=$(find "$REPO_ROOT/build/actions" -mindepth 2 -maxdepth 2 \
+        -name action.yml -type f | wc -l)
+    [[ "$count" -gt 0 ]]
+}
+
+@test "build-guard-coverage: every build composite references the stop-commands guard" {
+    # Enumerate build/actions/<name>/action.yml. For each non-exempt
+    # composite, the action.yml MUST reference lib/stop_commands_guard.sh
+    # at least once. New composites added without wiring in the guard
+    # fail here — the test does not need to be updated for new build
+    # types, only for new exemptions (which require updating the
+    # EXEMPT_COMPOSITES allowlist above with a rationale).
+    local missing=()
+    while IFS= read -r -d '' action_yml; do
+        local composite_dir composite_name
+        composite_dir="$(dirname "$action_yml")"
+        composite_name="$(basename "$composite_dir")"
+
+        if is_exempt "$composite_name"; then
+            continue
+        fi
+
+        if ! grep -qF "$GUARD" "$action_yml"; then
+            missing+=("$composite_name")
+        fi
+    done < <(find "$REPO_ROOT/build/actions" -mindepth 2 -maxdepth 2 \
+        -name action.yml -type f -print0)
+
+    if (( ${#missing[@]} > 0 )); then
+        printf 'Build composites missing stop_commands_guard.sh reference: %s\n' \
+            "${missing[*]}" >&2
+        printf 'Either wire in lib/stop_commands_guard.sh (see existing\n' >&2
+        printf 'composites for the pattern) or add the composite to\n' >&2
+        printf 'EXEMPT_COMPOSITES in %s with a written rationale.\n' \
+            "$BATS_TEST_FILENAME" >&2
+        return 1
+    fi
+}
+
+@test "build-guard-coverage: every build composite test.bats pins guard coverage" {
+    # A per-composite assertion that its action.yml actually wraps the
+    # ecosystem invocation (not just imports the helper somewhere
+    # inert). Each composite's test.bats MUST mention the guard at
+    # least once, so a future maintainer who silently drops the wrap
+    # but leaves an import comment behind still trips a test.
+    local missing=()
+    while IFS= read -r -d '' action_yml; do
+        local composite_dir composite_name test_bats
+        composite_dir="$(dirname "$action_yml")"
+        composite_name="$(basename "$composite_dir")"
+        test_bats="$composite_dir/test.bats"
+
+        if is_exempt "$composite_name"; then
+            continue
+        fi
+        if [[ ! -f "$test_bats" ]]; then
+            missing+=("$composite_name (no test.bats)")
+            continue
+        fi
+        if ! grep -qE 'stop_commands_guard|stop-commands guard' "$test_bats"; then
+            missing+=("$composite_name")
+        fi
+    done < <(find "$REPO_ROOT/build/actions" -mindepth 2 -maxdepth 2 \
+        -name action.yml -type f -print0)
+
+    if (( ${#missing[@]} > 0 )); then
+        printf 'Build composite test.bats missing guard-coverage assertion: %s\n' \
+            "${missing[*]}" >&2
+        return 1
+    fi
+}

--- a/test/test_build_guard_coverage.bats
+++ b/test/test_build_guard_coverage.bats
@@ -84,9 +84,12 @@ is_exempt() {
 @test "build-guard-coverage: every build composite test.bats pins guard coverage" {
     # A per-composite assertion that its action.yml actually wraps the
     # ecosystem invocation (not just imports the helper somewhere
-    # inert). Each composite's test.bats MUST mention the guard at
-    # least once, so a future maintainer who silently drops the wrap
-    # but leaves an import comment behind still trips a test.
+    # inert). Each composite's test.bats MUST reference the literal
+    # helper filename `stop_commands_guard.sh` — which is what an
+    # actual assertion grep'ing the action.yml looks like, not what
+    # pure prose would say. A maintainer dropping the assertion and
+    # leaving a section-header comment that reads "stop-commands guard"
+    # alone does NOT satisfy this check.
     local missing=()
     while IFS= read -r -d '' action_yml; do
         local composite_dir composite_name test_bats
@@ -101,7 +104,7 @@ is_exempt() {
             missing+=("$composite_name (no test.bats)")
             continue
         fi
-        if ! grep -qE 'stop_commands_guard|stop-commands guard' "$test_bats"; then
+        if ! grep -qF 'stop_commands_guard.sh' "$test_bats"; then
             missing+=("$composite_name")
         fi
     done < <(find "$REPO_ROOT/build/actions" -mindepth 2 -maxdepth 2 \


### PR DESCRIPTION
claude: implements Finding 3 of the SLSA v1.2 Build L3 audit (`docs/SLSA_L3_AUDIT.md`) — the first half of issue #225. The adopter-tunable PR-cache knobs (the second half of #225) land in a separate stacked PR.

## Problem

GitHub Actions interprets any line on a step's output stream beginning with `::` as a workflow command (`::add-mask::`, `::add-path::`, `::set-output::`, ...). A build tool — or a malicious dependency lifecycle hook (npm `postinstall`), a hostile test, a build backend, a poisoned Dockerfile `RUN` — can hijack the build job just by printing such a line. The SLSA ecosystem-specific Go builder shadows the `::` prefix with a per-run token before invoking the compile; wrangle did not.

## Change

New `lib/stop_commands_guard.sh` helper with three subcommands:

- `run <command> [args...]` — emit `::stop-commands::<token>`, run the command, then **always** emit the matching `::<token>::` (re-enable), preserving the command's exit status. Wraps a single build/test script invocation inside one `run:` step.
- `begin` / `end <token>` — split form for guarding a `uses:` build step that cannot be wrapped in-process.

The token is 32 bytes of `/dev/urandom`, hex-encoded, and is never exported into the guarded command's environment, so the build tool cannot read it and re-enable commands itself.

Wired into every composite that runs ecosystem build tooling:

- **npm** — wraps the `build_and_pack.sh` invocation (install / build / test / pack).
- **python** — wraps the `install_deps.sh` and `run_tests.sh` invocations.
- **container** — brackets the `docker/build-push-action` step with `begin` / `end` steps. The guard spans two steps (not a one-process wrapper) because the docker build is a `uses:` step; this is sound because the runner's stop-commands state is **job-scoped** (the `ActionCommandManager` is a per-job singleton with no per-step reset). The re-enable step runs with `if: always()` — leaving stop-commands suspended would silently disable `::add-mask::` secret redaction for the rest of the job.

## Tests

- `test/lib/test_stop_commands_guard.bats` — new, covers all three subcommands: token shape/randomness, exit-status preservation, re-enable-on-failure, token-not-in-environment, `begin`/`end` round-trip, empty-token no-op.
- `build/actions/{npm,python,container}/test.bats` — structural assertions that each build/test invocation runs under the guard, ordering (begin → build → end), and that the container re-enable step is `if: always()` and passes the token via `env:` (not `run:` interpolation).

## Post-merge follow-up required

This PR changes the npm, python, and container **composite actions**. The reusable workflows pin those composites by SHA, so a follow-up self-ref pin bump (`make bump-action-pins` / `tools/bump_action_pins.sh`) is needed post-merge for the reusable workflows — and therefore the cross-repo integration test — to pick up the guarded composites. Unit-test CI (`test.yml`) exercises the new code directly on this branch.

Closes part of #225.

https://claude.ai/code/session_01HTRhX1N45AeZ1izPjzzvaH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTRhX1N45AeZ1izPjzzvaH)_