### PR TITLE
bump: codeql-action/upload-sarif v4.35.2 -> v4.36.0 for Node 24 (#140)

### DIFF
--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -114,7 +114,7 @@ runs:
     # produced — see issue #189.
     - name: Upload OSV SARIF
       if: always() && contains(inputs.tools, 'osv')
-      uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       continue-on-error: true
       with:
         sarif_file: ${{ github.workspace }}/.wrangle/metadata/osv/output.sarif
@@ -126,7 +126,7 @@ runs:
 
     - name: Upload Scorecard SARIF
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       continue-on-error: true
       with:
         sarif_file: ${{ github.workspace }}/.wrangle/metadata/scorecard/output.sarif
@@ -134,7 +134,7 @@ runs:
 
     - name: Upload Dependency Review SARIF
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       continue-on-error: true
       with:
         sarif_file: ${{ github.workspace }}/.wrangle/metadata/dependency-review/output.sarif


### PR DESCRIPTION
## Summary

Addresses #140 partially. GitHub Actions emits a Node.js 20 deprecation warning naming two actions; this PR fixes one of them.

- Bumps `github/codeql-action/upload-sarif` from `v4.35.2` (Node 20) to `v4.36.0` (Node 24).
  - v4.36.0 declares `using: node24` in its `action.yml`.
  - All three call sites in `actions/scan/action.yml` (OSV, Scorecard, dependency-review uploads) are updated to the same pin.
- Format follows the CLAUDE.md "Action Reference Pinning" table: `<sha> # vX.Y.Z`.

## Deferred: slsa-verifier installer

`slsa-framework/slsa-verifier/actions/installer` still runs on Node 20. The latest upstream release (`v2.7.1`, SHA `ea584f4502babc6f60d9bc799dbbb13c1caa9ee6`) does not yet declare Node 24. Waiting for an upstream release; #140 stays open until that bump lands.

## Test plan

- [x] `./test.sh` passes locally (actionlint + shellcheck + bats; 656 bats tests, no failures)
- [ ] CI green on this PR
- [ ] Confirm the Node 20 deprecation warning for `codeql-action/upload-sarif` no longer appears in subsequent workflow runs

claude: Generated with [Claude Code](https://claude.com/claude-code)