### PR TITLE
Bump self-ref pins to main HEAD (post-#230, post-#231)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -105,7 +105,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
 
   gate:
     needs: [guard]
@@ -116,7 +116,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/release_gate@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -138,7 +138,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
+      uses: TomHennen/wrangle/build/actions/container@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -125,7 +125,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
 
   gate:
     needs: [guard]
@@ -136,7 +136,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/release_gate@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -160,7 +160,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
+      - uses: TomHennen/wrangle/build/actions/npm@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -104,7 +104,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -119,7 +119,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/release_gate@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
+      - uses: TomHennen/wrangle/build/actions/python@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -29,7 +29,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
 
   shell-build:
     needs: [guard]
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
+        uses: TomHennen/wrangle/build/actions/shell@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -20,7 +20,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
+      - uses: TomHennen/wrangle/actions/preflight_guard@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
 
   check-change:
     needs: [guard]
@@ -38,6 +38,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@204995dd53f5fb91b5f3363579e81f98c2c16aac # main 2026-05-17
+        uses: TomHennen/wrangle/actions/scan@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
         with:
           tools: ${{ inputs.tools }}


### PR DESCRIPTION
## Summary

Post-merge cleanup after #230 (stop-commands guard) and #231 (PR-to-PR cache knobs). Bumps every `TomHennen/wrangle/...@<sha>` self-ref in `.github/workflows/` from the pre-#230 SHA (`204995dd`, dated 2026-05-17) to the post-#231 SHA (`f0a0b4ac`, 2026-05-20).

No behavior change in the composites themselves — just the workflow-side SHA references catching up to the merged composite state, so the cross-repo integration test (`test/integration/`) exercises the new guarded composites and the new `pr-cache` input. Same pattern as #227's bump after #226.

Files touched (5):
- `.github/workflows/build_and_publish_container.yml`
- `.github/workflows/build_and_publish_npm.yml`
- `.github/workflows/build_and_publish_python.yml`
- `.github/workflows/build_shell.yml`
- `.github/workflows/check_source_change.yml`

Generated via `make bump-action-pins`.

## Test plan

- [x] CI passes (the bump itself is what `tools/bump_action_pins.sh` tests for; cross-repo integration test will exercise the new composites)
- [ ] Verify the integration test against the companion repo picks up the new SHAs and exercises the stop-commands guard + isolated PR cache scope

Co-authored-by: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWbQKtKiaZzKztZHKCRxsP)_