### PR TITLE
claude: Bump self-ref pins to main HEAD (post-#238)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -105,7 +105,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
 
   gate:
     needs: [guard]
@@ -116,7 +116,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
+      - uses: TomHennen/wrangle/actions/release_gate@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -138,7 +138,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
+      uses: TomHennen/wrangle/build/actions/container@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -141,7 +141,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@2510122c14f8503a43c6fef5e88394d29af43d1d # main 2026-05-23
+      - uses: TomHennen/wrangle/actions/preflight_guard@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
 
   gate:
     needs: [guard]
@@ -151,7 +151,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@2510122c14f8503a43c6fef5e88394d29af43d1d # main 2026-05-23
+      - uses: TomHennen/wrangle/actions/release_gate@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -176,7 +176,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@a7ac75597bf63f6f252395f3ce4ebea8aabb6570
+      - uses: TomHennen/wrangle/build/actions/go/checks@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -234,7 +234,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@a7ac75597bf63f6f252395f3ce4ebea8aabb6570
+      - uses: TomHennen/wrangle/build/actions/go/release@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
         id: release
         with:
           path: ${{ inputs.path }}
@@ -304,7 +304,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/build/actions/go/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/go/verify@2d54a9ba95ec5c7ce1f88308f05b5d257472625e
+      - uses: TomHennen/wrangle/build/actions/go/verify@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
         with:
           dist-dir: dist
           provenance-path: provenance/${{ needs.provenance.outputs.provenance-name }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -125,7 +125,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
 
   gate:
     needs: [guard]
@@ -136,7 +136,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
+      - uses: TomHennen/wrangle/actions/release_gate@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -160,7 +160,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
+      - uses: TomHennen/wrangle/build/actions/npm@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -104,7 +104,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -119,7 +119,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
+      - uses: TomHennen/wrangle/actions/release_gate@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
+      - uses: TomHennen/wrangle/build/actions/python@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -29,7 +29,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
 
   shell-build:
     needs: [guard]
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
+        uses: TomHennen/wrangle/build/actions/shell@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -20,7 +20,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
 
   check-change:
     needs: [guard]
@@ -38,6 +38,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@f0a0b4acbd065ba47dfae170341ce4340bc18b72 # main 2026-05-20
+        uses: TomHennen/wrangle/actions/scan@68f81972937f778cc38202f18370a177002da73e # bump-action-pins 2026-05-24
         with:
           tools: ${{ inputs.tools }}


### PR DESCRIPTION
Bumps all `TomHennen/wrangle/...@<sha>` pins in `.github/workflows/` to the current main HEAD (`68f8197`) after merging #238 (Go build type).

6 workflow files updated: `build_and_publish_container.yml`, `build_and_publish_go.yml`, `build_and_publish_npm.yml`, `build_and_publish_python.yml`, `build_shell.yml`, `check_source_change.yml`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)