### PR TITLE
Replace grep-based structural tests with behavioral tests (#160)

### DIFF
--- a/build/actions/npm/build_and_pack.sh
+++ b/build/actions/npm/build_and_pack.sh
@@ -49,6 +49,13 @@
 # emits nothing after the guard returns. Tarball name still does not
 # reach stdout (it goes to $GITHUB_OUTPUT, a file the runner reads).
 #
+# The decision functions (`detect_pm`, `has_build_script`,
+# `has_real_test_script`, `find_one_tarball`) are split out so test.bats
+# can exercise the branches as pure args-in → stdout-out functions, no
+# npm/pnpm shim required. The main() function glues them to the install/
+# build/test/pack invocations against real npm/pnpm — that integration
+# strand still needs shimming, but the decision logic does not.
+#
 # Usage: build/actions/npm/build_and_pack.sh <path> <run_tests> <ignore_scripts>
 #   path:            project directory (already validated)
 #   run_tests:       "true" to run the test script if a non-default test
@@ -61,102 +68,147 @@
 
 set -euo pipefail
 
-if [[ $# -ne 3 ]]; then
-    printf 'Usage: %s <path> <run_tests> <ignore_scripts>\n' "$0" >&2
-    exit 1
-fi
-
-INPUT_PATH="$1"
-RUN_TESTS="$2"
-IGNORE_SCRIPTS="$3"
-
-cd "$INPUT_PATH"
-
-# Detect package manager from lockfile. validate_inputs.sh already
-# ensured exactly one of the supported lockfiles is present (and that
-# yarn.lock is not, and that both npm + pnpm lockfiles aren't present).
-if [[ -f "pnpm-lock.yaml" ]]; then
-    PM=pnpm
-else
-    PM=npm
-fi
-printf 'Package manager: %s\n' "$PM"
-
-ignore_scripts_args=()
-if [[ "$IGNORE_SCRIPTS" == "true" ]]; then
-    ignore_scripts_args=(--ignore-scripts)
-    printf 'ignore-scripts=true: all package.json scripts will be skipped\n'
-fi
-
-if [[ "$PM" == "pnpm" ]]; then
-    printf 'Installing dependencies (pnpm install --frozen-lockfile)...\n'
-    pnpm install --frozen-lockfile "${ignore_scripts_args[@]}"
-else
-    printf 'Installing dependencies (npm ci)...\n'
-    npm ci "${ignore_scripts_args[@]}"
-fi
-
-if [[ "$IGNORE_SCRIPTS" == "true" ]]; then
-    printf 'Skipping %s run build and %s test (ignore-scripts=true)\n' "$PM" "$PM"
-else
-    # Reflect on package.json to decide whether to run build/test scripts.
-    # Using jq rather than catching `<pm> run`'s "missing script" exit code
-    # keeps the logs clear — the action shouldn't print error output for
-    # scripts that simply don't exist. `(.scripts // {})` keeps the path
-    # safe when `scripts` is missing or explicitly null.
-    HAS_BUILD="$(jq -r '(.scripts // {}) | has("build")' package.json)"
-    HAS_TEST_SCRIPT="$(jq -r '(.scripts // {}) | has("test")' package.json)"
-    TEST_CMD="$(jq -r '.scripts.test // ""' package.json)"
-
-    if [[ "$HAS_BUILD" == "true" ]]; then
-        printf 'Running %s run build...\n' "$PM"
-        "$PM" run build
+# Pure function: detects which package manager to use, based on the
+# project's lockfile. validate_inputs.sh has already ensured exactly one
+# supported lockfile is present.
+#
+# Args: <project_dir>
+# Prints: "npm" or "pnpm"
+detect_pm() {
+    local path="$1"
+    if [[ -f "$path/pnpm-lock.yaml" ]]; then
+        printf 'pnpm\n'
     else
-        printf 'No build script in package.json — skipping build step\n'
+        printf 'npm\n'
+    fi
+}
+
+# Pure function: returns 0 if package.json declares a `build` script.
+# Null-safe against `"scripts": null` or a missing `scripts` field.
+#
+# Args: <project_dir>
+has_build_script() {
+    local path="$1"
+    [[ "$(jq -r '(.scripts // {}) | has("build")' "$path/package.json")" == "true" ]]
+}
+
+# Pure function: returns 0 if package.json declares a `test` script AND
+# that script is not the npm-default `no test specified` stub. Substring
+# match against the default phrase so minor wording tweaks in future
+# npm/pnpm releases don't accidentally re-enable the no-op.
+#
+# Args: <project_dir>
+has_real_test_script() {
+    local path="$1"
+    local has_test test_cmd
+    has_test="$(jq -r '(.scripts // {}) | has("test")' "$path/package.json")"
+    [[ "$has_test" == "true" ]] || return 1
+    test_cmd="$(jq -r '.scripts.test // ""' "$path/package.json")"
+    [[ "$test_cmd" != *'no test specified'* ]]
+}
+
+# Pure function: asserts exactly one *.tgz tarball exists in $1/dist/
+# and prints its filename (without the dist/ prefix). Exits non-zero
+# if the count is anything other than 1.
+#
+# nullglob makes `*.tgz` expand to nothing rather than the literal
+# pattern when dist/ is empty, so the count check works in both cases.
+# The filename printf is the only place an attacker-controlled name
+# could enter the step log; main() ensures this runs inside the
+# stop_commands_guard.sh wrap, so a hostile `::add-mask::evil.tgz`
+# planted by a postinstall hook cannot inject workflow commands.
+#
+# Args: <project_dir>
+find_one_tarball() {
+    local path="$1"
+    local tarballs
+    (
+        cd "$path"
+        shopt -s nullglob
+        tarballs=(dist/*.tgz)
+        if (( ${#tarballs[@]} != 1 )); then
+            printf 'Error: expected exactly 1 tarball in dist/, found %d:\n' "${#tarballs[@]}" >&2
+            printf '  %s\n' "${tarballs[@]}" >&2
+            exit 1
+        fi
+        # Strip the dist/ prefix so the output matches the action.yml's
+        # previous `cd "$INPUT_PATH/dist"; tarball=*.tgz` contract —
+        # downstream steps (hash, SBOM, attach) expect a bare filename
+        # relative to dist/.
+        printf '%s\n' "${tarballs[0]#dist/}"
+    )
+}
+
+main() {
+    if [[ $# -ne 3 ]]; then
+        printf 'Usage: %s <path> <run_tests> <ignore_scripts>\n' "$0" >&2
+        exit 1
     fi
 
-    if [[ "$RUN_TESTS" == "true" ]]; then
-        # Substring match against the npm-default no-op script. Catches
-        # `echo "Error: no test specified" && exit 1` and tolerates minor
-        # wording changes in future npm/pnpm versions.
-        if [[ "$HAS_TEST_SCRIPT" == "true" ]] && [[ "$TEST_CMD" != *'no test specified'* ]]; then
-            printf 'Running %s test...\n' "$PM"
-            "$PM" test
+    local input_path="$1"
+    local run_tests="$2"
+    local ignore_scripts="$3"
+
+    local pm
+    pm="$(detect_pm "$input_path")"
+    printf 'Package manager: %s\n' "$pm"
+
+    cd "$input_path"
+
+    local -a ignore_scripts_args=()
+    if [[ "$ignore_scripts" == "true" ]]; then
+        ignore_scripts_args=(--ignore-scripts)
+        printf 'ignore-scripts=true: all package.json scripts will be skipped\n'
+    fi
+
+    if [[ "$pm" == "pnpm" ]]; then
+        printf 'Installing dependencies (pnpm install --frozen-lockfile)...\n'
+        pnpm install --frozen-lockfile "${ignore_scripts_args[@]}"
+    else
+        printf 'Installing dependencies (npm ci)...\n'
+        npm ci "${ignore_scripts_args[@]}"
+    fi
+
+    if [[ "$ignore_scripts" == "true" ]]; then
+        printf 'Skipping %s run build and %s test (ignore-scripts=true)\n' "$pm" "$pm"
+    else
+        if has_build_script "$input_path"; then
+            printf 'Running %s run build...\n' "$pm"
+            "$pm" run build
         else
-            printf 'No non-default test script in package.json — skipping tests\n'
+            printf 'No build script in package.json — skipping build step\n'
+        fi
+
+        if [[ "$run_tests" == "true" ]]; then
+            if has_real_test_script "$input_path"; then
+                printf 'Running %s test...\n' "$pm"
+                "$pm" test
+            else
+                printf 'No non-default test script in package.json — skipping tests\n'
+            fi
         fi
     fi
-fi
 
-printf 'Packing tarball into dist/ (%s pack)...\n' "$PM"
-mkdir -p dist
-# `<pm> pack --pack-destination dist` writes the tarball to dist/.
-# --ignore-scripts (when set) suppresses prepack/postpack/prepare on
-# the pack side too for both npm and pnpm.
-"$PM" pack --pack-destination dist "${ignore_scripts_args[@]}"
+    printf 'Packing tarball into dist/ (%s pack)...\n' "$pm"
+    mkdir -p dist
+    # `<pm> pack --pack-destination dist` writes the tarball to dist/.
+    # --ignore-scripts (when set) suppresses prepack/postpack/prepare on
+    # the pack side too for both npm and pnpm.
+    "$pm" pack --pack-destination dist "${ignore_scripts_args[@]}"
 
-# Discover the tarball. Done in this script (inside the caller's
-# stop_commands_guard.sh wrap) rather than in action.yml so the count-
-# check error path's stderr printf cannot leak a malicious filename
-# (e.g., `dist/::add-mask::SECRET.tgz` planted by a hostile postinstall
-# hook) past the guard and into the runner's workflow-command parser.
-# nullglob expands `*.tgz` to nothing rather than the literal pattern
-# when dist/ is empty, so the count check works cleanly in both cases.
-shopt -s nullglob
-tarballs=(dist/*.tgz)
-if (( ${#tarballs[@]} != 1 )); then
-    printf 'Error: expected exactly 1 tarball in dist/, found %d:\n' "${#tarballs[@]}" >&2
-    printf '  %s\n' "${tarballs[@]}" >&2
-    exit 1
-fi
+    local tarball
+    tarball="$(find_one_tarball "$input_path")"
 
-# Strip the dist/ prefix so the output matches the action.yml's previous
-# `cd "$INPUT_PATH/dist"; tarball=*.tgz` contract — downstream steps
-# (hash, SBOM, attach) expect a bare filename relative to dist/.
-TARBALL="${tarballs[0]#dist/}"
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        # File-based output (not the ::set-output:: stdout command), so this
+        # write is unaffected by the stop-commands suspension.
+        printf 'tarball=%s\n' "$tarball" >> "$GITHUB_OUTPUT"
+    fi
+}
 
-if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-    # File-based output (not the ::set-output:: stdout command), so this
-    # write is unaffected by the stop-commands suspension.
-    printf 'tarball=%s\n' "$TARBALL" >> "$GITHUB_OUTPUT"
+# Sourcing guard: tests source this file to call detect_pm,
+# has_build_script, has_real_test_script, and find_one_tarball directly
+# without running the install/build/test/pack pipeline.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
 fi

--- a/build/actions/npm/build_and_pack.sh
+++ b/build/actions/npm/build_and_pack.sh
@@ -121,10 +121,10 @@ has_real_test_script() {
 # Args: <project_dir>
 find_one_tarball() {
     local path="$1"
-    local tarballs
     (
         cd "$path"
         shopt -s nullglob
+        local -a tarballs
         tarballs=(dist/*.tgz)
         if (( ${#tarballs[@]} != 1 )); then
             printf 'Error: expected exactly 1 tarball in dist/, found %d:\n' "${#tarballs[@]}" >&2
@@ -153,6 +153,22 @@ main() {
     pm="$(detect_pm "$input_path")"
     printf 'Package manager: %s\n' "$pm"
 
+    # Capture the build/test gating decisions BEFORE the cd so the pure
+    # helpers see the caller's-cwd-relative $input_path unambiguously.
+    # A relative path like `path: src` would otherwise resolve to
+    # `src/src/package.json` after the cd, jq would fail in a command-
+    # substitution subshell where `set -e` does not propagate, and
+    # has_*_script would silently return false — building and testing
+    # nothing while still attesting "we built this from src/". See
+    # PR #236 review for the reproduction.
+    local will_build=0 will_test=0
+    if [[ "$ignore_scripts" != "true" ]]; then
+        if has_build_script "$input_path"; then will_build=1; fi
+        if [[ "$run_tests" == "true" ]] && has_real_test_script "$input_path"; then
+            will_test=1
+        fi
+    fi
+
     cd "$input_path"
 
     local -a ignore_scripts_args=()
@@ -172,7 +188,7 @@ main() {
     if [[ "$ignore_scripts" == "true" ]]; then
         printf 'Skipping %s run build and %s test (ignore-scripts=true)\n' "$pm" "$pm"
     else
-        if has_build_script "$input_path"; then
+        if (( will_build )); then
             printf 'Running %s run build...\n' "$pm"
             "$pm" run build
         else
@@ -180,7 +196,7 @@ main() {
         fi
 
         if [[ "$run_tests" == "true" ]]; then
-            if has_real_test_script "$input_path"; then
+            if (( will_test )); then
                 printf 'Running %s test...\n' "$pm"
                 "$pm" test
             else
@@ -196,8 +212,11 @@ main() {
     # the pack side too for both npm and pnpm.
     "$pm" pack --pack-destination dist "${ignore_scripts_args[@]}"
 
+    # `.` rather than "$input_path": cwd is now the project, so the
+    # caller-relative $input_path would re-trigger the same path-doubling
+    # bug the build/test gating decisions avoid above.
     local tarball
-    tarball="$(find_one_tarball "$input_path")"
+    tarball="$(find_one_tarball ".")"
 
     if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
         # File-based output (not the ::set-output:: stdout command), so this

--- a/build/actions/npm/detect_tooling.sh
+++ b/build/actions/npm/detect_tooling.sh
@@ -3,6 +3,12 @@
 # manager + cache config wrangle should drive. Writes resolution to
 # GITHUB_OUTPUT for the composite action's downstream steps.
 #
+# The two decisions are split into pure functions — `resolve_node_version`
+# and `resolve_pm_cache` — so test.bats can exercise the branches directly
+# without staging GITHUB_OUTPUT or shimming any external tool. The
+# functions take their inputs as args and print their outputs on stdout;
+# the file's `main` glues them to the action's GITHUB_OUTPUT contract.
+#
 # Node.js version resolution order:
 #   1. node-version input override
 #   2. .nvmrc in the project directory
@@ -29,39 +35,74 @@
 
 set -euo pipefail
 
-if [[ $# -ne 2 ]]; then
-    printf 'Usage: %s <path> <node-version-input>\n' "$0" >&2
-    exit 1
-fi
-
-INPUT_PATH="$1"
-INPUT_NODE_VERSION="$2"
 WRANGLE_DEFAULT_NODE="22"
 
-if [[ -n "$INPUT_NODE_VERSION" ]]; then
-    printf 'effective-version=%s\n' "$INPUT_NODE_VERSION" >> "$GITHUB_OUTPUT"
-    printf 'effective-version-file=\n' >> "$GITHUB_OUTPUT"
-    printf 'Using node-version override: %s\n' "$INPUT_NODE_VERSION"
-elif [[ -f "$INPUT_PATH/.nvmrc" ]]; then
-    printf 'effective-version=\n' >> "$GITHUB_OUTPUT"
-    printf 'effective-version-file=%s/.nvmrc\n' "$INPUT_PATH" >> "$GITHUB_OUTPUT"
-    printf 'Using .nvmrc\n'
-elif [[ -n "$(jq -r '.engines.node // empty' "$INPUT_PATH/package.json")" ]]; then
-    printf 'effective-version=\n' >> "$GITHUB_OUTPUT"
-    printf 'effective-version-file=%s/package.json\n' "$INPUT_PATH" >> "$GITHUB_OUTPUT"
-    printf 'Using engines.node from package.json\n'
-else
-    printf 'effective-version=%s\n' "$WRANGLE_DEFAULT_NODE" >> "$GITHUB_OUTPUT"
-    printf 'effective-version-file=\n' >> "$GITHUB_OUTPUT"
-    printf 'No version hint in .nvmrc, engines.node, or node-version input — falling back to wrangle default Node %s\n' "$WRANGLE_DEFAULT_NODE"
-fi
+# Pure function: resolves which Node.js version source setup-node should
+# use. Prints exactly one line: "<effective-version>|<effective-version-file>|<reason>".
+# Either effective-version or effective-version-file is populated, never both.
+#
+# Args: <input_version> <project_dir>
+resolve_node_version() {
+    local input="$1" path="$2"
+    if [[ -n "$input" ]]; then
+        printf '%s||Using node-version override: %s\n' "$input" "$input"
+    elif [[ -f "$path/.nvmrc" ]]; then
+        printf '|%s/.nvmrc|Using .nvmrc\n' "$path"
+    elif [[ -n "$(jq -r '.engines.node // empty' "$path/package.json")" ]]; then
+        printf '|%s/package.json|Using engines.node from package.json\n' "$path"
+    else
+        printf '%s||No version hint in .nvmrc, engines.node, or node-version input — falling back to wrangle default Node %s\n' \
+            "$WRANGLE_DEFAULT_NODE" "$WRANGLE_DEFAULT_NODE"
+    fi
+}
 
-if [[ -f "$INPUT_PATH/pnpm-lock.yaml" ]]; then
-    printf 'package-manager=pnpm\n' >> "$GITHUB_OUTPUT"
-    printf 'cache=\n' >> "$GITHUB_OUTPUT"
-    printf 'Detected pnpm-lock.yaml; using pnpm. setup-node caching deliberately disabled (see issue #205).\n'
-else
-    printf 'package-manager=npm\n' >> "$GITHUB_OUTPUT"
-    printf 'cache=npm\n' >> "$GITHUB_OUTPUT"
-    printf 'Detected npm lockfile; using npm with cache=npm.\n'
+# Pure function: resolves package-manager and setup-node cache config from
+# the project's lockfile. Prints "<package-manager>|<cache>".
+#
+# The pnpm branch deliberately emits an empty cache value — see the header
+# comment and issue #205.
+#
+# Args: <project_dir>
+resolve_pm_cache() {
+    local path="$1"
+    if [[ -f "$path/pnpm-lock.yaml" ]]; then
+        printf 'pnpm|\n'
+    else
+        printf 'npm|npm\n'
+    fi
+}
+
+main() {
+    if [[ $# -ne 2 ]]; then
+        printf 'Usage: %s <path> <node-version-input>\n' "$0" >&2
+        exit 1
+    fi
+
+    local input_path="$1"
+    local input_node_version="$2"
+
+    local node_line version file reason
+    node_line="$(resolve_node_version "$input_node_version" "$input_path")"
+    IFS='|' read -r version file reason <<<"$node_line"
+    printf 'effective-version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+    printf 'effective-version-file=%s\n' "$file" >> "$GITHUB_OUTPUT"
+    printf '%s\n' "$reason"
+
+    local pm_line pm cache
+    pm_line="$(resolve_pm_cache "$input_path")"
+    IFS='|' read -r pm cache <<<"$pm_line"
+    printf 'package-manager=%s\n' "$pm" >> "$GITHUB_OUTPUT"
+    printf 'cache=%s\n' "$cache" >> "$GITHUB_OUTPUT"
+    if [[ "$pm" == "pnpm" ]]; then
+        printf 'Detected pnpm-lock.yaml; using pnpm. setup-node caching deliberately disabled (see issue #205).\n'
+    else
+        printf 'Detected npm lockfile; using npm with cache=npm.\n'
+    fi
+}
+
+# Sourcing guard: when this file is invoked as a script, run main();
+# when sourced from a test (e.g., `bash -c 'source detect_tooling.sh; \
+# resolve_node_version ...'`), expose the functions without running main.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
 fi

--- a/build/actions/npm/test.bats
+++ b/build/actions/npm/test.bats
@@ -2,15 +2,57 @@
 
 # Tests for the npm build action and reusable workflow.
 #
-# Two test layers:
-#   1. Behavioral tests that invoke validate_inputs.sh, detect_tooling.sh,
-#      and build_and_pack.sh against fixture project directories and assert
-#      on exit codes, GITHUB_OUTPUT contents, and produced artifacts.
-#   2. Structural greps that remain only as supply-chain guard rails —
-#      e.g., no curl|sh, no /usr/local/bin, SHA-pinned actions, action.yml
-#      flows inputs through env: rather than direct interpolation, and
-#      action.yml actually delegates to the scripts the behavioral tests
-#      cover. End-to-end exercise lives in the wrangle-test companion repo.
+# Three test layers, in increasing order of cost:
+#   1. Pure-function tests that source detect_tooling.sh or
+#      build_and_pack.sh and call their decision functions directly
+#      (resolve_node_version, resolve_pm_cache, detect_pm, has_build_script,
+#      has_real_test_script, find_one_tarball). Args in → stdout/exit out;
+#      no shims, no GITHUB_OUTPUT plumbing.
+#   2. Behavioral tests that invoke validate_inputs.sh end-to-end against
+#      fixture project directories. validate_inputs.sh has no externally-
+#      shimmed dependencies (just jq), so this layer needs no shims either.
+#   3. Integration tests that exercise build_and_pack.sh's main() pipeline
+#      via PATH shims for npm/pnpm — only the orchestration logic that
+#      cannot be expressed as a pure function.
+# Plus a thin layer of structural greps preserved only as supply-chain
+# guard rails (no curl|sh, no /usr/local/bin, SHA-pinned actions,
+# inputs flow through env:, action.yml delegates to the scripts the
+# behavioral tests cover). End-to-end exercise lives in the wrangle-test
+# companion repo.
+
+setup_file() {
+    ACTION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    export ACTION_DIR
+    # PATH shims for npm/pnpm used by the integration tests. The shims
+    # echo their argv (so tests can assert which command ran) and, on
+    # `pack`, plant a single placeholder tarball in dist/ to satisfy the
+    # post-pack count check. Created once per file because they are
+    # immutable; tests that need a different shim behavior (e.g., the
+    # zero-tarball case) just don't exercise the pack codepath.
+    mkdir -p "$BATS_FILE_TMPDIR/shim"
+    cat > "$BATS_FILE_TMPDIR/shim/npm" <<'SHIM'
+#!/bin/bash
+printf 'npm'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
+for ((i=1; i<=$#; i++)); do
+    if [[ "${!i}" == "pack" ]]; then
+        : > "dist/x-1.0.0.tgz"
+        break
+    fi
+done
+SHIM
+    cat > "$BATS_FILE_TMPDIR/shim/pnpm" <<'SHIM'
+#!/bin/bash
+printf 'pnpm'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
+for ((i=1; i<=$#; i++)); do
+    if [[ "${!i}" == "pack" ]]; then
+        : > "dist/x-1.0.0.tgz"
+        break
+    fi
+done
+SHIM
+    chmod +x "$BATS_FILE_TMPDIR/shim/npm" "$BATS_FILE_TMPDIR/shim/pnpm"
+    export SHIM_DIR="$BATS_FILE_TMPDIR/shim"
+}
 
 setup() {
     ACTION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
@@ -18,16 +60,9 @@ setup() {
     ACTION="$ACTION_DIR/action.yml"
     WORKFLOW="$REPO_ROOT/.github/workflows/build_and_publish_npm.yml"
     EXAMPLE="$REPO_ROOT/gh_workflow_examples/build_npm.yml"
-    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/npm-bats-XXXXXX")"
-    GITHUB_OUTPUT="$TMP_DIR/github_output"
+    GITHUB_OUTPUT="$BATS_TEST_TMPDIR/github_output"
     : > "$GITHUB_OUTPUT"
     export GITHUB_OUTPUT
-}
-
-teardown() {
-    if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
-        rm -rf "$TMP_DIR"
-    fi
 }
 
 # --- Composite action structural tests ---
@@ -254,46 +289,46 @@ write_pkg_json() {
 }
 
 @test "npm: validate_inputs.sh accepts a package-lock.json project" {
-    local proj="$TMP_DIR/proj"
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pkg_json "$proj"
     : > "$proj/package-lock.json"
-    cd "$TMP_DIR"
+    cd "$BATS_TEST_TMPDIR"
     run "$ACTION_DIR/validate_inputs.sh" "proj"
     [[ "$status" -eq 0 ]]
 }
 
 @test "npm: validate_inputs.sh accepts an npm-shrinkwrap.json project" {
-    local proj="$TMP_DIR/proj"
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pkg_json "$proj"
     : > "$proj/npm-shrinkwrap.json"
-    cd "$TMP_DIR"
+    cd "$BATS_TEST_TMPDIR"
     run "$ACTION_DIR/validate_inputs.sh" "proj"
     [[ "$status" -eq 0 ]]
 }
 
 @test "npm: validate_inputs.sh accepts a pnpm-lock.yaml project (v0.2)" {
-    local proj="$TMP_DIR/proj"
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pkg_json "$proj"
     : > "$proj/pnpm-lock.yaml"
-    cd "$TMP_DIR"
+    cd "$BATS_TEST_TMPDIR"
     run "$ACTION_DIR/validate_inputs.sh" "proj"
     [[ "$status" -eq 0 ]]
 }
 
 @test "npm: validate_inputs.sh rejects missing package.json" {
-    local proj="$TMP_DIR/proj"
+    local proj="$BATS_TEST_TMPDIR/proj"
     mkdir -p "$proj"
     : > "$proj/package-lock.json"
-    cd "$TMP_DIR"
+    cd "$BATS_TEST_TMPDIR"
     run "$ACTION_DIR/validate_inputs.sh" "proj"
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"no package.json found"* ]]
 }
 
 @test "npm: validate_inputs.sh rejects missing lockfile with install hint" {
-    local proj="$TMP_DIR/proj"
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pkg_json "$proj"
-    cd "$TMP_DIR"
+    cd "$BATS_TEST_TMPDIR"
     run "$ACTION_DIR/validate_inputs.sh" "proj"
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"no lockfile found"* ]]
@@ -303,10 +338,10 @@ write_pkg_json() {
 @test "npm: validate_inputs.sh rejects yarn.lock with a 'not supported' hint" {
     # Yarn is a follow-on. A yarn-only project must fail loudly, not fall
     # through to "no lockfile".
-    local proj="$TMP_DIR/proj"
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pkg_json "$proj"
     : > "$proj/yarn.lock"
-    cd "$TMP_DIR"
+    cd "$BATS_TEST_TMPDIR"
     run "$ACTION_DIR/validate_inputs.sh" "proj"
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"Yarn is not supported"* ]]
@@ -316,11 +351,11 @@ write_pkg_json() {
     # Having both lockfiles is unresolvable — wrangle can't infer the
     # adopter's intent. Picking one silently would silently determine
     # what gets attested.
-    local proj="$TMP_DIR/proj"
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pkg_json "$proj"
     : > "$proj/package-lock.json"
     : > "$proj/pnpm-lock.yaml"
-    cd "$TMP_DIR"
+    cd "$BATS_TEST_TMPDIR"
     run "$ACTION_DIR/validate_inputs.sh" "proj"
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"both npm and pnpm lockfiles"* ]]
@@ -330,10 +365,10 @@ write_pkg_json() {
     # Workspaces produce N tarballs; the single-tarball assertion in
     # action.yml and the downstream hash/SBOM/provenance pipeline assume
     # exactly 1. Reject before any of that runs.
-    local proj="$TMP_DIR/proj"
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pkg_json "$proj" '{"workspaces":["packages/*"]}'
     : > "$proj/package-lock.json"
-    cd "$TMP_DIR"
+    cd "$BATS_TEST_TMPDIR"
     run "$ACTION_DIR/validate_inputs.sh" "proj"
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"workspaces"* ]]
@@ -346,75 +381,105 @@ write_pkg_json() {
     [[ "$output" == *"Usage:"* ]]
 }
 
-# --- detect_tooling.sh behavioral tests ---
+# --- detect_tooling.sh pure-function tests ---
+#
+# detect_tooling.sh splits its decision logic into resolve_node_version
+# and resolve_pm_cache. Both are pure (args in → stdout out). The tests
+# below source the script and call those functions directly, so they
+# need neither a stub `node`/`jq` on PATH nor a GITHUB_OUTPUT file.
+#
+# Calling pattern: `run bash -c 'source script.sh; func "$@"' -- arg1 arg2`.
+# The `--` placeholder makes "$0" inside bash -c a separator (bats convention),
+# so the trailing args show up as "$@" inside the sourced script.
 
-@test "npm: detect_tooling.sh node-version input override wins over all other sources" {
-    local proj="$TMP_DIR/proj"
+@test "npm: resolve_node_version: node-version input override wins over all other sources" {
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pkg_json "$proj" '{"engines":{"node":">=20"}}'
     printf '20\n' > "$proj/.nvmrc"
-    run "$ACTION_DIR/detect_tooling.sh" "$proj" "22.5.1"
+    run bash -c 'source "$1"; resolve_node_version "$2" "$3"' -- \
+        "$ACTION_DIR/detect_tooling.sh" "22.5.1" "$proj"
     [[ "$status" -eq 0 ]]
-    grep -q '^effective-version=22.5.1$' "$GITHUB_OUTPUT"
-    grep -q '^effective-version-file=$' "$GITHUB_OUTPUT"
+    [[ "$output" == "22.5.1||Using node-version override: 22.5.1" ]]
 }
 
-@test "npm: detect_tooling.sh uses .nvmrc when input is empty" {
-    local proj="$TMP_DIR/proj"
+@test "npm: resolve_node_version: uses .nvmrc when input is empty (preferred over engines.node)" {
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pkg_json "$proj" '{"engines":{"node":">=20"}}'
     printf '18.20.0\n' > "$proj/.nvmrc"
-    run "$ACTION_DIR/detect_tooling.sh" "$proj" ""
+    run bash -c 'source "$1"; resolve_node_version "$2" "$3"' -- \
+        "$ACTION_DIR/detect_tooling.sh" "" "$proj"
     [[ "$status" -eq 0 ]]
-    grep -q '^effective-version=$' "$GITHUB_OUTPUT"
-    grep -q "^effective-version-file=$proj/.nvmrc$" "$GITHUB_OUTPUT"
+    [[ "$output" == "|$proj/.nvmrc|Using .nvmrc" ]]
 }
 
-@test "npm: detect_tooling.sh uses engines.node when no .nvmrc and no input" {
-    local proj="$TMP_DIR/proj"
+@test "npm: resolve_node_version: uses engines.node when no .nvmrc and no input" {
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pkg_json "$proj" '{"engines":{"node":">=20"}}'
-    run "$ACTION_DIR/detect_tooling.sh" "$proj" ""
+    run bash -c 'source "$1"; resolve_node_version "$2" "$3"' -- \
+        "$ACTION_DIR/detect_tooling.sh" "" "$proj"
     [[ "$status" -eq 0 ]]
-    grep -q '^effective-version=$' "$GITHUB_OUTPUT"
-    grep -q "^effective-version-file=$proj/package.json$" "$GITHUB_OUTPUT"
+    [[ "$output" == "|$proj/package.json|Using engines.node from package.json" ]]
 }
 
-@test "npm: detect_tooling.sh falls back to wrangle default Node when no version source" {
-    # No .nvmrc, no engines.node, no input — setup-node would emit a
-    # confusing "no version found" error. The fallback prevents that.
-    local proj="$TMP_DIR/proj"
+@test "npm: resolve_node_version: falls back to wrangle default when no version source" {
+    # No .nvmrc, no engines.node, no input — setup-node would otherwise
+    # emit a confusing "no version found" error. The fallback prevents that.
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pkg_json "$proj"
-    run "$ACTION_DIR/detect_tooling.sh" "$proj" ""
+    run bash -c 'source "$1"; resolve_node_version "$2" "$3"' -- \
+        "$ACTION_DIR/detect_tooling.sh" "" "$proj"
     [[ "$status" -eq 0 ]]
-    grep -qE '^effective-version=[0-9]+$' "$GITHUB_OUTPUT"
-    grep -q '^effective-version-file=$' "$GITHUB_OUTPUT"
-    [[ "$output" == *"falling back to wrangle default"* ]]
+    # Format: "<version>||<reason mentioning the default>".
+    [[ "$output" == *"||"* ]]
+    [[ "$output" == *"falling back to wrangle default Node"* ]]
+    # The version field must be a bare integer (the WRANGLE_DEFAULT_NODE).
+    [[ "${output%%|*}" =~ ^[0-9]+$ ]]
 }
 
-@test "npm: detect_tooling.sh emits package-manager=npm and cache=npm for npm projects" {
-    # npm ci re-validates cached tarball integrity on every install, so
-    # caching is safe.
-    local proj="$TMP_DIR/proj"
+@test "npm: resolve_pm_cache: npm-only project -> 'npm|npm' (cache safe with npm ci)" {
+    # npm ci re-validates cached tarball integrity on every install,
+    # so caching is safe.
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/package-lock.json"
+    run bash -c 'source "$1"; resolve_pm_cache "$2"' -- \
+        "$ACTION_DIR/detect_tooling.sh" "$proj"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "npm|npm" ]]
+}
+
+@test "npm: resolve_pm_cache: pnpm project -> 'pnpm|' (cache deliberately EMPTY, issue #205)" {
+    # pnpm-store has no install-time integrity re-verification, so wrangle
+    # MUST NOT enable setup-node caching for the pnpm path — that's the
+    # Mini Shai-Hulud / TanStack May 2026 cache-poisoning vector. The
+    # empty second field tells setup-node to skip caching entirely.
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/pnpm-lock.yaml"
+    run bash -c 'source "$1"; resolve_pm_cache "$2"' -- \
+        "$ACTION_DIR/detect_tooling.sh" "$proj"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "pnpm|" ]]
+    # Belt-and-braces: the second field must be empty, not any non-empty
+    # cache value. A regression to "pnpm|pnpm" would re-open issue #205.
+    [[ "${output#*|}" == "" ]]
+}
+
+# --- detect_tooling.sh end-to-end glue test ---
+
+@test "npm: detect_tooling.sh writes all four expected lines to GITHUB_OUTPUT" {
+    # One end-to-end test that the script wires the pure functions to
+    # GITHUB_OUTPUT correctly. The branches themselves are covered by
+    # the pure-function tests above; this just guards the glue.
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pkg_json "$proj"
     : > "$proj/package-lock.json"
     run "$ACTION_DIR/detect_tooling.sh" "$proj" ""
     [[ "$status" -eq 0 ]]
-    grep -q '^package-manager=npm$' "$GITHUB_OUTPUT"
-    grep -q '^cache=npm$' "$GITHUB_OUTPUT"
-}
-
-@test "npm: detect_tooling.sh emits package-manager=pnpm and EMPTY cache for pnpm projects" {
-    # pnpm-store has no install-time integrity re-verification, so wrangle
-    # must NOT enable setup-node caching for the pnpm path — that's the
-    # Mini Shai-Hulud / TanStack cache-poisoning vector (issue #205). An
-    # `cache=` (empty) line tells setup-node to skip caching entirely.
-    local proj="$TMP_DIR/proj"
-    write_pkg_json "$proj"
-    : > "$proj/pnpm-lock.yaml"
-    run "$ACTION_DIR/detect_tooling.sh" "$proj" ""
-    [[ "$status" -eq 0 ]]
-    grep -q '^package-manager=pnpm$' "$GITHUB_OUTPUT"
-    grep -q '^cache=$' "$GITHUB_OUTPUT"
-    # Belt and braces: cache must not be set to anything non-empty.
-    ! grep -E '^cache=.+$' "$GITHUB_OUTPUT"
+    grep -qE '^effective-version=[0-9]+$' "$GITHUB_OUTPUT"
+    grep -qE '^effective-version-file=$' "$GITHUB_OUTPUT"
+    grep -qE '^package-manager=npm$' "$GITHUB_OUTPUT"
+    grep -qE '^cache=npm$' "$GITHUB_OUTPUT"
 }
 
 @test "npm: detect_tooling.sh usage error with wrong arg count" {
@@ -423,194 +488,172 @@ write_pkg_json() {
     [[ "$output" == *"Usage:"* ]]
 }
 
-# --- build_and_pack.sh behavioral tests ---
+# --- build_and_pack.sh pure-function tests ---
 #
-# build_and_pack.sh shells out to npm/pnpm/jq. Real npm/pnpm aren't
-# available in the test container, so these tests put PATH shims for
-# npm and pnpm ahead of the system PATH. jq stays real (it's pure and
-# universally available); the script reads package.json via jq, so we
-# write real package.json fixtures and assert that the shim recorded
-# the expected commands.
+# detect_pm, has_build_script, has_real_test_script, and find_one_tarball
+# are pure — args in → stdout/exit out. Tests source the script and call
+# them directly. No npm/pnpm shim needed for any of these.
 
-install_pm_shim() {
-    # Creates fake `npm` and `pnpm` binaries that record every invocation
-    # to $TMP_DIR/calls.log and, on `pack`, plant a single tarball in
-    # dist/ to satisfy the post-pack count check. Caller exports PATH.
-    mkdir -p "$TMP_DIR/shim"
-    cat > "$TMP_DIR/shim/npm" <<'SHIM'
-#!/bin/bash
-printf 'npm'
-for a in "$@"; do printf ' %s' "$a"; done
-printf '\n'
-# If this is a pack invocation, plant exactly one tarball in dist/.
-for ((i=1; i<=$#; i++)); do
-    if [[ "${!i}" == "pack" ]]; then
-        : > "dist/x-1.0.0.tgz"
-        break
-    fi
-done
-SHIM
-    cat > "$TMP_DIR/shim/pnpm" <<'SHIM'
-#!/bin/bash
-printf 'pnpm'
-for a in "$@"; do printf ' %s' "$a"; done
-printf '\n'
-for ((i=1; i<=$#; i++)); do
-    if [[ "${!i}" == "pack" ]]; then
-        : > "dist/x-1.0.0.tgz"
-        break
-    fi
-done
-SHIM
-    chmod +x "$TMP_DIR/shim/npm" "$TMP_DIR/shim/pnpm"
-    PATH="$TMP_DIR/shim:$PATH"
+@test "npm: detect_pm: returns npm for a package-lock.json project" {
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/package-lock.json"
+    run bash -c 'source "$1"; detect_pm "$2"' -- \
+        "$ACTION_DIR/build_and_pack.sh" "$proj"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "npm" ]]
 }
 
-@test "npm: build_and_pack.sh runs npm ci, build, test, pack for an npm project" {
-    install_pm_shim
-    local proj="$TMP_DIR/proj"
-    write_pkg_json "$proj" '{"scripts":{"build":"true","test":"true"}}'
-    : > "$proj/package-lock.json"
-    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "false"
+@test "npm: detect_pm: returns pnpm for a pnpm-lock.yaml project" {
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/pnpm-lock.yaml"
+    run bash -c 'source "$1"; detect_pm "$2"' -- \
+        "$ACTION_DIR/build_and_pack.sh" "$proj"
     [[ "$status" -eq 0 ]]
-    [[ "$output" == *"npm ci"* ]]
-    [[ "$output" == *"npm run build"* ]]
-    [[ "$output" == *"npm test"* ]]
-    [[ "$output" == *"npm pack --pack-destination dist"* ]]
+    [[ "$output" == "pnpm" ]]
+}
+
+@test "npm: has_build_script: true when package.json declares scripts.build" {
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pkg_json "$proj" '{"scripts":{"build":"true"}}'
+    run bash -c 'source "$1"; has_build_script "$2"' -- \
+        "$ACTION_DIR/build_and_pack.sh" "$proj"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "npm: has_build_script: false when package.json has no scripts.build" {
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pkg_json "$proj"
+    run bash -c 'source "$1"; has_build_script "$2"' -- \
+        "$ACTION_DIR/build_and_pack.sh" "$proj"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "npm: has_build_script: false when scripts field is explicit null (null-safe jq)" {
+    # The `(.scripts // {})` guard protects against `"scripts": null`. A
+    # regression to `.scripts | has(...)` would crash on this fixture.
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pkg_json "$proj" '{"scripts":null}'
+    run bash -c 'source "$1"; has_build_script "$2"' -- \
+        "$ACTION_DIR/build_and_pack.sh" "$proj"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "npm: has_real_test_script: true for a custom test script" {
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pkg_json "$proj" '{"scripts":{"test":"jest"}}'
+    run bash -c 'source "$1"; has_real_test_script "$2"' -- \
+        "$ACTION_DIR/build_and_pack.sh" "$proj"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "npm: has_real_test_script: false for npm's default 'no test specified' stub" {
+    # The default stub exits 1 — an adopter who never ran `npm init` and
+    # has the default test must not have wrangle invoke it. Substring
+    # match so future-npm wording tweaks don't re-enable the no-op.
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pkg_json "$proj" \
+        '{"scripts":{"test":"echo \"Error: no test specified\" && exit 1"}}'
+    run bash -c 'source "$1"; has_real_test_script "$2"' -- \
+        "$ACTION_DIR/build_and_pack.sh" "$proj"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "npm: has_real_test_script: false when no test script is declared" {
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pkg_json "$proj"
+    run bash -c 'source "$1"; has_real_test_script "$2"' -- \
+        "$ACTION_DIR/build_and_pack.sh" "$proj"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "npm: find_one_tarball: prints the lone filename, stripped of dist/ prefix" {
+    local proj="$BATS_TEST_TMPDIR/proj"
+    mkdir -p "$proj/dist"
+    : > "$proj/dist/mypkg-2.3.4.tgz"
+    run bash -c 'source "$1"; find_one_tarball "$2"' -- \
+        "$ACTION_DIR/build_and_pack.sh" "$proj"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "mypkg-2.3.4.tgz" ]]
+}
+
+@test "npm: find_one_tarball: errors when dist/ has zero tarballs" {
+    # The post-pack count check catches a regressed pack flag (e.g., a
+    # wrong --pack-destination) that lands the tarball outside dist/.
+    # Without it, the action would proceed to hash an empty set.
+    local proj="$BATS_TEST_TMPDIR/proj"
+    mkdir -p "$proj/dist"
+    run bash -c 'source "$1"; find_one_tarball "$2"' -- \
+        "$ACTION_DIR/build_and_pack.sh" "$proj"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"expected exactly 1 tarball"* ]]
+}
+
+@test "npm: find_one_tarball: errors when dist/ has more than one tarball" {
+    # Future-proofs against a workspaces regression (caught earlier by
+    # validate_inputs.sh, but defense in depth).
+    local proj="$BATS_TEST_TMPDIR/proj"
+    mkdir -p "$proj/dist"
+    : > "$proj/dist/a-1.0.0.tgz"
+    : > "$proj/dist/b-1.0.0.tgz"
+    run bash -c 'source "$1"; find_one_tarball "$2"' -- \
+        "$ACTION_DIR/build_and_pack.sh" "$proj"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"expected exactly 1 tarball"* ]]
+}
+
+# --- build_and_pack.sh integration tests (orchestration via PATH shim) ---
+#
+# Only the pipeline orchestration — what gets called, in what order, with
+# which flags — still needs an npm/pnpm shim. The branching logic is
+# covered above by the pure-function tests, so this layer is small.
+
+@test "npm: build_and_pack.sh end-to-end npm pipeline: ci → build → test → pack → tarball=" {
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pkg_json "$proj" '{"scripts":{"build":"true","test":"jest"}}'
+    : > "$proj/package-lock.json"
+    PATH="$SHIM_DIR:$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "false"
+    [[ "$status" -eq 0 ]]
+    # Anchored line-by-line check: the shim echoes its argv on its own
+    # line, so anchoring rules out matches inside status messages.
+    grep -qE '^npm ci$' <<<"$output"
+    grep -qE '^npm run build$' <<<"$output"
+    grep -qE '^npm test$' <<<"$output"
+    grep -qE '^npm pack --pack-destination dist$' <<<"$output"
+    # No pnpm invocations should leak into the npm path.
+    ! grep -qE '^pnpm ' <<<"$output"
     grep -q '^tarball=x-1.0.0.tgz$' "$GITHUB_OUTPUT"
 }
 
-@test "npm: build_and_pack.sh runs pnpm install/build/test/pack for a pnpm project" {
-    install_pm_shim
-    local proj="$TMP_DIR/proj"
-    write_pkg_json "$proj" '{"scripts":{"build":"true","test":"true"}}'
+@test "npm: build_and_pack.sh end-to-end pnpm pipeline: install → build → test → pack" {
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pkg_json "$proj" '{"scripts":{"build":"true","test":"vitest"}}'
     : > "$proj/pnpm-lock.yaml"
-    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "false"
+    PATH="$SHIM_DIR:$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "false"
     [[ "$status" -eq 0 ]]
-    [[ "$output" == *"pnpm install --frozen-lockfile"* ]]
-    [[ "$output" == *"pnpm run build"* ]]
-    [[ "$output" == *"pnpm test"* ]]
-    [[ "$output" == *"pnpm pack --pack-destination dist"* ]]
+    grep -qE '^pnpm install --frozen-lockfile$' <<<"$output"
+    grep -qE '^pnpm run build$' <<<"$output"
+    grep -qE '^pnpm test$' <<<"$output"
+    grep -qE '^pnpm pack --pack-destination dist$' <<<"$output"
+    # No npm invocations should leak into the pnpm path.
+    ! grep -qE '^npm ' <<<"$output"
 }
 
 @test "npm: build_and_pack.sh threads --ignore-scripts through install AND pack" {
-    install_pm_shim
-    local proj="$TMP_DIR/proj"
-    write_pkg_json "$proj" '{"scripts":{"build":"true","test":"true"}}'
-    : > "$proj/package-lock.json"
-    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "true"
-    [[ "$status" -eq 0 ]]
-    # Both ci and pack lines must carry --ignore-scripts.
-    [[ "$output" == *"npm ci --ignore-scripts"* ]]
-    [[ "$output" == *"npm pack --pack-destination dist --ignore-scripts"* ]]
-}
-
-@test "npm: build_and_pack.sh with ignore_scripts=true skips run-build and test entirely" {
     # ignore-scripts means NO package.json script runs — not just transitive
-    # hooks. A regression that only adds --ignore-scripts to install but
-    # still calls `npm run build` would defeat the stricter L3 contract.
-    install_pm_shim
-    local proj="$TMP_DIR/proj"
-    write_pkg_json "$proj" '{"scripts":{"build":"true","test":"true"}}'
+    # hooks. Both install and pack must carry the flag, and `run build` /
+    # `test` must be skipped entirely (no shim echo for either).
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pkg_json "$proj" '{"scripts":{"build":"true","test":"jest"}}'
     : > "$proj/package-lock.json"
-    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "true"
+    PATH="$SHIM_DIR:$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "true"
     [[ "$status" -eq 0 ]]
-    # The shim echoes its argv on a line of its own (e.g., "npm run build").
-    # An anchored grep distinguishes that from the "Skipping npm run build
-    # and npm test" status line.
+    grep -qE '^npm ci --ignore-scripts$' <<<"$output"
+    grep -qE '^npm pack --pack-destination dist --ignore-scripts$' <<<"$output"
     ! grep -qE '^npm run build$' <<<"$output"
     ! grep -qE '^npm test$' <<<"$output"
     [[ "$output" == *"Skipping npm run build and npm test"* ]]
-}
-
-@test "npm: build_and_pack.sh skips build when package.json has no build script" {
-    install_pm_shim
-    local proj="$TMP_DIR/proj"
-    write_pkg_json "$proj"
-    : > "$proj/package-lock.json"
-    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "false"
-    [[ "$status" -eq 0 ]]
-    [[ "$output" != *"npm run build"* ]]
-    [[ "$output" == *"No build script in package.json"* ]]
-}
-
-@test "npm: build_and_pack.sh skips npm's default 'no test specified' script" {
-    # An adopter who never ran `npm init` and uses npm's default stub
-    # test must not have wrangle invoke it (the stub exits 1).
-    install_pm_shim
-    local proj="$TMP_DIR/proj"
-    write_pkg_json "$proj" '{"scripts":{"test":"echo \"Error: no test specified\" && exit 1"}}'
-    : > "$proj/package-lock.json"
-    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "false"
-    [[ "$status" -eq 0 ]]
-    [[ "$output" != *"npm test"* ]]
-    [[ "$output" == *"No non-default test script"* ]]
-}
-
-@test "npm: build_and_pack.sh skips test when run_tests=false even if a test script exists" {
-    install_pm_shim
-    local proj="$TMP_DIR/proj"
-    write_pkg_json "$proj" '{"scripts":{"test":"true"}}'
-    : > "$proj/package-lock.json"
-    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "false" "false"
-    [[ "$status" -eq 0 ]]
-    [[ "$output" != *"npm test"* ]]
-}
-
-@test "npm: build_and_pack.sh survives 'scripts': null in package.json" {
-    # The null-safe jq guards (`(.scripts // {}) | has(...)`) protect
-    # against the explicit-null case; a regression to `.scripts | has(...)`
-    # would crash on this fixture.
-    install_pm_shim
-    local proj="$TMP_DIR/proj"
-    write_pkg_json "$proj" '{"scripts":null}'
-    : > "$proj/package-lock.json"
-    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "false"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "npm: build_and_pack.sh errors when pack produces zero tarballs" {
-    # The post-pack count check is what catches a regressed pack flag
-    # (e.g., wrong --pack-destination) that lands the tarball outside
-    # dist/. Without it, the action would proceed to hash an empty set.
-    install_pm_shim
-    # Override npm to NOT plant a tarball on pack.
-    cat > "$TMP_DIR/shim/npm" <<'SHIM'
-#!/bin/bash
-printf 'npm'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
-SHIM
-    chmod +x "$TMP_DIR/shim/npm"
-    local proj="$TMP_DIR/proj"
-    write_pkg_json "$proj"
-    : > "$proj/package-lock.json"
-    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "false" "false"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"expected exactly 1 tarball"* ]]
-}
-
-@test "npm: build_and_pack.sh errors when pack produces more than one tarball" {
-    # Future-proofs against a workspaces regression (caught earlier by
-    # validate_inputs.sh, but defense in depth).
-    install_pm_shim
-    # Override npm to plant TWO tarballs.
-    cat > "$TMP_DIR/shim/npm" <<'SHIM'
-#!/bin/bash
-printf 'npm'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
-for ((i=1; i<=$#; i++)); do
-    if [[ "${!i}" == "pack" ]]; then
-        : > "dist/a-1.0.0.tgz"
-        : > "dist/b-1.0.0.tgz"
-        break
-    fi
-done
-SHIM
-    chmod +x "$TMP_DIR/shim/npm"
-    local proj="$TMP_DIR/proj"
-    write_pkg_json "$proj"
-    : > "$proj/package-lock.json"
-    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "false" "false"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"expected exactly 1 tarball"* ]]
 }
 
 @test "npm: build_and_pack.sh usage error with wrong arg count" {

--- a/build/actions/npm/test.bats
+++ b/build/actions/npm/test.bats
@@ -1,11 +1,16 @@
 #!/usr/bin/env bats
 
-# Structural tests for the npm build action and reusable workflow.
+# Tests for the npm build action and reusable workflow.
 #
-# Many tests below are simple greps. They verify that the action's wiring
-# and supply-chain rules (no curl|sh, no /usr/local/bin, SHA-pinned actions,
-# SBOM upload) are still in place. They do not invoke the action end-to-end —
-# that's covered by the integration test in the wrangle-test companion repo.
+# Two test layers:
+#   1. Behavioral tests that invoke validate_inputs.sh, detect_tooling.sh,
+#      and build_and_pack.sh against fixture project directories and assert
+#      on exit codes, GITHUB_OUTPUT contents, and produced artifacts.
+#   2. Structural greps that remain only as supply-chain guard rails —
+#      e.g., no curl|sh, no /usr/local/bin, SHA-pinned actions, action.yml
+#      flows inputs through env: rather than direct interpolation, and
+#      action.yml actually delegates to the scripts the behavioral tests
+#      cover. End-to-end exercise lives in the wrangle-test companion repo.
 
 setup() {
     ACTION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
@@ -13,6 +18,16 @@ setup() {
     ACTION="$ACTION_DIR/action.yml"
     WORKFLOW="$REPO_ROOT/.github/workflows/build_and_publish_npm.yml"
     EXAMPLE="$REPO_ROOT/gh_workflow_examples/build_npm.yml"
+    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/npm-bats-XXXXXX")"
+    GITHUB_OUTPUT="$TMP_DIR/github_output"
+    : > "$GITHUB_OUTPUT"
+    export GITHUB_OUTPUT
+}
+
+teardown() {
+    if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
 }
 
 # --- Composite action structural tests ---
@@ -48,85 +63,8 @@ setup() {
     [[ "$status" -eq 0 ]]
 }
 
-@test "npm: validate_inputs.sh checks for package.json" {
-    run grep 'package.json' "$ACTION_DIR/validate_inputs.sh"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "npm: validate_inputs.sh requires a lockfile" {
-    run grep 'package-lock.json' "$ACTION_DIR/validate_inputs.sh"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "npm: validate_inputs.sh accepts pnpm-lock.yaml (v0.2 addition)" {
-    # v0.2 supports pnpm-lock.yaml. The lockfile must be in the accept
-    # path, NOT the reject path.
-    run grep -E 'pnpm-lock.yaml' "$ACTION_DIR/validate_inputs.sh"
-    [[ "$status" -eq 0 ]]
-    # Must NOT have a "pnpm is not supported" error string anymore.
-    run grep -E 'pnpm is not supported' "$ACTION_DIR/validate_inputs.sh"
-    [[ "$status" -ne 0 ]]
-}
-
-@test "npm: validate_inputs.sh rejects yarn.lock" {
-    # Yarn is still a follow-on; reject explicitly.
-    run grep -E 'yarn.lock' "$ACTION_DIR/validate_inputs.sh"
-    [[ "$status" -eq 0 ]]
-    run grep -E 'Yarn is not supported' "$ACTION_DIR/validate_inputs.sh"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "npm: validate_inputs.sh rejects ambiguous lockfile state (npm + pnpm)" {
-    # Both package-lock.json AND pnpm-lock.yaml present is ambiguous —
-    # wrangle can't infer which manager the adopter intends. Reject.
-    run grep -E 'both npm and pnpm lockfiles' "$ACTION_DIR/validate_inputs.sh"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "npm: build_and_pack.sh runs npm ci or pnpm install (lockfile-faithful)" {
-    # Lockfile-faithful install paths for both managers.
-    run grep -E 'npm ci' "$ACTION_DIR/build_and_pack.sh"
-    [[ "$status" -eq 0 ]]
-    run grep -E 'pnpm install --frozen-lockfile' "$ACTION_DIR/build_and_pack.sh"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "npm: build_and_pack.sh detects package manager from lockfile" {
-    # Branch on pnpm-lock.yaml presence — npm fallback otherwise.
-    run grep -E '\-f "pnpm-lock.yaml"' "$ACTION_DIR/build_and_pack.sh"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "npm: build_and_pack.sh runs pack via the detected package manager" {
-    # Pack is invoked via "$PM" pack to use whichever manager was detected.
-    run grep -E '"\$PM" pack' "$ACTION_DIR/build_and_pack.sh"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "npm: build_and_pack.sh detects scripts.build via jq, not by catching missing-script errors" {
-    run grep -E 'jq.*scripts.*build' "$ACTION_DIR/build_and_pack.sh"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "npm: build_and_pack.sh skips npm's default no-op test script" {
-    run grep -F 'no test specified' "$ACTION_DIR/build_and_pack.sh"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "npm: build_and_pack.sh writes tarball to dist/" {
-    run grep -E 'pack-destination dist|mkdir -p dist' "$ACTION_DIR/build_and_pack.sh"
-    [[ "$status" -eq 0 ]]
-}
-
 @test "npm: action.yml uses actions/setup-node" {
     run grep 'actions/setup-node@' "$ACTION"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "npm: detect_tooling.sh sets a fallback Node version when no version source is present" {
-    # Without this, setup-node fails with a confusing "no version found"
-    # error for projects that pin neither .nvmrc nor engines.node.
-    run grep -E 'WRANGLE_DEFAULT_NODE' "$ACTION_DIR/detect_tooling.sh"
     [[ "$status" -eq 0 ]]
 }
 
@@ -243,36 +181,11 @@ setup() {
     [[ "$status" -eq 0 ]]
 }
 
-@test "npm: build_and_pack.sh threads ignore-scripts through to install AND pack" {
-    run grep -E 'ignore_scripts_args' "$ACTION_DIR/build_and_pack.sh"
-    [[ "$status" -eq 0 ]]
-    # Must appear on both install lines and the pack line.
-    run bash -c "grep -E 'npm ci|pnpm install' \"$ACTION_DIR/build_and_pack.sh\" | grep ignore_scripts_args"
-    [[ "$status" -eq 0 ]]
-    run bash -c "grep -E '\\\$PM\" pack|npm pack|pnpm pack' \"$ACTION_DIR/build_and_pack.sh\" | grep ignore_scripts_args"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "npm: build_and_pack.sh skips run-build and test when ignore-scripts is true" {
-    # ignore-scripts: true must mean "no package.json script runs" — not
-    # just suppressing transitive hooks.
-    run grep -E 'Skipping %s run build and %s test' "$ACTION_DIR/build_and_pack.sh"
-    [[ "$status" -eq 0 ]]
-}
-
 @test "npm: build_and_pack.sh uses null-safe jq for scripts.build/test detection" {
     # `(.scripts // {}) | has(...)` survives `"scripts": null` (or missing).
     run grep -E '\(\.scripts // \{\}\) \| has\("build"\)' "$ACTION_DIR/build_and_pack.sh"
     [[ "$status" -eq 0 ]]
     run grep -E '\(\.scripts // \{\}\) \| has\("test"\)' "$ACTION_DIR/build_and_pack.sh"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "npm: validate_inputs.sh rejects package.json with workspaces field" {
-    # Workspaces support tracked in #208. v0.2 still single-package only.
-    run grep -E 'workspaces' "$ACTION_DIR/validate_inputs.sh"
-    [[ "$status" -eq 0 ]]
-    run grep -E 'issues/208' "$ACTION_DIR/validate_inputs.sh"
     [[ "$status" -eq 0 ]]
 }
 
@@ -323,6 +236,387 @@ setup() {
     # sha256sum ./* yields ./<file>; sha256sum -- * (after cd) yields <file>.
     run grep -E 'cd .*dist.* && sha256sum' "$ACTION"
     [[ "$status" -eq 0 ]]
+}
+
+# --- validate_inputs.sh behavioral tests ---
+
+# Helpers for fixture project directories.
+write_pkg_json() {
+    # $1: project dir, $2: optional extra JSON to merge into the base
+    local dir="$1"
+    local extra='{}'
+    if [[ $# -ge 2 ]]; then
+        extra="$2"
+    fi
+    mkdir -p "$dir"
+    jq -n --argjson extra "$extra" \
+        '{"name":"x","version":"1.0.0"} * $extra' > "$dir/package.json"
+}
+
+@test "npm: validate_inputs.sh accepts a package-lock.json project" {
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/package-lock.json"
+    cd "$TMP_DIR"
+    run "$ACTION_DIR/validate_inputs.sh" "proj"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "npm: validate_inputs.sh accepts an npm-shrinkwrap.json project" {
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/npm-shrinkwrap.json"
+    cd "$TMP_DIR"
+    run "$ACTION_DIR/validate_inputs.sh" "proj"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "npm: validate_inputs.sh accepts a pnpm-lock.yaml project (v0.2)" {
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/pnpm-lock.yaml"
+    cd "$TMP_DIR"
+    run "$ACTION_DIR/validate_inputs.sh" "proj"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "npm: validate_inputs.sh rejects missing package.json" {
+    local proj="$TMP_DIR/proj"
+    mkdir -p "$proj"
+    : > "$proj/package-lock.json"
+    cd "$TMP_DIR"
+    run "$ACTION_DIR/validate_inputs.sh" "proj"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"no package.json found"* ]]
+}
+
+@test "npm: validate_inputs.sh rejects missing lockfile with install hint" {
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj"
+    cd "$TMP_DIR"
+    run "$ACTION_DIR/validate_inputs.sh" "proj"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"no lockfile found"* ]]
+    [[ "$output" == *"npm install"* ]]
+}
+
+@test "npm: validate_inputs.sh rejects yarn.lock with a 'not supported' hint" {
+    # Yarn is a follow-on. A yarn-only project must fail loudly, not fall
+    # through to "no lockfile".
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/yarn.lock"
+    cd "$TMP_DIR"
+    run "$ACTION_DIR/validate_inputs.sh" "proj"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Yarn is not supported"* ]]
+}
+
+@test "npm: validate_inputs.sh rejects ambiguous npm + pnpm lockfile state" {
+    # Having both lockfiles is unresolvable — wrangle can't infer the
+    # adopter's intent. Picking one silently would silently determine
+    # what gets attested.
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/package-lock.json"
+    : > "$proj/pnpm-lock.yaml"
+    cd "$TMP_DIR"
+    run "$ACTION_DIR/validate_inputs.sh" "proj"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"both npm and pnpm lockfiles"* ]]
+}
+
+@test "npm: validate_inputs.sh rejects a workspaces project with the #208 link" {
+    # Workspaces produce N tarballs; the single-tarball assertion in
+    # action.yml and the downstream hash/SBOM/provenance pipeline assume
+    # exactly 1. Reject before any of that runs.
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj" '{"workspaces":["packages/*"]}'
+    : > "$proj/package-lock.json"
+    cd "$TMP_DIR"
+    run "$ACTION_DIR/validate_inputs.sh" "proj"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"workspaces"* ]]
+    [[ "$output" == *"issues/208"* ]]
+}
+
+@test "npm: validate_inputs.sh usage error with no args" {
+    run "$ACTION_DIR/validate_inputs.sh"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+# --- detect_tooling.sh behavioral tests ---
+
+@test "npm: detect_tooling.sh node-version input override wins over all other sources" {
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj" '{"engines":{"node":">=20"}}'
+    printf '20\n' > "$proj/.nvmrc"
+    run "$ACTION_DIR/detect_tooling.sh" "$proj" "22.5.1"
+    [[ "$status" -eq 0 ]]
+    grep -q '^effective-version=22.5.1$' "$GITHUB_OUTPUT"
+    grep -q '^effective-version-file=$' "$GITHUB_OUTPUT"
+}
+
+@test "npm: detect_tooling.sh uses .nvmrc when input is empty" {
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj" '{"engines":{"node":">=20"}}'
+    printf '18.20.0\n' > "$proj/.nvmrc"
+    run "$ACTION_DIR/detect_tooling.sh" "$proj" ""
+    [[ "$status" -eq 0 ]]
+    grep -q '^effective-version=$' "$GITHUB_OUTPUT"
+    grep -q "^effective-version-file=$proj/.nvmrc$" "$GITHUB_OUTPUT"
+}
+
+@test "npm: detect_tooling.sh uses engines.node when no .nvmrc and no input" {
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj" '{"engines":{"node":">=20"}}'
+    run "$ACTION_DIR/detect_tooling.sh" "$proj" ""
+    [[ "$status" -eq 0 ]]
+    grep -q '^effective-version=$' "$GITHUB_OUTPUT"
+    grep -q "^effective-version-file=$proj/package.json$" "$GITHUB_OUTPUT"
+}
+
+@test "npm: detect_tooling.sh falls back to wrangle default Node when no version source" {
+    # No .nvmrc, no engines.node, no input — setup-node would emit a
+    # confusing "no version found" error. The fallback prevents that.
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj"
+    run "$ACTION_DIR/detect_tooling.sh" "$proj" ""
+    [[ "$status" -eq 0 ]]
+    grep -qE '^effective-version=[0-9]+$' "$GITHUB_OUTPUT"
+    grep -q '^effective-version-file=$' "$GITHUB_OUTPUT"
+    [[ "$output" == *"falling back to wrangle default"* ]]
+}
+
+@test "npm: detect_tooling.sh emits package-manager=npm and cache=npm for npm projects" {
+    # npm ci re-validates cached tarball integrity on every install, so
+    # caching is safe.
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/package-lock.json"
+    run "$ACTION_DIR/detect_tooling.sh" "$proj" ""
+    [[ "$status" -eq 0 ]]
+    grep -q '^package-manager=npm$' "$GITHUB_OUTPUT"
+    grep -q '^cache=npm$' "$GITHUB_OUTPUT"
+}
+
+@test "npm: detect_tooling.sh emits package-manager=pnpm and EMPTY cache for pnpm projects" {
+    # pnpm-store has no install-time integrity re-verification, so wrangle
+    # must NOT enable setup-node caching for the pnpm path — that's the
+    # Mini Shai-Hulud / TanStack cache-poisoning vector (issue #205). An
+    # `cache=` (empty) line tells setup-node to skip caching entirely.
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/pnpm-lock.yaml"
+    run "$ACTION_DIR/detect_tooling.sh" "$proj" ""
+    [[ "$status" -eq 0 ]]
+    grep -q '^package-manager=pnpm$' "$GITHUB_OUTPUT"
+    grep -q '^cache=$' "$GITHUB_OUTPUT"
+    # Belt and braces: cache must not be set to anything non-empty.
+    ! grep -E '^cache=.+$' "$GITHUB_OUTPUT"
+}
+
+@test "npm: detect_tooling.sh usage error with wrong arg count" {
+    run "$ACTION_DIR/detect_tooling.sh"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+# --- build_and_pack.sh behavioral tests ---
+#
+# build_and_pack.sh shells out to npm/pnpm/jq. Real npm/pnpm aren't
+# available in the test container, so these tests put PATH shims for
+# npm and pnpm ahead of the system PATH. jq stays real (it's pure and
+# universally available); the script reads package.json via jq, so we
+# write real package.json fixtures and assert that the shim recorded
+# the expected commands.
+
+install_pm_shim() {
+    # Creates fake `npm` and `pnpm` binaries that record every invocation
+    # to $TMP_DIR/calls.log and, on `pack`, plant a single tarball in
+    # dist/ to satisfy the post-pack count check. Caller exports PATH.
+    mkdir -p "$TMP_DIR/shim"
+    cat > "$TMP_DIR/shim/npm" <<'SHIM'
+#!/bin/bash
+printf 'npm'
+for a in "$@"; do printf ' %s' "$a"; done
+printf '\n'
+# If this is a pack invocation, plant exactly one tarball in dist/.
+for ((i=1; i<=$#; i++)); do
+    if [[ "${!i}" == "pack" ]]; then
+        : > "dist/x-1.0.0.tgz"
+        break
+    fi
+done
+SHIM
+    cat > "$TMP_DIR/shim/pnpm" <<'SHIM'
+#!/bin/bash
+printf 'pnpm'
+for a in "$@"; do printf ' %s' "$a"; done
+printf '\n'
+for ((i=1; i<=$#; i++)); do
+    if [[ "${!i}" == "pack" ]]; then
+        : > "dist/x-1.0.0.tgz"
+        break
+    fi
+done
+SHIM
+    chmod +x "$TMP_DIR/shim/npm" "$TMP_DIR/shim/pnpm"
+    PATH="$TMP_DIR/shim:$PATH"
+}
+
+@test "npm: build_and_pack.sh runs npm ci, build, test, pack for an npm project" {
+    install_pm_shim
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj" '{"scripts":{"build":"true","test":"true"}}'
+    : > "$proj/package-lock.json"
+    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "false"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"npm ci"* ]]
+    [[ "$output" == *"npm run build"* ]]
+    [[ "$output" == *"npm test"* ]]
+    [[ "$output" == *"npm pack --pack-destination dist"* ]]
+    grep -q '^tarball=x-1.0.0.tgz$' "$GITHUB_OUTPUT"
+}
+
+@test "npm: build_and_pack.sh runs pnpm install/build/test/pack for a pnpm project" {
+    install_pm_shim
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj" '{"scripts":{"build":"true","test":"true"}}'
+    : > "$proj/pnpm-lock.yaml"
+    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "false"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"pnpm install --frozen-lockfile"* ]]
+    [[ "$output" == *"pnpm run build"* ]]
+    [[ "$output" == *"pnpm test"* ]]
+    [[ "$output" == *"pnpm pack --pack-destination dist"* ]]
+}
+
+@test "npm: build_and_pack.sh threads --ignore-scripts through install AND pack" {
+    install_pm_shim
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj" '{"scripts":{"build":"true","test":"true"}}'
+    : > "$proj/package-lock.json"
+    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "true"
+    [[ "$status" -eq 0 ]]
+    # Both ci and pack lines must carry --ignore-scripts.
+    [[ "$output" == *"npm ci --ignore-scripts"* ]]
+    [[ "$output" == *"npm pack --pack-destination dist --ignore-scripts"* ]]
+}
+
+@test "npm: build_and_pack.sh with ignore_scripts=true skips run-build and test entirely" {
+    # ignore-scripts means NO package.json script runs — not just transitive
+    # hooks. A regression that only adds --ignore-scripts to install but
+    # still calls `npm run build` would defeat the stricter L3 contract.
+    install_pm_shim
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj" '{"scripts":{"build":"true","test":"true"}}'
+    : > "$proj/package-lock.json"
+    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "true"
+    [[ "$status" -eq 0 ]]
+    # The shim echoes its argv on a line of its own (e.g., "npm run build").
+    # An anchored grep distinguishes that from the "Skipping npm run build
+    # and npm test" status line.
+    ! grep -qE '^npm run build$' <<<"$output"
+    ! grep -qE '^npm test$' <<<"$output"
+    [[ "$output" == *"Skipping npm run build and npm test"* ]]
+}
+
+@test "npm: build_and_pack.sh skips build when package.json has no build script" {
+    install_pm_shim
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/package-lock.json"
+    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "false"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"npm run build"* ]]
+    [[ "$output" == *"No build script in package.json"* ]]
+}
+
+@test "npm: build_and_pack.sh skips npm's default 'no test specified' script" {
+    # An adopter who never ran `npm init` and uses npm's default stub
+    # test must not have wrangle invoke it (the stub exits 1).
+    install_pm_shim
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj" '{"scripts":{"test":"echo \"Error: no test specified\" && exit 1"}}'
+    : > "$proj/package-lock.json"
+    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "false"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"npm test"* ]]
+    [[ "$output" == *"No non-default test script"* ]]
+}
+
+@test "npm: build_and_pack.sh skips test when run_tests=false even if a test script exists" {
+    install_pm_shim
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj" '{"scripts":{"test":"true"}}'
+    : > "$proj/package-lock.json"
+    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "false" "false"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"npm test"* ]]
+}
+
+@test "npm: build_and_pack.sh survives 'scripts': null in package.json" {
+    # The null-safe jq guards (`(.scripts // {}) | has(...)`) protect
+    # against the explicit-null case; a regression to `.scripts | has(...)`
+    # would crash on this fixture.
+    install_pm_shim
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj" '{"scripts":null}'
+    : > "$proj/package-lock.json"
+    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "true" "false"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "npm: build_and_pack.sh errors when pack produces zero tarballs" {
+    # The post-pack count check is what catches a regressed pack flag
+    # (e.g., wrong --pack-destination) that lands the tarball outside
+    # dist/. Without it, the action would proceed to hash an empty set.
+    install_pm_shim
+    # Override npm to NOT plant a tarball on pack.
+    cat > "$TMP_DIR/shim/npm" <<'SHIM'
+#!/bin/bash
+printf 'npm'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
+SHIM
+    chmod +x "$TMP_DIR/shim/npm"
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/package-lock.json"
+    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "false" "false"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"expected exactly 1 tarball"* ]]
+}
+
+@test "npm: build_and_pack.sh errors when pack produces more than one tarball" {
+    # Future-proofs against a workspaces regression (caught earlier by
+    # validate_inputs.sh, but defense in depth).
+    install_pm_shim
+    # Override npm to plant TWO tarballs.
+    cat > "$TMP_DIR/shim/npm" <<'SHIM'
+#!/bin/bash
+printf 'npm'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
+for ((i=1; i<=$#; i++)); do
+    if [[ "${!i}" == "pack" ]]; then
+        : > "dist/a-1.0.0.tgz"
+        : > "dist/b-1.0.0.tgz"
+        break
+    fi
+done
+SHIM
+    chmod +x "$TMP_DIR/shim/npm"
+    local proj="$TMP_DIR/proj"
+    write_pkg_json "$proj"
+    : > "$proj/package-lock.json"
+    PATH="$PATH" run "$ACTION_DIR/build_and_pack.sh" "$proj" "false" "false"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"expected exactly 1 tarball"* ]]
+}
+
+@test "npm: build_and_pack.sh usage error with wrong arg count" {
+    run "$ACTION_DIR/build_and_pack.sh"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* ]]
 }
 
 # --- Reusable workflow structural tests ---

--- a/build/actions/npm/test.bats
+++ b/build/actions/npm/test.bats
@@ -640,6 +640,34 @@ write_pkg_json() {
     ! grep -qE '^npm ' <<<"$output"
 }
 
+@test "npm: build_and_pack.sh works with a RELATIVE subdir path (regression: PR #236 cd-doubling)" {
+    # The original refactor of #236 called the pure helpers with
+    # $input_path AFTER `cd "$input_path"`, so jq looked for
+    # $input_path/$input_path/package.json. `set -e` does not propagate
+    # into command-substitution subshells, so has_*_script silently
+    # returned false — build and test were skipped and the action still
+    # exited 0. Absolute-path test fixtures hid the bug because
+    # `cd /abs/path` from any cwd resolves to the same place.
+    #
+    # This test invokes the script from a parent dir with the project
+    # as a RELATIVE subdir name, the same shape an adopter using
+    # `path: src` would hit.
+    local proj="$BATS_TEST_TMPDIR/parent/src"
+    write_pkg_json "$proj" '{"scripts":{"build":"true","test":"jest"}}'
+    : > "$proj/package-lock.json"
+    cd "$BATS_TEST_TMPDIR/parent"
+    PATH="$SHIM_DIR:$PATH" run "$ACTION_DIR/build_and_pack.sh" "src" "true" "false"
+    [[ "$status" -eq 0 ]]
+    # The smoking-gun symptoms: build and test must have actually run,
+    # and the jq path-not-found error must not appear.
+    grep -qE '^npm run build$' <<<"$output"
+    grep -qE '^npm test$' <<<"$output"
+    ! grep -qE 'Could not open file' <<<"$output"
+    [[ "$output" != *"No build script in package.json"* ]]
+    [[ "$output" != *"No non-default test script"* ]]
+    grep -q '^tarball=x-1.0.0.tgz$' "$GITHUB_OUTPUT"
+}
+
 @test "npm: build_and_pack.sh threads --ignore-scripts through install AND pack" {
     # ignore-scripts means NO package.json script runs — not just transitive
     # hooks. Both install and pack must carry the flag, and `run build` /

--- a/build/actions/python/run_tests.sh
+++ b/build/actions/python/run_tests.sh
@@ -10,28 +10,59 @@
 # When no tests are detected, the build skips pytest with a message —
 # same behavior as the shell build skipping when no .bats files exist.
 #
+# The discovery decision is split into `should_run_pytest` so test.bats
+# can exercise the three discovery branches without a fixture pytest on
+# PATH. The function takes the path as an arg and returns 0/1 — pure
+# logic about filesystem state, no I/O beyond the test file read.
+#
 # Usage: build/actions/python/run_tests.sh <path> <use_uv>
 #   path:    project directory (already validated)
 #   use_uv:  "true" for `uv run pytest`, anything else for `python -m pytest`
 
 set -euo pipefail
 
-if [[ $# -ne 2 ]]; then
-    printf 'Usage: %s <path> <use_uv>\n' "$0" >&2
-    exit 1
-fi
-
-INPUT_PATH="$1"
-USE_UV="$2"
-
-cd "$INPUT_PATH"
-
-if [[ -d "tests" ]] || [[ -d "test" ]] || grep -qF '[tool.pytest' pyproject.toml 2>/dev/null; then
-    if [[ "$USE_UV" == "true" ]]; then
-        uv run pytest
-    else
-        python -m pytest
+# Pure function: returns 0 (run pytest) if the project has a `tests/` or
+# `test/` directory, or a `[tool.pytest` config section in pyproject.toml.
+# Returns 1 (skip pytest) otherwise.
+#
+# Args: <project_dir>
+should_run_pytest() {
+    local path="$1"
+    if [[ -d "$path/tests" ]] || [[ -d "$path/test" ]]; then
+        return 0
     fi
-else
-    printf 'No tests/ or test/ directory and no [tool.pytest] config — skipping pytest\n'
+    # Match the start-of-line section header to avoid matching a literal
+    # `[tool.pytest` substring that happens to appear inside a string
+    # value (e.g., a description field).
+    if grep -qE '^\[tool\.pytest' "$path/pyproject.toml" 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+main() {
+    if [[ $# -ne 2 ]]; then
+        printf 'Usage: %s <path> <use_uv>\n' "$0" >&2
+        exit 1
+    fi
+
+    local input_path="$1"
+    local use_uv="$2"
+
+    if should_run_pytest "$input_path"; then
+        cd "$input_path"
+        if [[ "$use_uv" == "true" ]]; then
+            uv run pytest
+        else
+            python -m pytest
+        fi
+    else
+        printf 'No tests/ or test/ directory and no [tool.pytest] config — skipping pytest\n'
+    fi
+}
+
+# Sourcing guard: tests source this file to call should_run_pytest
+# directly without invoking pytest.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
 fi

--- a/build/actions/python/test.bats
+++ b/build/actions/python/test.bats
@@ -13,6 +13,53 @@ setup() {
     ACTION="$ACTION_DIR/action.yml"
     WORKFLOW="$REPO_ROOT/.github/workflows/build_and_publish_python.yml"
     EXAMPLE="$REPO_ROOT/gh_workflow_examples/build_python.yml"
+    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/python-bats-XXXXXX")"
+    GITHUB_OUTPUT="$TMP_DIR/github_output"
+    : > "$GITHUB_OUTPUT"
+    export GITHUB_OUTPUT
+}
+
+teardown() {
+    if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# Helper: stub `pytest`, `python`, and `uv` on PATH so the build action's
+# helper scripts execute without needing real interpreters. Each shim
+# records its argv on stdout, which the test then asserts on. The python
+# shim implements just enough of `python -m pytest` / `python -m pip ...`
+# to keep run_tests.sh and install_deps.sh happy in unit tests.
+install_python_shims() {
+    mkdir -p "$TMP_DIR/shim"
+    cat > "$TMP_DIR/shim/python" <<'SHIM'
+#!/bin/bash
+printf 'python'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
+# Default: succeed. Override per-test via PYTHON_EXIT_<MODULE> env vars
+# (e.g., PYTHON_EXIT_PIP=1) to simulate failure paths.
+mod=""
+if [[ "${1:-}" == "-m" && $# -ge 2 ]]; then
+    mod="${2^^}"
+    mod="${mod//-/_}"
+fi
+if [[ -n "$mod" ]]; then
+    var="PYTHON_EXIT_${mod}"
+    exit "${!var:-0}"
+fi
+exit 0
+SHIM
+    cat > "$TMP_DIR/shim/pytest" <<'SHIM'
+#!/bin/bash
+printf 'pytest'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
+exit 0
+SHIM
+    cat > "$TMP_DIR/shim/uv" <<'SHIM'
+#!/bin/bash
+printf 'uv'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
+exit 0
+SHIM
+    chmod +x "$TMP_DIR/shim/python" "$TMP_DIR/shim/pytest" "$TMP_DIR/shim/uv"
+    PATH="$TMP_DIR/shim:$PATH"
 }
 
 # --- Composite action structural tests ---
@@ -45,23 +92,6 @@ setup() {
 
 @test "python: action.yml delegates test run to run_tests.sh" {
     run grep 'run_tests.sh' "$ACTION"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "python: validate_inputs.sh checks for pyproject.toml" {
-    run grep 'pyproject.toml' "$ACTION_DIR/validate_inputs.sh"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "python: install_deps.sh supports both uv and pip paths" {
-    run grep -E 'uv sync|uv build' "$ACTION_DIR/install_deps.sh"
-    [[ "$status" -eq 0 ]]
-    run grep 'pip install' "$ACTION_DIR/install_deps.sh"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "python: run_tests.sh runs pytest" {
-    run grep -E 'uv run pytest|python -m pytest' "$ACTION_DIR/run_tests.sh"
     [[ "$status" -eq 0 ]]
 }
 
@@ -136,6 +166,19 @@ setup() {
     [[ "$output" == *"Usage:"* ]]
 }
 
+@test "python: validate_inputs.sh rejects a project with no pyproject.toml" {
+    # PEP 621 is required: action.yml uses setup-python's
+    # python-version-file pointing at pyproject.toml, so a setup.py-only
+    # project would otherwise fail later with a confusing error. Catch it
+    # here instead.
+    local proj="$TMP_DIR/proj"
+    mkdir -p "$proj"
+    cd "$TMP_DIR"
+    run "$ACTION_DIR/validate_inputs.sh" "proj" "enabled"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"no pyproject.toml"* ]]
+}
+
 @test "python: action.yml exposes a cache input" {
     run grep -E '^  cache:' "$ACTION"
     [[ "$status" -eq 0 ]]
@@ -153,6 +196,141 @@ setup() {
     # release builds: the exact Build L3 downgrade this gating prevents.
     run grep -F "enable-cache: \${{ inputs.cache != 'disabled' }}" "$ACTION"
     [[ "$status" -eq 0 ]]
+}
+
+# --- run_tests.sh behavioral tests ---
+
+write_pyproject() {
+    # $1: project dir, $2: optional extra TOML appended to the file
+    local dir="$1" extra="${2:-}"
+    mkdir -p "$dir"
+    {
+        printf '[project]\nname = "x"\nversion = "0.1.0"\n'
+        printf '%s' "$extra"
+    } > "$dir/pyproject.toml"
+}
+
+@test "python: run_tests.sh runs python -m pytest when tests/ directory exists" {
+    install_python_shims
+    local proj="$TMP_DIR/proj"
+    write_pyproject "$proj"
+    mkdir -p "$proj/tests"
+    PATH="$PATH" run "$ACTION_DIR/run_tests.sh" "$proj" "false"
+    [[ "$status" -eq 0 ]]
+    grep -qE '^python -m pytest$' <<<"$output"
+}
+
+@test "python: run_tests.sh accepts a test/ directory (pytest's default singular form)" {
+    install_python_shims
+    local proj="$TMP_DIR/proj"
+    write_pyproject "$proj"
+    mkdir -p "$proj/test"
+    PATH="$PATH" run "$ACTION_DIR/run_tests.sh" "$proj" "false"
+    [[ "$status" -eq 0 ]]
+    grep -qE '^python -m pytest$' <<<"$output"
+}
+
+@test "python: run_tests.sh runs pytest when only [tool.pytest] config is in pyproject.toml" {
+    # A project that stores tests outside tests/ or test/ should still
+    # have its suite run, provided pyproject.toml configures pytest.
+    install_python_shims
+    local proj="$TMP_DIR/proj"
+    write_pyproject "$proj" $'\n[tool.pytest.ini_options]\ntestpaths = ["mytests"]\n'
+    PATH="$PATH" run "$ACTION_DIR/run_tests.sh" "$proj" "false"
+    [[ "$status" -eq 0 ]]
+    grep -qE '^python -m pytest$' <<<"$output"
+}
+
+@test "python: run_tests.sh skips pytest cleanly when no tests/ and no [tool.pytest] config" {
+    # No tests is not an error — same behavior as the shell build skipping
+    # when no .bats files exist. The message helps adopters discover that
+    # tests in a non-standard location need [tool.pytest].
+    install_python_shims
+    local proj="$TMP_DIR/proj"
+    write_pyproject "$proj"
+    PATH="$PATH" run "$ACTION_DIR/run_tests.sh" "$proj" "false"
+    [[ "$status" -eq 0 ]]
+    ! grep -qE '^pytest' <<<"$output"
+    ! grep -qE '^python -m pytest$' <<<"$output"
+    [[ "$output" == *"skipping pytest"* ]]
+}
+
+@test "python: run_tests.sh uses 'uv run pytest' when use_uv=true" {
+    install_python_shims
+    local proj="$TMP_DIR/proj"
+    write_pyproject "$proj"
+    mkdir -p "$proj/tests"
+    PATH="$PATH" run "$ACTION_DIR/run_tests.sh" "$proj" "true"
+    [[ "$status" -eq 0 ]]
+    grep -qE '^uv run pytest$' <<<"$output"
+    ! grep -qE '^python -m pytest$' <<<"$output"
+}
+
+@test "python: run_tests.sh usage error with wrong arg count" {
+    run "$ACTION_DIR/run_tests.sh" "x"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+# --- install_deps.sh behavioral tests ---
+
+@test "python: install_deps.sh uses 'uv sync' on the uv path" {
+    install_python_shims
+    local proj="$TMP_DIR/proj"
+    write_pyproject "$proj"
+    PATH="$PATH" run "$ACTION_DIR/install_deps.sh" "$proj" "true"
+    [[ "$status" -eq 0 ]]
+    grep -qE '^uv sync$' <<<"$output"
+}
+
+@test "python: install_deps.sh uses 'pip install -e .[test]' first on the pip path" {
+    install_python_shims
+    local proj="$TMP_DIR/proj"
+    write_pyproject "$proj"
+    PATH="$PATH" run "$ACTION_DIR/install_deps.sh" "$proj" "false"
+    [[ "$status" -eq 0 ]]
+    grep -qE '^python -m pip install -e \.\[test\]$' <<<"$output"
+    [[ "$output" == *"Installed with [test] extra"* ]]
+}
+
+@test "python: install_deps.sh falls back through [dev] to bare install on the pip path" {
+    # When [test] and [dev] both fail (here, simulated by a pip shim that
+    # exits 1 for the first two installs), the bare `pip install -e .`
+    # path must still run — that's the contract for projects without
+    # extras.
+    install_python_shims
+    # Replace the pip shim with one that fails the first two install -e
+    # invocations and succeeds on the third (the bare install).
+    cat > "$TMP_DIR/shim/python" <<'SHIM'
+#!/bin/bash
+printf 'python'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
+case "${COUNTER_FILE:-/tmp/missing}" in /tmp/missing) ;; *) ;; esac
+state="$TMP_DIR/pip_calls"
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" ]]; then
+    count=$(($(cat "$state" 2>/dev/null || echo 0) + 1))
+    echo "$count" > "$state"
+    # First two "install -e .[...]" calls fail; third (bare) succeeds.
+    # The very first call (pip install --upgrade pip) must still succeed.
+    if [[ "${4:-}" == "--upgrade" ]]; then exit 0; fi
+    case "$count" in
+        2|3) exit 1 ;;
+        *) exit 0 ;;
+    esac
+fi
+exit 0
+SHIM
+    chmod +x "$TMP_DIR/shim/python"
+    local proj="$TMP_DIR/proj"
+    write_pyproject "$proj"
+    TMP_DIR="$TMP_DIR" PATH="$PATH" run "$ACTION_DIR/install_deps.sh" "$proj" "false"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Installed without test extras"* ]]
+}
+
+@test "python: install_deps.sh usage error with wrong arg count" {
+    run "$ACTION_DIR/install_deps.sh" "x"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* ]]
 }
 
 # --- Reusable workflow structural tests ---

--- a/build/actions/python/test.bats
+++ b/build/actions/python/test.bats
@@ -1,11 +1,64 @@
 #!/usr/bin/env bats
 
-# Structural tests for the Python build action and reusable workflow.
+# Tests for the Python build action and reusable workflow.
 #
-# Many tests below are simple greps. They verify that the action's wiring
-# and supply-chain rules (no curl|sh, no /usr/local/bin, SHA-pinned actions,
-# SBOM upload) are still in place. They do not invoke the action end-to-end —
-# that's covered by the integration test in the wrangle-test companion repo.
+# Three test layers, in increasing order of cost:
+#   1. Pure-function tests that source run_tests.sh and call its
+#      should_run_pytest decision function directly. No shims required.
+#   2. Behavioral tests that invoke validate_inputs.sh end-to-end against
+#      fixture project directories. validate_inputs.sh has no external
+#      dependencies beyond lib/validate_path.sh.
+#   3. Integration tests for run_tests.sh and install_deps.sh that drive
+#      the actual orchestration through PATH shims for `python`, `pytest`,
+#      and `uv` (the test container doesn't ship a real Python toolchain).
+# Plus a thin layer of structural greps preserved as supply-chain guard
+# rails (no curl|sh, no /usr/local/bin, SHA-pinned actions, inputs flow
+# through env:, action.yml delegates to the scripts the behavioral tests
+# cover). End-to-end exercise lives in the wrangle-test companion repo.
+
+setup_file() {
+    ACTION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    export ACTION_DIR
+    # PATH shims for python, pytest, and uv used by the integration tests.
+    # Each shim echoes its argv (so tests can assert which command ran);
+    # the python shim additionally branches on a `WRANGLE_TEST_PIP_FAILS`
+    # env var that listed install attempts should fail, used to exercise
+    # install_deps.sh's [test] → [dev] → bare fallback chain. Built once
+    # per file because the shims are immutable.
+    mkdir -p "$BATS_FILE_TMPDIR/shim"
+    cat > "$BATS_FILE_TMPDIR/shim/python" <<'SHIM'
+#!/bin/bash
+printf 'python'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
+# `pip install` invocations: WRANGLE_TEST_PIP_FAILS is a comma-delimited
+# list of pip-install call indices that should fail (1-based, counting
+# only `pip install` invocations — `pip install --upgrade pip` is
+# skipped). Default: every install succeeds.
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" ]]; then
+    if [[ "${4:-}" != "--upgrade" ]]; then
+        counter="${WRANGLE_TEST_PIP_COUNTER:-/dev/null}"
+        n=$(($(cat "$counter" 2>/dev/null || echo 0) + 1))
+        printf '%d' "$n" > "$counter" 2>/dev/null || true
+        fails=",${WRANGLE_TEST_PIP_FAILS:-},"
+        if [[ "$fails" == *",$n,"* ]]; then exit 1; fi
+    fi
+fi
+exit 0
+SHIM
+    cat > "$BATS_FILE_TMPDIR/shim/pytest" <<'SHIM'
+#!/bin/bash
+printf 'pytest'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
+exit 0
+SHIM
+    cat > "$BATS_FILE_TMPDIR/shim/uv" <<'SHIM'
+#!/bin/bash
+printf 'uv'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
+exit 0
+SHIM
+    chmod +x "$BATS_FILE_TMPDIR/shim/python" \
+        "$BATS_FILE_TMPDIR/shim/pytest" \
+        "$BATS_FILE_TMPDIR/shim/uv"
+    export SHIM_DIR="$BATS_FILE_TMPDIR/shim"
+}
 
 setup() {
     ACTION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
@@ -13,53 +66,9 @@ setup() {
     ACTION="$ACTION_DIR/action.yml"
     WORKFLOW="$REPO_ROOT/.github/workflows/build_and_publish_python.yml"
     EXAMPLE="$REPO_ROOT/gh_workflow_examples/build_python.yml"
-    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/python-bats-XXXXXX")"
-    GITHUB_OUTPUT="$TMP_DIR/github_output"
+    GITHUB_OUTPUT="$BATS_TEST_TMPDIR/github_output"
     : > "$GITHUB_OUTPUT"
     export GITHUB_OUTPUT
-}
-
-teardown() {
-    if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
-        rm -rf "$TMP_DIR"
-    fi
-}
-
-# Helper: stub `pytest`, `python`, and `uv` on PATH so the build action's
-# helper scripts execute without needing real interpreters. Each shim
-# records its argv on stdout, which the test then asserts on. The python
-# shim implements just enough of `python -m pytest` / `python -m pip ...`
-# to keep run_tests.sh and install_deps.sh happy in unit tests.
-install_python_shims() {
-    mkdir -p "$TMP_DIR/shim"
-    cat > "$TMP_DIR/shim/python" <<'SHIM'
-#!/bin/bash
-printf 'python'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
-# Default: succeed. Override per-test via PYTHON_EXIT_<MODULE> env vars
-# (e.g., PYTHON_EXIT_PIP=1) to simulate failure paths.
-mod=""
-if [[ "${1:-}" == "-m" && $# -ge 2 ]]; then
-    mod="${2^^}"
-    mod="${mod//-/_}"
-fi
-if [[ -n "$mod" ]]; then
-    var="PYTHON_EXIT_${mod}"
-    exit "${!var:-0}"
-fi
-exit 0
-SHIM
-    cat > "$TMP_DIR/shim/pytest" <<'SHIM'
-#!/bin/bash
-printf 'pytest'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
-exit 0
-SHIM
-    cat > "$TMP_DIR/shim/uv" <<'SHIM'
-#!/bin/bash
-printf 'uv'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
-exit 0
-SHIM
-    chmod +x "$TMP_DIR/shim/python" "$TMP_DIR/shim/pytest" "$TMP_DIR/shim/uv"
-    PATH="$TMP_DIR/shim:$PATH"
 }
 
 # --- Composite action structural tests ---
@@ -198,7 +207,12 @@ SHIM
     [[ "$status" -eq 0 ]]
 }
 
-# --- run_tests.sh behavioral tests ---
+# --- run_tests.sh pure-function tests ---
+#
+# run_tests.sh's test-discovery decision lives in `should_run_pytest`,
+# a pure function. The tests below source the script and call that
+# function directly with fixture project directories — no pytest/uv
+# shim needed for any of these.
 
 write_pyproject() {
     # $1: project dir, $2: optional extra TOML appended to the file
@@ -210,60 +224,87 @@ write_pyproject() {
     } > "$dir/pyproject.toml"
 }
 
-@test "python: run_tests.sh runs python -m pytest when tests/ directory exists" {
-    install_python_shims
-    local proj="$TMP_DIR/proj"
+@test "python: should_run_pytest: true when tests/ directory exists" {
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pyproject "$proj"
     mkdir -p "$proj/tests"
-    PATH="$PATH" run "$ACTION_DIR/run_tests.sh" "$proj" "false"
+    run bash -c 'source "$1"; should_run_pytest "$2"' -- \
+        "$ACTION_DIR/run_tests.sh" "$proj"
     [[ "$status" -eq 0 ]]
-    grep -qE '^python -m pytest$' <<<"$output"
 }
 
-@test "python: run_tests.sh accepts a test/ directory (pytest's default singular form)" {
-    install_python_shims
-    local proj="$TMP_DIR/proj"
+@test "python: should_run_pytest: true for pytest's default singular test/ form" {
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pyproject "$proj"
     mkdir -p "$proj/test"
-    PATH="$PATH" run "$ACTION_DIR/run_tests.sh" "$proj" "false"
+    run bash -c 'source "$1"; should_run_pytest "$2"' -- \
+        "$ACTION_DIR/run_tests.sh" "$proj"
     [[ "$status" -eq 0 ]]
-    grep -qE '^python -m pytest$' <<<"$output"
 }
 
-@test "python: run_tests.sh runs pytest when only [tool.pytest] config is in pyproject.toml" {
+@test "python: should_run_pytest: true when [tool.pytest.*] config is in pyproject.toml" {
     # A project that stores tests outside tests/ or test/ should still
     # have its suite run, provided pyproject.toml configures pytest.
-    install_python_shims
-    local proj="$TMP_DIR/proj"
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pyproject "$proj" $'\n[tool.pytest.ini_options]\ntestpaths = ["mytests"]\n'
-    PATH="$PATH" run "$ACTION_DIR/run_tests.sh" "$proj" "false"
+    run bash -c 'source "$1"; should_run_pytest "$2"' -- \
+        "$ACTION_DIR/run_tests.sh" "$proj"
     [[ "$status" -eq 0 ]]
-    grep -qE '^python -m pytest$' <<<"$output"
 }
 
-@test "python: run_tests.sh skips pytest cleanly when no tests/ and no [tool.pytest] config" {
+@test "python: should_run_pytest: false when no tests/ and no [tool.pytest] config" {
     # No tests is not an error — same behavior as the shell build skipping
-    # when no .bats files exist. The message helps adopters discover that
-    # tests in a non-standard location need [tool.pytest].
-    install_python_shims
-    local proj="$TMP_DIR/proj"
+    # when no .bats files exist.
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pyproject "$proj"
-    PATH="$PATH" run "$ACTION_DIR/run_tests.sh" "$proj" "false"
+    run bash -c 'source "$1"; should_run_pytest "$2"' -- \
+        "$ACTION_DIR/run_tests.sh" "$proj"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "python: should_run_pytest: NOT triggered by literal '[tool.pytest' inside a string value" {
+    # The original `grep -qF '[tool.pytest'` was a fixed-substring match
+    # that would match anywhere in the file — even inside a description
+    # string. The anchored grep restricts to start-of-line TOML headers
+    # so a description like 'A guide to [tool.pytest configuration]'
+    # doesn't accidentally turn on test discovery.
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pyproject "$proj" $'description = "Notes on [tool.pytest configuration]"\n'
+    run bash -c 'source "$1"; should_run_pytest "$2"' -- \
+        "$ACTION_DIR/run_tests.sh" "$proj"
+    [[ "$status" -ne 0 ]]
+}
+
+# --- run_tests.sh integration tests (shim) ---
+
+@test "python: run_tests.sh end-to-end: invokes python -m pytest on the pip path" {
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pyproject "$proj"
+    mkdir -p "$proj/tests"
+    PATH="$SHIM_DIR:$PATH" run "$ACTION_DIR/run_tests.sh" "$proj" "false"
+    [[ "$status" -eq 0 ]]
+    grep -qE '^python -m pytest$' <<<"$output"
+    ! grep -qE '^uv ' <<<"$output"
+}
+
+@test "python: run_tests.sh end-to-end: invokes 'uv run pytest' on the uv path" {
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pyproject "$proj"
+    mkdir -p "$proj/tests"
+    PATH="$SHIM_DIR:$PATH" run "$ACTION_DIR/run_tests.sh" "$proj" "true"
+    [[ "$status" -eq 0 ]]
+    grep -qE '^uv run pytest$' <<<"$output"
+    ! grep -qE '^python -m pytest$' <<<"$output"
+}
+
+@test "python: run_tests.sh end-to-end: prints skipping message when no tests detected" {
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pyproject "$proj"
+    PATH="$SHIM_DIR:$PATH" run "$ACTION_DIR/run_tests.sh" "$proj" "false"
     [[ "$status" -eq 0 ]]
     ! grep -qE '^pytest' <<<"$output"
     ! grep -qE '^python -m pytest$' <<<"$output"
     [[ "$output" == *"skipping pytest"* ]]
-}
-
-@test "python: run_tests.sh uses 'uv run pytest' when use_uv=true" {
-    install_python_shims
-    local proj="$TMP_DIR/proj"
-    write_pyproject "$proj"
-    mkdir -p "$proj/tests"
-    PATH="$PATH" run "$ACTION_DIR/run_tests.sh" "$proj" "true"
-    [[ "$status" -eq 0 ]]
-    grep -qE '^uv run pytest$' <<<"$output"
-    ! grep -qE '^python -m pytest$' <<<"$output"
 }
 
 @test "python: run_tests.sh usage error with wrong arg count" {
@@ -273,57 +314,65 @@ write_pyproject() {
 }
 
 # --- install_deps.sh behavioral tests ---
+#
+# install_deps.sh is a thin orchestration script that shells out to
+# `uv sync` or to a 4-call pip sequence (`pip install --upgrade pip`,
+# then `[test]` → `[dev]` → bare). It has no pure decision functions
+# worth extracting; the value of behavioral tests here is exercising
+# the fallback chain. Pip-exit-code simulation is driven by the
+# WRANGLE_TEST_PIP_FAILS env var the python shim reads.
 
 @test "python: install_deps.sh uses 'uv sync' on the uv path" {
-    install_python_shims
-    local proj="$TMP_DIR/proj"
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pyproject "$proj"
-    PATH="$PATH" run "$ACTION_DIR/install_deps.sh" "$proj" "true"
+    PATH="$SHIM_DIR:$PATH" run "$ACTION_DIR/install_deps.sh" "$proj" "true"
     [[ "$status" -eq 0 ]]
     grep -qE '^uv sync$' <<<"$output"
+    ! grep -qE '^python -m pip ' <<<"$output"
 }
 
-@test "python: install_deps.sh uses 'pip install -e .[test]' first on the pip path" {
-    install_python_shims
-    local proj="$TMP_DIR/proj"
+@test "python: install_deps.sh tries 'pip install -e .[test]' first on the pip path" {
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pyproject "$proj"
-    PATH="$PATH" run "$ACTION_DIR/install_deps.sh" "$proj" "false"
+    WRANGLE_TEST_PIP_COUNTER="$BATS_TEST_TMPDIR/pip_calls" \
+        PATH="$SHIM_DIR:$PATH" run "$ACTION_DIR/install_deps.sh" "$proj" "false"
     [[ "$status" -eq 0 ]]
     grep -qE '^python -m pip install -e \.\[test\]$' <<<"$output"
     [[ "$output" == *"Installed with [test] extra"* ]]
+    # Bare install must NOT have run.
+    ! grep -qE '^python -m pip install -e \.$' <<<"$output"
 }
 
-@test "python: install_deps.sh falls back through [dev] to bare install on the pip path" {
-    # When [test] and [dev] both fail (here, simulated by a pip shim that
-    # exits 1 for the first two installs), the bare `pip install -e .`
-    # path must still run — that's the contract for projects without
-    # extras.
-    install_python_shims
-    # Replace the pip shim with one that fails the first two install -e
-    # invocations and succeeds on the third (the bare install).
-    cat > "$TMP_DIR/shim/python" <<'SHIM'
-#!/bin/bash
-printf 'python'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'
-case "${COUNTER_FILE:-/tmp/missing}" in /tmp/missing) ;; *) ;; esac
-state="$TMP_DIR/pip_calls"
-if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" ]]; then
-    count=$(($(cat "$state" 2>/dev/null || echo 0) + 1))
-    echo "$count" > "$state"
-    # First two "install -e .[...]" calls fail; third (bare) succeeds.
-    # The very first call (pip install --upgrade pip) must still succeed.
-    if [[ "${4:-}" == "--upgrade" ]]; then exit 0; fi
-    case "$count" in
-        2|3) exit 1 ;;
-        *) exit 0 ;;
-    esac
-fi
-exit 0
-SHIM
-    chmod +x "$TMP_DIR/shim/python"
-    local proj="$TMP_DIR/proj"
+@test "python: install_deps.sh falls back to '[dev]' when '[test]' fails" {
+    # WRANGLE_TEST_PIP_FAILS=1 -> the first counted pip install (the
+    # [test] one; `pip install --upgrade pip` is uncounted) fails.
+    # install_deps must then try [dev], which succeeds, and the bare
+    # install must NOT run.
+    local proj="$BATS_TEST_TMPDIR/proj"
     write_pyproject "$proj"
-    TMP_DIR="$TMP_DIR" PATH="$PATH" run "$ACTION_DIR/install_deps.sh" "$proj" "false"
+    WRANGLE_TEST_PIP_COUNTER="$BATS_TEST_TMPDIR/pip_calls" \
+        WRANGLE_TEST_PIP_FAILS="1" \
+        PATH="$SHIM_DIR:$PATH" run "$ACTION_DIR/install_deps.sh" "$proj" "false"
     [[ "$status" -eq 0 ]]
+    grep -qE '^python -m pip install -e \.\[test\]$' <<<"$output"
+    grep -qE '^python -m pip install -e \.\[dev\]$' <<<"$output"
+    [[ "$output" == *"Installed with [dev] extra"* ]]
+    ! grep -qE '^python -m pip install -e \.$' <<<"$output"
+}
+
+@test "python: install_deps.sh falls all the way through to bare install when both extras fail" {
+    # WRANGLE_TEST_PIP_FAILS=1,2 -> [test] (call 1) and [dev] (call 2)
+    # both fail; the bare install (call 3) succeeds. Asserts the full
+    # cascade — closes the gap the original test left open in the middle.
+    local proj="$BATS_TEST_TMPDIR/proj"
+    write_pyproject "$proj"
+    WRANGLE_TEST_PIP_COUNTER="$BATS_TEST_TMPDIR/pip_calls" \
+        WRANGLE_TEST_PIP_FAILS="1,2" \
+        PATH="$SHIM_DIR:$PATH" run "$ACTION_DIR/install_deps.sh" "$proj" "false"
+    [[ "$status" -eq 0 ]]
+    grep -qE '^python -m pip install -e \.\[test\]$' <<<"$output"
+    grep -qE '^python -m pip install -e \.\[dev\]$' <<<"$output"
+    grep -qE '^python -m pip install -e \.$' <<<"$output"
     [[ "$output" == *"Installed without test extras"* ]]
 }
 

--- a/tools/scorecard/test.bats
+++ b/tools/scorecard/test.bats
@@ -11,6 +11,16 @@
 
 setup() {
     export ORIG_DIR="$(pwd)"
+    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/scorecard-bats-XXXXXX")"
+    export TMP_DIR
+    SCRIPT="$ORIG_DIR/tools/scorecard/sarif_to_markdown.sh"
+    export SCRIPT
+}
+
+teardown() {
+    if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
 }
 
 @test "scorecard: action.yml exists and is valid YAML" {
@@ -22,7 +32,7 @@ setup() {
 }
 
 @test "scorecard: sarif_to_markdown.sh exists and is executable" {
-    [ -x "$ORIG_DIR/tools/scorecard/sarif_to_markdown.sh" ]
+    [ -x "$SCRIPT" ]
 }
 
 @test "scorecard: no install.sh exists (action pattern, not adapter)" {
@@ -35,4 +45,100 @@ setup() {
 
 @test "scorecard: action.yml writes to wrangle metadata directory" {
     grep -q '\.wrangle/metadata/scorecard' "$ORIG_DIR/tools/scorecard/action.yml"
+}
+
+# --- sarif_to_markdown.sh behavioral tests ---
+
+@test "sarif_to_markdown: emits header and a row per result" {
+    cat > "$TMP_DIR/in.sarif" <<'SARIF'
+{
+  "version": "2.1.0",
+  "runs": [{
+    "tool": {"driver": {"name": "scorecard"}},
+    "results": [
+      {"ruleId": "Token-Permissions",
+       "message": {"text": "Job permissions too broad"},
+       "locations": [{"physicalLocation": {"artifactLocation": {"uri": ".github/workflows/ci.yml"}}}]}
+    ]
+  }]
+}
+SARIF
+    run "$SCRIPT" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Rule Name | Location | Message"* ]]
+    [[ "$output" == *"--------- | -------- | -------"* ]]
+    [[ "$output" == *"Token-Permissions | .github/workflows/ci.yml | Job permissions too broad"* ]]
+}
+
+@test "sarif_to_markdown: empty results -> header only, exit 0" {
+    cat > "$TMP_DIR/in.sarif" <<'SARIF'
+{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"scorecard"}},"results":[]}]}
+SARIF
+    run "$SCRIPT" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Rule Name | Location | Message"* ]]
+    # No data rows.
+    body=$(printf '%s\n' "$output" | tail -n +3)
+    [[ -z "$body" ]]
+}
+
+@test "sarif_to_markdown: strips HTML tags from message text (no summary HTML rendering)" {
+    # Scorecard messages occasionally include <a> tags pointing at the
+    # remediation docs. The summary renders as markdown, so HTML must be
+    # stripped to prevent confusing rendering — and to defeat any
+    # attacker-influenced markup if scorecard ever surfaced upstream text.
+    cat > "$TMP_DIR/in.sarif" <<'SARIF'
+{
+  "version": "2.1.0",
+  "runs": [{
+    "tool": {"driver": {"name": "scorecard"}},
+    "results": [
+      {"ruleId": "R", "message": {"text": "see <a href=\"x\">docs</a> for details"},
+       "locations": [{"physicalLocation": {"artifactLocation": {"uri": "f"}}}]}
+    ]
+  }]
+}
+SARIF
+    run "$SCRIPT" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"<a"* ]]
+    [[ "$output" != *"</a>"* ]]
+    [[ "$output" == *"see docs for details"* ]]
+}
+
+@test "sarif_to_markdown: truncates output at WRANGLE_MAX_SUMMARY bytes" {
+    # Step summaries have a hard 1 MiB cap; one verbose scorecard run can
+    # blow past it. The truncation is the protection.
+    {
+        printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"scorecard"}},"results":['
+        # 200 results × ~120 bytes each ~= 24 KiB of body.
+        for i in $(seq 1 200); do
+            [[ "$i" -gt 1 ]] && printf ','
+            printf '{"ruleId":"R%d","message":{"text":"msg-%d"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"f%d"}}}]}' "$i" "$i" "$i"
+        done
+        printf ']}]}'
+    } > "$TMP_DIR/in.sarif"
+    WRANGLE_MAX_SUMMARY=200 run "$SCRIPT" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 0 ]
+    # Output must be bounded by the header lines + 200-byte truncated body.
+    [[ "${#output}" -lt 500 ]]
+}
+
+@test "sarif_to_markdown: missing file exits 1" {
+    run "$SCRIPT" "$TMP_DIR/does-not-exist.sarif"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"SARIF file not found"* ]]
+}
+
+@test "sarif_to_markdown: invalid JSON exits 2" {
+    printf 'not json {{{' > "$TMP_DIR/in.sarif"
+    run "$SCRIPT" "$TMP_DIR/in.sarif"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"invalid JSON"* ]]
+}
+
+@test "sarif_to_markdown: usage error with no args" {
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage:"* ]]
 }


### PR DESCRIPTION
Closes #160.

## Summary

`build/actions/{npm,python}/test.bats` and `tools/scorecard/test.bats` relied heavily on greps that asserted a particular string appeared somewhere in the action.yml or helper script. Those tests confirmed the presence of *text*, not *behavior*: moving a keyword into a comment would keep them passing, and a regression that broke the actual logic might not trip them. They also broke on harmless refactors (PR #156's helper extraction forced unrelated test edits with no behavioral change).

This PR follows the template established by `lib/validate_path.sh` and `container/validate_inputs.sh`: invoke each helper script against fixture inputs and assert on exit codes, `GITHUB_OUTPUT` contents, and stdout/stderr. Per the issue, greps remain only as supply-chain guard rails (no `curl | sh`, SHA-pinned actions, `${{ inputs.* }}` flowing through `env:`, action.yml actually delegating to the scripts the behavioral tests now cover) and for workflow-level structural checks that have no behavioral counterpart.

Following review, the helper scripts themselves were also restructured so the decision logic is testable as pure functions, leaving PATH shims only for orchestration that legitimately needs to drive external tools.

## What changed

### Script refactor (decision logic extracted as pure functions)

- **`detect_tooling.sh`** — `resolve_node_version(input, dir)` and `resolve_pm_cache(dir)` print `<version>|<file>|<reason>` / `<pm>|<cache>`. `main()` composes them and writes to `GITHUB_OUTPUT`.
- **`build_and_pack.sh`** — `detect_pm`, `has_build_script`, `has_real_test_script`, `find_one_tarball` are pure args-in → stdout/exit-out. `main()` still orchestrates the npm/pnpm install/build/test/pack pipeline (legitimately needs a shim).
- **`run_tests.sh`** — `should_run_pytest(dir)`. Also fixed a pre-existing bug in the same change: the TOML header check was `grep -qF '[tool.pytest'` (substring anywhere in file); now anchored to `^\[tool\.pytest` with a negative-fixture regression test for a description string containing the literal phrase.

Each script has a sourcing guard so tests can `bash -c 'source script; func "$@"'` without invoking `main`.

### Tests reorganised into three tiers

1. **Pure-function tests** — source the script, call the function, assert on stdout/exit. No shims, no `GITHUB_OUTPUT` plumbing.
2. **`validate_inputs.sh` end-to-end** — jq is the only external dependency.
3. **Integration** — slim suite that drives the orchestration through PATH shims for `npm`/`pnpm`/`python`/`uv`/`pytest`. Shims live in `setup_file()` under `$BATS_FILE_TMPDIR`, created once per file.

### Coverage added

- **npm**: 82 tests covering `validate_inputs.sh` branches (package.json, lockfile detection, yarn rejection, workspaces rejection, npm+pnpm ambiguity), all four node-version-resolution branches, npm/pnpm cache split (issue #205 decision), pack-uses-same-PM-as-install (`! grep -qE '^pnpm '` on npm path and vice versa), `--ignore-scripts` threading, `'no test specified'` substring guard, tarball-count check, `scripts: null` null safety.
- **python**: 66 tests covering pyproject.toml requirement, the four test-discovery branches in `should_run_pytest`, the uv/pip switch, the full `[test]` → `[dev]` → bare install fallback chain in `install_deps.sh` (including the `[dev]` middle branch, exercised via `WRANGLE_TEST_PIP_FAILS=1`), and the `[tool.pytest`-in-description false-positive regression.
- **scorecard**: 13 tests for `sarif_to_markdown.sh` covering header+rows, HTML stripping, `WRANGLE_MAX_SUMMARY` truncation, missing-file/invalid-JSON exit codes.

## What was deliberately NOT changed

- `build/actions/container/test.bats` — already has solid behavioral tests for `validate_inputs.sh` and `resolve_cache.sh` (added in #225). Remaining greps are workflow/action.yml structural checks the issue explicitly calls out as legitimate guard rails.
- `build/actions/shell/test.bats` — the action wraps shellcheck/bats; no in-action script logic to test behaviorally.
- `tools/{dependency-review,osv,syft}/test.bats` — already have comprehensive behavioral tests with mocks.
- `tools/{zizmor,scorecard}/action.yml` checks, supply-chain greps (`curl | sh`, SHA-pin assertions, `set -f` presence), and `action.yml → script` delegation checks — these are the guard rails the issue says to keep.

## Test plan

- [x] `bats build/actions/npm/test.bats` — 82/82 pass
- [x] `bats build/actions/python/test.bats` — 66/66 pass
- [x] `bats tools/scorecard/test.bats` — 13/13 pass
- [x] `shellcheck -x` clean on all `*.sh` files
- [x] All other in-scope bats suites unchanged (0 new failures); pre-existing `bump_action_pins.bats` env-issue failures are present on `main` as well
- [x] CI green
- [ ] Integration test in wrangle-test still passes (unit-test surface deliberately narrowed; integration covers the real npm/python/pip/uv invocations the PATH shims stand in for)