### PR TITLE
Tighten user-facing READMEs for one-pass readability (#206)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # wrangle
 
-Wrangle is a toy project where I try to figure out if we can easily
-integrate best practices and all the various tools available for
-users without them needing to know all the details.
-
-NOTE: I've never really used GitHub for professional development
-before, so this is a bit of a learning process too.
+A composable CI/CD security framework for GitHub Actions. Adopters get source scanning, signed builds, SBOMs, and SLSA L3 provenance out of the box — by referencing wrangle's reusable workflows. Maintainers can update the tooling without adopters touching their repos.
 
 ## Quick Start
 
@@ -28,34 +23,14 @@ jobs:
     uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.1.0
 ```
 
-This runs OSV-Scanner, Zizmor, and OSSF Scorecard on every PR. Results appear in the Actions step summary and the Security tab.
+Runs OSV-Scanner, Zizmor, OSSF Scorecard, and dependency-review on every PR. Findings appear in the Security tab and the Actions step summary.
 
-For shell and container build types, see the [workflow examples](gh_workflow_examples/README.md).
-
-## Goals
-
-### Project Owners
-
-Project owners should be able to easily find the documentation and tools for how they can write, build, and publish their software easily.
-
-Once adopted project owners should get, for free, industry leading best practices for how software should be developed within that ecosystem.
-
-Project owners should be able to focus, exclusively, on the features they want to develop for their project.  They should not have to worry
-about the various details of the tooling used under the hood unless they really want to.
-
-### Security Folks
-
-Security professionals should be able to easily tweak existing tools and integrations and add new tools to Wrangle. These tools should then
-be adopted transparently by all of Wrangle's users without those users needing to take any action beyond bumping their integrations to the
-next version of Wrangle.
+For build/publish — npm, Python, container, shell — see the [workflow examples](gh_workflow_examples/README.md).
 
 ## Pieces
 
-Wrangle is composed of a few pieces:
-
-
-- [Workflow examples](gh_workflow_examples/README.md) — starter workflows for adopting wrangle
-- [Reusable workflows](.github/workflows/README.md) — the workflows adopters call via `uses:`
-- [Composite actions](actions/) — scan orchestration and tool wrappers
-- [Build actions](build/) — build types (shell, container)
-- [Spec](docs/SPEC.md) — architecture, contracts, and security model
+- [Workflow examples](gh_workflow_examples/README.md) — copy-paste starting points
+- [Reusable workflows](.github/workflows/) — what adopters call via `uses:`
+- [Source scan action](actions/scan/README.md) — OSV, Zizmor, Scorecard, dependency-review orchestration
+- [Build actions](build/) — npm, python, container, shell
+- [Spec](docs/SPEC.md) — architecture, contracts, threat model

--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ For build/publish — npm, Python, container, shell — see the [workflow exampl
 - [Reusable workflows](.github/workflows/) — what adopters call via `uses:`
 - [Source scan action](actions/scan/README.md) — OSV, Zizmor, Scorecard, dependency-review orchestration
 - [Build actions](build/) — npm, python, container, shell
+- [Tools](tools/) — per-tool adapters and install scripts (OSV, Zizmor, Scorecard, Syft, dependency-review)
 - [Spec](docs/SPEC.md) — architecture, contracts, threat model

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wrangle
 
-A composable CI/CD security framework for GitHub Actions. Adopters get source scanning, signed builds, SBOMs, and SLSA L3 provenance out of the box — by referencing wrangle's reusable workflows. Maintainers can update the tooling without adopters touching their repos.
+A composable CI/CD security framework for GitHub Actions. Adopters reference wrangle's reusable workflows and get source scanning, signed builds, SBOMs, and SLSA L3 provenance out of the box. Maintainers update the underlying tooling without adopters touching their repos.
 
 ## Quick Start
 

--- a/actions/scan/README.md
+++ b/actions/scan/README.md
@@ -21,7 +21,7 @@ jobs:
       actions: read
       contents: read
       security-events: write   # SARIF upload to the Security tab
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@<version>
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.1.0
 ```
 
 Findings appear in the Security tab; the run's step summary shows an overview. Pair with whichever build/publish workflow your project uses.
@@ -35,7 +35,9 @@ Findings appear in the Security tab; the run's step summary shows an overview. P
 
 ## Why pair with build/publish
 
-Wrangle's build workflows produce signed SLSA L3 provenance over the bytes they ship — that attests *how* the build ran, not whether the source was trustworthy. Without source scan, an attacker who lands a malicious dep or a dangerous workflow trigger routes around the build-side hardening, and wrangle will faithfully L3-sign the malicious output because the build itself *was* legitimate. The May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical example: a `pull_request_target` workflow with checkout of PR-head SHA let attacker code execute in the privileged base context, poison the GitHub Actions cache, and pollute legitimate downstream builds. The build was honest; the source side was the gap.
+Wrangle's build workflows produce signed SLSA L3 provenance over the bytes they ship — that attests *how* the build ran, not whether the source was trustworthy. Without source scan, an attacker who lands a malicious dep or a dangerous workflow trigger routes around the build-side hardening, and wrangle will faithfully L3-sign the malicious output because the build itself *was* legitimate.
+
+The May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical example: a `pull_request_target` workflow with checkout of PR-head SHA let attacker code execute in the privileged base context, poison the GitHub Actions cache, and pollute legitimate downstream builds. The build was honest; the source side was the gap.
 
 ## Customizing which tools run
 

--- a/actions/scan/README.md
+++ b/actions/scan/README.md
@@ -1,23 +1,8 @@
 # Wrangle Source Scan
 
-Run wrangle's bundled source-stage security scanners (OSV-Scanner, Zizmor, Scorecard, Dependency Review) against your repo on every PR and on push to main. The companion to wrangle's build/publish reusable workflows: build/publish hardens *how* your artifact is produced; source scan covers *what was checked into the repo you're building from*.
+OSV-Scanner, Zizmor, Scorecard, and Dependency Review against your repo on every PR and push to main. The companion to wrangle's build/publish workflows: build hardens *how* your artifact is produced; source scan covers *what was checked into the repo you're building from*.
 
-> **Note:** This README documents currently-shipped behavior. For the design and adoption philosophy, see [`../../docs/SPEC.md`](../../docs/SPEC.md).
-
-## Why pair this with a build/publish workflow
-
-Wrangle's build/publish workflows produce signed SLSA provenance (Build L3) over the bytes they ship. That provenance attests *how* the build happened — but it does not attest that the source was trustworthy. The May 2026 Mini Shai-Hulud compromise of TanStack/router illustrates the gap: a `pull_request_target` workflow with checkout of PR-head SHA let attacker code execute in the privileged base context, poison the GitHub Actions cache, and pollute legitimate downstream builds with malicious modules. The build was honest; the attestation was honest; the source side was the gap.
-
-This scan composite closes that gap on every PR and push to main:
-
-- **[OSV-Scanner](https://github.com/google/osv-scanner)** against your lockfiles. Catches known-vulnerable dependencies before they ship.
-- **[Zizmor](https://github.com/woodruffw/zizmor)** static analysis over `.github/workflows/`. Flags dangerous-trigger patterns like the `pull_request_target` + fork-head checkout combination that initiated Mini Shai-Hulud, plus expression injection, unpinned actions, and other known workflow footguns.
-- **[Scorecard](https://github.com/ossf/scorecard)** against your repo configuration. Surfaces missing branch protection, code-review requirements, signed-commits, and similar repo-config gaps.
-- **[Dependency Review](https://github.com/actions/dependency-review-action)** on PRs that touch lockfiles. Blocks a merge when the PR introduces a known-vulnerable dependency at or above the configured severity (default: `high`). Complements OSV — OSV is the periodic, whole-lockfile scan; dependency-review is the PR-time gate that fires only on what's being added.
-
-Without source scan, an attacker who lands a malicious dep in your lockfile or introduces a dangerous workflow trigger can route around wrangle's build-side hardening — wrangle will then faithfully L3-sign the malicious output, because the build itself *was* legitimate.
-
-## Quick-start (one workflow file)
+## Quick-start
 
 Copy [`../../gh_workflow_examples/check_source_change.yml`](../../gh_workflow_examples/check_source_change.yml) into your repo at `.github/workflows/check_source_change.yml`:
 
@@ -39,11 +24,22 @@ jobs:
     uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@<version>
 ```
 
-That's it. Findings appear in the Security tab; the workflow run's step summary shows a quick overview. Pair this with whichever build/publish workflow your project uses (npm, python, container, shell) for end-to-end coverage.
+Findings appear in the Security tab; the run's step summary shows an overview. Pair with whichever build/publish workflow your project uses.
+
+## What runs
+
+- **[OSV-Scanner](https://github.com/google/osv-scanner)** — known-vulnerable dependencies in your lockfiles.
+- **[Zizmor](https://github.com/woodruffw/zizmor)** — static analysis over `.github/workflows/`. Flags dangerous triggers (`pull_request_target` + fork-head checkout), expression injection, unpinned actions.
+- **[Scorecard](https://github.com/ossf/scorecard)** — repo-config gaps (branch protection, code review, signed commits).
+- **[Dependency Review](https://github.com/actions/dependency-review-action)** — PR-time gate on lockfile changes. Blocks the merge when a PR adds a vulnerable dep at the configured severity (default `high`). Complements OSV: OSV is the periodic whole-lockfile scan; dependency-review fires only on what's being added.
+
+## Why pair with build/publish
+
+Wrangle's build workflows produce signed SLSA L3 provenance over the bytes they ship — that attests *how* the build ran, not whether the source was trustworthy. Without source scan, an attacker who lands a malicious dep or a dangerous workflow trigger routes around the build-side hardening, and wrangle will faithfully L3-sign the malicious output because the build itself *was* legitimate. The May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical example: a `pull_request_target` workflow with checkout of PR-head SHA let attacker code execute in the privileged base context, poison the GitHub Actions cache, and pollute legitimate downstream builds. The build was honest; the source side was the gap.
 
 ## Customizing which tools run
 
-The `tools` input is a space-separated list. Default: `"osv zizmor scorecard:info dependency-review"`. Suffix a tool with `:info` to make its findings informational (non-blocking).
+The `tools` input is a space-separated list. Default: `"osv zizmor scorecard:info dependency-review"`. Suffix with `:info` to make a tool's findings non-blocking.
 
 ```yaml
 uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@<version>
@@ -51,23 +47,22 @@ with:
   tools: "osv zizmor"   # skip Scorecard and dependency-review
 ```
 
-`dependency-review` only runs on `pull_request` events (the upstream action needs the PR diff). On `push` events it is silently skipped, the same way `scorecard` is silently skipped on PRs. It defaults to `fail-on-severity: high` and posts no PR comment. Per-tool configuration is not exposed through `actions/scan` or `check_source_change.yml` yet — it is deferred to the native per-tool config-file design in [#221](https://github.com/TomHennen/wrangle/issues/221).
+`dependency-review` only runs on `pull_request` events (the upstream action needs the PR diff); on `push` it is silently skipped, the same way `scorecard` is skipped on PRs. Per-tool configuration is not yet exposed — see [#221](https://github.com/TomHennen/wrangle/issues/221).
 
-## What this composite does NOT do (yet)
+## Out of scope (today)
 
-- **Build-time vulnerability scanning of compiled dependencies.** OSV reads lockfiles, not installed `node_modules/`, installed wheels, or extracted container layers. Layered binary scanners (Trivy, Grype) against installed artifacts complement this and are out of wrangle's scope today.
-- **Active remediation.** Findings are reported, not fixed. Dependabot-style auto-remediation is roadmap.
-- **Source provenance attestations.** Coming via [#201](https://github.com/TomHennen/wrangle/issues/201) — integrating [slsa-framework/source-tool](https://github.com/slsa-framework/source-tool) into this same `check_source_change.yml` workflow so adopters keep their one workflow file and gain per-commit source provenance + SLSA Source Track conformance assessment.
+- **Build-time scanning of installed dependencies.** OSV reads lockfiles, not installed `node_modules/`, wheels, or extracted container layers. Layer binary scanners (Trivy, Grype) at install time if you need that.
+- **Active remediation.** Findings are reported, not fixed.
+- **Source provenance.** Coming via [#201](https://github.com/TomHennen/wrangle/issues/201) — SLSA Source Track integration in this same workflow.
 
 ## Roadmap
 
-- **[#201](https://github.com/TomHennen/wrangle/issues/201)** — SLSA Source Track integration via `source-tool`. Per-commit source provenance attestations + level-aware status reporting in this same workflow.
-- **[#194](https://github.com/TomHennen/wrangle/issues/194)** — npm-specific source-scan tools (ESLint, `tsc --noEmit`). (`dependency-review` already ships ecosystem-agnostic.)
-- **[#203](https://github.com/TomHennen/wrangle/issues/203)** — Surface Scorecard findings as actionable remediations rather than informational warnings.
-- **[#202](https://github.com/TomHennen/wrangle/issues/202)** — Refuse `pull_request_target` invocations in wrangle's reusable workflows as defense-in-depth alongside Zizmor's static check.
+- [#201](https://github.com/TomHennen/wrangle/issues/201) — SLSA Source Track via `source-tool` (per-commit source provenance).
+- [#194](https://github.com/TomHennen/wrangle/issues/194) — npm-specific tools (ESLint, `tsc --noEmit`).
+- [#203](https://github.com/TomHennen/wrangle/issues/203) — Surface Scorecard findings as actionable remediations.
+- [#202](https://github.com/TomHennen/wrangle/issues/202) — Refuse `pull_request_target` invocations in wrangle's reusable workflows.
 
 ## Further reading
 
-- [`../../docs/SPEC.md`](../../docs/SPEC.md) — wrangle's overall architecture.
-- [`../../gh_workflow_examples/check_source_change.yml`](../../gh_workflow_examples/check_source_change.yml) — copy-paste starting point.
-- [`./action.yml`](./action.yml) — the composite action this README documents.
+- [`../../docs/SPEC.md`](../../docs/SPEC.md) — architecture, contracts, threat model.
+- [`./action.yml`](./action.yml) — the composite this README documents.

--- a/actions/scan/README.md
+++ b/actions/scan/README.md
@@ -44,7 +44,7 @@ The May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical exam
 The `tools` input is a space-separated list. Default: `"osv zizmor scorecard:info dependency-review"`. Suffix with `:info` to make a tool's findings non-blocking.
 
 ```yaml
-uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@<version>
+uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.1.0
 with:
   tools: "osv zizmor"   # skip Scorecard and dependency-review
 ```

--- a/actions/scan/README.md
+++ b/actions/scan/README.md
@@ -1,6 +1,8 @@
 # Wrangle Source Scan
 
-Runs OSV-Scanner, Zizmor, Scorecard, and Dependency Review against your repo on every PR and push to main — catching vulnerable dependencies, workflow-config mistakes, and supply-chain gaps before they're merged. As wrangle adds new source-side tools over time, adopters get them automatically by bumping the version pin. The companion to wrangle's build/publish workflows: build hardens *how* your artifact is produced; source scan covers *what was checked into the repo you're building from*.
+Runs OSV-Scanner, Zizmor, Scorecard, and Dependency Review against your repo on every PR and push to main. Catches vulnerable dependencies, workflow-config mistakes, and supply-chain gaps before they merge. As wrangle adds source-side tools over time, adopters pick them up automatically by bumping the version pin — no per-tool wiring in your repo.
+
+This is the companion to wrangle's build/publish workflows: build hardens *how* your artifact is produced; source scan covers *what was checked into the repo you're building from*.
 
 ## Quick-start
 
@@ -65,7 +67,7 @@ with:
 - [#201](https://github.com/TomHennen/wrangle/issues/201) — SLSA Source Track via `source-tool` (per-commit source provenance).
 - [#194](https://github.com/TomHennen/wrangle/issues/194) — npm-specific tools (ESLint, `tsc --noEmit`).
 - [#203](https://github.com/TomHennen/wrangle/issues/203) — Surface Scorecard findings as actionable remediations.
-- [#202](https://github.com/TomHennen/wrangle/issues/202) — Refuse `pull_request_target` invocations in wrangle's reusable workflows.
+- [#202](https://github.com/TomHennen/wrangle/issues/202) — Block any workflow that invokes a wrangle reusable workflow from a `pull_request_target` trigger.
 
 ## Further reading
 

--- a/actions/scan/README.md
+++ b/actions/scan/README.md
@@ -1,6 +1,6 @@
 # Wrangle Source Scan
 
-OSV-Scanner, Zizmor, Scorecard, and Dependency Review against your repo on every PR and push to main. The companion to wrangle's build/publish workflows: build hardens *how* your artifact is produced; source scan covers *what was checked into the repo you're building from*.
+Runs OSV-Scanner, Zizmor, Scorecard, and Dependency Review against your repo on every PR and push to main — catching vulnerable dependencies, workflow-config mistakes, and supply-chain gaps before they're merged. As wrangle adds new source-side tools over time, adopters get them automatically by bumping the version pin. The companion to wrangle's build/publish workflows: build hardens *how* your artifact is produced; source scan covers *what was checked into the repo you're building from*.
 
 ## Quick-start
 
@@ -35,9 +35,12 @@ Findings appear in the Security tab; the run's step summary shows an overview. P
 
 ## Why pair with build/publish
 
-Wrangle's build workflows produce signed SLSA L3 provenance over the bytes they ship — that attests *how* the build ran, not whether the source was trustworthy. Without source scan, an attacker who lands a malicious dep or a dangerous workflow trigger routes around the build-side hardening, and wrangle will faithfully L3-sign the malicious output because the build itself *was* legitimate.
+Source scan catches two distinct classes of problem the build side can't see:
 
-The May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical example: a `pull_request_target` workflow with checkout of PR-head SHA let attacker code execute in the privileged base context, poison the GitHub Actions cache, and pollute legitimate downstream builds. The build was honest; the source side was the gap.
+- **Honest mistakes that ship anyway.** A vulnerable dep in your lockfile, a `pull_request_target` workflow that grants too much, a missing branch-protection rule — wrangle's build path will faithfully L3-sign whatever you point it at, including code that introduced these issues by accident. Source scan flags them at PR time, before they reach a release.
+- **Deliberate attacks the build side authenticates as legitimate.** Wrangle's build workflows produce signed SLSA L3 provenance over the bytes they ship — that attests *how* the build ran, not whether the source was trustworthy. Without source scan, an attacker who lands a malicious dep or a dangerous workflow trigger routes around the build-side hardening, and wrangle will L3-sign the malicious output because the build itself *was* legitimate.
+
+The May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical example of the second case: a `pull_request_target` workflow with checkout of PR-head SHA let attacker code execute in the privileged base context, poison the GitHub Actions cache, and pollute legitimate downstream builds. The build was honest; the source side was the gap.
 
 ## Customizing which tools run
 

--- a/build/README.md
+++ b/build/README.md
@@ -11,6 +11,8 @@ Build types live here. Each produces a signed artifact with an SBOM and SLSA pro
 
 ## Build Track level
 
-Every build type that produces an artifact (npm, pnpm, pip, uv, container) meets **SLSA v1.2 Build L3** when consumed through wrangle's reusable workflow on GitHub-hosted runners. Shell produces no artifact, so no Build Track level applies. Each build type's README lists the conditions its claim depends on; see [`docs/SPEC.md` §"Build Track level"](../docs/SPEC.md) and [`docs/SLSA_L3_AUDIT.md`](../docs/SLSA_L3_AUDIT.md) for the full analysis.
+Every build type that produces an artifact (npm, pnpm, pip, uv, container) meets **SLSA v1.2 Build L3** when consumed through wrangle's reusable workflow on GitHub-hosted runners. Shell produces no artifact, so no Build Track level applies.
+
+Each build type's README lists the conditions its claim depends on. For the cross-build analysis, see [`docs/SPEC.md` §"Build Track level"](../docs/SPEC.md) and [`docs/SLSA_L3_AUDIT.md`](../docs/SLSA_L3_AUDIT.md).
 
 ![Wrangle Build Container Summary showing vulns found by OSV](/assets/images/osv_sbom_summary.png)

--- a/build/README.md
+++ b/build/README.md
@@ -1,35 +1,16 @@
 # Wrangle Build
 
-This folder contains all the tools and actions for dealing with building packages.
+Build types live here. Each produces a signed artifact with an SBOM and SLSA provenance.
 
-Wrangle will have customized build methods for each supported artifact type/destination.
-
-Currently supported build types:
-- **Containers** — see below.
-- **Python** — see [`actions/python/README.md`](actions/python/README.md).
-- **Shell** — see the [example workflow](/gh_workflow_examples/build_shell.yml).
+| Build type | README | Example workflow |
+|-----------|--------|------------------|
+| npm / pnpm | [`actions/npm/README.md`](actions/npm/README.md) | [`build_npm.yml`](/gh_workflow_examples/build_npm.yml) |
+| Python (pip / uv) | [`actions/python/README.md`](actions/python/README.md) | [`build_python.yml`](/gh_workflow_examples/build_python.yml) |
+| Container | [`actions/container/README.md`](actions/container/README.md) | [`build_and_publish_containers.yml`](/gh_workflow_examples/build_and_publish_containers.yml) |
+| Shell | (no artifact — shellcheck + bats only) | [`build_shell.yml`](/gh_workflow_examples/build_shell.yml) |
 
 ## Build Track level
 
-Every wrangle build-type reusable workflow that produces provenance — npm, pnpm, pip, uv, and container — meets **SLSA v1.2 Build L3** when consumed through wrangle's reusable workflow on GitHub-hosted runners. Shell produces no artifact and no provenance, so no Build Track level applies to it. Each build type's README states its level and the conditions that narrow it; the source-of-truth discussion is [`docs/SPEC.md` §"Build Track level"](../docs/SPEC.md) and the full per-builder analysis is [`docs/SLSA_L3_AUDIT.md`](../docs/SLSA_L3_AUDIT.md).
+Every build type that produces an artifact (npm, pnpm, pip, uv, container) meets **SLSA v1.2 Build L3** when consumed through wrangle's reusable workflow on GitHub-hosted runners. Shell produces no artifact, so no Build Track level applies. Each build type's README states the conditions that narrow its claim; see [`docs/SPEC.md` §"Build Track level"](../docs/SPEC.md) and [`docs/SLSA_L3_AUDIT.md`](../docs/SLSA_L3_AUDIT.md) for the full analysis.
 
-## Containers with GitHub Actions
-
-### User Instructions
-
-Wrangle supports building containers with GitHub actions in two ways:
-
-* A reusable workflow that handles everything, SBOM generation, vuln scanning, and provenance generation. [Example](/gh_workflow_examples/build_and_publish_containers.yml)
-* An [action](/build/actions/container/action.yml) that you can plug into your existing workflow.  Handles SBOM generation and vuln scanning.
-
-Example vulnerability scan results:
 ![Wrangle Build Container Summary showing vulns found by OSV](/assets/images/osv_sbom_summary.png)
-
-## Python with GitHub Actions
-
-Build Python wheels and sdists, run pytest, generate an SPDX SBOM, and produce SLSA provenance (Build L3) via `slsa-github-generator`. Publish to PyPI via Trusted Publishing (no API tokens required) with PEP 740 attestations.
-
-* A reusable workflow that runs build + test + SBOM + SLSA provenance. [Example](/gh_workflow_examples/build_python.yml)
-* The composite [action](/build/actions/python/action.yml) for plugging into existing workflows (build + test + SBOM only).
-
-The example workflow demonstrates the recommended pattern of verifying SLSA provenance before publish — adopters can keep or remove that step. See [`actions/python/README.md`](actions/python/README.md) for full details.

--- a/build/README.md
+++ b/build/README.md
@@ -11,6 +11,6 @@ Build types live here. Each produces a signed artifact with an SBOM and SLSA pro
 
 ## Build Track level
 
-Every build type that produces an artifact (npm, pnpm, pip, uv, container) meets **SLSA v1.2 Build L3** when consumed through wrangle's reusable workflow on GitHub-hosted runners. Shell produces no artifact, so no Build Track level applies. Each build type's README states the conditions that narrow its claim; see [`docs/SPEC.md` §"Build Track level"](../docs/SPEC.md) and [`docs/SLSA_L3_AUDIT.md`](../docs/SLSA_L3_AUDIT.md) for the full analysis.
+Every build type that produces an artifact (npm, pnpm, pip, uv, container) meets **SLSA v1.2 Build L3** when consumed through wrangle's reusable workflow on GitHub-hosted runners. Shell produces no artifact, so no Build Track level applies. Each build type's README lists the conditions its claim depends on; see [`docs/SPEC.md` §"Build Track level"](../docs/SPEC.md) and [`docs/SLSA_L3_AUDIT.md`](../docs/SLSA_L3_AUDIT.md) for the full analysis.
 
 ![Wrangle Build Container Summary showing vulns found by OSV](/assets/images/osv_sbom_summary.png)

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -1,36 +1,44 @@
 # Wrangle Build Container
 
-A GitHub composite action that builds and publishes a container image to GitHub Container Registry (ghcr.io), generates and extracts an SBOM, and (when wired into the reusable workflow) signs the image with Cosign and attaches SLSA provenance (Build L3).
+Build and publish a container image to ghcr.io with an SBOM, Cosign signature, and SLSA L3 provenance.
 
-> **Note:** This README documents *currently-shipped* behavior. For the full design — including Cosign signing, SLSA L3 provenance, the release gate, failure contract, and trust model — see [`SPEC.md`](./SPEC.md). The spec is forward-looking; features described there but not yet implemented in `action.yml` will land in follow-up PRs, and this README will be updated in the same commit. The full structure this README must eventually cover (quick-start example, verification commands, failure runbook) is defined in [`SPEC.md` §"Required contents of `build/actions/container/README.md`"](./SPEC.md#required-contents-of-buildactionscontainerreadmemd).
+## Quick-start
 
-## Recommended companion: source scan
+```yaml
+jobs:
+  build:
+    permissions:
+      contents: write   # SLSA generator's upload-assets job
+      id-token: write   # OIDC for Sigstore signing
+      packages: write   # push to ghcr.io
+      actions: read
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.2.0
+    with:
+      path: .
+      imagename: ghcr.io/<owner>/<repo>
+      registry: ghcr.io
+```
 
-This action hardens *how* your container image is produced. It does NOT scan your source — vulnerable deps in your Dockerfile's base image or pinned packages, dangerous workflow triggers, or missing branch protection still slip through and would be faithfully L3-attested by wrangle as legitimately built. Pair this with wrangle's source-scan workflow ([`actions/scan/README.md`](../../../actions/scan/README.md)) to close that gap on every PR and push. Without it, an attacker who lands a malicious dep or workflow misconfiguration routes around the build-side hardening — the May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical recent example of why this matters.
+Pair with [`check_source_change.yml`](../../../actions/scan/README.md) — build hardens *how*, source scan covers *what was committed*.
+
+For the full design (failure contract, trust model, planned signing/provenance steps in the composite), see [`SPEC.md`](./SPEC.md). This README only describes shipped behavior.
 
 ## Build Track level
 
-Consumed through wrangle's reusable workflow (`build_and_publish_container.yml`), the container build meets **SLSA v1.2 Build L3**. You do not need to reason about individual SLSA L3 requirements to use this — the single Build Track level is the claim. Two conditions narrow it:
+Consumed through `build_and_publish_container.yml`, the container build meets **SLSA v1.2 Build L3**. Two conditions narrow the claim:
 
-- **Reusable consumption only.** Calling the `build/actions/container` composite directly from a workflow you author yourself forfeits the build-vs-sign job separation and is **not** a supported L3 path.
-- **GitHub-hosted runners only.** Self-hosted runners invalidate the build-environment isolation the L3 verdict assumes.
+- **Reusable consumption only.** Calling the composite from your own workflow forfeits the build-vs-sign job separation and is **not** a supported L3 path.
+- **GitHub-hosted runners only.** Self-hosted runners invalidate the build-environment isolation L3 assumes.
 
-Release builds run with the BuildKit `type=gha` cache disabled, so the attested image cannot be influenced by a shared, cross-build cache that BuildKit does not re-verify on cache hits (SLSA's "Isolated" requirement). PR builds default to an isolated, per-PR cache scope so one PR cannot poison another's cache entries. The full per-builder analysis is [`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md) (Finding 2).
+Release builds run with the BuildKit `type=gha` cache disabled (BuildKit doesn't re-verify cache hits, so a shared cache violates SLSA's "Isolated" requirement). PR builds default to a per-PR isolated cache. Full analysis: [`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md) Finding 2.
 
-## What this action does today
+## What this action does
 
-- Builds a Docker image from a Dockerfile at a caller-provided path
-- Pushes the image to a container registry (ghcr.io supported; other registries are out of scope — see [`SPEC.md`](./SPEC.md#current-scope-ghcrio-only))
-- Generates a BuildKit-native SBOM and attaches it to the image as an OCI attestation
-- Extracts the SBOM in SPDX JSON format and uploads it as a workflow artifact
-- Generates a step summary with the results
+- Builds a Docker image from a caller-provided Dockerfile path.
+- Pushes to ghcr.io (other registries out of scope — see [`SPEC.md`](./SPEC.md#current-scope-ghcrio-only)).
+- Generates a BuildKit-native SBOM, attaches it to the image as an OCI attestation, and uploads it as a workflow artifact in SPDX JSON.
 
-## Planned (per spec, not yet implemented)
-
-- Cosign keyless signing of the pushed image digest
-- SLSA L3 provenance via `slsa-github-generator` (the reusable workflow in `.github/workflows/build_and_publish_container.yml` is the entry point for this)
-- SBOM vulnerability scanning with `osv-scanner` (non-blocking)
-- The release gate job that enforces "image is signed AND attested before any downstream release job runs"
+The reusable workflow `build_and_publish_container.yml` adds `slsa-github-generator` for L3 provenance, `cosign verify-attestation` of that provenance against the just-pushed digest, and the release-gate job. Still planned (not yet wired into either layer): Cosign keyless signing of the image digest itself and OSV-Scanner against the SBOM (non-blocking) — see [`SPEC.md`](./SPEC.md).
 
 ## Controlling when provenance is generated
 
@@ -49,75 +57,47 @@ Note: `release-events` currently scopes the SLSA provenance and verify jobs. The
 
 ## Controlling the PR build cache
 
-Release builds always run cache-free. BuildKit's `type=gha` cache is not re-verified on cache hits and is shared cross-build via GitHub's branch-scoped cache service, so an L3-attested release build must not consume it ([`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md) Finding 2). That is not configurable — it is what keeps the container path at Build L3.
+Release builds always run cache-free — BuildKit's `type=gha` cache isn't re-verified on hits and is shared cross-build, which would violate SLSA's "Isolated" requirement ([`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md) Finding 2). Not configurable.
 
-**PR / non-release builds** default to a per-PR isolated cache. They produce no attested artifact, so cache poisoning is not a SLSA L3 concern at that layer — but it is still a CI-hygiene concern. A malicious PR that obtains code execution in its build step (a poisoned `Dockerfile`, an exploited build-tool vulnerability) can write a poisoned entry to the GitHub Actions cache that a *later* PR build reads; the later build's "tests pass" and SBOM signals can then be quietly wrong. This is **PR-to-PR cache poisoning** — [Cacheract](https://adnanthekhan.com/2024/12/21/cacheract-the-monster-in-your-build-cache/) demonstrates poisoned entries surviving in the cache for the full eviction window.
-
-The reusable workflow's `pr-cache` input tunes the PR-build cache, trading PR-build speed against this exposure. It never affects release builds — those are cache-free unconditionally.
+**PR builds** default to a per-PR isolated cache. PR builds produce no attested artifact, so cache poisoning isn't an L3 concern at that layer — but it's still a CI-hygiene concern: a malicious PR with code execution can poison cache entries a *later* PR reads, silently corrupting that build's "tests pass" and SBOM signals ([Cacheract](https://adnanthekhan.com/2024/12/21/cacheract-the-monster-in-your-build-cache/)). The `pr-cache` input tunes the trade-off:
 
 | `pr-cache` | PR build behavior | When to use |
 |------------|-------------------|-------------|
-| `isolated` (default) | Each PR gets its own cache scope, keyed by the GitHub-assigned PR number; PR A cannot write entries PR B reads. Rebuilds within a PR still hit cache. | Safe default — closes PR-to-PR poisoning while keeping in-PR cache speedup. |
-| `enabled` | Shares the cross-branch BuildKit cache. Fastest first-build off main's entries, but a malicious PR can poison entries that later PR builds read. | Trusted-contributor repos where PR authors are vetted *and* the first-build speedup matters more than isolation. |
-| `read-only` | PR builds read the shared cache (fast first build off main's entries) but never write it, so a PR cannot poison it. | When you want shared-cache *reads* but no PR write path. |
-| `disabled` | PR builds also run cache-free. Strictest, slowest. | Strict-isolation contexts (regulated, government), or repos that treat every PR as untrusted. |
+| `isolated` (default) | Per-PR cache scope, keyed by PR number. PR A cannot write entries PR B reads; rebuilds within a PR still hit cache. | Safe default — closes PR-to-PR poisoning, keeps in-PR speedup. |
+| `enabled` | Shares the cross-branch cache. Fastest first build, but a malicious PR can poison later PR builds. | Trusted-contributor repos. |
+| `read-only` | PR builds read the shared cache but never write it. | Shared-cache reads, no PR write path. |
+| `disabled` | PR builds also run cache-free. | Strict-isolation contexts. |
 
-The per-PR scope is keyed by `github.event.pull_request.number` — a GitHub-assigned, monotonically unique integer per PR. It is *not* keyed by branch name, so two PRs that happen to share a source branch name (e.g. both `patch-1` from different forks) get distinct cache scopes. On non-PR events (push, workflow_dispatch) the scope falls back to the ref name.
+The scope is keyed by `github.event.pull_request.number` (a GitHub-assigned unique integer), not branch name — two PRs sharing a branch name from different forks get distinct scopes. On non-PR events the scope falls back to the ref name.
 
-```yaml
-uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.2.0
-with:
-  path: .
-  imagename: ghcr.io/<owner>/<repo>
-  registry: ghcr.io
-  # pr-cache: isolated   # this is the default; shown here for clarity
-```
-
-> **Never invoke this workflow from a `pull_request_target` trigger.** Such workflows run in the base-repo context with base-repo cache *write* access, which makes a fork PR the highest-risk cache-poisoning vector. Wrangle's reusable workflows refuse `pull_request_target` ([#202](https://github.com/TomHennen/wrangle/issues/202)); do not work around that refusal.
+> **Never invoke this workflow from `pull_request_target`.** That trigger runs in the base-repo context with cache write access, making a fork PR the highest-risk poisoning vector. Wrangle's reusable workflows refuse it ([#202](https://github.com/TomHennen/wrangle/issues/202)).
 
 ## SLSA attestation verification (default-on, opt-out)
 
-After the SLSA generator emits the provenance attestation, wrangle's reusable workflow runs `cosign verify-attestation --type slsaprovenance` against the just-pushed image digest before declaring the workflow successful. This catches the "registry served bytes that don't match what wrangle pushed" attack window. If verification fails, the workflow fails — and any downstream release-time job that depends on it via `needs:` is blocked.
+The reusable workflow runs `cosign verify-attestation --type slsaprovenance` against the just-pushed image digest before declaring success. This catches the "registry served different bytes than wrangle pushed" attack window — failure blocks any downstream `needs:` job. The cert identity is pinned to the SLSA generator's tag (`v2.1.0` today) and to your repository, so attestations from a different generator version or a different repo do not pass.
 
-Wrangle pins the cert identity to the SLSA generator's tag (`v2.1.0` today) so verification only succeeds against attestations signed by *that* generator workflow. The `--certificate-github-workflow-repository` claim is additionally pinned to your repository, so attestations minted from another repo using the same generator version do not pass.
-
-To opt out (e.g., you maintain a custom verification flow), pass `verify-image: false`:
+To opt out (custom verification flow):
 
 ```yaml
-uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.2.0
 with:
-  path: .
-  imagename: ghcr.io/<owner>/<repo>
-  registry: ghcr.io
-  verify-image: false   # skip wrangle's verification; you handle it
+  verify-image: false
 ```
 
-### Private-repo limitation
-
-`cosign verify-attestation` against ghcr.io public images works without registry authentication. For **private** images (or registries with anonymous-pull disabled), the manifest and attestation pulls require auth that wrangle's verify job doesn't currently provide — so private-repo adopters must set `verify-image: false` and verify in their own job today. If this affects you, please comment or thumbs-up [#182](https://github.com/TomHennen/wrangle/issues/182) so we can prioritize.
-
-### Future: image-signature verification
-
-When `cosign sign` of the image digest lands in the composite action, this verify job will additionally check the image signature with the adopter's `workflow_ref` as the cert identity.
+**Private-repo limitation.** Verify currently does no registry auth, so private-repo adopters must set `verify-image: false` and verify in their own job. See [#182](https://github.com/TomHennen/wrangle/issues/182). When `cosign sign` of the image digest lands, this verify job will additionally check the image signature against the caller's `workflow_ref`.
 
 ## SBOM
 
-The action generates an SBOM for the container it builds. Today the SBOM is available two ways:
+Generated for every build. Available two ways:
 
-- As a workflow artifact named `container-metadata-<shortname>`, downloadable from the Actions run page or via `actions/download-artifact` in a downstream job. The artifact is the zip of `metadata/container/<shortname>/`'s contents — downloading it extracts the metadata files at the top level of whatever `path:` you choose, not nested under `metadata/container/<shortname>/`. The reusable workflow exposes the artifact name as the `metadata-artifact-name` output so callers don't have to hardcode it.
-- Embedded in the OCI image manifest as a BuildKit attestation, retrievable from the image itself with `docker buildx imagetools inspect --format '{{ json .SBOM.SPDX }}' <image>@<digest>`
+- **Workflow artifact** `container-metadata-<shortname>` — exposed via the workflow's `metadata-artifact-name` output. Download with `actions/download-artifact`; the metadata files land at the top level of whatever `path:` you choose (the `metadata/container/<shortname>/` prefix is a workspace convention, not preserved in the zip).
+- **OCI image attestation** — `docker buildx imagetools inspect --format '{{ json .SBOM.SPDX }}' <image>@<digest>`.
 
-See [`SPEC.md` §"Where to find the SBOM"](./SPEC.md#where-to-find-the-sbom) for the full publication story (including the planned cosign SBOM attestation).
-
-## Container vulnerability scanning
-
-Per the failure contract in [`SPEC.md`](./SPEC.md#failure-contract), SBOM vulnerability scanning is **non-blocking**: findings are uploaded as SARIF and visible in the Security tab, but they do not fail the build. This is a deliberate design choice — vulnerability triage is a policy decision adopters own, and hard-blocking can itself become a release blocker when a fix needs to ship despite an unavoidable upstream CVE. See the spec for the full rationale.
+OSV-Scanner against the SBOM is planned (non-blocking — vulnerability triage is a policy decision adopters own); the failure contract in [`SPEC.md`](./SPEC.md#failure-contract) describes the eventual behavior.
 
 ![Wrangle Build Container Summary showing vulns found by OSV](/assets/images/osv_sbom_summary.png)
 
 ## Further reading
 
-- [`SPEC.md`](./SPEC.md) — this action's full specification
-- [`../../../docs/SPEC.md`](../../../docs/SPEC.md) — wrangle's overall architecture and build-type model
-- [`../../README.md`](../../README.md) — the build/ directory overview
-- [`../../../actions/scan/README.md`](../../../actions/scan/README.md) — recommended source-scan companion
+- [`SPEC.md`](./SPEC.md) — this action's full specification.
+- [`../../../docs/SPEC.md`](../../../docs/SPEC.md) — wrangle's architecture.
+- [`../../../actions/scan/README.md`](../../../actions/scan/README.md) — source-scan companion.

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -40,7 +40,7 @@ Two things from the spec aren't shipped yet in either the composite or the reusa
 
 ## Controlling when provenance is generated
 
-The reusable workflow's `release-events` input controls which events trigger SLSA provenance generation. Accepted values:
+The reusable workflow's `release-events` input controls which events trigger release-time actions — SLSA provenance generation, verification, and (downstream, via the `should-release` output) any release-time job in your own workflow that gates on it. Accepted values:
 
 - `non-pull-request` (default) — every event except `pull_request` (the common case: provenance on merges to main, tags, manual dispatches, etc.).
 - `tag-only` — only `push` events to `refs/tags/*`.

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -4,22 +4,15 @@ Build and publish a container image to ghcr.io with an SBOM, Cosign signature, a
 
 ## Quick-start
 
-```yaml
-jobs:
-  build:
-    permissions:
-      contents: write   # SLSA generator's upload-assets job
-      id-token: write   # OIDC for Sigstore signing
-      packages: write   # push to ghcr.io
-      actions: read
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.2.0
-    with:
-      path: .
-      imagename: ghcr.io/<owner>/<repo>
-      registry: ghcr.io
-```
+Copy [`gh_workflow_examples/build_and_publish_containers.yml`](../../../gh_workflow_examples/build_and_publish_containers.yml) into your repo at `.github/workflows/` and fill in:
 
-Pair with [`check_source_change.yml`](../../../actions/scan/README.md) — build hardens *how*, source scan covers *what was committed*.
+| Input | Value |
+|-------|-------|
+| `path` | path to the folder containing your `Dockerfile` |
+| `imagename` | `ghcr.io/<owner>/<repo>/<image>` |
+| `registry` | `ghcr.io` |
+
+The example wires in the required permissions and `gh_token` secret. Pair with [source scan](../../../actions/scan/README.md) — build hardens *how*, source scan covers *what was committed*.
 
 For the full design (failure contract, trust model, planned signing/provenance steps in the composite), see [`SPEC.md`](./SPEC.md). This README only describes shipped behavior.
 
@@ -42,10 +35,9 @@ The reusable workflow `build_and_publish_container.yml` adds `slsa-github-genera
 
 ## Controlling when provenance is generated
 
-The reusable workflow's `release-events` input controls which events trigger SLSA provenance generation. Default: `non-pull-request`. Other shorthands: `tag-only`, `main-and-tags`. A comma-separated `github.event_name` list is also accepted. See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full vocabulary.
+The reusable workflow's `release-events` input controls which events trigger SLSA provenance generation. Default: `non-pull-request`. Other shorthands: `tag-only`, `main-and-tags`. A comma-separated `github.event_name` list is also accepted — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating".
 
 ```yaml
-uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.2.0
 with:
   path: .
   imagename: ghcr.io/<owner>/<repo>
@@ -53,17 +45,17 @@ with:
   release-events: tag-only   # only tag pushes mint provenance
 ```
 
-Note: `release-events` currently scopes the SLSA provenance and verify jobs. The docker push happens mid-composite and is gated by your workflow's own trigger configuration (see [`SPEC.md` §"Trigger restriction"](./SPEC.md#trigger-restriction)).
+`release-events` currently scopes the SLSA provenance and verify jobs. The docker push happens mid-composite and is gated by your workflow's own trigger configuration (see [`SPEC.md` §"Trigger restriction"](./SPEC.md#trigger-restriction)).
 
 ## Controlling the PR build cache
 
 Release builds always run cache-free — BuildKit's `type=gha` cache isn't re-verified on hits and is shared cross-build, which would violate SLSA's "Isolated" requirement ([`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md) Finding 2). Not configurable.
 
-**PR builds** default to a per-PR isolated cache. PR builds produce no attested artifact, so cache poisoning isn't an L3 concern at that layer — but it's still a CI-hygiene concern: a malicious PR with code execution can poison cache entries a *later* PR reads, silently corrupting that build's "tests pass" and SBOM signals ([Cacheract](https://adnanthekhan.com/2024/12/21/cacheract-the-monster-in-your-build-cache/)). The `pr-cache` input tunes the trade-off:
+**PR builds** default to a per-PR isolated cache. PR builds produce no attested artifact, so cache poisoning isn't an L3 concern at that layer — but it's still a CI-hygiene concern: a malicious PR with code execution can poison cache entries a *later* PR reads (PR-to-PR cache poisoning), silently corrupting that build's "tests pass" and SBOM signals ([Cacheract](https://adnanthekhan.com/2024/12/21/cacheract-the-monster-in-your-build-cache/)). The `pr-cache` input tunes the trade-off:
 
 | `pr-cache` | PR build behavior | When to use |
 |------------|-------------------|-------------|
-| `isolated` (default) | Per-PR cache scope, keyed by PR number. PR A cannot write entries PR B reads; rebuilds within a PR still hit cache. | Safe default — closes PR-to-PR poisoning, keeps in-PR speedup. |
+| `isolated` (default) | Per-PR cache scope, keyed by PR number. PR A cannot write entries PR B reads; rebuilds within a PR still hit cache. | Safe default — closes PR-to-PR cache poisoning, keeps in-PR speedup. |
 | `enabled` | Shares the cross-branch cache. Fastest first build, but a malicious PR can poison later PR builds. | Trusted-contributor repos. |
 | `read-only` | PR builds read the shared cache but never write it. | Shared-cache reads, no PR write path. |
 | `disabled` | PR builds also run cache-free. | Strict-isolation contexts. |

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -18,7 +18,7 @@ For the full design (failure contract, trust model, planned signing/provenance s
 
 ## Build Track level
 
-Consumed through `build_and_publish_container.yml`, the container build meets **SLSA v1.2 Build L3**. Two conditions narrow the claim:
+Consumed through `build_and_publish_container.yml`, the container build meets **SLSA v1.2 Build L3** if both of these conditions hold:
 
 - **Reusable consumption only.** Calling the composite from your own workflow forfeits the build-vs-sign job separation and is **not** a supported L3 path.
 - **GitHub-hosted runners only.** Self-hosted runners invalidate the build-environment isolation L3 assumes.
@@ -31,11 +31,23 @@ Release builds run with the BuildKit `type=gha` cache disabled (BuildKit doesn't
 - Pushes to ghcr.io (other registries out of scope — see [`SPEC.md`](./SPEC.md#current-scope-ghcrio-only)).
 - Generates a BuildKit-native SBOM, attaches it to the image as an OCI attestation, and uploads it as a workflow artifact in SPDX JSON.
 
-The reusable workflow `build_and_publish_container.yml` adds `slsa-github-generator` for L3 provenance, `cosign verify-attestation` of that provenance against the just-pushed digest, and the release-gate job. Still planned (not yet wired into either layer): Cosign keyless signing of the image digest itself and OSV-Scanner against the SBOM (non-blocking) — see [`SPEC.md`](./SPEC.md).
+The reusable workflow `build_and_publish_container.yml` adds `slsa-github-generator` for L3 provenance, `cosign verify-attestation` of that provenance against the just-pushed digest, and the release-gate job.
+
+Two things from the spec aren't shipped yet in either the composite or the reusable workflow:
+
+- **Cosign keyless signing of the image digest itself.** The reusable workflow already pulls in `cosign-installer` for `verify-attestation`, but it does not yet run `cosign sign` against the digest. Verified via grep on this branch — no tracking issue today; please file one if you need it prioritized. Design: [`SPEC.md` §"Cosign image signing"](./SPEC.md#cosign-image-signing).
+- **OSV-Scanner against the produced SBOM (non-blocking).** The SBOM is generated and uploaded, but not yet scanned in the container path. No tracking issue today; same suggestion. Design: [`SPEC.md` §"Failure contract"](./SPEC.md#failure-contract).
 
 ## Controlling when provenance is generated
 
-The reusable workflow's `release-events` input controls which events trigger SLSA provenance generation. Default: `non-pull-request`. Other shorthands: `tag-only`, `main-and-tags`. A comma-separated `github.event_name` list is also accepted — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating".
+The reusable workflow's `release-events` input controls which events trigger SLSA provenance generation. Accepted values:
+
+- `non-pull-request` (default) — every event except `pull_request` (the common case: provenance on merges to main, tags, manual dispatches, etc.).
+- `tag-only` — only `push` events to `refs/tags/*`.
+- `main-and-tags` — `push` to `refs/heads/main` or `refs/tags/*`.
+- A comma-separated `github.event_name` list (e.g., `push,workflow_dispatch`).
+
+See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full vocabulary.
 
 ```yaml
 with:
@@ -45,7 +57,7 @@ with:
   release-events: tag-only   # only tag pushes mint provenance
 ```
 
-`release-events` currently scopes the SLSA provenance and verify jobs. The docker push happens mid-composite and is gated by your workflow's own trigger configuration (see [`SPEC.md` §"Trigger restriction"](./SPEC.md#trigger-restriction)).
+This input gates only the SLSA provenance and verify jobs. The docker push happens earlier in the composite and is gated by your workflow's own `on:` triggers (see [`SPEC.md` §"Trigger restriction"](./SPEC.md#trigger-restriction)).
 
 ## Controlling the PR build cache
 
@@ -62,7 +74,7 @@ Release builds always run cache-free — BuildKit's `type=gha` cache isn't re-ve
 
 The scope is keyed by `github.event.pull_request.number` (a GitHub-assigned unique integer), not branch name — two PRs sharing a branch name from different forks get distinct scopes. On non-PR events the scope falls back to the ref name.
 
-> **Never invoke this workflow from `pull_request_target`.** That trigger runs in the base-repo context with cache write access, making a fork PR the highest-risk poisoning vector. Wrangle's reusable workflows refuse it ([#202](https://github.com/TomHennen/wrangle/issues/202)).
+> **Never invoke this workflow from `pull_request_target`.** That trigger runs in the base-repo context with cache write access, making a fork PR the highest-risk poisoning vector. Wrangle's reusable workflows will block any workflow that uses `pull_request_target` ([#202](https://github.com/TomHennen/wrangle/issues/202)).
 
 ## SLSA attestation verification (default-on, opt-out)
 

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -31,16 +31,16 @@ Release builds run with the BuildKit `type=gha` cache disabled (BuildKit doesn't
 - Pushes to ghcr.io (other registries out of scope — see [`SPEC.md`](./SPEC.md#current-scope-ghcrio-only)).
 - Generates a BuildKit-native SBOM, attaches it to the image as an OCI attestation, and uploads it as a workflow artifact in SPDX JSON.
 
-The reusable workflow `build_and_publish_container.yml` adds `slsa-github-generator` for L3 provenance, `cosign verify-attestation` of that provenance against the just-pushed digest, and the release-gate job.
+The reusable workflow `build_and_publish_container.yml` layers on top: `slsa-github-generator` produces L3 provenance, `cosign verify-attestation` checks that provenance against the just-pushed digest, and the release-gate job enforces the order.
 
-Two things from the spec aren't shipped yet in either the composite or the reusable workflow:
+Two pieces from the spec are not yet shipped — neither in the composite nor in the reusable workflow:
 
-- **Cosign keyless signing of the image digest itself.** The reusable workflow already pulls in `cosign-installer` for `verify-attestation`, but it does not yet run `cosign sign` against the digest. Verified via grep on this branch — no tracking issue today; please file one if you need it prioritized. Design: [`SPEC.md` §"Cosign image signing"](./SPEC.md#cosign-image-signing).
-- **OSV-Scanner against the produced SBOM (non-blocking).** The SBOM is generated and uploaded, but not yet scanned in the container path. No tracking issue today; same suggestion. Design: [`SPEC.md` §"Failure contract"](./SPEC.md#failure-contract).
+- **Cosign keyless signing of the image digest itself.** The reusable workflow already pulls in `cosign-installer` for `verify-attestation`, but it does not yet run `cosign sign` against the digest. No tracking issue today; please file one if you need it prioritized. Design: [`SPEC.md` §"Cosign image signing"](./SPEC.md#cosign-image-signing).
+- **OSV-Scanner against the produced SBOM (non-blocking).** The SBOM is generated and uploaded, but nothing in the container path scans it yet. No tracking issue today; same suggestion. Design: [`SPEC.md` §"Failure contract"](./SPEC.md#failure-contract).
 
 ## Controlling when provenance is generated
 
-The reusable workflow's `release-events` input controls which events trigger release-time actions — SLSA provenance generation, verification, and (downstream, via the `should-release` output) any release-time job in your own workflow that gates on it. Accepted values:
+The reusable workflow's `release-events` input controls which events trigger release-time actions: SLSA provenance generation, verification, and — via the `should-release` output — any downstream release-time job in your own workflow that gates on it. Accepted values:
 
 - `non-pull-request` (default) — every event except `pull_request` (the common case: provenance on merges to main, tags, manual dispatches, etc.).
 - `tag-only` — only `push` events to `refs/tags/*`.

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -14,11 +14,11 @@ This README documents shipped behavior. For the full design (attestation model, 
 
 ## Before first use
 
-Complete in order — step 1 requires an `NPM_TOKEN` that step 3 then disallows.
+Complete in order. Step 1 only applies to brand-new packages; migrating an existing package skips straight to step 2.
 
-1. **Bootstrap the first version manually.** npm Trusted Publishing can't publish a package's *first* version ([npm/cli#8544](https://github.com/npm/cli/issues/8544)). Run `npm publish` once from a maintainer's terminal with an `NPM_TOKEN` to mint v0.0.1 (or whatever your initial version is). Skip this and the first workflow run fails with a non-obvious "package not found".
+1. **Brand-new package — bootstrap the first version manually.** npm Trusted Publishing can't publish a package's *first* version ([npm/cli#8544](https://github.com/npm/cli/issues/8544)) — unlike PyPI, npm has no "pending publisher" flow. Run `npm publish` once from a maintainer's terminal with an `NPM_TOKEN` to mint v0.0.1 (or whatever your initial version is). Skip this and the first workflow run fails with a non-obvious "package not found". (If you're migrating an already-published package, skip this step.)
 2. **Configure the trusted publisher.** npmjs.com → your package → Settings → Trusted publishing. Pin: GitHub repo, workflow filename (`build_npm.yml`), optionally an environment.
-3. **Enable "Require two-factor authentication and disallow tokens"** on the package (Settings → Publishing access). This blocks all classic / granular publish tokens, leaving Trusted Publishing's OIDC flow as the only publish path. **Without this, a stolen token bypasses your CI entirely** — the attack vector behind the May 2026 mistralai / guardrails-ai and December 2024 ultralytics compromises, where attackers shipped malware by pushing directly to the registry, never triggering the legitimate workflow. After enabling, revoke the bootstrap `NPM_TOKEN`.
+3. **Enable "Require two-factor authentication and disallow tokens"** on the package (Settings → Publishing access). This blocks all classic / granular publish tokens, leaving Trusted Publishing's OIDC flow as the only publish path. **Without this, a stolen token bypasses your CI entirely** — the attack vector behind the May 2026 mistralai / guardrails-ai and December 2024 ultralytics compromises, where attackers shipped malware by pushing directly to the registry, never triggering the legitimate workflow. After enabling, revoke any token you used for step 1 (or any token migrating from your pre-Trusted-Publishing setup).
 
 ## Build Track level
 

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -54,7 +54,7 @@ The build-platform L3 claim is distinct from — and additional to — the SLSA 
 
 ## Controlling when releases happen
 
-`release-events` controls which events produce SLSA provenance. Accepted values:
+`release-events` controls which events trigger release-time actions — SLSA provenance generation, verification, and (downstream, via the `should-release` output) your publish job. Accepted values:
 
 - `non-pull-request` (default) — every event except `pull_request`.
 - `tag-only` — only `push` events to `refs/tags/*`.

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -4,6 +4,8 @@ Build an npm or pnpm package (`npm pack` / `pnpm pack`), run tests, generate an 
 
 ## Quick-start
 
+Wrangle publishes via [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/) — no `NPM_TOKEN` lives in your repo. You'll do a one-time setup on npmjs.com first; see [Before first use](#before-first-use). Then:
+
 Copy [`gh_workflow_examples/build_npm.yml`](../../../gh_workflow_examples/build_npm.yml) into your repo at `.github/workflows/`. The example wires the required permissions (`contents: write` for the SLSA generator's upload-assets job, `id-token: write` for Sigstore, `actions: read`) and includes the publish job. Most adopters only need to set the `path` input.
 
 Pair with [source scan](../../../actions/scan/README.md) for source-side coverage. For the composite-only path (build + test + SBOM, you wire your own provenance and publish), `uses: TomHennen/wrangle/build/actions/npm@v0.2.0`.
@@ -20,14 +22,14 @@ Complete in order — step 1 requires an `NPM_TOKEN` that step 3 then disallows.
 
 ## Build Track level
 
-Consumed through `build_and_publish_npm.yml`, the build meets **SLSA v1.2 Build L3** for both the npm and pnpm sub-paths. Two conditions narrow the claim:
+Consumed through `build_and_publish_npm.yml`, the build meets **SLSA v1.2 Build L3** for both the npm and pnpm sub-paths if both of these conditions hold:
 
 - **Reusable consumption only.** Calling the composite directly forfeits the build-vs-sign job separation — **not** a supported L3 path.
 - **GitHub-hosted runners only.** Self-hosted runners invalidate the build-environment isolation L3 assumes.
 
 The npm sub-path keeps dependency caching on: `npm ci` re-verifies every cached tarball's `integrity` against `package-lock.json`, so the cache cannot poison the attested output. The pnpm sub-path uses no cross-build cache — pnpm-store doesn't re-verify content-addressed paths at install time (the May 2026 Mini Shai-Hulud / TanStack cache-poisoning vector; see [#205](https://github.com/TomHennen/wrangle/issues/205)). Full analysis: [`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md).
 
-The build-platform L3 claim is distinct from — and additional to — the SLSA L2 in-CLI attestation that `npm publish --provenance` writes into the npm registry slot. Both attestations share the Sigstore Public Good Instance; the L2-vs-L3 distinction is builder isolation, not crypto root.
+The build-platform L3 claim is distinct from — and additional to — the SLSA L2 in-CLI attestation that `npm publish --provenance` writes into the npm registry slot. Both attestations share the Sigstore Public Good Instance; the L2-vs-L3 distinction is that npm's in-CLI publish path lacks builder isolation, wrangle's reusable workflow does not.
 
 ## What this action does
 
@@ -47,12 +49,19 @@ The build-platform L3 claim is distinct from — and additional to — the SLSA 
 - `tarball` — `.tgz` filename relative to the dist artifact root. Scoped packages produce `scope-name-version.tgz`.
 - `provenance-artifact-name` — workflow-artifact name for the SLSA provenance (`npm-<shortname>.intoto.jsonl`; empty when `should-release` is false).
 - `metadata-artifact-name` — workflow-artifact name for the SBOM (`npm-metadata-<shortname>`).
-- `should-release` — `"true"` if the event matches `release-events`. Your publish job MUST gate on this.
+- `should-release` — `"true"` if the package should be released — today that's exactly "the event matched `release-events`", but the gate is the source of truth (future versions may apply additional checks). Your publish job MUST gate on this.
 - `hashes`, `version`.
 
 ## Controlling when releases happen
 
-`release-events` controls which events produce SLSA provenance. Shorthands: `non-pull-request` (default), `tag-only`, `main-and-tags`. A comma-separated `github.event_name` list is also accepted — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating".
+`release-events` controls which events produce SLSA provenance. Accepted values:
+
+- `non-pull-request` (default) — every event except `pull_request`.
+- `tag-only` — only `push` events to `refs/tags/*`.
+- `main-and-tags` — `push` to `refs/heads/main` or `refs/tags/*`.
+- A comma-separated `github.event_name` list (e.g., `push,workflow_dispatch`).
+
+See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full vocabulary.
 
 > **Required wiring.** Your publish job MUST also gate on `should-release` — wrangle can't enforce this because publish lives in your workflow (npm's OIDC constraint). The canonical shape:
 >

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -1,6 +1,10 @@
 # Wrangle Build npm
 
-Build an npm or pnpm package (`npm pack` / `pnpm pack`), run tests, generate an SBOM, and produce SLSA L3 provenance. Package manager is detected from the lockfile (`package-lock.json` / `npm-shrinkwrap.json` → npm; `pnpm-lock.yaml` → pnpm). Publishes to npmjs.org via Trusted Publishing — the publish job lives in the caller workflow because npm's OIDC token must come from the caller's workflow filename, not a reusable workflow ([npm/documentation#1755](https://github.com/npm/documentation/issues/1755)).
+Build an npm or pnpm package (`npm pack` / `pnpm pack`), run tests, generate an SBOM, and produce SLSA L3 provenance. Publish goes to npmjs.org via Trusted Publishing.
+
+Package manager is detected from the lockfile: `package-lock.json` or `npm-shrinkwrap.json` selects npm; `pnpm-lock.yaml` selects pnpm.
+
+The publish job lives in your own workflow — not in a wrangle reusable workflow — because npm's OIDC token must come from the caller's workflow filename ([npm/documentation#1755](https://github.com/npm/documentation/issues/1755)).
 
 ## Quick-start
 
@@ -8,7 +12,9 @@ Wrangle publishes via [npm Trusted Publishing](https://docs.npmjs.com/trusted-pu
 
 Copy [`gh_workflow_examples/build_npm.yml`](../../../gh_workflow_examples/build_npm.yml) into your repo at `.github/workflows/`. The example wires the required permissions (`contents: write` for the SLSA generator's upload-assets job, `id-token: write` for Sigstore, `actions: read`) and includes the publish job. Most adopters only need to set the `path` input.
 
-Pair with [source scan](../../../actions/scan/README.md) for source-side coverage. For the composite-only path (build + test + SBOM, you wire your own provenance and publish), `uses: TomHennen/wrangle/build/actions/npm@v0.2.0`.
+Pair with [source scan](../../../actions/scan/README.md) — build hardens *how* your artifact is produced; source scan covers *what was checked into the repo you're building from*.
+
+For the composite-only path (build + test + SBOM; you wire your own provenance and publish), use `TomHennen/wrangle/build/actions/npm@v0.2.0` as a step.
 
 This README documents shipped behavior. For the full design (attestation model, step sequence), see [`SPEC.md`](./SPEC.md); workspaces support is designed in [`WORKSPACES_PHASE_1.md`](./WORKSPACES_PHASE_1.md) but not yet implemented.
 
@@ -49,12 +55,12 @@ The build-platform L3 claim is distinct from — and additional to — the SLSA 
 - `tarball` — `.tgz` filename relative to the dist artifact root. Scoped packages produce `scope-name-version.tgz`.
 - `provenance-artifact-name` — workflow-artifact name for the SLSA provenance (`npm-<shortname>.intoto.jsonl`; empty when `should-release` is false).
 - `metadata-artifact-name` — workflow-artifact name for the SBOM (`npm-metadata-<shortname>`).
-- `should-release` — `"true"` if the package should be released — today that's exactly "the event matched `release-events`", but the gate is the source of truth (future versions may apply additional checks). Your publish job MUST gate on this.
+- `should-release` — `"true"` if the package should be released. Today that means the event matched `release-events`; future versions may apply additional checks, so treat the output as the source of truth rather than re-evaluating `release-events` yourself. Your publish job MUST gate on this (see below).
 - `hashes`, `version`.
 
 ## Controlling when releases happen
 
-`release-events` controls which events trigger release-time actions — SLSA provenance generation, verification, and (downstream, via the `should-release` output) your publish job. Accepted values:
+`release-events` controls which events trigger release-time actions: SLSA provenance generation, verification, and — via the `should-release` output — your downstream publish job. Accepted values:
 
 - `non-pull-request` (default) — every event except `pull_request`.
 - `tag-only` — only `push` events to `refs/tags/*`.

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -1,91 +1,80 @@
 # Wrangle Build npm
 
-Build an npm or pnpm package (tarball via `npm pack` or `pnpm pack`), run tests, generate an SBOM, and produce SLSA provenance (Build L3) via `slsa-github-generator`. Package manager is detected from the lockfile (`package-lock.json` / `npm-shrinkwrap.json` → npm; `pnpm-lock.yaml` → pnpm). The publish step itself runs in the adopter's own workflow because npm Trusted Publishing's OIDC token must come from the caller's workflow filename, not a reusable workflow ([npm/documentation#1755](https://github.com/npm/documentation/issues/1755)).
-
-> **Note:** This README documents *currently-shipped* behavior. For the full design — architecture, attestation model, full step sequence — see [`SPEC.md`](./SPEC.md). For npm workspaces support (multi-package monorepos), see [`WORKSPACES_PHASE_1.md`](./WORKSPACES_PHASE_1.md) — design only; not yet implemented.
-
-## Recommended companion: source scan
-
-This action hardens *how* your artifact is produced. It does NOT scan your source — vulnerable deps in your lockfile, dangerous workflow triggers, or missing branch protection still slip through and would be faithfully L3-attested by wrangle as legitimately built. Pair this with wrangle's source-scan workflow ([`actions/scan/README.md`](../../../actions/scan/README.md)) to close that gap on every PR and push. The May 2026 Mini Shai-Hulud compromise of TanStack/router is the most recent example of why this matters — the build side wasn't the vulnerability; the source side was.
-
-## Build Track level
-
-Consumed through wrangle's reusable workflow (`build_and_publish_npm.yml`), the npm build meets **SLSA v1.2 Build L3** — for both the npm and the pnpm sub-path. You do not need to reason about individual SLSA L3 requirements to use this — the single Build Track level is the claim. Two conditions narrow it:
-
-- **Reusable consumption only.** Calling the `build/actions/npm` composite directly from a workflow you author yourself forfeits the build-vs-sign job separation and is **not** a supported L3 path.
-- **GitHub-hosted runners only.** Self-hosted runners invalidate the build-environment isolation the L3 verdict assumes.
-
-The npm sub-path keeps dependency caching on in both PR and release builds: `npm ci` re-verifies every cached tarball against `package-lock.json` on install, so the cache cannot poison the attested output (SLSA's "Isolated" requirement). The pnpm sub-path uses no cross-build cache at all (see [#205](https://github.com/TomHennen/wrangle/issues/205)). The full per-builder analysis is [`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md).
-
-This Build Track level is wrangle's build-platform claim. It is distinct from — and additional to — the SLSA L2 in-CLI attestation that `npm publish --provenance` writes into the npm registry slot from your publish job; see ["SLSA provenance verification"](#slsa-provenance-verification-default-on-opt-out) below for how the two attestations relate.
-
-## Before first use
-
-Complete these in order — step 1's bootstrap publish requires an `NPM_TOKEN`, which step 3 disallows.
-
-1. **Bootstrap the package's first version manually.** npm Trusted Publishing cannot publish a package's *first* version ([npm/cli#8544](https://github.com/npm/cli/issues/8544)). For a brand-new package, run `npm publish` once from a maintainer's terminal with an `NPM_TOKEN` to mint v0.0.1 (or whatever the initial version is). After that, every subsequent version goes through the automated path. Skip this step and your first run of the workflow will fail with a non-obvious "package not found" error from the registry.
-
-2. **Configure the trusted publisher.** On npmjs.com → your package → Settings → Trusted publishing, pin: GitHub repo, workflow filename (`build_npm.yml`), and optionally an environment.
-
-3. **Enable npm's "Require two-factor authentication and disallow tokens" setting on the package.** On npmjs.com → your package → Settings → Publishing access, select **"Require two-factor authentication and disallow tokens (recommended)"**. This is npm's equivalent of PyPI's "disable token uploads": it blocks all classic / granular publish tokens from being used on the package, leaving Trusted Publishing's OIDC flow as the only publish path (npm's own UI confirms: "All publishing access options above are compatible with OIDC trusted publishers"). **Without this**, a stolen or leftover token bypasses your CI entirely — the attack vector behind the May 2026 `mistralai` / `guardrails-ai` PyPI compromise and the December 2024 ultralytics compromise (both shipped malware to the registry by pushing directly, never triggering the legitimate workflow, even though Trusted Publishing was configured on the affected projects). After enabling the setting, revoke the bootstrap NPM_TOKEN you used in step 1 at npmjs.com → account settings → access tokens — defense in depth.
+Build an npm or pnpm package (`npm pack` / `pnpm pack`), run tests, generate an SBOM, and produce SLSA L3 provenance. Package manager is detected from the lockfile (`package-lock.json` / `npm-shrinkwrap.json` → npm; `pnpm-lock.yaml` → pnpm). Publishes to npmjs.org via Trusted Publishing — the publish job lives in the caller workflow because npm's OIDC token must come from the caller's workflow filename, not a reusable workflow ([npm/documentation#1755](https://github.com/npm/documentation/issues/1755)).
 
 ## Quick-start
 
-Two ways to adopt:
+Most adopters want the reusable workflow:
 
-1. **Reusable workflow** — single `uses:` line in your CI. Runs the full pipeline (build → test → SBOM → SLSA L3 provenance → verify), with a publish job in your own workflow. This is what most adopters want.
+```yaml
+jobs:
+  build:
+    permissions:
+      contents: write   # SLSA generator's upload-assets job
+      id-token: write   # OIDC for Sigstore signing
+      actions: read     # SLSA generator detects the GitHub Actions environment
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.2.0
+    with:
+      path: "."
+```
 
-   ```yaml
-   jobs:
-     build:
-       permissions:
-         # Required because wrangle's reusable workflow has a nested
-         # provenance job that calls slsa-github-generator. GitHub
-         # validates these permissions at workflow startup.
-         contents: write   # SLSA generator's upload-assets job (write required even when upload-assets is false)
-         id-token: write   # OIDC for Sigstore signing
-         actions: read     # SLSA generator detects the GitHub Actions environment
-       uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.2.0
-       with:
-         path: "."
-   ```
+Then add a publish job — see [`gh_workflow_examples/build_npm.yml`](../../../gh_workflow_examples/build_npm.yml) for the template. Pair with [`check_source_change.yml`](../../../actions/scan/README.md) for source-side coverage.
 
-   Then add a publish job. See [`gh_workflow_examples/build_npm.yml`](../../../gh_workflow_examples/build_npm.yml) for the full template.
+Or use the composite directly (build + test + SBOM only; you wire your own provenance and publish):
 
-2. **Composite action** — drop into an existing workflow. Runs build + test + SBOM only; you wire in your own provenance and publish.
+```yaml
+- uses: TomHennen/wrangle/build/actions/npm@v0.2.0
+  with:
+    path: "."
+```
 
-   ```yaml
-   - uses: TomHennen/wrangle/build/actions/npm@v0.2.0
-     with:
-       path: "."
-   ```
+This README documents shipped behavior. For the full design (attestation model, step sequence), see [`SPEC.md`](./SPEC.md); workspaces support is designed in [`WORKSPACES_PHASE_1.md`](./WORKSPACES_PHASE_1.md) but not yet implemented.
+
+## Before first use
+
+Complete in order — step 1 requires an `NPM_TOKEN` that step 3 then disallows.
+
+1. **Bootstrap v0.0.1 manually.** npm Trusted Publishing can't publish a package's *first* version ([npm/cli#8544](https://github.com/npm/cli/issues/8544)). Run `npm publish` once from a maintainer's terminal with an `NPM_TOKEN`. Skip this and the first workflow run fails with a non-obvious "package not found".
+2. **Configure the trusted publisher.** npmjs.com → your package → Settings → Trusted publishing. Pin: GitHub repo, workflow filename (`build_npm.yml`), optionally an environment.
+3. **Enable "Require two-factor authentication and disallow tokens"** on the package (Settings → Publishing access). This blocks all classic / granular publish tokens, leaving Trusted Publishing's OIDC flow as the only publish path. **Without this, a stolen token bypasses your CI entirely** — the attack vector behind the May 2026 mistralai / guardrails-ai and December 2024 ultralytics compromises, where attackers shipped malware by pushing directly to the registry, never triggering the legitimate workflow. After enabling, revoke the bootstrap `NPM_TOKEN`.
+
+## Build Track level
+
+Consumed through `build_and_publish_npm.yml`, the build meets **SLSA v1.2 Build L3** for both the npm and pnpm sub-paths. Two conditions narrow the claim:
+
+- **Reusable consumption only.** Calling the composite directly forfeits the build-vs-sign job separation — **not** a supported L3 path.
+- **GitHub-hosted runners only.** Self-hosted runners invalidate the build-environment isolation L3 assumes.
+
+The npm sub-path keeps dependency caching on: `npm ci` re-verifies every cached tarball's `integrity` against `package-lock.json`, so the cache cannot poison the attested output. The pnpm sub-path uses no cross-build cache — pnpm-store doesn't re-verify content-addressed paths at install time (the May 2026 Mini Shai-Hulud / TanStack cache-poisoning vector; see [#205](https://github.com/TomHennen/wrangle/issues/205)). Full analysis: [`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md).
+
+The build-platform L3 claim is distinct from — and additional to — the SLSA L2 in-CLI attestation that `npm publish --provenance` writes into the npm registry slot. Both attestations share the Sigstore Public Good Instance; the L2-vs-L3 distinction is builder isolation, not crypto root.
 
 ## What this action does
 
-- Validates that `package.json` and a supported lockfile (`package-lock.json`, `npm-shrinkwrap.json`, or `pnpm-lock.yaml`) exist. Yarn (`yarn.lock`) is rejected — Yarn support is a follow-on. If both an npm-style lockfile AND `pnpm-lock.yaml` are present, the action rejects the ambiguous state.
-- Installs Node.js via `actions/setup-node`. Version resolution order: the `node-version` input, then `.nvmrc`, then `package.json`'s `engines.node`, then a wrangle-default LTS (currently Node 22). Adopters who care about a specific version should set one of the first three explicitly rather than rely on the fallback.
-- For pnpm projects: enables [Corepack](https://nodejs.org/api/corepack.html) (bundled with Node 16.10+) to provide pnpm on the runner. Corepack uses the version pinned by `package.json`'s `packageManager` field if set, otherwise its bundled default. **Adopters who want deterministic builds should set `packageManager`** — that's the modern ecosystem-standard pin for pnpm and Yarn versions.
-- Installs dependencies with `npm ci` (lockfile-faithful, fails on lockfile drift) or `pnpm install --frozen-lockfile` (the pnpm equivalent).
-- Runs the project's build script (`npm run build` or `pnpm run build`) if `package.json` declares a `scripts.build` entry. Skipped if absent.
-- Runs tests (`npm test` or `pnpm test`) if `package.json` declares a non-default `scripts.test` entry (the npm-default `"echo \"Error: no test specified\" && exit 1"` is detected and skipped).
-- Produces the package tarball via `npm pack` or `pnpm pack`, written to `dist/`.
-- Generates an SPDX SBOM via [`syft`](https://github.com/anchore/syft) (Cosign-keyless-verified install, same tool python uses) over the project source tree.
-- Computes SHA-256 hashes of the tarball in the format `slsa-github-generator`'s `base64-subjects` input expects.
+- Validates `package.json` + a supported lockfile (`package-lock.json`, `npm-shrinkwrap.json`, or `pnpm-lock.yaml`). Yarn is rejected — support is a follow-on. Both an npm-style lockfile AND `pnpm-lock.yaml` together is rejected as ambiguous.
+- Installs Node.js via `actions/setup-node`. Version resolution: `node-version` input → `.nvmrc` → `package.json` `engines.node` → wrangle-default LTS (Node 22). Set one of the first three explicitly if you care about a specific version.
+- For pnpm: enables [Corepack](https://nodejs.org/api/corepack.html) and uses `package.json`'s `packageManager` field if set. **Set `packageManager` for deterministic builds.**
+- Installs (`npm ci` or `pnpm install --frozen-lockfile`).
+- Runs `scripts.build` if present (skipped if absent).
+- Runs tests if `scripts.test` is non-default (the npm-default `"echo \"Error: no test specified\" && exit 1"` is detected and skipped).
+- Packs to `dist/` via `npm pack` or `pnpm pack`.
+- Generates an SPDX SBOM via [`syft`](https://github.com/anchore/syft) (Cosign-keyless-verified install) over the source tree.
+- Computes SHA-256 hashes for `slsa-github-generator`'s `base64-subjects`.
 
 ## Outputs from the reusable workflow
 
-- `dist-artifact-name` — workflow-artifact name to download with `actions/download-artifact` to retrieve the built tarball.
-- `tarball` — filename of the produced `.tgz` (relative to the dist artifact root). Scoped packages produce `scope-name-version.tgz` rather than `name-version.tgz`.
-- `provenance-artifact-name` — workflow-artifact name for the SLSA provenance (empty when `should-release` is false). Format: `npm-<shortname>.intoto.jsonl` so multiple npm builds in one workflow don't collide.
+- `dist-artifact-name` — workflow-artifact name for the tarball.
+- `tarball` — `.tgz` filename relative to the dist artifact root. Scoped packages produce `scope-name-version.tgz`.
+- `provenance-artifact-name` — workflow-artifact name for the SLSA provenance (`npm-<shortname>.intoto.jsonl`; empty when `should-release` is false).
 - `metadata-artifact-name` — workflow-artifact name for the SBOM (`npm-metadata-<shortname>`).
-- `should-release` — `"true"` if the current event matches `release-events`. Your publish job MUST gate on this.
+- `should-release` — `"true"` if the event matches `release-events`. Your publish job MUST gate on this.
 - `hashes`, `version`.
 
 ## Controlling when releases happen
 
-The `release-events` input controls which events produce SLSA provenance. Your publish job MUST also gate on `should-release` so wrangle's provenance gating and your publish gating stay in lockstep.
+`release-events` controls which events produce SLSA provenance. Shorthands: `non-pull-request` (default), `tag-only`, `main-and-tags`. A comma-separated `github.event_name` list is also accepted — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating".
 
-> **Required wiring.** Without the gate, your publish job runs on every non-PR event regardless of what you pass as `release-events`. The example workflow at [`gh_workflow_examples/build_npm.yml`](../../../gh_workflow_examples/build_npm.yml) shows the canonical shape:
+> **Required wiring.** Your publish job MUST also gate on `should-release` — wrangle can't enforce this because publish lives in your workflow (npm's OIDC constraint). The canonical shape:
 >
 > ```yaml
 > publish:
@@ -93,49 +82,31 @@ The `release-events` input controls which events produce SLSA provenance. Your p
 >   needs: [build]
 > ```
 >
-> Wrangle cannot enforce this from inside its reusable workflow — publish lives in your workflow due to npm Trusted Publishing's OIDC `workflow_ref` constraint. If you forget the gate, builds still succeed, provenance still respects `release-events`, but your publish runs more often than you intended.
-
-`release-events` accepts: `non-pull-request` (default), `tag-only`, `main-and-tags`, or a comma-separated `github.event_name` list. See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full vocabulary.
+> Without the gate, publish runs on every non-PR event regardless of `release-events`.
 
 ## SLSA provenance verification (default-on, opt-out)
 
-Wrangle's reusable workflow generates non-falsifiable SLSA L3 build provenance via `slsa-github-generator`, **then verifies the just-built tarball against that provenance** before declaring the workflow successful. If verification fails, the workflow fails — and your publish job is blocked via standard `needs:` propagation. Pass `verify-provenance: false` to opt out of wrangle's verification (e.g., adopters with a custom verification flow).
-
-## Two attestations, two surfaces
-
-The npm pipeline produces two distinct attestations:
-
-1. **Wrangle's L3 SLSA provenance**, generated by `slsa-github-generator` over the packed `.tgz` and uploaded as a separate workflow artifact (named per the reusable workflow's `provenance-artifact-name` output, format `npm-<shortname>.intoto.jsonl`). Verifiable offline by any consumer via `slsa-verifier verify-artifact` against the bundle. On tag pushes the bundle is also attached as a GitHub Release asset.
-2. **npm's L2 in-CLI attestation**, populated by your publish job's `npm publish --provenance --access public` and stored in the npm registry's per-version slot. Verifiable by consumers via `npm audit signatures`.
-
-Both bundles share the same Sigstore Public Good Instance (Fulcio, Rekor, TUF). The L2-vs-L3 distinction is builder isolation, not the cryptographic root of trust. See [`SPEC.md`](./SPEC.md) for the full attestation design.
-
-**End-to-end coverage.** Wrangle's `verify` job closes the wrangle→caller-publish handoff: it re-fetches the dist artifact and confirms it matches wrangle's L3 provenance before letting the publish step run. The caller→registry segment is bound by Trusted Publishing's OIDC `workflow_ref` claim, which the npm registry validates against the publisher's registered workflow filename. Consumers verifying the L2 attestation get end-to-end coverage by checking that `workflow_ref` matches the expected caller workflow path.
+The reusable workflow re-fetches the dist and verifies it against the L3 provenance before declaring success — failure blocks your publish job via `needs:`. This closes the wrangle→caller-publish handoff (the caller→registry segment is bound by Trusted Publishing's `workflow_ref` claim, which npm validates at upload time). Opt out with `verify-provenance: false` if you maintain a custom verification flow.
 
 ## Verifying after install (downstream consumers)
 
-Your package's consumers can verify it two complementary ways. Each answers a different question, and they trust different roots.
+Two complementary verification paths, different roots of trust:
 
-### npm's L2 in-CLI attestation (against the registry)
-
-`npm audit signatures` reports whether the registry-served bundle verifies against the package's published Sigstore attestation. This is the default consumer flow.
+**npm's L2 in-CLI attestation (against the registry).** Default consumer flow:
 
 ```bash
 npm install <pkg>@<version>
 npm audit signatures
-# Expected output: "<pkg>@<version> ... has a verified attestation"
+# Expected: "<pkg>@<version> ... has a verified attestation"
 ```
 
-This proves the bundle was published from the expected GitHub repo + workflow, but does **not** independently attest to the build environment beyond what the npm CLI's in-process signing captures (SLSA L2).
+Proves the bundle was published from the expected GitHub repo + workflow.
 
-> **Known limitation.** `npm install` does NOT run `npm audit signatures` by default. Consumers who care about attestation verification must opt in by running `npm audit signatures` as a separate step. Until verification is the default, the load-bearing check is the registry-side `workflow_ref` validation at *upload* time — but that check is only meaningful when "Require two-factor authentication and disallow tokens" is enabled on the package (see "Before first use" above), since a stolen token bypasses the workflow-identity binding entirely.
+> **Known limitation.** `npm install` doesn't run `npm audit signatures` by default; consumers must opt in. Until verification is the default, the load-bearing check is npm's upload-time `workflow_ref` validation — but that only holds when "Require two-factor authentication and disallow tokens" is enabled on the package (see "Before first use"), since a stolen token bypasses it entirely.
 
-### Wrangle's L3 SLSA provenance (against the GitHub release)
-
-For tag-pushed releases, wrangle attaches the L3 bundle as a release asset. SLSA provenance is non-falsifiable because the generator runs in an isolated reusable workflow.
+**Wrangle's L3 SLSA provenance (against the GitHub release).** Non-falsifiable because the generator runs in an isolated reusable workflow. Attached to the GitHub release on tag pushes:
 
 ```bash
-# Download tarball + provenance from the GitHub release
 curl -LO https://github.com/<owner>/<repo>/releases/download/<tag>/<scope>-<name>-<version>.tgz
 curl -LO https://github.com/<owner>/<repo>/releases/download/<tag>/npm-<shortname>.intoto.jsonl
 
@@ -145,30 +116,25 @@ slsa-verifier verify-artifact \
   <scope>-<name>-<version>.tgz
 ```
 
-> **Important limitation.** Provenance is **only** in the GitHub release on tag pushes. On non-tag publishes (e.g., `workflow_dispatch` from a branch) the provenance lives only as a 90-day workflow artifact and is not retrievable by external consumers. Adopters whose workflows don't push tags should publicize how to obtain provenance — wrangle's convention is "tag pushes attach provenance to the release; non-tag publishes don't have consumer-retrievable provenance." Adopters publishing to private npm registries (Artifactory, etc.) face the same constraint: the L3 bundle lives at the GitHub release, not in the private registry.
-
-[`#181`](https://github.com/TomHennen/wrangle/issues/181) tracks moving to a single bundled `multiple.intoto.jsonl` at the release/consumer layer; until that ships, use the per-build filename.
+> **Tag-push only.** On non-tag publishes the provenance lives only as a 90-day workflow artifact, not retrievable by external consumers. Same constraint applies to private npm registries: the L3 bundle lives at the GitHub release, not the private registry. [#181](https://github.com/TomHennen/wrangle/issues/181) tracks moving to a single bundled `multiple.intoto.jsonl` at the release layer.
 
 ## Lifecycle hooks
 
-Wrangle runs `npm ci` and `npm pack` (or `pnpm install --frozen-lockfile` and `pnpm pack`) against your project. By default, lifecycle hooks fire normally — `prepare`, `prepack`, `postpack`, and any `install` hooks in dependencies all run, just as they would for an adopter running these commands locally. The L3 attestation thus binds to "what wrangle built from this commit's source + lockfile" — which is what source-control review processes are already designed to govern. A malicious script in `package.json` or a pinned dev-dep is the same threat surface as malicious source code in `src/`: the source/lockfile is version-controlled, code review applies.
+By default, hooks fire normally — `prepare`, `prepack`, `postpack`, and dependency `install` hooks run just as they would locally. The L3 attestation binds to "what wrangle built from this commit's source + lockfile," which is what source-control review already governs (a malicious `package.json` script is the same threat surface as malicious code in `src/`).
 
-What this means concretely:
+- **`prepack` / `prepare` run** during wrangle's pipeline; whatever they produce is what wrangle hashes and attests.
+- **`prepublishOnly` does NOT fire** — it only runs when `npm publish` is invoked against a directory, not against a pre-built tarball. Move type-checking work into `scripts.build`.
+- **Tarball-direct publish is intentional.** Your publish job runs `npm publish <packed.tgz>`, so the bytes wrangle hashes are exactly the bytes consumers download.
 
-- **`prepack` and `prepare` run during wrangle's pipeline.** Whatever they produce is what wrangle hashes and attests. If you change `prepack`, the produced tarball — and thus the L3 attestation — changes accordingly. Same for transitive dev-deps' `prepare` scripts.
-- **`prepublishOnly` does NOT fire.** It only runs when `npm publish` is invoked against a directory, not against a pre-built tarball. If you relied on it for type-checking, move the work into a regular `build` script — wrangle runs `npm run build` automatically when `package.json` declares one.
-- **Tarball-direct publish is intentional.** Your publish job runs `npm publish <packed.tgz>`, so the bytes wrangle hashes are exactly the bytes consumers download. This is what makes wrangle's L3 attestation actionable.
-
-**Opt-in hardening.** For adopters who want the stricter "source bytes only, no script execution" model, set `ignore-scripts: true` on the reusable workflow. When true, **nothing in your `package.json`'s `scripts` field runs**: `--ignore-scripts` is passed to both install and pack (suppressing `prepare`/`prepack`/`postpack`/`install` hooks, including in transitive dev-deps), AND `npm run build` / `npm test` (or pnpm equivalents) are skipped outright. The L3 attestation then binds to "what pack produces against this source with no script execution at all." Default is off because common ecosystem tools (husky's `prepare`, prebuild-install's `install`) rely on these hooks, and most projects expect their declared build/test to run; turning it on breaks those flows. If you need a finer-grained mode (suppress hooks but still run your own build), open an issue.
+**Opt-in hardening.** Set `ignore-scripts: true` for "source bytes only, no script execution": `--ignore-scripts` on install + pack, and `npm run build` / `npm test` are skipped outright. Default off because common ecosystem tools (husky, prebuild-install) rely on these hooks.
 
 ## Caching
 
-Wrangle's npm path enables [`actions/setup-node`'s `cache: 'npm'`](https://github.com/actions/setup-node#caching-global-packages-data) keyed on the lockfile. This caches `~/.npm` (the registry tarball cache), which is safe because `npm ci` re-validates each cached tarball's `integrity` field against `package-lock.json` on every install — a poisoned cache that produces non-matching bytes is rejected before extraction.
-
-Wrangle's **pnpm path does NOT enable setup-node caching.** pnpm-store stores extracted modules under content-addressed paths and does not re-verify content matches the path's claimed hash at install time. That's the cache-poisoning vector the May 2026 Mini Shai-Hulud / TanStack compromise exploited (see [issue #205](https://github.com/TomHennen/wrangle/issues/205) for the full analysis). For pnpm projects, wrangle accepts the cold-install overhead in exchange for closing that attack vector.
+- **npm path** enables [`setup-node`'s `cache: 'npm'`](https://github.com/actions/setup-node#caching-global-packages-data), keyed on the lockfile. Safe because `npm ci` re-validates each cached tarball's `integrity` field on install.
+- **pnpm path** does NOT enable caching. pnpm-store doesn't re-verify content-addressed paths at install — see Build Track level above and [#205](https://github.com/TomHennen/wrangle/issues/205).
 
 ## v0.2 status
 
-- **Supported package managers:** npm (`package-lock.json` / `npm-shrinkwrap.json`) and pnpm (`pnpm-lock.yaml`). Yarn is a follow-on.
-- **Single-package only.** `package.json` with a `workspaces` field is rejected at validation; the action also errors out if pack produces more than one `.tgz`. Workspaces support (the N-tarball case) is tracked in [#208](https://github.com/TomHennen/wrangle/issues/208); design in [`WORKSPACES_PHASE_1.md`](./WORKSPACES_PHASE_1.md).
-- **SBOM scope is the project source tree, not the tarball contents.** Wrangle runs `syft dir:<path>` over your source. If `package.json`'s `files` field restricts what `npm pack` ships, the SBOM lists components that aren't in the published `.tgz`. Conversely, bundled C/C++ binaries that `prebuild-install` fetches at consumer install time aren't in source — they don't appear in the SBOM either. Adopters who care about CVE coverage of compiled native portions SHOULD layer binary scanners (Trivy, Grype) against installed `node_modules/` in their own CI. The L3 attestation still covers the exact bytes of the npm `.tgz` regardless of what's inside it.
+- **Supported:** npm and pnpm. Yarn is a follow-on.
+- **Single-package only.** Workspaces (`package.json` with a `workspaces` field, or pack producing >1 `.tgz`) is rejected. Tracked in [#208](https://github.com/TomHennen/wrangle/issues/208).
+- **SBOM scope is the source tree, not the tarball.** Wrangle runs `syft dir:<path>`. If `package.json`'s `files` field restricts what ships, the SBOM may list components not in the `.tgz`; conversely, native binaries `prebuild-install` fetches at consumer install time aren't in source and aren't in the SBOM. Layer binary scanners (Trivy, Grype) against installed `node_modules/` if you need that coverage. The L3 attestation covers the exact `.tgz` bytes regardless.

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -4,29 +4,9 @@ Build an npm or pnpm package (`npm pack` / `pnpm pack`), run tests, generate an 
 
 ## Quick-start
 
-Most adopters want the reusable workflow:
+Copy [`gh_workflow_examples/build_npm.yml`](../../../gh_workflow_examples/build_npm.yml) into your repo at `.github/workflows/`. The example wires the required permissions (`contents: write` for the SLSA generator's upload-assets job, `id-token: write` for Sigstore, `actions: read`) and includes the publish job. Most adopters only need to set the `path` input.
 
-```yaml
-jobs:
-  build:
-    permissions:
-      contents: write   # SLSA generator's upload-assets job
-      id-token: write   # OIDC for Sigstore signing
-      actions: read     # SLSA generator detects the GitHub Actions environment
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.2.0
-    with:
-      path: "."
-```
-
-Then add a publish job — see [`gh_workflow_examples/build_npm.yml`](../../../gh_workflow_examples/build_npm.yml) for the template. Pair with [`check_source_change.yml`](../../../actions/scan/README.md) for source-side coverage.
-
-Or use the composite directly (build + test + SBOM only; you wire your own provenance and publish):
-
-```yaml
-- uses: TomHennen/wrangle/build/actions/npm@v0.2.0
-  with:
-    path: "."
-```
+Pair with [source scan](../../../actions/scan/README.md) for source-side coverage. For the composite-only path (build + test + SBOM, you wire your own provenance and publish), `uses: TomHennen/wrangle/build/actions/npm@v0.2.0`.
 
 This README documents shipped behavior. For the full design (attestation model, step sequence), see [`SPEC.md`](./SPEC.md); workspaces support is designed in [`WORKSPACES_PHASE_1.md`](./WORKSPACES_PHASE_1.md) but not yet implemented.
 
@@ -34,7 +14,7 @@ This README documents shipped behavior. For the full design (attestation model, 
 
 Complete in order — step 1 requires an `NPM_TOKEN` that step 3 then disallows.
 
-1. **Bootstrap v0.0.1 manually.** npm Trusted Publishing can't publish a package's *first* version ([npm/cli#8544](https://github.com/npm/cli/issues/8544)). Run `npm publish` once from a maintainer's terminal with an `NPM_TOKEN`. Skip this and the first workflow run fails with a non-obvious "package not found".
+1. **Bootstrap the first version manually.** npm Trusted Publishing can't publish a package's *first* version ([npm/cli#8544](https://github.com/npm/cli/issues/8544)). Run `npm publish` once from a maintainer's terminal with an `NPM_TOKEN` to mint v0.0.1 (or whatever your initial version is). Skip this and the first workflow run fails with a non-obvious "package not found".
 2. **Configure the trusted publisher.** npmjs.com → your package → Settings → Trusted publishing. Pin: GitHub repo, workflow filename (`build_npm.yml`), optionally an environment.
 3. **Enable "Require two-factor authentication and disallow tokens"** on the package (Settings → Publishing access). This blocks all classic / granular publish tokens, leaving Trusted Publishing's OIDC flow as the only publish path. **Without this, a stolen token bypasses your CI entirely** — the attack vector behind the May 2026 mistralai / guardrails-ai and December 2024 ultralytics compromises, where attackers shipped malware by pushing directly to the registry, never triggering the legitimate workflow. After enabling, revoke the bootstrap `NPM_TOKEN`.
 

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -4,29 +4,9 @@ Build a Python package (wheel + sdist), run pytest, generate an SBOM, and produc
 
 ## Quick-start
 
-Most adopters want the reusable workflow:
+Copy [`gh_workflow_examples/build_python.yml`](../../../gh_workflow_examples/build_python.yml) into your repo at `.github/workflows/`. The example wires the required permissions (`contents: write` for the SLSA generator's upload-assets job, `id-token: write` for Sigstore, `actions: read`) and includes the publish job with verify-before-publish. Most adopters only need to set the `path` input.
 
-```yaml
-jobs:
-  build:
-    permissions:
-      contents: write   # SLSA generator's upload-assets job
-      id-token: write   # OIDC for Sigstore signing
-      actions: read     # SLSA generator detects the GitHub Actions environment
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.0
-    with:
-      path: "."
-```
-
-Then add a publish job — see [`gh_workflow_examples/build_python.yml`](../../../gh_workflow_examples/build_python.yml) for the template (includes verify-before-publish). Pair with [`check_source_change.yml`](../../../actions/scan/README.md) for source-side coverage.
-
-Or use the composite directly (build + test + SBOM only; you wire your own provenance and publish):
-
-```yaml
-- uses: TomHennen/wrangle/build/actions/python@v0.2.0
-  with:
-    path: "."
-```
+Pair with [source scan](../../../actions/scan/README.md) for source-side coverage. For the composite-only path (build + test + SBOM, you wire your own provenance and publish), `uses: TomHennen/wrangle/build/actions/python@v0.2.0`.
 
 This README documents shipped behavior. For architecture and the full step sequence, see [`SPEC.md`](./SPEC.md).
 

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -1,12 +1,16 @@
 # Wrangle Build Python
 
-Build a Python package (wheel + sdist), run pytest, generate an SBOM, and produce SLSA L3 provenance. Publishes to PyPI via Trusted Publishing — the publish job lives in the caller workflow because PyPI's OIDC token must come from the caller, not a reusable workflow ([pypi/warehouse#11096](https://github.com/pypi/warehouse/issues/11096)).
+Build a Python package (wheel + sdist), run pytest, generate an SBOM, and produce SLSA L3 provenance. Publish goes to PyPI via Trusted Publishing.
+
+The publish job lives in your own workflow — not in a wrangle reusable workflow — because PyPI's OIDC token must come from the caller ([pypi/warehouse#11096](https://github.com/pypi/warehouse/issues/11096)).
 
 ## Quick-start
 
 Copy [`gh_workflow_examples/build_python.yml`](../../../gh_workflow_examples/build_python.yml) into your repo at `.github/workflows/`. The example wires the required permissions (`contents: write` for the SLSA generator's upload-assets job, `id-token: write` for Sigstore, `actions: read`) and includes the publish job with verify-before-publish. Most adopters only need to set the `path` input.
 
-Pair with [source scan](../../../actions/scan/README.md) for source-side coverage. For the composite-only path (build + test + SBOM, you wire your own provenance and publish), `uses: TomHennen/wrangle/build/actions/python@v0.2.0`.
+Pair with [source scan](../../../actions/scan/README.md) — build hardens *how* your artifact is produced; source scan covers *what was checked into the repo you're building from*.
+
+For the composite-only path (build + test + SBOM; you wire your own provenance and publish), use `TomHennen/wrangle/build/actions/python@v0.2.0` as a step.
 
 This README documents shipped behavior. For architecture and the full step sequence, see [`SPEC.md`](./SPEC.md).
 
@@ -41,14 +45,14 @@ On the uv sub-path, release builds disable `setup-uv`'s cache (uv doesn't re-ver
 - `dist-artifact-name` — workflow-artifact name to download with `actions/download-artifact` to retrieve the built wheel + sdist.
 - `provenance-artifact-name` — workflow-artifact name for the SLSA provenance (empty when `should-release` is false). Format: `python-<shortname>.intoto.jsonl` so multiple python builds in one workflow don't collide on the same artifact name. (When [#181](https://github.com/TomHennen/wrangle/issues/181) ships, consumers will see a single bundled `multiple.intoto.jsonl` on the release; the per-build namespaced files will become workflow-internal intermediates.)
 - `metadata-artifact-name` — workflow-artifact name for the SBOM and any scan output (`python-metadata-<shortname>`). See [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout."
-- `should-release` — `"true"` if the package should be released — today that's exactly "the current event matched `release-events`", but the gate is the source of truth (future versions may apply additional checks). Your publish job MUST gate on this (see below).
+- `should-release` — `"true"` if the package should be released. Today that means the event matched `release-events`; future versions may apply additional checks, so treat the output as the source of truth rather than re-evaluating `release-events` yourself. Your publish job MUST gate on this (see below).
 - `hashes`, `version`.
 
 `<shortname>` is path-derived (`.` → `_`, `pkg/foo` → `pkg_foo`) so multiple python builds in one workflow don't collide on artifact names.
 
 ## Controlling when releases happen
 
-`release-events` controls which events trigger release-time actions — SLSA provenance generation, verification, and (downstream, via the `should-release` output) your publish job. Accepted values:
+`release-events` controls which events trigger release-time actions: SLSA provenance generation, verification, and — via the `should-release` output — your downstream publish job. Accepted values:
 
 - `non-pull-request` (default) — every event except `pull_request`.
 - `tag-only` — only `push` events to `refs/tags/*`.

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -48,7 +48,7 @@ On the uv sub-path, release builds disable `setup-uv`'s cache (uv doesn't re-ver
 
 ## Controlling when releases happen
 
-`release-events` controls which events produce SLSA provenance. Accepted values:
+`release-events` controls which events trigger release-time actions — SLSA provenance generation, verification, and (downstream, via the `should-release` output) your publish job. Accepted values:
 
 - `non-pull-request` (default) — every event except `pull_request`.
 - `tag-only` — only `push` events to `refs/tags/*`.

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -1,60 +1,49 @@
 # Wrangle Build Python
 
-Build a Python package (wheel + sdist), run tests, generate an SBOM, and produce SLSA provenance (Build L3) — composing PyPI Trusted Publishing (PEP 740 attestations) with `slsa-github-generator`. The publish step itself runs in the adopter's own workflow because PyPI Trusted Publishing's OIDC token must come from the caller, not a reusable workflow ([pypi/warehouse#11096](https://github.com/pypi/warehouse/issues/11096)).
-
-> **Note:** This README documents *currently-shipped* behavior. For the full design — architecture, security model, full step sequence — see [`SPEC.md`](./SPEC.md).
-
-## Recommended companion: source scan
-
-This action hardens *how* your artifact is produced. It does NOT scan your source — vulnerable deps in your lockfile, dangerous workflow triggers, or missing branch protection still slip through and would be faithfully L3-attested by wrangle as legitimately built. Pair this with wrangle's source-scan workflow ([`actions/scan/README.md`](../../../actions/scan/README.md)) to close that gap on every PR and push. Without it, an attacker who lands a malicious dep or workflow misconfiguration routes around the build-side hardening — the May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical recent example.
-
-## Build Track level
-
-Consumed through wrangle's reusable workflow (`build_and_publish_python.yml`), the python build meets **SLSA v1.2 Build L3** — for both the pip and the uv sub-path. You do not need to reason about individual SLSA L3 requirements to use this — the single Build Track level is the claim. Two conditions narrow it:
-
-- **Reusable consumption only.** Calling the `build/actions/python` composite directly from a workflow you author yourself forfeits the build-vs-sign job separation and is **not** a supported L3 path.
-- **GitHub-hosted runners only.** Self-hosted runners invalidate the build-environment isolation the L3 verdict assumes.
-
-On the uv sub-path, release builds run with the uv cache disabled (`setup-uv`'s `enable-cache: false`), so the attested artifact cannot be influenced by a shared, cross-build cache that uv does not re-verify on cache hits (SLSA's "Isolated" requirement). PR builds keep the cache for fast iteration — they produce no attested artifact. The pip sub-path consumes no cross-build cache in either case. The full per-builder analysis is [`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md) (Finding 1).
-
-## Before first use
-
-1. **Configure a Trusted Publisher on PyPI.** Project → Publishing → Add a trusted publisher. Specify your GitHub repository, workflow filename (`build_python.yml`), and optionally an environment name.
-
-2. **Disable legacy API token uploads on PyPI** (Project → Publishing). PyPI allows both Trusted Publishing AND legacy API tokens by default. **A stolen or leftover token bypasses your CI entirely** — including all of wrangle's hardening — because the attacker can `twine upload` malicious artifacts directly without ever triggering your trusted workflow. This is exactly the attack vector behind the December 2024 ultralytics compromise and the May 2026 `mistralai` / `guardrails-ai` compromise (both shipped malware to PyPI by pushing directly to the registry, never triggering the legitimate GitHub Actions release workflow). Wrangle's pipeline can't enforce this; the toggle lives in PyPI's settings.
-
-3. **(Optional) Configure TestPyPI.** For pre-release testing, repeat step 1 on test.pypi.org with a separate Trusted Publisher.
+Build a Python package (wheel + sdist), run pytest, generate an SBOM, and produce SLSA L3 provenance. Publishes to PyPI via Trusted Publishing — the publish job lives in the caller workflow because PyPI's OIDC token must come from the caller, not a reusable workflow ([pypi/warehouse#11096](https://github.com/pypi/warehouse/issues/11096)).
 
 ## Quick-start
 
-Two ways to adopt:
+Most adopters want the reusable workflow:
 
-1. **Reusable workflow** — single `uses:` line in your CI. Runs the full pipeline (build → test → SBOM → SLSA L3 provenance), with a publish job in your own workflow. This is what most adopters want.
+```yaml
+jobs:
+  build:
+    permissions:
+      contents: write   # SLSA generator's upload-assets job
+      id-token: write   # OIDC for Sigstore signing
+      actions: read     # SLSA generator detects the GitHub Actions environment
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.0
+    with:
+      path: "."
+```
 
-   ```yaml
-   jobs:
-     build:
-       permissions:
-         # Required because wrangle's reusable workflow has a nested
-         # provenance job that calls slsa-github-generator. GitHub
-         # validates these permissions at workflow startup.
-         contents: write   # SLSA generator's upload-assets job (write required even when upload-assets is false)
-         id-token: write   # OIDC for Sigstore signing
-         actions: read     # SLSA generator detects the GitHub Actions environment
-       uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.0
-       with:
-         path: "."
-   ```
+Then add a publish job — see [`gh_workflow_examples/build_python.yml`](../../../gh_workflow_examples/build_python.yml) for the template (includes verify-before-publish). Pair with [`check_source_change.yml`](../../../actions/scan/README.md) for source-side coverage.
 
-   Then add a publish job. See [`gh_workflow_examples/build_python.yml`](../../../gh_workflow_examples/build_python.yml) for the full template, including verifying SLSA provenance before publish.
+Or use the composite directly (build + test + SBOM only; you wire your own provenance and publish):
 
-2. **Composite action** — drop into an existing workflow. Runs build + test + SBOM only; you wire in your own provenance and publish.
+```yaml
+- uses: TomHennen/wrangle/build/actions/python@v0.2.0
+  with:
+    path: "."
+```
 
-   ```yaml
-   - uses: TomHennen/wrangle/build/actions/python@v0.2.0
-     with:
-       path: "."
-   ```
+This README documents shipped behavior. For architecture and the full step sequence, see [`SPEC.md`](./SPEC.md).
+
+## Before first use
+
+1. **Configure a Trusted Publisher on PyPI.** Project → Publishing → Add a trusted publisher. Specify your GitHub repo, workflow filename (`build_python.yml`), and optionally an environment.
+2. **Disable legacy API token uploads on PyPI** (same page). **A stolen or leftover token bypasses your CI entirely**: an attacker can `twine upload` directly to the registry without ever triggering your trusted workflow — the attack vector behind the December 2024 ultralytics and May 2026 mistralai / guardrails-ai compromises. Wrangle can't enforce this; the toggle lives in PyPI's settings.
+3. **(Optional) Configure TestPyPI** with a separate Trusted Publisher for pre-release testing.
+
+## Build Track level
+
+Consumed through `build_and_publish_python.yml`, the build meets **SLSA v1.2 Build L3** — for both the pip and the uv sub-path. Two conditions narrow the claim:
+
+- **Reusable consumption only.** Calling the composite directly forfeits the build-vs-sign job separation and is **not** a supported L3 path.
+- **GitHub-hosted runners only.** Self-hosted runners invalidate the build-environment isolation L3 assumes.
+
+On the uv sub-path, release builds disable `setup-uv`'s cache (uv doesn't re-verify cache hits — would violate SLSA's "Isolated" requirement); PR builds keep it for fast iteration. The pip sub-path uses no cross-build cache. Full analysis: [`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md) Finding 1.
 
 ## What this action does
 
@@ -75,9 +64,15 @@ Two ways to adopt:
 
 ## Controlling when releases happen
 
-The `release-events` input controls which events produce SLSA provenance. Your publish job MUST also gate on `should-release` so wrangle's provenance gating and your publish gating stay in lockstep.
+`release-events` controls which events produce SLSA provenance. Shorthands: `non-pull-request` (default), `tag-only`, `main-and-tags`. A comma-separated `github.event_name` list (e.g., `push,workflow_dispatch`) is also accepted — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating".
 
-> **Required wiring.** Without the gate, your publish job runs on every non-PR event regardless of what you pass as `release-events`. The example workflow at [`gh_workflow_examples/build_python.yml`](../../../gh_workflow_examples/build_python.yml) shows the canonical shape:
+```yaml
+with:
+  path: "."
+  release-events: tag-only
+```
+
+> **Required wiring.** Your publish job MUST also gate on `should-release` — wrangle can't enforce this because publish lives in your workflow (PyPI's OIDC constraint). The canonical shape:
 >
 > ```yaml
 > publish:
@@ -85,86 +80,60 @@ The `release-events` input controls which events produce SLSA provenance. Your p
 >   needs: [build]
 > ```
 >
-> Wrangle cannot enforce this from inside its reusable workflow — publish lives in your workflow due to PyPI Trusted Publishing's OIDC `workflow_ref` constraint ([pypi/warehouse#11096](https://github.com/pypi/warehouse/issues/11096)). If you forget the gate, builds still succeed, provenance still respects `release-events`, but your publish runs more often than you intended.
-
-`release-events` accepts: `non-pull-request` (default), `tag-only`, `main-and-tags`, or a comma-separated `github.event_name` list (e.g., `push,workflow_dispatch`). See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full vocabulary.
-
-```yaml
-uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.0
-with:
-  path: "."
-  release-events: tag-only   # only tag pushes mint provenance and publish
-```
+> Without the gate, publish runs on every non-PR event regardless of `release-events`.
 
 ## SLSA provenance verification (default-on, opt-out)
 
-Wrangle's reusable workflow generates non-falsifiable SLSA L3 build provenance via `slsa-github-generator`, **then verifies the just-built dist against that provenance** before declaring the workflow successful. If verification fails, the workflow fails — and your publish job is blocked via standard `needs:` propagation. This catches the case where the dist is tampered with between wrangle's build and your publish.
-
-You don't need to wire `slsa-verifier` into your own publish job. The example workflow's publish job is just `download-artifact` + `pypa/gh-action-pypi-publish`.
-
-To opt out (e.g., you maintain a custom verification flow), pass `verify-provenance: false`:
-
-```yaml
-uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.0
-with:
-  path: "."
-  verify-provenance: false   # skip wrangle's verification; you handle it
-```
-
-When opted out, the dist's integrity between wrangle's build and your publish becomes your concern. The boilerplate to add a verify step in your own publish job is the same shape wrangle uses internally — see the [reusable workflow source](../../../.github/workflows/build_and_publish_python.yml) for reference.
+The reusable workflow verifies the just-built dist against the SLSA L3 provenance before declaring success — failure blocks your publish job via `needs:`. This catches tampering between wrangle's build and your publish, so your publish job stays as simple as `download-artifact` + `pypa/gh-action-pypi-publish`. Opt out with `verify-provenance: false` if you maintain a custom verification flow (the integrity guarantee then shifts to you).
 
 ## Verifying after install (downstream consumers)
 
-Your package's consumers — anyone who installs your wheel — can verify it two complementary ways. Each answers a different question, and they trust different roots.
+Two complementary verification paths, different roots of trust:
 
-### PEP 740 attestations (against PyPI)
+**PEP 740 attestations (against PyPI).** PyPI stores Sigstore-based attestations alongside every wheel published with `attestations: true` (which `pypa/gh-action-pypi-publish` does). Proves *who published* — the GitHub workflow identity, recorded in Sigstore's transparency log. The wheel's PyPI page shows verification status; `sigstore-python` verifies on the command line.
 
-PyPI stores Sigstore-based PEP 740 attestations alongside every wheel published with `attestations: true` (which `pypa/gh-action-pypi-publish` does in the example workflow). These prove **who published the package** — the GitHub workflow identity, recorded in Sigstore's transparency log. `pip` verifies them natively (experimental as of pip 24.x); `sigstore-python` verifies them on the command line. The wheel's PyPI page also displays the verification status. No download from your repo needed — PyPI is the source of truth.
+> **Known limitation.** `pip install` does NOT verify PEP 740 attestations by default (experimental in pip 24.x). Until verification is the default, the load-bearing check is PyPI's upload-time `workflow_ref` validation — but that only holds when legacy token uploads are disabled (see "Before first use"), since a stolen token bypasses it entirely.
 
-> **Known limitation.** `pip install` does NOT verify PEP 740 attestations by default — verification is experimental in pip 24.x and requires opt-in flags. Until verification is the default, consumers who care about provenance must opt in via `sigstore-python` or pip's experimental flag. This is a pip-ecosystem gap, not a wrangle gap; the legitimate-publish guarantee ("this version was published from the registered trusted workflow") is enforced by PyPI at *upload* time — but only when legacy token uploads are disabled (see "Before first use" above), since a stolen token bypasses that enforcement entirely.
-
-### SLSA L3 provenance (against your repo's release)
-
-SLSA provenance proves **how the artifact was built** — inputs, builder, materials — and is non-falsifiable because the generator runs in an isolated reusable workflow. Wrangle uploads the provenance to your GitHub release on tag pushes (because the reusable workflow sets `upload-assets: ${{ startsWith(github.ref, 'refs/tags/') }}`). The filename today is `python-<shortname>.intoto.jsonl` (e.g., `python-_.intoto.jsonl` for a top-level project, where `_` is the shortname for `.`). [#181](https://github.com/TomHennen/wrangle/issues/181) tracks moving to a single `multiple.intoto.jsonl` bundle (in-toto convention) at the release/consumer layer; until that ships, use the per-build filename. Verify with `slsa-verifier`:
+**SLSA L3 provenance (against your GitHub release).** Proves *how the artifact was built* — inputs, builder, materials. Non-falsifiable because the generator runs in an isolated reusable workflow. Wrangle attaches the bundle to the GitHub release on tag pushes (`python-<shortname>.intoto.jsonl`, where `<shortname>` is the path-derived name — `.` becomes `_`):
 
 ```bash
-# Download wheel + provenance from your GitHub release
 curl -LO "https://github.com/<owner>/<repo>/releases/download/<tag>/<package>-<version>-py3-none-any.whl"
 curl -LO "https://github.com/<owner>/<repo>/releases/download/<tag>/python-<shortname>.intoto.jsonl"
 
-# Install slsa-verifier (https://github.com/slsa-framework/slsa-verifier#installation)
-
-# Verify
 slsa-verifier verify-artifact \
   --provenance-path python-<shortname>.intoto.jsonl \
   --source-uri "github.com/<owner>/<repo>" \
   <package>-<version>-py3-none-any.whl
 ```
 
-Provenance is **only** in the GitHub release on tag pushes. On non-tag publishes (e.g., `workflow_dispatch` from a branch) the provenance lives only as a 90-day workflow artifact and is not retrievable by external consumers. Adopters whose workflows don't push tags should publicize how to obtain provenance — wrangle's convention is "tag pushes attach provenance to the release; non-tag publishes don't have consumer-retrievable provenance."
+> **Tag-push only.** On non-tag publishes (e.g., `workflow_dispatch` from a branch) the provenance lives only as a 90-day workflow artifact and isn't retrievable by external consumers. [#181](https://github.com/TomHennen/wrangle/issues/181) tracks moving to a single bundled `multiple.intoto.jsonl` at the release layer.
 
-The same `slsa-verifier verify-artifact` invocation is exercised by wrangle's integration test against TestPyPI in [`gh_workflow_examples/build_python.yml`](../../../gh_workflow_examples/build_python.yml)'s publish job (which downloads provenance from a workflow artifact instead of a release asset, but the verify call is identical). Consumer-side verification against a real GitHub release is not yet integration-tested; see [#163](https://github.com/TomHennen/wrangle/issues/163).
+## What this action does
+
+- Detects `uv` (presence of `uv.lock`) vs PEP 517 tooling and routes dependencies, build, and tests accordingly.
+- Installs the project (`pip install -e ".[test]"` or `uv sync`).
+- Runs `pytest` if `tests/`, `test/`, or `[tool.pytest.ini_options]` is present in `pyproject.toml`.
+- Builds wheel + sdist (`python -m build` or `uv build`).
+- Generates an SPDX SBOM via `syft` (Cosign-keyless-verified install).
+- Computes SHA-256 hashes in the format `slsa-github-generator`'s `base64-subjects` expects.
+
+## Outputs from the reusable workflow
+
+- `dist-artifact-name` — workflow-artifact name for the wheel + sdist.
+- `provenance-artifact-name` — workflow-artifact name for the SLSA provenance (`python-<shortname>.intoto.jsonl`; empty when `should-release` is false).
+- `metadata-artifact-name` — workflow-artifact name for the SBOM (`python-metadata-<shortname>`).
+- `should-release` — `"true"` if the event matches `release-events`. Your publish job MUST gate on this.
+- `hashes`, `version`.
+
+`<shortname>` is path-derived (`.` → `_`, `pkg/foo` → `pkg_foo`) so multiple python builds in one workflow don't collide on artifact names.
 
 ## SBOM
 
-The action writes an SPDX JSON SBOM to `metadata/python/<shortname>/sbom.spdx.json`. The reusable workflow zips the contents of `metadata/python/<shortname>/` and uploads them as the workflow artifact `python-metadata-<shortname>`, exposed as the `metadata-artifact-name` output. Downloading the artifact (e.g., via `actions/download-artifact`) extracts the metadata files at the top level of whatever `path:` the adopter chooses — the `metadata/python/<shortname>/` prefix is a workspace convention, not part of the artifact's interior layout.
-
-Naming and layout follow the unified-metadata convention shared across every build type — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout" for how the directory maps to the artifact zip.
-
-```yaml
-- uses: actions/download-artifact@<sha>
-  with:
-    name: ${{ needs.build.outputs.metadata-artifact-name }}
-    path: metadata/  # `sbom.spdx.json` lands directly here, not under metadata/python/<shortname>/
-```
-
-`<shortname>` is the path-derived short name — `.` becomes `_`, `pkg/foo` becomes `pkg_foo`. This namespacing lets you run multiple python builds in one workflow without artifact-name collisions.
+Written to `metadata/python/<shortname>/sbom.spdx.json` and uploaded as the `python-metadata-<shortname>` workflow artifact (exposed via the `metadata-artifact-name` output). Download lands the files at the top level of whatever `path:` you pick — the `metadata/python/<shortname>/` prefix is a workspace convention, not preserved in the zip. See [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout".
 
 ## Further reading
 
-- [`SPEC.md`](./SPEC.md) — this action's full specification
-- [`../../../docs/SPEC.md`](../../../docs/SPEC.md) — wrangle's overall architecture
-- [`../../README.md`](../../README.md) — the build/ directory overview
-- [`../../../actions/scan/README.md`](../../../actions/scan/README.md) — recommended source-scan companion
-- [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) — the underlying PyPI feature
-- [SLSA generic generator](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md)
+- [`SPEC.md`](./SPEC.md) — this action's full specification.
+- [`../../../docs/SPEC.md`](../../../docs/SPEC.md) — wrangle's architecture.
+- [`../../../actions/scan/README.md`](../../../actions/scan/README.md) — source-scan companion.
+- [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/), [SLSA generic generator](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md).

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -12,13 +12,15 @@ This README documents shipped behavior. For architecture and the full step seque
 
 ## Before first use
 
-1. **Configure a Trusted Publisher on PyPI.** Project → Publishing → Add a trusted publisher. Specify your GitHub repo, workflow filename (`build_python.yml`), and optionally an environment.
-2. **Disable legacy API token uploads on PyPI** (same page). **A stolen or leftover token bypasses your CI entirely**: an attacker can `twine upload` directly to the registry without ever triggering your trusted workflow — the attack vector behind the December 2024 ultralytics and May 2026 mistralai / guardrails-ai compromises. Wrangle can't enforce this; the toggle lives in PyPI's settings.
+1. **Configure a Trusted Publisher on PyPI.** Pin your GitHub repo, workflow filename (`build_python.yml`), and optionally an environment.
+   - **Migrating an existing project:** Project → Publishing → Add a trusted publisher.
+   - **Brand-new package (not yet on PyPI):** use PyPI's [pending publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/) flow — Your projects → Publishing → Add a pending publisher. The first successful CI publish then creates the project. No manual bootstrap-publish needed (unlike npm).
+2. **Disable legacy API token uploads on PyPI** (Publishing settings). **A stolen or leftover token bypasses your CI entirely**: an attacker can `twine upload` directly to the registry without ever triggering your trusted workflow — the attack vector behind the December 2024 ultralytics and May 2026 mistralai / guardrails-ai compromises. Wrangle can't enforce this; the toggle lives in PyPI's settings. For brand-new packages there's no legacy token to revoke; just leave the toggle off from the start.
 3. **(Optional) Configure TestPyPI** with a separate Trusted Publisher for pre-release testing.
 
 ## Build Track level
 
-Consumed through `build_and_publish_python.yml`, the build meets **SLSA v1.2 Build L3** — for both the pip and the uv sub-path. Two conditions narrow the claim:
+Consumed through `build_and_publish_python.yml`, the build meets **SLSA v1.2 Build L3** — for both the pip and the uv sub-path — if both of these conditions hold:
 
 - **Reusable consumption only.** Calling the composite directly forfeits the build-vs-sign job separation and is **not** a supported L3 path.
 - **GitHub-hosted runners only.** Self-hosted runners invalidate the build-environment isolation L3 assumes.
@@ -39,12 +41,21 @@ On the uv sub-path, release builds disable `setup-uv`'s cache (uv doesn't re-ver
 - `dist-artifact-name` — workflow-artifact name to download with `actions/download-artifact` to retrieve the built wheel + sdist.
 - `provenance-artifact-name` — workflow-artifact name for the SLSA provenance (empty when `should-release` is false). Format: `python-<shortname>.intoto.jsonl` so multiple python builds in one workflow don't collide on the same artifact name. (When [#181](https://github.com/TomHennen/wrangle/issues/181) ships, consumers will see a single bundled `multiple.intoto.jsonl` on the release; the per-build namespaced files will become workflow-internal intermediates.)
 - `metadata-artifact-name` — workflow-artifact name for the SBOM and any scan output (`python-metadata-<shortname>`). See [`docs/SPEC.md`](../../../docs/SPEC.md) "Unified metadata layout."
-- `should-release` — `"true"` if the current event matches `release-events`. Your publish job MUST gate on this (see below).
+- `should-release` — `"true"` if the package should be released — today that's exactly "the current event matched `release-events`", but the gate is the source of truth (future versions may apply additional checks). Your publish job MUST gate on this (see below).
 - `hashes`, `version`.
+
+`<shortname>` is path-derived (`.` → `_`, `pkg/foo` → `pkg_foo`) so multiple python builds in one workflow don't collide on artifact names.
 
 ## Controlling when releases happen
 
-`release-events` controls which events produce SLSA provenance. Shorthands: `non-pull-request` (default), `tag-only`, `main-and-tags`. A comma-separated `github.event_name` list (e.g., `push,workflow_dispatch`) is also accepted — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating".
+`release-events` controls which events produce SLSA provenance. Accepted values:
+
+- `non-pull-request` (default) — every event except `pull_request`.
+- `tag-only` — only `push` events to `refs/tags/*`.
+- `main-and-tags` — `push` to `refs/heads/main` or `refs/tags/*`.
+- A comma-separated `github.event_name` list (e.g., `push,workflow_dispatch`).
+
+See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full vocabulary.
 
 ```yaml
 with:
@@ -87,25 +98,6 @@ slsa-verifier verify-artifact \
 ```
 
 > **Tag-push only.** On non-tag publishes (e.g., `workflow_dispatch` from a branch) the provenance lives only as a 90-day workflow artifact and isn't retrievable by external consumers. [#181](https://github.com/TomHennen/wrangle/issues/181) tracks moving to a single bundled `multiple.intoto.jsonl` at the release layer.
-
-## What this action does
-
-- Detects `uv` (presence of `uv.lock`) vs PEP 517 tooling and routes dependencies, build, and tests accordingly.
-- Installs the project (`pip install -e ".[test]"` or `uv sync`).
-- Runs `pytest` if `tests/`, `test/`, or `[tool.pytest.ini_options]` is present in `pyproject.toml`.
-- Builds wheel + sdist (`python -m build` or `uv build`).
-- Generates an SPDX SBOM via `syft` (Cosign-keyless-verified install).
-- Computes SHA-256 hashes in the format `slsa-github-generator`'s `base64-subjects` expects.
-
-## Outputs from the reusable workflow
-
-- `dist-artifact-name` — workflow-artifact name for the wheel + sdist.
-- `provenance-artifact-name` — workflow-artifact name for the SLSA provenance (`python-<shortname>.intoto.jsonl`; empty when `should-release` is false).
-- `metadata-artifact-name` — workflow-artifact name for the SBOM (`python-metadata-<shortname>`).
-- `should-release` — `"true"` if the event matches `release-events`. Your publish job MUST gate on this.
-- `hashes`, `version`.
-
-`<shortname>` is path-derived (`.` → `_`, `pkg/foo` → `pkg_foo`) so multiple python builds in one workflow don't collide on artifact names.
 
 ## SBOM
 

--- a/gh_workflow_examples/README.md
+++ b/gh_workflow_examples/README.md
@@ -12,4 +12,6 @@ Starting points for adopting wrangle. Copy to `.github/workflows/` in your repo 
 | `build_npm.yml` | `npm pack` / `pnpm pack`, test, SBOM, SLSA L3 provenance. Publishes via npm Trusted Publishing — publish job stays in the caller workflow ([npm constraint](https://github.com/npm/documentation/issues/1755)). | [`../build/actions/npm/README.md`](../build/actions/npm/README.md) |
 | `build_python.yml` | Wheel + sdist, pytest, SBOM, SLSA L3 provenance. Publishes via PyPI Trusted Publishing — publish job stays in the caller. | [`../build/actions/python/README.md`](../build/actions/python/README.md) |
 
-The npm and python README "Before first use" sections walk through Trusted Publishing setup (bootstrap publish, disable token uploads). Roadmap: [#201](https://github.com/TomHennen/wrangle/issues/201) adds per-commit SLSA Source Track attestations to `check_source_change.yml`.
+The npm and python READMEs each have a "Before first use" section covering Trusted Publishing setup — bootstrap publish (npm only), trusted-publisher registration, and disabling legacy token uploads. Read those before your first run.
+
+Roadmap: [#201](https://github.com/TomHennen/wrangle/issues/201) adds per-commit SLSA Source Track attestations to `check_source_change.yml`.

--- a/gh_workflow_examples/README.md
+++ b/gh_workflow_examples/README.md
@@ -8,8 +8,8 @@ Starting points for adopting wrangle. Copy to `.github/workflows/` in your repo 
 |----------|-------------|------------------------|
 | `check_source_change.yml` | OSV-Scanner, Zizmor, Scorecard, dependency-review on every PR and push. | [`actions/scan/README.md`](../actions/scan/README.md) |
 | `build_shell.yml` | shellcheck + bats. No artifact. | — |
-| `build_and_publish_containers.yml` | Build, sign, publish a container image with SBOM and SLSA L3 provenance. | [`build/actions/container/README.md`](/build/actions/container/README.md) |
-| `build_npm.yml` | `npm pack` / `pnpm pack`, test, SBOM, SLSA L3 provenance. Publishes via npm Trusted Publishing — publish job stays in the caller workflow ([npm constraint](https://github.com/npm/documentation/issues/1755)). | [`build/actions/npm/README.md`](/build/actions/npm/README.md) |
-| `build_python.yml` | Wheel + sdist, pytest, SBOM, SLSA L3 provenance. Publishes via PyPI Trusted Publishing — publish job stays in the caller. | [`build/actions/python/README.md`](/build/actions/python/README.md) |
+| `build_and_publish_containers.yml` | Build, sign, publish a container image with SBOM and SLSA L3 provenance. | [`../build/actions/container/README.md`](../build/actions/container/README.md) |
+| `build_npm.yml` | `npm pack` / `pnpm pack`, test, SBOM, SLSA L3 provenance. Publishes via npm Trusted Publishing — publish job stays in the caller workflow ([npm constraint](https://github.com/npm/documentation/issues/1755)). | [`../build/actions/npm/README.md`](../build/actions/npm/README.md) |
+| `build_python.yml` | Wheel + sdist, pytest, SBOM, SLSA L3 provenance. Publishes via PyPI Trusted Publishing — publish job stays in the caller. | [`../build/actions/python/README.md`](../build/actions/python/README.md) |
 
 The npm and python README "Before first use" sections walk through Trusted Publishing setup (bootstrap publish, disable token uploads). Roadmap: [#201](https://github.com/TomHennen/wrangle/issues/201) adds per-commit SLSA Source Track attestations to `check_source_change.yml`.

--- a/gh_workflow_examples/README.md
+++ b/gh_workflow_examples/README.md
@@ -1,25 +1,15 @@
 # Wrangle Workflow Examples
 
-Starting points for adopting wrangle. Copy to `.github/workflows/` in your repo and customize the inputs (paths, image names, etc.) for your project.
+Starting points for adopting wrangle. Copy to `.github/workflows/` in your repo and customize the inputs for your project.
 
-**Recommended pattern:** pair *any* build/publish workflow below with `check_source_change.yml`. Build/publish hardens *how* your artifact is produced; the source-scan workflow covers *what was checked into the repo you're building from*. Without both, an attacker who lands a malicious dep or workflow misconfiguration routes around the build-side hardening — wrangle will still faithfully attest the result. See [`../actions/scan/README.md`](../actions/scan/README.md) for the full rationale.
+**Pair any build/publish workflow with `check_source_change.yml`.** Build hardens *how* your artifact is produced; source scan covers *what was checked into the repo you're building from*. See [`../actions/scan/README.md`](../actions/scan/README.md) for the rationale.
 
-## check_source_change.yml
+| Workflow | What it does | Per-build-type README |
+|----------|-------------|------------------------|
+| `check_source_change.yml` | OSV-Scanner, Zizmor, Scorecard, dependency-review on every PR and push. | [`actions/scan/README.md`](../actions/scan/README.md) |
+| `build_shell.yml` | shellcheck + bats. No artifact. | — |
+| `build_and_publish_containers.yml` | Build, sign, publish a container image with SBOM and SLSA L3 provenance. | [`build/actions/container/README.md`](/build/actions/container/README.md) |
+| `build_npm.yml` | `npm pack` / `pnpm pack`, test, SBOM, SLSA L3 provenance. Publishes via npm Trusted Publishing — publish job stays in the caller workflow ([npm constraint](https://github.com/npm/documentation/issues/1755)). | [`build/actions/npm/README.md`](/build/actions/npm/README.md) |
+| `build_python.yml` | Wheel + sdist, pytest, SBOM, SLSA L3 provenance. Publishes via PyPI Trusted Publishing — publish job stays in the caller. | [`build/actions/python/README.md`](/build/actions/python/README.md) |
 
-Run OSV-Scanner, Zizmor, and Scorecard source scanning on every PR and push to main. **Adopt alongside whichever build/publish workflow below matches your project.** Roadmap: [#201](https://github.com/TomHennen/wrangle/issues/201) extends this with per-commit SLSA Source Track attestations via [slsa-framework/source-tool](https://github.com/slsa-framework/source-tool) — adoption stays a single workflow file.
-
-## build_shell.yml
-
-Run shellcheck and bats tests on shell projects.
-
-## build_and_publish_containers.yml
-
-Build, sign, and publish a container image with SBOM and SLSA provenance (Build L3).
-
-## build_npm.yml
-
-Build an npm package (`npm pack`), run tests, generate an SPDX SBOM, and produce SLSA provenance (Build L3). Publishes to npmjs.org via Trusted Publishing (no `NPM_TOKEN`) — the publish job lives in the caller workflow because npm's Trusted Publishing OIDC token must come from the caller's workflow filename, not a reusable workflow. Adopters must bootstrap-publish v0.0.1 once manually and configure a [Trusted Publisher on npmjs.com](https://docs.npmjs.com/trusted-publishers/) before the first automated publish — see [`build/actions/npm/README.md`](/build/actions/npm/README.md) for the onboarding checklist.
-
-## build_python.yml
-
-Build a Python package (wheel + sdist), run pytest, generate an SPDX SBOM, and produce SLSA provenance (Build L3). Optionally verify the provenance with `slsa-verifier` before publishing to PyPI via Trusted Publishing (no API tokens). Adopters must configure a [Trusted Publisher on PyPI](https://docs.pypi.org/trusted-publishers/) before the first publish — see [`build/actions/python/README.md`](/build/actions/python/README.md) for the onboarding checklist.
+The npm and python README "Before first use" sections walk through Trusted Publishing setup (bootstrap publish, disable token uploads). Roadmap: [#201](https://github.com/TomHennen/wrangle/issues/201) adds per-commit SLSA Source Track attestations to `check_source_change.yml`.


### PR DESCRIPTION
## Summary

Sweep of the user-facing READMEs per #206. Goal: a new adopter can reach a copy-pasteable example within ~30s of scrolling. Substance is preserved — this is a delivery pass, not a correctness change.

| File | Before | After |
|------|-------:|------:|
| `README.md` | 2.3 KB | 1.4 KB |
| `build/README.md` | 2.3 KB | 1.3 KB |
| `gh_workflow_examples/README.md` | 2.4 KB | 1.7 KB |
| `actions/scan/README.md` | 6.0 KB | 4.3 KB |
| `build/actions/container/README.md` | 11.4 KB | 7.1 KB |
| `build/actions/python/README.md` | 14.7 KB | 9.9 KB |
| `build/actions/npm/README.md` | 19.2 KB | 11.0 KB |
| **total** | **58.3 KB** | **36.7 KB** |

### Per-file changes
- **`README.md`**: drop the "toy project" framing and the multi-paragraph Goals section in favor of a one-line value prop. Update the Pieces list (was missing npm/python).
- **`build/README.md`**: collapse per-build prose into a single table; tighten the Build Track level paragraph.
- **`gh_workflow_examples/README.md`**: collapse per-workflow descriptions into a table; lead with the pairing recommendation.
- **`actions/scan/README.md`**: lead with quick-start, then "what runs", then the Mini Shai-Hulud rationale (kept here as the canonical detailed exposition since this is where it most naturally belongs).
- **`build/actions/container/README.md`**: lead with quick-start; clarify what ships today vs what's still planned (cosign image-digest signing and OSV-Scanner over the SBOM are still planned in both the composite and the reusable workflow); fold the standalone "Container vulnerability scanning" section into SBOM.
- **`build/actions/python/README.md`**: reorder to lead with quick-start; compress the "Recommended companion" duplication and the "Required wiring" prose; trim the verification-after-install section.
- **`build/actions/npm/README.md`**: same reordering; remove the "Recommended companion" duplication; compress the token-bypass narrative in "Before first use" (kept the incident list, dropped the recap prose); compress lifecycle hooks, caching, and v0.2 status sections.

### Scope notes
- **`docs/SPEC.md` is deferred.** The issue lists it in scope but contemplates "one PR per file or one big PR — TBD." SPEC.md is 1054 lines of contract material, and tightening it without affecting precision is beyond a one-PR delivery pass. Happy to do that as a follow-up.
- **No new docs created** (per the issue's out-of-scope list).
- **No anchor links broken** — verified with grep across `docs/` and `test/`.

### Repetition that got compressed
- "Recommended companion: source scan" appeared in all three build READMEs with near-identical Mini Shai-Hulud paragraphs. The canonical detailed exposition now lives only in `actions/scan/README.md`; the build READMEs link to it.
- "Build Track level" two-conditions boilerplate (Reusable consumption only / GitHub-hosted runners only) was identical across npm/python/container. Same wording is now reused but the surrounding prose is per-build-specific.
- Token-bypass narrative around mistralai / ultralytics appeared in both npm and python "Before first use." Each now references the incidents in one sentence rather than restating the attack vector twice.

## Test plan
- [ ] Skim each README cold and time how long it takes to find the copy-paste example. Target: <30s of scrolling.
- [ ] Confirm `make test` / `./test.sh` still passes (no test parses README content, so this is a sanity check rather than a coverage check).
- [ ] Spot-check the markdown rendering on GitHub once the PR is up — particularly the new tables in `build/README.md` and `gh_workflow_examples/README.md`.

Closes part of #206; SPEC.md follow-up to come.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Uz8Xctf67FD8Ee5rLnQ4e)_