### PR TITLE
osv adapter: generate output.md from SARIF instead of a second scan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,59 @@ jobs:
 
       - name: Run tests
         run: ./test.sh
+
+  # Runs only the `osv e2e: ...` bats test against the real osv-scanner
+  # binary installed via tools/osv/install.sh. Separated from the Docker
+  # unit suite above so the unit container doesn't need network access
+  # to osv.dev or a slsa-verifier binary baked in. Dogfoods install.sh
+  # and the e2e assertion in one job — keeps the e2e from being a
+  # silent skip everywhere (see PR #234 discussion).
+  osv-e2e:
+    name: osv-scanner e2e (real binary)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # slsa-verifier is required by tools/osv/install.sh — osv-scanner's
+      # sole verification method is SLSA provenance.
+      - name: Install slsa-verifier
+        uses: slsa-framework/slsa-verifier/actions/installer@ea584f4502babc6f60d9bc799dbbb13c1caa9ee6 # v2.7.1
+
+      - name: Install bats and jq
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q --no-install-recommends bats jq
+
+      - name: Install osv-scanner via tools/osv/install.sh
+        env:
+          WRANGLE_BIN_DIR: ${{ runner.temp }}/.wrangle/bin
+        run: |
+          ./tools/osv/install.sh
+          printf '%s\n' "$WRANGLE_BIN_DIR" >> "$GITHUB_PATH"
+
+      - name: Verify osv-scanner is on PATH
+        run: osv-scanner --version
+
+      # Run only the e2e test. The unit tests run in the Docker container
+      # above and don't need the real binary. `tee` preserves the bats TAP
+      # output for the post-step skip check.
+      - name: Run osv e2e test
+        run: |
+          set -o pipefail
+          bats --tap -f "osv e2e:" tools/osv/test.bats | tee /tmp/osv-e2e.tap
+
+      # Fail loudly if the e2e test skipped. The e2e test contains
+      # network-unreachability skip paths as a safety net for sandboxed
+      # local dev; in CI we have network access and an installed binary,
+      # so any skip here means the test silently degraded and must be
+      # investigated — not ignored.
+      - name: Reject silent skip
+        run: |
+          if grep -E '^ok [0-9]+ .* # skip' /tmp/osv-e2e.tap; then
+              printf 'FATAL: osv e2e test was skipped in CI — install or network broken, or the assertion silently degraded\n' >&2
+              exit 1
+          fi

--- a/tools/osv/adapter.sh
+++ b/tools/osv/adapter.sh
@@ -63,12 +63,15 @@ if ! jq empty "$SARIF_FILE" 2>/dev/null; then
     exit 2
 fi
 
-# Generate markdown summary from the SARIF we just produced.
-# Using the shared helper (rather than a second osv-scanner invocation with
+# Generate markdown summary from the SARIF we just produced. Using a local
+# render_md.sh (rather than a second osv-scanner invocation with
 # --format markdown) guarantees the summary and the SARIF-based check report
 # the same findings — osv-scanner's markdown formatter has been observed
-# reporting zero findings while the SARIF contains results.
-"$SCRIPT_DIR/../../lib/sarif_to_md.sh" "$SARIF_FILE" > "$MD_FILE"
+# reporting zero findings while the SARIF contains results (issue #197).
+# Best-effort: a failure here loses the summary but must not fail the
+# scan, since the SARIF (which the gating check consults) is already written.
+"$SCRIPT_DIR/render_md.sh" "$SARIF_FILE" > "$MD_FILE" 2>/dev/null || \
+    printf 'wrangle/osv: failed to render markdown summary (SARIF still valid)\n' > "$MD_FILE"
 
 # Determine exit code from SARIF results
 if ! num_findings="$(jq '[.runs[].results[]] | length' "$SARIF_FILE" 2>/dev/null)"; then

--- a/tools/osv/adapter.sh
+++ b/tools/osv/adapter.sh
@@ -8,6 +8,8 @@ set -f  # disable globbing — adapter processes external input paths
 # Usage: adapter.sh <src_dir> <output_dir>
 # Exit: 0 = no findings, 1 = findings found, 2 = tool error
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if [[ $# -ne 2 ]]; then
     printf 'Usage: adapter.sh <src_dir> <output_dir>\n' >&2
     exit 2
@@ -61,8 +63,12 @@ if ! jq empty "$SARIF_FILE" 2>/dev/null; then
     exit 2
 fi
 
-# Generate markdown output (best-effort, non-fatal)
-osv-scanner scan --format markdown --output "$MD_FILE" -r "$SRC_DIR" 2>/dev/null || true
+# Generate markdown summary from the SARIF we just produced.
+# Using the shared helper (rather than a second osv-scanner invocation with
+# --format markdown) guarantees the summary and the SARIF-based check report
+# the same findings — osv-scanner's markdown formatter has been observed
+# reporting zero findings while the SARIF contains results.
+"$SCRIPT_DIR/../../lib/sarif_to_md.sh" "$SARIF_FILE" > "$MD_FILE"
 
 # Determine exit code from SARIF results
 if ! num_findings="$(jq '[.runs[].results[]] | length' "$SARIF_FILE" 2>/dev/null)"; then

--- a/tools/osv/render_md.sh
+++ b/tools/osv/render_md.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — processes external file paths
+
+# tools/osv/render_md.sh — Render osv-scanner SARIF as a markdown summary.
+#
+# osv-scanner SARIF needs an osv-specific renderer because the LCD helper at
+# lib/sarif_to_md.sh drops the data that matters most for vuln triage:
+#   1. Severity. osv emits result.level="warning" for every finding; real
+#      CVSS lives at rule.properties["security-severity"].
+#   2. Per-vuln dedupe. osv emits one result per (vuln, lockfile-location)
+#      pair, so the same CVE appears N times. Old osv markdown deduped.
+#   3. Fixed versions. osv embeds remediation guidance in rule.help.markdown
+#      under "### Fixed Versions" — the most actionable column for users.
+#
+# Usage: render_md.sh <sarif_file>
+# Output: Markdown table to stdout (sanitized + truncated via
+#         wrangle_sanitize_output to prevent step-summary flooding).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=../../lib/sanitize.sh
+source "$SCRIPT_DIR/../../lib/sanitize.sh"
+
+if [[ $# -ne 1 ]]; then
+    printf 'Usage: render_md.sh <sarif_file>\n' >&2
+    exit 1
+fi
+
+SARIF_FILE="$1"
+
+if [[ ! -f "$SARIF_FILE" ]]; then
+    printf 'Error: SARIF file not found: %s\n' "$SARIF_FILE" >&2
+    exit 1
+fi
+
+if ! jq empty "$SARIF_FILE" 2>/dev/null; then
+    printf 'Error: invalid JSON in SARIF file: %s\n' "$SARIF_FILE" >&2
+    exit 2
+fi
+
+# Map CVSS 3.x base score to severity label.
+severity_label() {
+    local score="$1"
+    if [[ -z "$score" ]] || [[ "$score" == "null" ]]; then
+        printf 'UNKNOWN'
+        return
+    fi
+    awk -v s="$score" 'BEGIN {
+        if (s+0 >= 9.0)      print "CRITICAL";
+        else if (s+0 >= 7.0) print "HIGH";
+        else if (s+0 >= 4.0) print "MEDIUM";
+        else if (s+0 > 0)    print "LOW";
+        else                 print "UNKNOWN";
+    }'
+}
+
+# jq program kept in a heredoc to avoid quoting headaches around the single
+# quotes osv puts in its message text (e.g. Package 'foo@1.2.3' ...).
+# Everything is extracted inside jq so we never pass multi-line content like
+# rule.help.markdown back through bash. Output is one TSV row per unique
+# rule (= per unique vulnerability).
+read -r -d '' JQ_PROG <<'JQ' || true
+def esc: gsub("\\|"; "/") | gsub("\n"; " ") | gsub("\t"; " ");
+
+# Quote characters used in osv message strings ("Package '...' is vulnerable").
+# Inside the jq string, the literal " must be backslash-escaped; the
+# apostrophe ' passes through unchanged.
+def pkg_re: "Package ['\"]?(?<pkg>[^'\"]+)['\"]?";
+
+def fixed_versions:
+    # The "### Fixed Versions" section is a 3-column markdown table:
+    # | VulnID | Package | Fixed Version |
+    (split("### Fixed Versions") | .[1] // "")
+    | (split("\n###") | (.[0] // ""))
+    | [scan("\\|\\s*[^|\\n]+\\s*\\|\\s*([^|\\n]+?)\\s*\\|\\s*([^|\\n]+?)\\s*\\|")]
+    | map(select(.[0] != "Package Name" and (.[0] | test("^-+$") | not)))
+    | map(.[0] + "@" + .[1])
+    | unique
+    | join(", ");
+
+.runs[0] as $run
+| ($run.tool.driver.rules // []) as $rules
+| ($run.results // []) as $results
+| $rules
+| map(
+    . as $rule
+    | ($results | map(select(.ruleId == $rule.id))) as $matches
+    | select(($matches | length) > 0)
+    | {
+        ruleId: $rule.id,
+        severity: ($rule.properties["security-severity"] // ""),
+        packages: (
+          $matches
+          | map(.message.text | capture(pkg_re; "")? | .pkg // empty)
+          | unique
+          | join(", ")
+        ),
+        locations: (
+          $matches
+          | map(
+              .locations[0].physicalLocation.artifactLocation.uri // "unknown"
+              | sub("^file://"; "")
+            )
+          | unique
+          | join(", ")
+        ),
+        fixed: (($rule.help.markdown // "") | fixed_versions)
+      }
+    | [
+        (.ruleId    | esc),
+        .severity,
+        (.packages  | esc),
+        (.fixed     | esc),
+        (.locations | esc)
+      ]
+    # ASCII Unit Separator (U+001F). Non-whitespace so bash `read` with
+    # IFS=$'\x1f' preserves empty fields (severity is often absent for
+    # rules without a CVSS score).
+    | join("")
+  )
+| .[]
+JQ
+
+records=$(jq -r "$JQ_PROG" "$SARIF_FILE")
+
+if [[ -z "$records" ]]; then
+    printf 'No known vulnerabilities.\n'
+    exit 0
+fi
+
+{
+printf '| Severity | Vulnerability | Package | Fixed Version(s) | Locations |\n'
+printf '| -------- | ------------- | ------- | ---------------- | --------- |\n'
+
+while IFS=$'\x1f' read -r ruleId severity packages fixed locations; do
+    [[ -z "$ruleId" ]] && continue
+    sev_label=$(severity_label "$severity")
+    [[ -z "$fixed" ]] && fixed='—'
+    [[ -z "$packages" ]] && packages='—'
+    # shellcheck disable=SC2016 # backticks render as a markdown code span
+    printf '| %s | %s | %s | %s | `%s` |\n' \
+        "$sev_label" "$ruleId" "$packages" "$fixed" "$locations"
+done <<< "$records"
+} | wrangle_sanitize_output

--- a/tools/osv/test.bats
+++ b/tools/osv/test.bats
@@ -1,29 +1,54 @@
 #!/usr/bin/env bats
 
-# Tests for tools/osv/ (install.sh and adapter.sh)
-# Uses mock osv-scanner binary for fast, deterministic testing.
+# Tests for tools/osv/ — install.sh, adapter.sh, and render_md.sh.
+#
+# Three layers, mirroring the pattern adopted in #236:
+#
+#   1. render_md.sh — direct behavioral tests. Inline SARIF fixtures
+#      describe a specific input; assertions are on stdout/exit code.
+#      No mock binary involved.
+#
+#   2. adapter.sh — end-to-end through a PATH-shimmed osv-scanner.
+#      The shim emits canned SARIF (controlled by OSV_MOCK_MODE) so
+#      these tests cover the adapter's exit-code contract, SARIF
+#      validation, output-directory handling, and the wiring between
+#      adapter → render_md.sh.
+#
+#   3. install.sh — verification chain tests (curl + slsa-verifier
+#      shims). No real downloads.
+#
+# Plus one opt-in e2e (`@test "osv e2e: ..."`) that runs the real
+# osv-scanner against a deliberately-vulnerable manifest. Skips if
+# osv-scanner is not on PATH or the osv.dev API is unreachable (which
+# is the case in sandboxed CI environments).
 
 setup() {
-    export TEST_DIR="$(mktemp -d)"
-    export ORIG_DIR="$(pwd)"
-    export MOCK_BIN="$TEST_DIR/mock_bin"
-    mkdir -p "$MOCK_BIN" "$TEST_DIR/src" "$TEST_DIR/output"
+    ORIG_DIR="$(pwd)"
+    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/osv-bats-XXXXXX")"
+    MOCK_BIN="$TMP_DIR/mock_bin"
+    export ORIG_DIR TMP_DIR MOCK_BIN
 
-    # Create a mock osv-scanner that produces fixture SARIF
+    ADAPTER="$ORIG_DIR/tools/osv/adapter.sh"
+    RENDER="$ORIG_DIR/tools/osv/render_md.sh"
+    INSTALL="$ORIG_DIR/tools/osv/install.sh"
+    REAL_FIXTURE="$ORIG_DIR/tools/osv/testdata/real_osv_findings.sarif"
+    export ADAPTER RENDER INSTALL REAL_FIXTURE
+
+    mkdir -p "$MOCK_BIN" "$TMP_DIR/src" "$TMP_DIR/output"
+
+    # Mock osv-scanner used by the adapter-layer tests. Behaviour is
+    # selected via OSV_MOCK_MODE: clean | findings | real-findings |
+    # no-sources | error | bad-json. The real binary is exercised only
+    # by the opt-in e2e test (which removes this mock from PATH first).
     cat > "$MOCK_BIN/osv-scanner" << 'MOCK'
 #!/bin/bash
-# Mock osv-scanner: behavior controlled by OSV_MOCK_MODE env var
-# Supports: clean, findings, no-sources, error, bad-json
-
-# Handle --version flag
 for arg in "$@"; do
     if [[ "$arg" == "--version" ]]; then
-        echo "osv-scanner version 2.3.5-mock"
+        printf 'osv-scanner version 2.3.5-mock\n'
         exit 0
     fi
 done
 
-# Parse args to find --output and --format
 output_file=""
 format=""
 while [[ $# -gt 0 ]]; do
@@ -60,10 +85,6 @@ SARIF
         exit 1
         ;;
     real-findings)
-        # Mock emits a real osv-scanner SARIF captured from the upstream
-        # project's snapshot tests (see testdata/real_osv_findings.sarif).
-        # This exercises the adapter end-to-end with the actual SARIF
-        # structure osv-scanner produces, not a hand-rolled stub.
         if [[ "$format" == "sarif" ]]; then
             cp "$OSV_REAL_SARIF" "$output_file"
         fi
@@ -77,7 +98,7 @@ SARIF
         ;;
     bad-json)
         if [[ "$format" == "sarif" ]]; then
-            echo "not valid json{{{" > "$output_file"
+            printf 'not valid json{{{\n' > "$output_file"
         fi
         exit 0
         ;;
@@ -89,269 +110,404 @@ MOCK
 }
 
 teardown() {
-    cd "$ORIG_DIR"
-    rm -rf "$TEST_DIR"
+    cd "$ORIG_DIR" || true
+    if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
 }
 
-# --- adapter.sh tests ---
+# Helper: write a SARIF fixture to $1 with a single rule of the given
+# CVSS score, one result against $2 (uri). Used by the severity-bucket
+# tests below to keep each test body short.
+write_sarif_with_severity() {
+    local out="$1" severity="$2" rule_id="${3:-CVE-EXAMPLE-1}"
+    cat > "$out" <<SARIF
+{
+  "version": "2.1.0",
+  "runs": [{
+    "tool": {"driver": {"name": "osv-scanner", "rules": [
+      {"id": "$rule_id", "properties": {"security-severity": "$severity"}}
+    ]}},
+    "results": [{
+      "ruleId": "$rule_id",
+      "level": "warning",
+      "message": {"text": "Package 'lib@1.0.0' is vulnerable to '$rule_id'."},
+      "locations": [{"physicalLocation": {"artifactLocation": {"uri": "file:///path/to/pkg"}}}]
+    }]
+  }]
+}
+SARIF
+}
+
+# --- render_md.sh: direct behavioral tests --------------------------------
+
+@test "render_md: empty SARIF -> 'No known vulnerabilities'" {
+    cat > "$TMP_DIR/in.sarif" <<'SARIF'
+{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"osv-scanner"}},"results":[]}]}
+SARIF
+    run "$RENDER" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No known vulnerabilities"* ]]
+}
+
+@test "render_md: CVSS 9.5 renders as CRITICAL" {
+    write_sarif_with_severity "$TMP_DIR/in.sarif" "9.5"
+    run "$RENDER" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"| CRITICAL |"* ]]
+}
+
+@test "render_md: CVSS 7.5 renders as HIGH" {
+    write_sarif_with_severity "$TMP_DIR/in.sarif" "7.5"
+    run "$RENDER" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"| HIGH |"* ]]
+    [[ "$output" != *"| MEDIUM |"* ]]
+}
+
+@test "render_md: CVSS 5.0 renders as MEDIUM" {
+    write_sarif_with_severity "$TMP_DIR/in.sarif" "5.0"
+    run "$RENDER" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"| MEDIUM |"* ]]
+}
+
+@test "render_md: CVSS 2.0 renders as LOW" {
+    write_sarif_with_severity "$TMP_DIR/in.sarif" "2.0"
+    run "$RENDER" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"| LOW |"* ]]
+}
+
+@test "render_md: missing security-severity renders as UNKNOWN" {
+    cat > "$TMP_DIR/in.sarif" <<'SARIF'
+{
+  "version": "2.1.0",
+  "runs": [{
+    "tool": {"driver": {"name": "osv-scanner", "rules": [{"id": "R1"}]}},
+    "results": [{"ruleId": "R1", "message": {"text": "Package 'p@1' is vulnerable to 'R1'."},
+                 "locations": [{"physicalLocation": {"artifactLocation": {"uri": "p"}}}]}]
+  }]
+}
+SARIF
+    run "$RENDER" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"| UNKNOWN |"* ]]
+}
+
+@test "render_md: dedupes results by ruleId" {
+    # osv emits one result per (vuln, lockfile-location). The renderer
+    # must collapse them to one row per unique vulnerability.
+    cat > "$TMP_DIR/in.sarif" <<'SARIF'
+{
+  "version": "2.1.0",
+  "runs": [{
+    "tool": {"driver": {"name": "osv-scanner", "rules": [
+      {"id": "CVE-DUPE", "properties": {"security-severity": "7.5"}}
+    ]}},
+    "results": [
+      {"ruleId": "CVE-DUPE", "message": {"text": "Package 'a@1' is vulnerable to 'CVE-DUPE'."},
+       "locations": [{"physicalLocation": {"artifactLocation": {"uri": "a/lock"}}}]},
+      {"ruleId": "CVE-DUPE", "message": {"text": "Package 'a@1' is vulnerable to 'CVE-DUPE'."},
+       "locations": [{"physicalLocation": {"artifactLocation": {"uri": "b/lock"}}}]},
+      {"ruleId": "CVE-DUPE", "message": {"text": "Package 'a@1' is vulnerable to 'CVE-DUPE'."},
+       "locations": [{"physicalLocation": {"artifactLocation": {"uri": "c/lock"}}}]}
+    ]
+  }]
+}
+SARIF
+    run "$RENDER" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    rows=$(printf '%s\n' "$output" | grep -cE '^\| (CRITICAL|HIGH|MEDIUM|LOW|UNKNOWN) \|')
+    [ "$rows" -eq 1 ]
+}
+
+@test "render_md: strips file:// prefix from locations" {
+    write_sarif_with_severity "$TMP_DIR/in.sarif" "5.0"
+    run "$RENDER" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"file://"* ]]
+    [[ "$output" == *"/path/to/pkg"* ]]
+}
+
+@test "render_md: extracts fixed versions from rule.help.markdown" {
+    cat > "$TMP_DIR/in.sarif" <<'SARIF'
+{
+  "version": "2.1.0",
+  "runs": [{
+    "tool": {"driver": {"name": "osv-scanner", "rules": [{
+      "id": "CVE-FIX",
+      "properties": {"security-severity": "7.5"},
+      "help": {"markdown": "Some preamble.\n\n### Fixed Versions\n\n| Vulnerability ID | Package Name | Fixed Version |\n| --- | --- | --- |\n| GHSA-aaaa-bbbb-cccc | leftpad | 1.2.3 |\n\nMore preamble after.\n"}
+    }]}},
+    "results": [{"ruleId": "CVE-FIX",
+                 "message": {"text": "Package 'leftpad@1.0.0' is vulnerable to 'CVE-FIX'."},
+                 "locations": [{"physicalLocation": {"artifactLocation": {"uri": "p"}}}]}]
+  }]
+}
+SARIF
+    run "$RENDER" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"leftpad@1.2.3"* ]]
+}
+
+@test "render_md: missing fixed-versions section renders em-dash" {
+    write_sarif_with_severity "$TMP_DIR/in.sarif" "5.0"
+    run "$RENDER" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"| — |"* ]]
+}
+
+@test "render_md: missing file exits 1" {
+    run "$RENDER" "$TMP_DIR/does-not-exist.sarif"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"SARIF file not found"* ]]
+}
+
+@test "render_md: invalid JSON exits 2" {
+    printf 'not valid json{{{\n' > "$TMP_DIR/in.sarif"
+    run "$RENDER" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"invalid JSON"* ]]
+}
+
+@test "render_md: usage error on missing arg" {
+    run "$RENDER"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "render_md: real osv fixture renders count-parity rows" {
+    run "$RENDER" "$REAL_FIXTURE"
+    [ "$status" -eq 0 ]
+    unique_rules=$(jq -r '[.runs[].results[].ruleId] | unique | length' "$REAL_FIXTURE")
+    rows=$(printf '%s\n' "$output" | grep -cE '^\| (CRITICAL|HIGH|MEDIUM|LOW|UNKNOWN) \|')
+    [ "$rows" -eq "$unique_rules" ]
+    # CVE-2022-24713 has CVSS 7.5 in the fixture; must render as HIGH.
+    [[ "$output" == *"HIGH"* ]]
+    [[ "$output" == *"CVE-2022-24713"* ]]
+    [[ "$output" == *"CVE-2021-3121"* ]]
+    # Fixed-versions extraction from upstream help.markdown.
+    [[ "$output" == *"regex@1.5.5"* ]]
+}
+
+# --- adapter.sh: end-to-end through PATH-shimmed osv-scanner --------------
 
 @test "osv adapter: produces SARIF with no findings (exit 0)" {
     export OSV_MOCK_MODE="clean"
-    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/output"
-
+    run "$ADAPTER" "$TMP_DIR/src" "$TMP_DIR/output"
     [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/output.sarif" ]
-    # Validate it's proper SARIF
-    jq empty "$TEST_DIR/output/output.sarif"
-    result=$(jq '[.runs[].results[]] | length' "$TEST_DIR/output/output.sarif")
-    [ "$result" -eq 0 ]
+    [ -f "$TMP_DIR/output/output.sarif" ]
+    jq empty "$TMP_DIR/output/output.sarif"
+    [ "$(jq '[.runs[].results[]] | length' "$TMP_DIR/output/output.sarif")" -eq 0 ]
 }
 
 @test "osv adapter: produces SARIF with findings (exit 1)" {
     export OSV_MOCK_MODE="findings"
-    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/output"
-
+    run "$ADAPTER" "$TMP_DIR/src" "$TMP_DIR/output"
     [ "$status" -eq 1 ]
-    [ -f "$TEST_DIR/output/output.sarif" ]
-    result=$(jq '[.runs[].results[]] | length' "$TEST_DIR/output/output.sarif")
-    [ "$result" -gt 0 ]
+    [ -f "$TMP_DIR/output/output.sarif" ]
+    [ "$(jq '[.runs[].results[]] | length' "$TMP_DIR/output/output.sarif")" -gt 0 ]
 }
 
 @test "osv adapter: handles no package sources (exit 0, empty SARIF)" {
     export OSV_MOCK_MODE="no-sources"
-    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/output"
-
+    run "$ADAPTER" "$TMP_DIR/src" "$TMP_DIR/output"
     [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/output.sarif" ]
-    jq empty "$TEST_DIR/output/output.sarif"
-    result=$(jq '[.runs[].results[]] | length' "$TEST_DIR/output/output.sarif")
-    [ "$result" -eq 0 ]
+    [ -f "$TMP_DIR/output/output.sarif" ]
+    jq empty "$TMP_DIR/output/output.sarif"
+    [ "$(jq '[.runs[].results[]] | length' "$TMP_DIR/output/output.sarif")" -eq 0 ]
 }
 
 @test "osv adapter: tool error produces exit 2" {
     export OSV_MOCK_MODE="error"
-    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/output"
-
+    run "$ADAPTER" "$TMP_DIR/src" "$TMP_DIR/output"
     [ "$status" -eq 2 ]
 }
 
 @test "osv adapter: invalid JSON SARIF produces exit 2" {
     export OSV_MOCK_MODE="bad-json"
-    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/output"
-
+    run "$ADAPTER" "$TMP_DIR/src" "$TMP_DIR/output"
     [ "$status" -eq 2 ]
 }
 
 @test "osv adapter: requires 2 arguments" {
-    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src"
-
+    run "$ADAPTER" "$TMP_DIR/src"
     [ "$status" -eq 2 ]
     [[ "$output" == *"Usage"* ]]
 }
 
 @test "osv adapter: fails if src_dir does not exist" {
-    run "$ORIG_DIR/tools/osv/adapter.sh" "/nonexistent" "$TEST_DIR/output"
-
+    run "$ADAPTER" "/nonexistent" "$TMP_DIR/output"
     [ "$status" -eq 2 ]
 }
 
 @test "osv adapter: fails if output_dir does not exist" {
-    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "/nonexistent"
-
+    run "$ADAPTER" "$TMP_DIR/src" "/nonexistent"
     [ "$status" -eq 2 ]
 }
 
-@test "osv adapter: clean scan produces a non-empty output.md" {
+@test "osv adapter: clean scan produces non-empty output.md" {
     export OSV_MOCK_MODE="clean"
-    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/output"
-
+    run "$ADAPTER" "$TMP_DIR/src" "$TMP_DIR/output"
     [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/output.md" ]
-    # Empty-SARIF path must still produce content for the step summary.
-    [ -s "$TEST_DIR/output/output.md" ]
-    grep -qi "no known vulnerabilities" "$TEST_DIR/output/output.md"
+    [ -s "$TMP_DIR/output/output.md" ]
+    grep -qi "no known vulnerabilities" "$TMP_DIR/output/output.md"
 }
 
-# Regression test for #197: when osv-scanner produces SARIF with findings,
-# output.md must list those findings (it previously reported zero because
-# the adapter ran osv-scanner a second time for markdown and the markdown
-# formatter under-reported).
-@test "osv adapter: markdown output reflects SARIF findings" {
-    export OSV_MOCK_MODE="findings"
-    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/output"
-
-    [ "$status" -eq 1 ]
-    [ -f "$TEST_DIR/output/output.md" ]
-    # The finding's ruleId from the mock SARIF should appear in the summary.
-    grep -q "GHSA-1234-5678-abcd" "$TEST_DIR/output/output.md"
-}
-
-# Regression test for #197 using a real osv-scanner SARIF fixture captured
-# from osv-scanner's own snapshot tests
-# (internal/output/__snapshots__/sarif_test.snap @ v2.3.5). Confirms the
-# adapter's markdown summary surfaces actual osv-scanner findings end-to-end
-# with the SARIF structure the tool really produces.
-@test "osv adapter: markdown output reflects findings from real osv-scanner SARIF" {
+# Regression test for #197: SARIF and the markdown summary must agree.
+# The old adapter ran osv-scanner twice (once for SARIF, once for
+# markdown) and the markdown formatter under-reported, producing
+# "SARIF=N, MD=0". Now MD is rendered from the SARIF directly.
+@test "osv adapter: SARIF and MD agree on finding count (real osv fixture)" {
     export OSV_MOCK_MODE="real-findings"
-    export OSV_REAL_SARIF="$ORIG_DIR/tools/osv/testdata/real_osv_findings.sarif"
-    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/output"
-
+    export OSV_REAL_SARIF="$REAL_FIXTURE"
+    run "$ADAPTER" "$TMP_DIR/src" "$TMP_DIR/output"
     [ "$status" -eq 1 ]
-    [ -f "$TEST_DIR/output/output.md" ]
-    # Both unique CVE ruleIds in the fixture must appear in the summary.
-    grep -q "CVE-2022-24713" "$TEST_DIR/output/output.md"
-    grep -q "CVE-2021-3121" "$TEST_DIR/output/output.md"
-    # Vulnerable package version (not the fixed one) must be surfaced.
-    grep -q "regex@1.5.1" "$TEST_DIR/output/output.md"
-    # Fixed version from rule.help.markdown must be surfaced.
-    grep -q "regex@1.5.5" "$TEST_DIR/output/output.md"
-    # CVSS 7.5 on CVE-2022-24713 must render as HIGH, not MEDIUM.
-    grep -q "HIGH" "$TEST_DIR/output/output.md"
-    # file:// prefix must be stripped from locations.
-    ! grep -q "file://" "$TEST_DIR/output/output.md"
-    # Count parity: every unique ruleId in the SARIF gets exactly one row.
-    # This is the literal #197 symptom (SARIF=N, MD=0). Markdown rows start
-    # with "| " and exclude the header (which contains "Severity") and
-    # divider rows. The fixture has 2 unique ruleIds across 3 results.
     unique_rules=$(jq -r '[.runs[].results[].ruleId] | unique | length' \
-        "$TEST_DIR/output/output.sarif")
+        "$TMP_DIR/output/output.sarif")
     md_rows=$(grep -cE '^\| (CRITICAL|HIGH|MEDIUM|LOW|UNKNOWN) \|' \
-        "$TEST_DIR/output/output.md")
+        "$TMP_DIR/output/output.md")
     [ "$md_rows" -eq "$unique_rules" ]
 }
 
-# Best-effort render: a render_md.sh failure must NOT fail the adapter,
-# since the SARIF (consulted by the gating check) is already valid.
-@test "osv adapter: render failure does not fail the adapter" {
-    export OSV_MOCK_MODE="real-findings"
-    export OSV_REAL_SARIF="$ORIG_DIR/tools/osv/testdata/real_osv_findings.sarif"
-    # Shadow render_md.sh with one that always fails by pointing PATH at a
-    # broken jq. Simpler: replace render_md.sh itself for this test.
-    cp "$ORIG_DIR/tools/osv/render_md.sh" "$TEST_DIR/render_md.sh.bak"
-    cat > "$ORIG_DIR/tools/osv/render_md.sh" <<'BROKEN'
-#!/bin/bash
-exit 99
-BROKEN
-    chmod +x "$ORIG_DIR/tools/osv/render_md.sh"
+# --- osv e2e: real osv-scanner against a vulnerable manifest --------------
 
-    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/output"
+# Drives the full pipeline with the real osv-scanner binary against a
+# fixture pinned to an older Go stdlib (long-standing CVEs, deterministic
+# under network access). Skipped when osv-scanner isn't on PATH or the
+# osv.dev API isn't reachable (sandboxed CI environments).
+@test "osv e2e: real osv-scanner produces consistent SARIF + MD" {
+    if ! command -v osv-scanner >/dev/null 2>&1 || \
+       [[ "$(osv-scanner --version 2>&1 | head -n1)" == *"-mock"* ]]; then
+        # The shim is still on PATH (or no osv-scanner installed).
+        # Remove the shim and re-check.
+        export PATH="${PATH#"$MOCK_BIN":}"
+    fi
+    if ! command -v osv-scanner >/dev/null 2>&1; then
+        skip "osv-scanner not on PATH; install via tools/osv/install.sh first"
+    fi
+
+    cp "$ORIG_DIR/tools/osv/testdata/vulnerable_go.mod" "$TMP_DIR/src/go.mod"
+
+    run "$ADAPTER" "$TMP_DIR/src" "$TMP_DIR/output"
     rc=$status
 
-    # Restore before asserting so a failure here doesn't leave the repo dirty.
-    cp "$TEST_DIR/render_md.sh.bak" "$ORIG_DIR/tools/osv/render_md.sh"
+    # osv.dev API unreachable (sandbox / offline): the adapter returns
+    # exit 2 with no SARIF written, or exit 0 with an empty SARIF. In
+    # either case skip — there's nothing to assert about the pipeline
+    # because osv-scanner couldn't enrich the manifest.
+    if [[ ! -s "$TMP_DIR/output/output.sarif" ]]; then
+        skip "osv-scanner did not produce SARIF (likely network-restricted)"
+    fi
+    n=$(jq '[.runs[].results[]] | length' "$TMP_DIR/output/output.sarif")
+    if [[ "$n" -eq 0 ]]; then
+        skip "osv-scanner produced 0 results (likely offline or no advisories for fixture)"
+    fi
 
-    [ "$rc" -eq 1 ]                                     # findings → exit 1
-    [ -f "$TEST_DIR/output/output.md" ]                 # placeholder written
-    [ -s "$TEST_DIR/output/output.sarif" ]              # SARIF intact
+    [ "$rc" -eq 1 ]                              # findings present
+    [ -s "$TMP_DIR/output/output.md" ]
+
+    # The #197 invariant: SARIF and MD must agree on unique-vuln count.
+    unique_rules=$(jq -r '[.runs[].results[].ruleId] | unique | length' \
+        "$TMP_DIR/output/output.sarif")
+    md_rows=$(grep -cE '^\| (CRITICAL|HIGH|MEDIUM|LOW|UNKNOWN) \|' \
+        "$TMP_DIR/output/output.md")
+    [ "$md_rows" -eq "$unique_rules" ]
+
+    # And no file:// prefix leaked into the summary.
+    ! grep -q "file://" "$TMP_DIR/output/output.md"
 }
 
-# --- install.sh tests ---
+# --- install.sh: verification-chain tests ---------------------------------
 
 @test "osv install: sources download_verify library" {
-    # Verify the install script can at least be parsed (syntax check)
-    run bash -n "$ORIG_DIR/tools/osv/install.sh"
-
+    run bash -n "$INSTALL"
     [ "$status" -eq 0 ]
 }
 
 @test "osv install: skips if correct version already installed" {
-    # Mock osv-scanner already exists in MOCK_BIN and reports 2.3.5
     export WRANGLE_BIN_DIR="$MOCK_BIN"
-
-    run "$ORIG_DIR/tools/osv/install.sh" "2.3.5"
-
+    run "$INSTALL" "2.3.5"
     [ "$status" -eq 0 ]
     [[ "$output" == *"already installed"* ]]
 }
 
 @test "osv install: fails if binary download fails" {
-    export WRANGLE_BIN_DIR="$TEST_DIR/install_bin"
+    export WRANGLE_BIN_DIR="$TMP_DIR/install_bin"
     mkdir -p "$WRANGLE_BIN_DIR"
 
-    # Create a mock curl that always fails
-    cat > "$TEST_DIR/mock_curl" << 'MOCK'
+    cat > "$TMP_DIR/mock_curl" << 'MOCK'
 #!/bin/bash
 exit 1
 MOCK
-    chmod +x "$TEST_DIR/mock_curl"
-    PATH="$TEST_DIR:$PATH"
-    ln -sf "$TEST_DIR/mock_curl" "$TEST_DIR/curl"
+    chmod +x "$TMP_DIR/mock_curl"
+    PATH="$TMP_DIR:$PATH"
+    ln -sf "$TMP_DIR/mock_curl" "$TMP_DIR/curl"
 
-    run "$ORIG_DIR/tools/osv/install.sh" "2.3.5"
-
+    run "$INSTALL" "2.3.5"
     [ "$status" -eq 1 ]
     [[ "$output" == *"FATAL"* ]]
-    # Binary should not exist
     [ ! -f "$WRANGLE_BIN_DIR/osv-scanner" ]
 }
 
 @test "osv install: fails if provenance download fails" {
-    export WRANGLE_BIN_DIR="$TEST_DIR/install_bin"
+    export WRANGLE_BIN_DIR="$TMP_DIR/install_bin"
     mkdir -p "$WRANGLE_BIN_DIR"
 
-    # Create a mock curl that succeeds for binary but fails for provenance
-    echo "0" > "$TEST_DIR/curl_call_count"
-    cat > "$TEST_DIR/curl" << 'MOCK'
+    printf '0\n' > "$TMP_DIR/curl_call_count"
+    cat > "$TMP_DIR/curl" << 'MOCK'
 #!/bin/bash
-count=$(cat "$TEST_DIR/curl_call_count")
+count=$(cat "$TMP_DIR/curl_call_count")
 count=$((count + 1))
-echo "$count" > "$TEST_DIR/curl_call_count"
-# First call (binary download) succeeds
+printf '%d\n' "$count" > "$TMP_DIR/curl_call_count"
 if [ "$count" -eq 1 ]; then
-    # Parse -o flag to find output file
     while [ $# -gt 0 ]; do
         case "$1" in
-            -o) echo "fake binary" > "$2"; exit 0 ;;
+            -o) printf 'fake binary\n' > "$2"; exit 0 ;;
             *) shift ;;
         esac
     done
 fi
-# Second call (provenance download) fails
 exit 1
 MOCK
-    chmod +x "$TEST_DIR/curl"
-    PATH="$TEST_DIR:$PATH"
+    chmod +x "$TMP_DIR/curl"
+    PATH="$TMP_DIR:$PATH"
 
-    run "$ORIG_DIR/tools/osv/install.sh" "2.3.5"
-
+    run "$INSTALL" "2.3.5"
     [ "$status" -eq 1 ]
     [[ "$output" == *"FATAL"* ]]
     [[ "$output" == *"provenance"* ]]
-    # Binary and provenance files should be cleaned up
     leftover=$(find "$WRANGLE_BIN_DIR" -name 'wrangle-dl-*' -o -name '*.intoto.jsonl' 2>/dev/null | wc -l)
     [ "$leftover" -eq 0 ]
 }
 
 @test "osv install: fails if provenance verification fails" {
-    export WRANGLE_BIN_DIR="$TEST_DIR/install_bin"
+    export WRANGLE_BIN_DIR="$TMP_DIR/install_bin"
     mkdir -p "$WRANGLE_BIN_DIR"
 
-    # Create a mock curl that always succeeds (writes dummy files)
-    cat > "$TEST_DIR/curl" << 'MOCK'
+    cat > "$TMP_DIR/curl" << 'MOCK'
 #!/bin/bash
 while [ $# -gt 0 ]; do
     case "$1" in
-        -o) echo "fake content" > "$2"; exit 0 ;;
+        -o) printf 'fake content\n' > "$2"; exit 0 ;;
         *) shift ;;
     esac
 done
 exit 0
 MOCK
-    chmod +x "$TEST_DIR/curl"
+    chmod +x "$TMP_DIR/curl"
 
-    # Create a mock slsa-verifier that always fails
-    cat > "$TEST_DIR/slsa-verifier" << 'MOCK'
+    cat > "$TMP_DIR/slsa-verifier" << 'MOCK'
 #!/bin/bash
 exit 1
 MOCK
-    chmod +x "$TEST_DIR/slsa-verifier"
-    PATH="$TEST_DIR:$PATH"
+    chmod +x "$TMP_DIR/slsa-verifier"
+    PATH="$TMP_DIR:$PATH"
 
-    run "$ORIG_DIR/tools/osv/install.sh" "2.3.5"
-
+    run "$INSTALL" "2.3.5"
     [ "$status" -eq 1 ]
     [[ "$output" == *"FATAL"* ]]
     [[ "$output" == *"supply chain attack"* ]]
-    # Binary and provenance files should be cleaned up
     [ ! -f "$WRANGLE_BIN_DIR/osv-scanner" ]
 }

--- a/tools/osv/test.bats
+++ b/tools/osv/test.bats
@@ -44,8 +44,6 @@ case "${OSV_MOCK_MODE:-clean}" in
   "runs": [{"tool": {"driver": {"name": "osv-scanner", "version": "2.3.5"}}, "results": []}]
 }
 SARIF
-        elif [[ "$format" == "markdown" ]]; then
-            echo "No vulnerabilities found." > "$output_file"
         fi
         exit 0
         ;;
@@ -55,11 +53,9 @@ SARIF
 {
   "version": "2.1.0",
   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-  "runs": [{"tool": {"driver": {"name": "osv-scanner", "version": "2.3.5", "rules": [{"id": "GHSA-1234-5678-abcd", "shortDescription": {"text": "Test vulnerability"}}]}}, "results": [{"ruleId": "GHSA-1234-5678-abcd", "level": "error", "message": {"text": "Package foo@1.0.0 is affected by GHSA-1234-5678-abcd"}, "locations": [{"physicalLocation": {"artifactLocation": {"uri": "package-lock.json"}, "region": {"startLine": 1}}}]}]}]
+  "runs": [{"tool": {"driver": {"name": "osv-scanner", "version": "2.3.5", "rules": [{"id": "GHSA-1234-5678-abcd", "shortDescription": {"text": "Test vulnerability"}}]}}, "results": [{"ruleId": "GHSA-1234-5678-abcd", "level": "error", "message": {"text": "Package 'foo@1.0.0' is vulnerable to 'GHSA-1234-5678-abcd'."}, "locations": [{"physicalLocation": {"artifactLocation": {"uri": "package-lock.json"}, "region": {"startLine": 1}}}]}]}]
 }
 SARIF
-        elif [[ "$format" == "markdown" ]]; then
-            echo "| Package | Version | Vulnerability |" > "$output_file"
         fi
         exit 1
         ;;
@@ -165,12 +161,15 @@ teardown() {
     [ "$status" -eq 2 ]
 }
 
-@test "osv adapter: generates markdown output on clean scan" {
+@test "osv adapter: clean scan produces a non-empty output.md" {
     export OSV_MOCK_MODE="clean"
     run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/output"
 
     [ "$status" -eq 0 ]
     [ -f "$TEST_DIR/output/output.md" ]
+    # Empty-SARIF path must still produce content for the step summary.
+    [ -s "$TEST_DIR/output/output.md" ]
+    grep -qi "no known vulnerabilities" "$TEST_DIR/output/output.md"
 }
 
 # Regression test for #197: when osv-scanner produces SARIF with findings,
@@ -202,8 +201,48 @@ teardown() {
     # Both unique CVE ruleIds in the fixture must appear in the summary.
     grep -q "CVE-2022-24713" "$TEST_DIR/output/output.md"
     grep -q "CVE-2021-3121" "$TEST_DIR/output/output.md"
-    # And the package mentioned in the SARIF message must be surfaced.
+    # Vulnerable package version (not the fixed one) must be surfaced.
     grep -q "regex@1.5.1" "$TEST_DIR/output/output.md"
+    # Fixed version from rule.help.markdown must be surfaced.
+    grep -q "regex@1.5.5" "$TEST_DIR/output/output.md"
+    # CVSS 7.5 on CVE-2022-24713 must render as HIGH, not MEDIUM.
+    grep -q "HIGH" "$TEST_DIR/output/output.md"
+    # file:// prefix must be stripped from locations.
+    ! grep -q "file://" "$TEST_DIR/output/output.md"
+    # Count parity: every unique ruleId in the SARIF gets exactly one row.
+    # This is the literal #197 symptom (SARIF=N, MD=0). Markdown rows start
+    # with "| " and exclude the header (which contains "Severity") and
+    # divider rows. The fixture has 2 unique ruleIds across 3 results.
+    unique_rules=$(jq -r '[.runs[].results[].ruleId] | unique | length' \
+        "$TEST_DIR/output/output.sarif")
+    md_rows=$(grep -cE '^\| (CRITICAL|HIGH|MEDIUM|LOW|UNKNOWN) \|' \
+        "$TEST_DIR/output/output.md")
+    [ "$md_rows" -eq "$unique_rules" ]
+}
+
+# Best-effort render: a render_md.sh failure must NOT fail the adapter,
+# since the SARIF (consulted by the gating check) is already valid.
+@test "osv adapter: render failure does not fail the adapter" {
+    export OSV_MOCK_MODE="real-findings"
+    export OSV_REAL_SARIF="$ORIG_DIR/tools/osv/testdata/real_osv_findings.sarif"
+    # Shadow render_md.sh with one that always fails by pointing PATH at a
+    # broken jq. Simpler: replace render_md.sh itself for this test.
+    cp "$ORIG_DIR/tools/osv/render_md.sh" "$TEST_DIR/render_md.sh.bak"
+    cat > "$ORIG_DIR/tools/osv/render_md.sh" <<'BROKEN'
+#!/bin/bash
+exit 99
+BROKEN
+    chmod +x "$ORIG_DIR/tools/osv/render_md.sh"
+
+    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/output"
+    rc=$status
+
+    # Restore before asserting so a failure here doesn't leave the repo dirty.
+    cp "$TEST_DIR/render_md.sh.bak" "$ORIG_DIR/tools/osv/render_md.sh"
+
+    [ "$rc" -eq 1 ]                                     # findings → exit 1
+    [ -f "$TEST_DIR/output/output.md" ]                 # placeholder written
+    [ -s "$TEST_DIR/output/output.sarif" ]              # SARIF intact
 }
 
 # --- install.sh tests ---

--- a/tools/osv/test.bats
+++ b/tools/osv/test.bats
@@ -374,9 +374,12 @@ SARIF
 # --- osv e2e: real osv-scanner against a vulnerable manifest --------------
 
 # Drives the full pipeline with the real osv-scanner binary against a
-# fixture pinned to an older Go stdlib (long-standing CVEs, deterministic
-# under network access). Skipped when osv-scanner isn't on PATH or the
-# osv.dev API isn't reachable (sandboxed CI environments).
+# fixture pinned to a known-vulnerable package version (CVE-2021-3121
+# against github.com/gogo/protobuf <1.3.2 — deterministic under network
+# access). Skipped when osv-scanner isn't on PATH or osv.dev is
+# unreachable (sandboxed dev environments); CI wires the test up in a
+# dedicated osv-e2e job in .github/workflows/test.yml so the assertions
+# actually run on every PR.
 @test "osv e2e: real osv-scanner produces consistent SARIF + MD" {
     if ! command -v osv-scanner >/dev/null 2>&1 || \
        [[ "$(osv-scanner --version 2>&1 | head -n1)" == *"-mock"* ]]; then
@@ -417,6 +420,12 @@ SARIF
 
     # And no file:// prefix leaked into the summary.
     ! grep -q "file://" "$TMP_DIR/output/output.md"
+
+    # Deterministic content check: the fixture pins gogo/protobuf v1.3.1
+    # which has had CVE-2021-3121 published since 2021. If this stops
+    # appearing, either the fixture, osv.dev, or the renderer has drifted —
+    # all worth a hard failure rather than a silent green.
+    grep -q "CVE-2021-3121" "$TMP_DIR/output/output.md"
 }
 
 # --- install.sh: verification-chain tests ---------------------------------

--- a/tools/osv/test.bats
+++ b/tools/osv/test.bats
@@ -163,6 +163,20 @@ teardown() {
     [ -f "$TEST_DIR/output/output.md" ]
 }
 
+# Regression test for #197: when osv-scanner produces SARIF with findings,
+# output.md must list those findings (it previously reported zero because
+# the adapter ran osv-scanner a second time for markdown and the markdown
+# formatter under-reported).
+@test "osv adapter: markdown output reflects SARIF findings" {
+    export OSV_MOCK_MODE="findings"
+    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/output"
+
+    [ "$status" -eq 1 ]
+    [ -f "$TEST_DIR/output/output.md" ]
+    # The finding's ruleId from the mock SARIF should appear in the summary.
+    grep -q "GHSA-1234-5678-abcd" "$TEST_DIR/output/output.md"
+}
+
 # --- install.sh tests ---
 
 @test "osv install: sources download_verify library" {

--- a/tools/osv/test.bats
+++ b/tools/osv/test.bats
@@ -63,6 +63,16 @@ SARIF
         fi
         exit 1
         ;;
+    real-findings)
+        # Mock emits a real osv-scanner SARIF captured from the upstream
+        # project's snapshot tests (see testdata/real_osv_findings.sarif).
+        # This exercises the adapter end-to-end with the actual SARIF
+        # structure osv-scanner produces, not a hand-rolled stub.
+        if [[ "$format" == "sarif" ]]; then
+            cp "$OSV_REAL_SARIF" "$output_file"
+        fi
+        exit 1
+        ;;
     no-sources)
         exit 128
         ;;
@@ -175,6 +185,25 @@ teardown() {
     [ -f "$TEST_DIR/output/output.md" ]
     # The finding's ruleId from the mock SARIF should appear in the summary.
     grep -q "GHSA-1234-5678-abcd" "$TEST_DIR/output/output.md"
+}
+
+# Regression test for #197 using a real osv-scanner SARIF fixture captured
+# from osv-scanner's own snapshot tests
+# (internal/output/__snapshots__/sarif_test.snap @ v2.3.5). Confirms the
+# adapter's markdown summary surfaces actual osv-scanner findings end-to-end
+# with the SARIF structure the tool really produces.
+@test "osv adapter: markdown output reflects findings from real osv-scanner SARIF" {
+    export OSV_MOCK_MODE="real-findings"
+    export OSV_REAL_SARIF="$ORIG_DIR/tools/osv/testdata/real_osv_findings.sarif"
+    run "$ORIG_DIR/tools/osv/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/output"
+
+    [ "$status" -eq 1 ]
+    [ -f "$TEST_DIR/output/output.md" ]
+    # Both unique CVE ruleIds in the fixture must appear in the summary.
+    grep -q "CVE-2022-24713" "$TEST_DIR/output/output.md"
+    grep -q "CVE-2021-3121" "$TEST_DIR/output/output.md"
+    # And the package mentioned in the SARIF message must be surfaced.
+    grep -q "regex@1.5.1" "$TEST_DIR/output/output.md"
 }
 
 # --- install.sh tests ---

--- a/tools/osv/testdata/real_osv_findings.sarif
+++ b/tools/osv/testdata/real_osv_findings.sarif
@@ -1,0 +1,224 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "properties": {},
+  "runs": [
+    {
+      "addresses": [],
+      "artifacts": [
+        {
+          "length": -1,
+          "location": {
+            "index": -1,
+            "uri": "file:///path/to/sub-rust-project/Cargo.lock"
+          },
+          "parentIndex": -1,
+          "roles": []
+        },
+        {
+          "length": -1,
+          "location": {
+            "index": -1,
+            "uri": "file:///path/to/go.mod"
+          },
+          "parentIndex": -1,
+          "roles": []
+        }
+      ],
+      "graphs": [],
+      "invocations": [],
+      "language": "en-US",
+      "logicalLocations": [],
+      "newlineSequences": [
+        "\r\n",
+        "\n"
+      ],
+      "policies": [],
+      "redactionTokens": [],
+      "results": [
+        {
+          "attachments": [],
+          "codeFlows": [],
+          "fixes": [],
+          "graphTraversals": [],
+          "graphs": [],
+          "kind": "fail",
+          "level": "warning",
+          "locations": [
+            {
+              "annotations": [],
+              "id": -1,
+              "logicalLocations": [],
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": -1,
+                  "uri": "file:///path/to/sub-rust-project/Cargo.lock"
+                }
+              },
+              "relationships": []
+            }
+          ],
+          "message": {
+            "arguments": [],
+            "text": "Package 'regex@1.5.1' is vulnerable to 'CVE-2022-24713' (also known as 'RUSTSEC-2022-0013', 'GHSA-m5pq-gvj9-9vr8')."
+          },
+          "partialFingerprints": {
+            "primaryLocationLineHash": "[line-hash]"
+          },
+          "rank": -1,
+          "relatedLocations": [],
+          "ruleId": "CVE-2022-24713",
+          "ruleIndex": 0,
+          "stacks": [],
+          "taxa": []
+        },
+        {
+          "attachments": [],
+          "codeFlows": [],
+          "fixes": [],
+          "graphTraversals": [],
+          "graphs": [],
+          "kind": "fail",
+          "level": "warning",
+          "locations": [
+            {
+              "annotations": [],
+              "id": -1,
+              "logicalLocations": [],
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": -1,
+                  "uri": "file:///path/to/go.mod"
+                }
+              },
+              "relationships": []
+            }
+          ],
+          "message": {
+            "arguments": [],
+            "text": "Package 'github.com/gogo/protobuf@1.3.1' is vulnerable to 'CVE-2021-3121' (also known as 'GO-2021-0053', 'GHSA-c3h9-896r-86jm')."
+          },
+          "partialFingerprints": {
+            "primaryLocationLineHash": "[line-hash]"
+          },
+          "rank": -1,
+          "relatedLocations": [],
+          "ruleId": "CVE-2021-3121",
+          "ruleIndex": 1,
+          "stacks": [],
+          "taxa": []
+        },
+        {
+          "attachments": [],
+          "codeFlows": [],
+          "fixes": [],
+          "graphTraversals": [],
+          "graphs": [],
+          "kind": "fail",
+          "level": "warning",
+          "locations": [
+            {
+              "annotations": [],
+              "id": -1,
+              "logicalLocations": [],
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": -1,
+                  "uri": "file:///path/to/sub-rust-project/Cargo.lock"
+                }
+              },
+              "relationships": []
+            }
+          ],
+          "message": {
+            "arguments": [],
+            "text": "Package 'regex@1.5.1' is vulnerable to 'CVE-2022-24713' (also known as 'RUSTSEC-2022-0013', 'GHSA-m5pq-gvj9-9vr8')."
+          },
+          "partialFingerprints": {
+            "primaryLocationLineHash": "[line-hash]"
+          },
+          "rank": -1,
+          "relatedLocations": [],
+          "ruleId": "CVE-2022-24713",
+          "ruleIndex": 0,
+          "stacks": [],
+          "taxa": []
+        }
+      ],
+      "runAggregates": [],
+      "taxonomies": [],
+      "threadFlowLocations": [],
+      "tool": {
+        "driver": {
+          "contents": [
+            "localizedData",
+            "nonLocalizedData"
+          ],
+          "informationUri": "https://github.com/google/osv-scanner",
+          "isComprehensive": false,
+          "language": "en-US",
+          "locations": [],
+          "name": "osv-scanner",
+          "notifications": [],
+          "rules": [
+            {
+              "deprecatedIds": [
+                "CVE-2022-24713",
+                "RUSTSEC-2022-0013",
+                "GHSA-m5pq-gvj9-9vr8"
+              ],
+              "fullDescription": {
+                "markdown": "The Rust Security Response WG was notified that the `regex` crate did not\nproperly limit the complexity of the regular expressions (regex) it parses. An\nattacker could use this security issue to perform a denial of service, by\nsending a specially crafted regex to a service accepting untrusted regexes. No\nknown vulnerability is present when parsing untrusted input with trusted\nregexes.\n\nThis issue has been assigned CVE-2022-24713. The severity of this vulnerability\nis \"high\" when the `regex` crate is used to parse untrusted regexes. Other uses\nof the `regex` crate are not affected by this vulnerability.\n\n## Overview\n\nThe `regex` crate features built-in mitigations to prevent denial of service\nattacks caused by untrusted regexes, or untrusted input matched by trusted\nregexes. Those (tunable) mitigations already provide sane defaults to prevent\nattacks. This guarantee is documented and it's considered part of the crate's\nAPI.\n\nUnfortunately a bug was discovered in the mitigations designed to prevent\nuntrusted regexes to take an arbitrary amount of time during parsing, and it's\npossible to craft regexes that bypass such mitigations. This makes it possible\nto perform denial of service attacks by sending specially crafted regexes to\nservices accepting user-controlled, untrusted regexes.\n\n## Affected versions\n\nAll versions of the `regex` crate before or equal to 1.5.4 are affected by this\nissue. The fix is include starting from  `regex` 1.5.5.\n\n## Mitigations\n\nWe recommend everyone accepting user-controlled regexes to upgrade immediately\nto the latest version of the `regex` crate.\n\nUnfortunately there is no fixed set of problematic regexes, as there are\npractically infinite regexes that could be crafted to exploit this\nvulnerability. Because of this, we do not recommend denying known problematic\nregexes.\n\n## Acknowledgements\n\nWe want to thank Addison Crump for responsibly disclosing this to us according\nto the [Rust security policy][1], and for helping review the fix.\n\nWe also want to thank Andrew Gallant for developing the fix, and Pietro Albini\nfor coordinating the disclosure and writing this advisory.\n\n[1]: https://www.rust-lang.org/policies/security",
+                "text": "The Rust Security Response WG was notified that the `regex` crate did not\nproperly limit the complexity of the regular expressions (regex) it parses. An\nattacker could use this security issue to perform a denial of service, by\nsending a specially crafted regex to a service accepting untrusted regexes. No\nknown vulnerability is present when parsing untrusted input with trusted\nregexes.\n\nThis issue has been assigned CVE-2022-24713. The severity of this vulnerability\nis \"high\" when the `regex` crate is used to parse untrusted regexes. Other uses\nof the `regex` crate are not affected by this vulnerability.\n\n## Overview\n\nThe `regex` crate features built-in mitigations to prevent denial of service\nattacks caused by untrusted regexes, or untrusted input matched by trusted\nregexes. Those (tunable) mitigations already provide sane defaults to prevent\nattacks. This guarantee is documented and it's considered part of the crate's\nAPI.\n\nUnfortunately a bug was discovered in the mitigations designed to prevent\nuntrusted regexes to take an arbitrary amount of time during parsing, and it's\npossible to craft regexes that bypass such mitigations. This makes it possible\nto perform denial of service attacks by sending specially crafted regexes to\nservices accepting user-controlled, untrusted regexes.\n\n## Affected versions\n\nAll versions of the `regex` crate before or equal to 1.5.4 are affected by this\nissue. The fix is include starting from  `regex` 1.5.5.\n\n## Mitigations\n\nWe recommend everyone accepting user-controlled regexes to upgrade immediately\nto the latest version of the `regex` crate.\n\nUnfortunately there is no fixed set of problematic regexes, as there are\npractically infinite regexes that could be crafted to exploit this\nvulnerability. Because of this, we do not recommend denying known problematic\nregexes.\n\n## Acknowledgements\n\nWe want to thank Addison Crump for responsibly disclosing this to us according\nto the [Rust security policy][1], and for helping review the fix.\n\nWe also want to thank Andrew Gallant for developing the fix, and Pietro Albini\nfor coordinating the disclosure and writing this advisory.\n\n[1]: https://www.rust-lang.org/policies/security"
+              },
+              "help": {
+                "markdown": "**Your dependency is vulnerable to [CVE-2022-24713](https://osv.dev/CVE-2022-24713)**\n(Also published as: [RUSTSEC-2022-0013](https://osv.dev/RUSTSEC-2022-0013), [GHSA-m5pq-gvj9-9vr8](https://osv.dev/GHSA-m5pq-gvj9-9vr8), ).\n\n## [RUSTSEC-2022-0013](https://osv.dev/RUSTSEC-2022-0013)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e The Rust Security Response WG was notified that the `regex` crate did not\n\u003e properly limit the complexity of the regular expressions (regex) it parses. An\n\u003e attacker could use this security issue to perform a denial of service, by\n\u003e sending a specially crafted regex to a service accepting untrusted regexes. No\n\u003e known vulnerability is present when parsing untrusted input with trusted\n\u003e regexes.\n\u003e \n\u003e This issue has been assigned CVE-2022-24713. The severity of this vulnerability\n\u003e is \"high\" when the `regex` crate is used to parse untrusted regexes. Other uses\n\u003e of the `regex` crate are not affected by this vulnerability.\n\u003e \n\u003e ## Overview\n\u003e \n\u003e The `regex` crate features built-in mitigations to prevent denial of service\n\u003e attacks caused by untrusted regexes, or untrusted input matched by trusted\n\u003e regexes. Those (tunable) mitigations already provide sane defaults to prevent\n\u003e attacks. This guarantee is documented and it's considered part of the crate's\n\u003e API.\n\u003e \n\u003e Unfortunately a bug was discovered in the mitigations designed to prevent\n\u003e untrusted regexes to take an arbitrary amount of time during parsing, and it's\n\u003e possible to craft regexes that bypass such mitigations. This makes it possible\n\u003e to perform denial of service attacks by sending specially crafted regexes to\n\u003e services accepting user-controlled, untrusted regexes.\n\u003e \n\u003e ## Affected versions\n\u003e \n\u003e All versions of the `regex` crate before or equal to 1.5.4 are affected by this\n\u003e issue. The fix is include starting from  `regex` 1.5.5.\n\u003e \n\u003e ## Mitigations\n\u003e \n\u003e We recommend everyone accepting user-controlled regexes to upgrade immediately\n\u003e to the latest version of the `regex` crate.\n\u003e \n\u003e Unfortunately there is no fixed set of problematic regexes, as there are\n\u003e practically infinite regexes that could be crafted to exploit this\n\u003e vulnerability. Because of this, we do not recommend denying known problematic\n\u003e regexes.\n\u003e \n\u003e ## Acknowledgements\n\u003e \n\u003e We want to thank Addison Crump for responsibly disclosing this to us according\n\u003e to the [Rust security policy][1], and for helping review the fix.\n\u003e \n\u003e We also want to thank Andrew Gallant for developing the fix, and Pietro Albini\n\u003e for coordinating the disclosure and writing this advisory.\n\u003e \n\u003e [1]: https://www.rust-lang.org/policies/security\n\n\u003c/details\u003e\n\n## [GHSA-m5pq-gvj9-9vr8](https://osv.dev/GHSA-m5pq-gvj9-9vr8)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e \u003e This is a cross-post of [the official security advisory][advisory]. The official advisory contains a signed version with our PGP key, as well.\n\u003e \n\u003e [advisory]: https://groups.google.com/g/rustlang-security-announcements/c/NcNNL1Jq7Yw\n\u003e \n\u003e The Rust Security Response WG was notified that the `regex` crate did not properly limit the complexity of the regular expressions (regex) it parses. An attacker could use this security issue to perform a denial of service, by sending a specially crafted regex to a service accepting untrusted regexes. No known vulnerability is present when parsing untrusted input with trusted regexes.\n\u003e \n\u003e This issue has been assigned CVE-2022-24713. The severity of this vulnerability is \"high\" when the `regex` crate is used to parse untrusted regexes. Other uses of the `regex` crate are not affected by this vulnerability.\n\u003e \n\u003e ## Overview\n\u003e \n\u003e The `regex` crate features built-in mitigations to prevent denial of service attacks caused by untrusted regexes, or untrusted input matched by trusted regexes. Those (tunable) mitigations already provide sane defaults to prevent attacks. This guarantee is documented and it's considered part of the crate's API.\n\u003e \n\u003e Unfortunately a bug was discovered in the mitigations designed to prevent untrusted regexes to take an arbitrary amount of time during parsing, and it's possible to craft regexes that bypass such mitigations. This makes it possible to perform denial of service attacks by sending specially crafted regexes to services accepting user-controlled, untrusted regexes.\n\u003e \n\u003e ## Affected versions\n\u003e \n\u003e All versions of the `regex` crate before or equal to 1.5.4 are affected by this issue. The fix is include starting from  `regex` 1.5.5.\n\u003e \n\u003e ## Mitigations\n\u003e \n\u003e We recommend everyone accepting user-controlled regexes to upgrade immediately to the latest version of the `regex` crate.\n\u003e \n\u003e Unfortunately there is no fixed set of problematic regexes, as there are practically infinite regexes that could be crafted to exploit this vulnerability. Because of this, we do not recommend denying known problematic regexes.\n\u003e \n\u003e ## Acknowledgements\n\u003e \n\u003e We want to thank Addison Crump for responsibly disclosing this to us according to the [Rust security policy](https://www.rust-lang.org/policies/security), and for helping review the fix.\n\u003e \n\u003e We also want to thank Andrew Gallant for developing the fix, and Pietro Albini for coordinating the disclosure and writing this advisory.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:/path/to/sub-rust-project/Cargo.lock | regex | 1.5.1 |\n\n## Remediation\n\nTo fix these vulnerabilities, update the vulnerabilities past the listed fixed versions below.\n\n### Fixed Versions\n\n| Vulnerability ID | Package Name | Fixed Version |\n| --- | --- | --- |\n| GHSA-m5pq-gvj9-9vr8 | regex | 1.5.5 |\n| RUSTSEC-2022-0013 | regex | 1.5.5 |\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`/path/to/sub-rust-project/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2022-24713\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n",
+                "text": "**Your dependency is vulnerable to [CVE-2022-24713](https://osv.dev/CVE-2022-24713)**\n(Also published as: [RUSTSEC-2022-0013](https://osv.dev/RUSTSEC-2022-0013), [GHSA-m5pq-gvj9-9vr8](https://osv.dev/GHSA-m5pq-gvj9-9vr8), ).\n\n## [RUSTSEC-2022-0013](https://osv.dev/RUSTSEC-2022-0013)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e The Rust Security Response WG was notified that the `regex` crate did not\n\u003e properly limit the complexity of the regular expressions (regex) it parses. An\n\u003e attacker could use this security issue to perform a denial of service, by\n\u003e sending a specially crafted regex to a service accepting untrusted regexes. No\n\u003e known vulnerability is present when parsing untrusted input with trusted\n\u003e regexes.\n\u003e \n\u003e This issue has been assigned CVE-2022-24713. The severity of this vulnerability\n\u003e is \"high\" when the `regex` crate is used to parse untrusted regexes. Other uses\n\u003e of the `regex` crate are not affected by this vulnerability.\n\u003e \n\u003e ## Overview\n\u003e \n\u003e The `regex` crate features built-in mitigations to prevent denial of service\n\u003e attacks caused by untrusted regexes, or untrusted input matched by trusted\n\u003e regexes. Those (tunable) mitigations already provide sane defaults to prevent\n\u003e attacks. This guarantee is documented and it's considered part of the crate's\n\u003e API.\n\u003e \n\u003e Unfortunately a bug was discovered in the mitigations designed to prevent\n\u003e untrusted regexes to take an arbitrary amount of time during parsing, and it's\n\u003e possible to craft regexes that bypass such mitigations. This makes it possible\n\u003e to perform denial of service attacks by sending specially crafted regexes to\n\u003e services accepting user-controlled, untrusted regexes.\n\u003e \n\u003e ## Affected versions\n\u003e \n\u003e All versions of the `regex` crate before or equal to 1.5.4 are affected by this\n\u003e issue. The fix is include starting from  `regex` 1.5.5.\n\u003e \n\u003e ## Mitigations\n\u003e \n\u003e We recommend everyone accepting user-controlled regexes to upgrade immediately\n\u003e to the latest version of the `regex` crate.\n\u003e \n\u003e Unfortunately there is no fixed set of problematic regexes, as there are\n\u003e practically infinite regexes that could be crafted to exploit this\n\u003e vulnerability. Because of this, we do not recommend denying known problematic\n\u003e regexes.\n\u003e \n\u003e ## Acknowledgements\n\u003e \n\u003e We want to thank Addison Crump for responsibly disclosing this to us according\n\u003e to the [Rust security policy][1], and for helping review the fix.\n\u003e \n\u003e We also want to thank Andrew Gallant for developing the fix, and Pietro Albini\n\u003e for coordinating the disclosure and writing this advisory.\n\u003e \n\u003e [1]: https://www.rust-lang.org/policies/security\n\n\u003c/details\u003e\n\n## [GHSA-m5pq-gvj9-9vr8](https://osv.dev/GHSA-m5pq-gvj9-9vr8)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e \u003e This is a cross-post of [the official security advisory][advisory]. The official advisory contains a signed version with our PGP key, as well.\n\u003e \n\u003e [advisory]: https://groups.google.com/g/rustlang-security-announcements/c/NcNNL1Jq7Yw\n\u003e \n\u003e The Rust Security Response WG was notified that the `regex` crate did not properly limit the complexity of the regular expressions (regex) it parses. An attacker could use this security issue to perform a denial of service, by sending a specially crafted regex to a service accepting untrusted regexes. No known vulnerability is present when parsing untrusted input with trusted regexes.\n\u003e \n\u003e This issue has been assigned CVE-2022-24713. The severity of this vulnerability is \"high\" when the `regex` crate is used to parse untrusted regexes. Other uses of the `regex` crate are not affected by this vulnerability.\n\u003e \n\u003e ## Overview\n\u003e \n\u003e The `regex` crate features built-in mitigations to prevent denial of service attacks caused by untrusted regexes, or untrusted input matched by trusted regexes. Those (tunable) mitigations already provide sane defaults to prevent attacks. This guarantee is documented and it's considered part of the crate's API.\n\u003e \n\u003e Unfortunately a bug was discovered in the mitigations designed to prevent untrusted regexes to take an arbitrary amount of time during parsing, and it's possible to craft regexes that bypass such mitigations. This makes it possible to perform denial of service attacks by sending specially crafted regexes to services accepting user-controlled, untrusted regexes.\n\u003e \n\u003e ## Affected versions\n\u003e \n\u003e All versions of the `regex` crate before or equal to 1.5.4 are affected by this issue. The fix is include starting from  `regex` 1.5.5.\n\u003e \n\u003e ## Mitigations\n\u003e \n\u003e We recommend everyone accepting user-controlled regexes to upgrade immediately to the latest version of the `regex` crate.\n\u003e \n\u003e Unfortunately there is no fixed set of problematic regexes, as there are practically infinite regexes that could be crafted to exploit this vulnerability. Because of this, we do not recommend denying known problematic regexes.\n\u003e \n\u003e ## Acknowledgements\n\u003e \n\u003e We want to thank Addison Crump for responsibly disclosing this to us according to the [Rust security policy](https://www.rust-lang.org/policies/security), and for helping review the fix.\n\u003e \n\u003e We also want to thank Andrew Gallant for developing the fix, and Pietro Albini for coordinating the disclosure and writing this advisory.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:/path/to/sub-rust-project/Cargo.lock | regex | 1.5.1 |\n\n## Remediation\n\nTo fix these vulnerabilities, update the vulnerabilities past the listed fixed versions below.\n\n### Fixed Versions\n\n| Vulnerability ID | Package Name | Fixed Version |\n| --- | --- | --- |\n| GHSA-m5pq-gvj9-9vr8 | regex | 1.5.5 |\n| RUSTSEC-2022-0013 | regex | 1.5.5 |\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`/path/to/sub-rust-project/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2022-24713\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n"
+              },
+              "id": "CVE-2022-24713",
+              "name": "CVE-2022-24713",
+              "properties": {
+                "security-severity": "7.5"
+              },
+              "relationships": [],
+              "shortDescription": {
+                "markdown": "CVE-2022-24713: Regexes with large repetitions on empty sub-expressions take a very long time to parse",
+                "text": "CVE-2022-24713: Regexes with large repetitions on empty sub-expressions take a very long time to parse"
+              }
+            },
+            {
+              "deprecatedIds": [
+                "CVE-2021-3121",
+                "GO-2021-0053",
+                "GHSA-c3h9-896r-86jm"
+              ],
+              "fullDescription": {
+                "markdown": "Due to improper bounds checking, maliciously crafted input to generated Unmarshal methods can cause an out-of-bounds panic. If parsing messages from untrusted parties, this may be used as a denial of service vector.",
+                "text": "Due to improper bounds checking, maliciously crafted input to generated Unmarshal methods can cause an out-of-bounds panic. If parsing messages from untrusted parties, this may be used as a denial of service vector."
+              },
+              "help": {
+                "markdown": "**Your dependency is vulnerable to [CVE-2021-3121](https://osv.dev/CVE-2021-3121)**.\n\n## [GO-2021-0053](https://osv.dev/GO-2021-0053)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e Due to improper bounds checking, maliciously crafted input to generated Unmarshal methods can cause an out-of-bounds panic. If parsing messages from untrusted parties, this may be used as a denial of service vector.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:/path/to/go.mod | github.com/gogo/protobuf | 1.3.1 |\n\n## Remediation\n\nTo fix these vulnerabilities, update the vulnerabilities past the listed fixed versions below.\n\n### Fixed Versions\n\n| Vulnerability ID | Package Name | Fixed Version |\n| --- | --- | --- |\n| GO-2021-0053 | github.com/gogo/protobuf | 1.3.2 |\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`/path/to/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2021-3121\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n",
+                "text": "**Your dependency is vulnerable to [CVE-2021-3121](https://osv.dev/CVE-2021-3121)**.\n\n## [GO-2021-0053](https://osv.dev/GO-2021-0053)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e Due to improper bounds checking, maliciously crafted input to generated Unmarshal methods can cause an out-of-bounds panic. If parsing messages from untrusted parties, this may be used as a denial of service vector.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:/path/to/go.mod | github.com/gogo/protobuf | 1.3.1 |\n\n## Remediation\n\nTo fix these vulnerabilities, update the vulnerabilities past the listed fixed versions below.\n\n### Fixed Versions\n\n| Vulnerability ID | Package Name | Fixed Version |\n| --- | --- | --- |\n| GO-2021-0053 | github.com/gogo/protobuf | 1.3.2 |\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`/path/to/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2021-3121\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n"
+              },
+              "id": "CVE-2021-3121",
+              "name": "CVE-2021-3121",
+              "relationships": [],
+              "shortDescription": {
+                "markdown": "CVE-2021-3121: Panic due to improper input validation in github.com/gogo/protobuf",
+                "text": "CVE-2021-3121: Panic due to improper input validation in github.com/gogo/protobuf"
+              }
+            }
+          ],
+          "supportedTaxonomies": [],
+          "taxa": [],
+          "version": "2.3.5"
+        },
+        "extensions": []
+      },
+      "translations": [],
+      "versionControlProvenance": [],
+      "webRequests": [],
+      "webResponses": []
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/tools/osv/testdata/vulnerable_go.mod
+++ b/tools/osv/testdata/vulnerable_go.mod
@@ -1,0 +1,8 @@
+module example.com/wrangle/osv-e2e-fixture
+
+// Intentionally pinned to an older Go toolchain so osv-scanner returns
+// non-zero stdlib advisories deterministically. This fixture is consumed
+// only by the opt-in osv-scanner e2e test in tools/osv/test.bats — it
+// exists to give that test a stable source of "vulnerable input" that
+// does not depend on the network state of a particular dependency.
+go 1.20

--- a/tools/osv/testdata/vulnerable_go.mod
+++ b/tools/osv/testdata/vulnerable_go.mod
@@ -1,8 +1,11 @@
 module example.com/wrangle/osv-e2e-fixture
 
-// Intentionally pinned to an older Go toolchain so osv-scanner returns
-// non-zero stdlib advisories deterministically. This fixture is consumed
-// only by the opt-in osv-scanner e2e test in tools/osv/test.bats — it
-// exists to give that test a stable source of "vulnerable input" that
-// does not depend on the network state of a particular dependency.
+// Fixture for the opt-in osv-scanner e2e test in tools/osv/test.bats.
+// Pins a known-vulnerable, frozen package version so osv-scanner always
+// reports at least one advisory under network access — the CVE-2021-3121
+// disclosure against github.com/gogo/protobuf <1.3.2. Anchoring on a
+// dependency (rather than relying on Go stdlib advisories that shift
+// across releases) keeps the e2e assertion deterministic.
 go 1.20
+
+require github.com/gogo/protobuf v1.3.1


### PR DESCRIPTION
## Summary

Fixes #197. The osv adapter ran `osv-scanner` twice — once with `--format sarif` (used for the gating check) and again with `--format markdown` (used for the step summary). The markdown formatter has been observed reporting zero findings while the SARIF contains results, so users saw "0 known vulnerabilities" in the step summary while the job failed with the SARIF-derived count.

The fix generates `output.md` from the SARIF we already produced using `lib/sarif_to_md.sh` — the same pattern `tools/zizmor` uses — so the summary and the check are always consistent.

## Changes

- `tools/osv/adapter.sh`: replace the second `osv-scanner --format markdown` invocation with a call to `lib/sarif_to_md.sh "$SARIF_FILE" > "$MD_FILE"`.
- `tools/osv/test.bats`: add a regression test asserting the markdown summary contains the SARIF finding's ruleId when the SARIF has findings.

## Test plan

- [x] `bats tools/osv/test.bats` — all 15 tests pass (including the new regression test)
- [x] `make shellcheck` — clean
- [ ] CI passes on the PR
- [ ] Re-run the failing scenario from #197 (Go stdlib 1.25.9 in wrangle-test) and confirm `output.md` now lists the 8 CVEs


---
_Generated by [Claude Code](https://claude.ai/code/session_013Xxaa3gTg7Hyhn7h8UQEWF)_