### PR TITLE
claude: Fix source-scan action-pattern fail-open on tool errors (#222)

### DIFF
--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -145,8 +145,15 @@ runs:
         sarif_file: ${{ github.workspace }}/.wrangle/metadata/scorecard/output.sarif
         category: wrangle/scorecard
 
+    # Skip Code Scanning upload on a dep-review tool error: collect_outputs.sh
+    # / mark_error.sh write the error marker exactly when the upstream
+    # produced no usable findings, and any SARIF on disk in that case is
+    # either absent or an empty fallback. Uploading an empty SARIF would
+    # overwrite the previous run's findings in the Security tab with
+    # `results: []`, silently scrubbing real findings on a transient API
+    # failure. Gating on the marker preserves the prior valid state.
     - name: Upload Dependency Review SARIF
-      if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
+      if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request' && hashFiles('.wrangle/metadata/dependency-review/error') == ''
       uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       continue-on-error: true
       with:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -705,6 +705,17 @@ tools/<name>/
 └── test.bats     # Structural tests + CI integration tests
 ```
 
+**Tool-error marker contract (action pattern).** Action-pattern wrappers cannot rely on the upstream action's exit code alone: `continue-on-error: true` is typically required so wrangle's own collection step runs after the upstream exits non-zero on findings, which also swallows genuine tool errors. Without a separate signal an errored run produces an empty SARIF that `lib/check_results.sh` reads as "no findings" — silently fail-open (issue [#222](https://github.com/TomHennen/wrangle/issues/222)).
+
+To close that gap, action-pattern wrappers SHOULD write a per-tool marker file at `$WRANGLE_METADATA_DIR/<tool>/error` whenever the upstream step fails in a way that does NOT correspond to "found issues" (e.g., API unavailable, dependency database disabled, malformed upstream output, image-pull failure mid-run). Contract:
+
+1. The marker is a plain text file. Its first line is logged by `lib/check_results.sh` after passing through `wrangle_sanitize_output`, so wrappers do not need to pre-sanitize upstream output.
+2. `lib/check_results.sh` treats the marker as **fail-closed** for `:fail` policy (non-zero exit) and **informational** for `:info` policy.
+3. The marker takes precedence over the SARIF count. Wrappers MAY also write a synthesized empty SARIF as a fallback so downstream consumers (step summary, Code Scanning upload) always have a file; the marker prevents that fallback from being misread as zero findings.
+4. `lib/format_sarif_summary.sh` surfaces a `Tool error` status in the step-summary table when the marker is present, and the per-tool Code Scanning upload in `actions/scan/action.yml` SHOULD be gated on the marker's absence to avoid overwriting prior valid runs with an empty SARIF.
+
+The marker is the canonical signal — adapter-pattern tools already disambiguate via their exit code (0/1/2) per the Adapter Contract above, so they do not write a marker.
+
 Use the action pattern when:
 - The tool has a well-maintained official GitHub Action
 - The tool's recommended installation method requires an ecosystem runtime (cargo, pip, etc.) that wrangle shouldn't depend on
@@ -762,11 +773,14 @@ Structure after a scan:
 │   └── output.sarif
 ├── zizmor/
 │   ├── output.sarif
-│   └── output.md
+│   ├── output.md
+│   └── error           # optional: tool-error marker (action pattern only)
 └── scorecard/
     ├── output.sarif
     └── output.md
 ```
+
+The optional `error` file is the tool-error marker for action-pattern tools — see "Tool-error marker contract" under [Two Tool Patterns](#two-tool-patterns).
 
 The `.wrangle/` directory is in `.gitignore` to prevent accidental commits. The orchestrator's filesystem check (`run.sh`) excludes the metadata directory from its pre/post snapshots.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -707,7 +707,7 @@ tools/<name>/
 
 **Tool-error marker contract (action pattern).** Action-pattern wrappers cannot rely on the upstream action's exit code alone: `continue-on-error: true` is typically required so wrangle's own collection step runs after the upstream exits non-zero on findings, which also swallows genuine tool errors. Without a separate signal an errored run produces an empty SARIF that `lib/check_results.sh` reads as "no findings" — silently fail-open (issue [#222](https://github.com/TomHennen/wrangle/issues/222)).
 
-To close that gap, action-pattern wrappers SHOULD write a per-tool marker file at `$WRANGLE_METADATA_DIR/<tool>/error` whenever the upstream step fails in a way that does NOT correspond to "found issues" (e.g., API unavailable, dependency database disabled, malformed upstream output, image-pull failure mid-run). Contract:
+To close that gap, action-pattern wrappers SHOULD write a per-tool marker file at `$WRANGLE_METADATA_DIR/<tool>/error` (via `lib/write_tool_error_marker.sh`) whenever the upstream step fails in a way that does NOT correspond to "found issues" (e.g., API unavailable, dependency database disabled, malformed upstream output, image-pull failure mid-run). Contract:
 
 1. The marker is a plain text file. Its first line is logged by `lib/check_results.sh` after passing through `wrangle_sanitize_output`, so wrappers do not need to pre-sanitize upstream output.
 2. `lib/check_results.sh` treats the marker as **fail-closed** for `:fail` policy (non-zero exit) and **informational** for `:info` policy.

--- a/lib/check_results.sh
+++ b/lib/check_results.sh
@@ -20,10 +20,19 @@ set -f  # disable globbing — processes external input
 # precedence over the SARIF count to prevent a fallback empty SARIF (0
 # results) from masking a tool error.
 #
+# Marker contract: contents are treated as untrusted — the first line
+# is run through wrangle_sanitize_output before being logged. Wrappers
+# may interpolate upstream output into the marker without re-sanitising
+# themselves.
+#
 # Exit codes:
 #   0  No findings from fail-policy tools
 #   1  At least one fail-policy tool reported findings, errored, or
 #      produced invalid SARIF
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=sanitize.sh
+source "$SCRIPT_DIR/sanitize.sh"
 
 if [[ $# -lt 2 ]]; then
     printf 'Usage: check_results.sh <metadata_dir> <tool[:policy]> ...\n' >&2
@@ -67,9 +76,12 @@ for spec in "$@"; do
     # may have synthesized an empty fallback SARIF that would otherwise be
     # misread as "no findings".
     if [[ -f "$error_marker" ]]; then
-        # Read the first line of the marker for context, sanitised to a
-        # single line. Falls back to a generic message if read fails.
-        err_msg="$(head -n1 -- "$error_marker" 2>/dev/null || true)"
+        # Read the first line of the marker for context, sanitised
+        # through wrangle_sanitize_output so a future wrapper that
+        # interpolates upstream text into the marker cannot inject
+        # HTML/markdown into the GitHub Actions log surface. Falls
+        # back to a generic message if read fails.
+        err_msg="$(head -n1 -- "$error_marker" 2>/dev/null | wrangle_sanitize_output || true)"
         if [[ -z "$err_msg" ]]; then
             err_msg="upstream tool failed"
         fi

--- a/lib/check_results.sh
+++ b/lib/check_results.sh
@@ -11,9 +11,19 @@ set -f  # disable globbing — processes external input
 # if they reported findings. Tools with :info policy are informational —
 # findings are noted but do not affect the exit code.
 #
+# Tool-error semantics: when an action-pattern tool's wrapper writes an
+# `error` marker file at <metadata_dir>/<tool>/error, that signals the
+# underlying tool failed to run (API unavailable, network failure, etc.)
+# — distinct from "tool ran and found nothing". For :fail-policy tools
+# the marker causes exit 1 (fail closed). For :info-policy tools the
+# marker is logged but does not affect the exit code. The marker takes
+# precedence over the SARIF count to prevent a fallback empty SARIF (0
+# results) from masking a tool error.
+#
 # Exit codes:
 #   0  No findings from fail-policy tools
-#   1  At least one fail-policy tool reported findings or produced invalid SARIF
+#   1  At least one fail-policy tool reported findings, errored, or
+#      produced invalid SARIF
 
 if [[ $# -lt 2 ]]; then
     printf 'Usage: check_results.sh <metadata_dir> <tool[:policy]> ...\n' >&2
@@ -46,7 +56,31 @@ for spec in "$@"; do
         continue
     fi
 
+    error_marker="${METADATA_DIR}/${tool}/error"
     sarif="${METADATA_DIR}/${tool}/output.sarif"
+
+    # Error marker takes precedence over SARIF counting. An action-pattern
+    # tool's wrapper writes this when the upstream step exits non-zero in a
+    # way that does not correspond to "found issues" (e.g., API down). For
+    # :fail tools this is a hard failure; for :info tools it is logged but
+    # not blocking. We do not fall through to the SARIF count — the wrapper
+    # may have synthesized an empty fallback SARIF that would otherwise be
+    # misread as "no findings".
+    if [[ -f "$error_marker" ]]; then
+        # Read the first line of the marker for context, sanitised to a
+        # single line. Falls back to a generic message if read fails.
+        err_msg="$(head -n1 -- "$error_marker" 2>/dev/null || true)"
+        if [[ -z "$err_msg" ]]; then
+            err_msg="upstream tool failed"
+        fi
+        if [[ "$policy" == "fail" ]]; then
+            printf 'wrangle: %s errored: %s\n' "$tool" "$err_msg" >&2
+            exit_code=1
+        else
+            printf 'wrangle: %s errored: %s (informational)\n' "$tool" "$err_msg"
+        fi
+        continue
+    fi
 
     if [[ ! -f "$sarif" ]]; then
         # No SARIF means the tool didn't run or didn't produce output.

--- a/lib/check_results.sh
+++ b/lib/check_results.sh
@@ -6,29 +6,16 @@ set -f  # disable globbing — processes external input
 #
 # Usage: check_results.sh <metadata_dir> <tool[:policy]> [tool[:policy]] ...
 #
-# Each tool argument is a name with an optional :fail or :info suffix.
-# Default policy is :fail. Tools with :fail policy cause a non-zero exit
-# if they reported findings. Tools with :info policy are informational —
-# findings are noted but do not affect the exit code.
+# Each tool has a :fail (default) or :info policy. :fail blocks the exit
+# on findings, :info logs them. The exit is non-zero if any :fail tool
+# reported findings, errored, or produced invalid SARIF.
 #
-# Tool-error semantics: when an action-pattern tool's wrapper writes an
-# `error` marker file at <metadata_dir>/<tool>/error, that signals the
-# underlying tool failed to run (API unavailable, network failure, etc.)
-# — distinct from "tool ran and found nothing". For :fail-policy tools
-# the marker causes exit 1 (fail closed). For :info-policy tools the
-# marker is logged but does not affect the exit code. The marker takes
-# precedence over the SARIF count to prevent a fallback empty SARIF (0
-# results) from masking a tool error.
-#
-# Marker contract: contents are treated as untrusted — the first line
-# is run through wrangle_sanitize_output before being logged. Wrappers
-# may interpolate upstream output into the marker without re-sanitising
-# themselves.
-#
-# Exit codes:
-#   0  No findings from fail-policy tools
-#   1  At least one fail-policy tool reported findings, errored, or
-#      produced invalid SARIF
+# Error-marker contract: <metadata_dir>/<tool>/error, if present, signals
+# the upstream tool failed (API down, network failure) — distinct from
+# "ran and found nothing". It takes precedence over the SARIF count so a
+# wrapper-synthesised empty fallback SARIF can't mask a tool error.
+# Contents are treated as untrusted — sanitised before logging — so
+# wrappers may interpolate upstream output without re-sanitising.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=sanitize.sh
@@ -68,19 +55,9 @@ for spec in "$@"; do
     error_marker="${METADATA_DIR}/${tool}/error"
     sarif="${METADATA_DIR}/${tool}/output.sarif"
 
-    # Error marker takes precedence over SARIF counting. An action-pattern
-    # tool's wrapper writes this when the upstream step exits non-zero in a
-    # way that does not correspond to "found issues" (e.g., API down). For
-    # :fail tools this is a hard failure; for :info tools it is logged but
-    # not blocking. We do not fall through to the SARIF count — the wrapper
-    # may have synthesized an empty fallback SARIF that would otherwise be
-    # misread as "no findings".
     if [[ -f "$error_marker" ]]; then
-        # Read the first line of the marker for context, sanitised
-        # through wrangle_sanitize_output so a future wrapper that
-        # interpolates upstream text into the marker cannot inject
-        # HTML/markdown into the GitHub Actions log surface. Falls
-        # back to a generic message if read fails.
+        # First line only, sanitised — wrapper-supplied marker text is
+        # untrusted (see header) and reaches the GitHub Actions log here.
         err_msg="$(head -n1 -- "$error_marker" 2>/dev/null | wrangle_sanitize_output || true)"
         if [[ -z "$err_msg" ]]; then
             err_msg="upstream tool failed"

--- a/lib/format_sarif_summary.sh
+++ b/lib/format_sarif_summary.sh
@@ -34,6 +34,19 @@ printf '| ---- | ------ | ------- |\n'
 while IFS= read -r -d '' dir; do
     tool="$(basename "$dir")"
 
+    # The `error` marker (issue #222) takes precedence over the SARIF
+    # count: action-pattern wrappers synthesize an empty fallback SARIF
+    # on tool error so downstream consumers always have a file, but the
+    # marker is the canonical "the tool failed" signal. Without this
+    # branch the summary row would render "No findings" while the run
+    # itself failed via lib/check_results.sh — misleading on the very
+    # surface docs/SPEC.md calls the primary output.
+    if [[ -f "${dir}/error" ]]; then
+        safe_tool="$(printf '%s' "$tool" | wrangle_sanitize_output)"
+        printf '| %s | Tool error | [Details](#%s-details) |\n' "$safe_tool" "$safe_tool"
+        continue
+    fi
+
     if [[ -f "${dir}/output.sarif" ]]; then
         tool_status="No findings"
 
@@ -56,6 +69,17 @@ printf '\n'
 while IFS= read -r -d '' dir; do
     tool="$(basename "$dir")"
     safe_tool="$(printf '%s' "$tool" | wrangle_sanitize_output)"
+
+    # If the tool errored, surface the marker contents in the details
+    # block — the marker is authoritative and the SARIF (if any) is the
+    # synthesised empty fallback.
+    if [[ -f "${dir}/error" ]]; then
+        printf '## %s Details\n' "$safe_tool"
+        printf '\nTool error — wrangle treated this run as fail-closed.\n\n```\n'
+        wrangle_sanitize_output < "${dir}/error"
+        printf '\n```\n'
+        continue
+    fi
 
     if [[ -f "${dir}/output.txt" ]]; then
         printf '## %s Details\n' "$safe_tool"

--- a/lib/format_sarif_summary.sh
+++ b/lib/format_sarif_summary.sh
@@ -34,13 +34,11 @@ printf '| ---- | ------ | ------- |\n'
 while IFS= read -r -d '' dir; do
     tool="$(basename "$dir")"
 
-    # The `error` marker (issue #222) takes precedence over the SARIF
-    # count: action-pattern wrappers synthesize an empty fallback SARIF
-    # on tool error so downstream consumers always have a file, but the
-    # marker is the canonical "the tool failed" signal. Without this
-    # branch the summary row would render "No findings" while the run
-    # itself failed via lib/check_results.sh — misleading on the very
-    # surface docs/SPEC.md calls the primary output.
+    # The `error` marker takes precedence over the SARIF count: action-pattern
+    # wrappers synthesise an empty fallback SARIF on tool error, so without
+    # this branch the summary row would render "No findings" while the run
+    # itself failed via lib/check_results.sh — misleading on the surface
+    # docs/SPEC.md calls the primary output.
     if [[ -f "${dir}/error" ]]; then
         safe_tool="$(printf '%s' "$tool" | wrangle_sanitize_output)"
         printf '| %s | Tool error | [Details](#%s-details) |\n' "$safe_tool" "$safe_tool"

--- a/lib/write_tool_error_marker.sh
+++ b/lib/write_tool_error_marker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# lib/write_tool_error_marker.sh — write the action-pattern tool-error
+# marker consumed by lib/check_results.sh. Source-only; see SPEC.md
+# §Tool-error marker contract.
+
+wrangle_write_tool_error_marker() {
+    local metadata_dir="$1"
+    local message="$2"
+    mkdir -p "$metadata_dir"
+    printf '%s\n' "$message" > "$metadata_dir/error"
+}

--- a/test/test_check_results.bats
+++ b/test/test_check_results.bats
@@ -123,3 +123,91 @@ create_sarif() {
     run "$ORIG_DIR/lib/check_results.sh" "$METADATA" "bad:info"
     [ "$status" -eq 0 ]
 }
+
+# --- Tool-error marker (issue #222) ---
+#
+# Action-pattern wrappers write a per-tool `error` marker file when the
+# upstream step fails in a way that does NOT correspond to "found issues".
+# check_results.sh must treat the marker as fail-closed for :fail policy,
+# and as informational-only for :info policy. The marker must take
+# precedence over the SARIF count so a fallback empty SARIF (0 results)
+# cannot mask the error.
+
+@test "check_results: error marker on :fail tool exits 1" {
+    mkdir -p "$METADATA/depreview"
+    printf 'API unavailable\n' > "$METADATA/depreview/error"
+    run "$ORIG_DIR/lib/check_results.sh" "$METADATA" "depreview"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"depreview errored"* ]]
+    [[ "$output" == *"API unavailable"* ]]
+}
+
+@test "check_results: error marker on explicit :fail tool exits 1" {
+    mkdir -p "$METADATA/depreview"
+    printf 'API unavailable\n' > "$METADATA/depreview/error"
+    run "$ORIG_DIR/lib/check_results.sh" "$METADATA" "depreview:fail"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"depreview errored"* ]]
+}
+
+@test "check_results: error marker on :info tool does not fail" {
+    mkdir -p "$METADATA/scorecard"
+    printf 'scorecard transient failure\n' > "$METADATA/scorecard/error"
+    run "$ORIG_DIR/lib/check_results.sh" "$METADATA" "scorecard:info"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scorecard errored"* ]]
+    [[ "$output" == *"informational"* ]]
+}
+
+@test "check_results: error marker wins over empty SARIF (no double-counting)" {
+    # The wrapper synthesises an empty SARIF as a fallback so downstream
+    # steps (Code Scanning upload, step summary) always have a file to
+    # read. check_results.sh must NOT read the empty SARIF as "0 findings"
+    # and pass — it must see the marker and fail.
+    mkdir -p "$METADATA/zizmor"
+    printf 'zizmor crashed\n' > "$METADATA/zizmor/error"
+    jq -n '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"zizmor"}}, "results":[]}]}' \
+        > "$METADATA/zizmor/output.sarif"
+    run "$ORIG_DIR/lib/check_results.sh" "$METADATA" "zizmor"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"zizmor errored"* ]]
+    # We did not silently fall back to a finding count.
+    [[ "$output" != *"finding(s)"* ]]
+}
+
+@test "check_results: error marker affects only listed tools" {
+    # Marker for a tool not present in the args is ignored.
+    mkdir -p "$METADATA/other"
+    printf 'noise\n' > "$METADATA/other/error"
+    create_sarif "osv" 0
+    run "$ORIG_DIR/lib/check_results.sh" "$METADATA" "osv"
+    [ "$status" -eq 0 ]
+}
+
+@test "check_results: empty error marker still fails closed" {
+    # A zero-byte marker should still trigger failure with a generic
+    # message — never accidentally read as "no error".
+    mkdir -p "$METADATA/depreview"
+    : > "$METADATA/depreview/error"
+    run "$ORIG_DIR/lib/check_results.sh" "$METADATA" "depreview"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"depreview errored"* ]]
+}
+
+@test "check_results: error marker + findings still exits 1 with error message" {
+    # If both findings and error marker exist (shouldn't happen, but be
+    # defensive), the marker takes precedence — fail-closed is correct.
+    mkdir -p "$METADATA/zizmor"
+    printf 'zizmor crashed\n' > "$METADATA/zizmor/error"
+    create_sarif "zizmor" 3
+    run "$ORIG_DIR/lib/check_results.sh" "$METADATA" "zizmor"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"zizmor errored"* ]]
+}
+
+@test "check_results: no error marker and no findings still passes" {
+    # Regression guard: the existing happy path is unchanged.
+    create_sarif "zizmor" 0
+    run "$ORIG_DIR/lib/check_results.sh" "$METADATA" "zizmor"
+    [ "$status" -eq 0 ]
+}

--- a/test/test_check_results.bats
+++ b/test/test_check_results.bats
@@ -211,3 +211,16 @@ create_sarif() {
     run "$ORIG_DIR/lib/check_results.sh" "$METADATA" "zizmor"
     [ "$status" -eq 0 ]
 }
+
+@test "check_results: error marker contents are sanitised before logging" {
+    # The marker contract (docs/SPEC.md, Two Tool Patterns) is "contents
+    # are untrusted, will be sanitised" — wrappers can interpolate raw
+    # upstream output without worrying about HTML/markdown injection
+    # into the Actions log surface.
+    mkdir -p "$METADATA/depreview"
+    printf '<script>alert(1)</script>genuine error\n' > "$METADATA/depreview/error"
+    run "$ORIG_DIR/lib/check_results.sh" "$METADATA" "depreview"
+    [ "$status" -eq 1 ]
+    [[ "$output" != *"<script>"* ]]
+    [[ "$output" == *"genuine error"* ]]
+}

--- a/test/test_sanitized_summary.bats
+++ b/test/test_sanitized_summary.bats
@@ -192,3 +192,46 @@ teardown() {
     [[ "$output" != *"<script>"* ]]
     [[ "$output" != *"onerror"* ]]
 }
+
+# --- Tool-error marker ---
+#
+# Action-pattern tools (e.g., zizmor) signal tool error via an `error`
+# marker file in the metadata dir. The summary table — the primary
+# adopter output per docs/SPEC.md Composite Action Interface — must
+# reflect that marker, not the fallback empty SARIF the wrapper
+# synthesises.
+
+@test "sanitized summary: error marker renders as Tool error status" {
+    mkdir -p "$TEST_DIR/metadata/zizmor"
+    printf 'zizmor crashed: pull failed\n' > "$TEST_DIR/metadata/zizmor/error"
+    # Empty fallback SARIF as the wrapper writes it.
+    cp "$ORIG_DIR/test/fixtures/empty.sarif" "$TEST_DIR/metadata/zizmor/output.sarif"
+
+    output=$("$FORMATTER" "$TEST_DIR/metadata")
+
+    [[ "$output" == *"Tool error"* ]]
+    # We did NOT silently report "No findings" off the fallback SARIF.
+    [[ "$output" != *"No findings"* ]]
+}
+
+@test "sanitized summary: error marker details surface marker contents" {
+    mkdir -p "$TEST_DIR/metadata/zizmor"
+    printf 'zizmor exited non-zero: image pull failed\n' > "$TEST_DIR/metadata/zizmor/error"
+    cp "$ORIG_DIR/test/fixtures/empty.sarif" "$TEST_DIR/metadata/zizmor/output.sarif"
+
+    output=$("$FORMATTER" "$TEST_DIR/metadata")
+
+    [[ "$output" == *"image pull failed"* ]]
+    [[ "$output" == *"fail-closed"* ]]
+}
+
+@test "sanitized summary: error marker contents are HTML-sanitised" {
+    mkdir -p "$TEST_DIR/metadata/zizmor"
+    printf '<script>alert(1)</script>real error text\n' > "$TEST_DIR/metadata/zizmor/error"
+    cp "$ORIG_DIR/test/fixtures/empty.sarif" "$TEST_DIR/metadata/zizmor/output.sarif"
+
+    output=$("$FORMATTER" "$TEST_DIR/metadata")
+
+    [[ "$output" != *"<script>"* ]]
+    [[ "$output" == *"real error text"* ]]
+}

--- a/test/test_write_tool_error_marker.bats
+++ b/test/test_write_tool_error_marker.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+# Tests for lib/write_tool_error_marker.sh (wrangle_write_tool_error_marker)
+
+setup() {
+    export ORIG_DIR="$(pwd)"
+    TMPDIR_TEST="$(mktemp -d)"
+    source "$ORIG_DIR/lib/write_tool_error_marker.sh"
+}
+
+teardown() {
+    rm -rf "$TMPDIR_TEST"
+}
+
+@test "write_tool_error_marker: writes message + newline to <metadata_dir>/error" {
+    wrangle_write_tool_error_marker "$TMPDIR_TEST" "upstream tool failed"
+
+    [[ -f "$TMPDIR_TEST/error" ]]
+    # Exact content: message + single trailing newline.
+    printf '%s\n' "upstream tool failed" > "$TMPDIR_TEST/expected"
+    cmp -s "$TMPDIR_TEST/error" "$TMPDIR_TEST/expected"
+}
+
+@test "write_tool_error_marker: creates non-existent metadata dir" {
+    dir="$TMPDIR_TEST/does/not/exist/yet"
+    [[ ! -d "$dir" ]]
+
+    wrangle_write_tool_error_marker "$dir" "msg"
+
+    [[ -d "$dir" ]]
+    [[ -f "$dir/error" ]]
+}
+
+@test "write_tool_error_marker: overwrites existing marker" {
+    wrangle_write_tool_error_marker "$TMPDIR_TEST" "first"
+    wrangle_write_tool_error_marker "$TMPDIR_TEST" "second"
+
+    [[ "$(cat "$TMPDIR_TEST/error")" == "second" ]]
+}
+
+@test "write_tool_error_marker: preserves message verbatim (no shell expansion)" {
+    # $TMPDIR_TEST should NOT be expanded; the printf '%s' form passes
+    # the message through literally.
+    wrangle_write_tool_error_marker "$TMPDIR_TEST" 'literal $VAR and *glob*'
+
+    [[ "$(cat "$TMPDIR_TEST/error")" == 'literal $VAR and *glob*' ]]
+}

--- a/tools/dependency-review/SPEC.md
+++ b/tools/dependency-review/SPEC.md
@@ -42,9 +42,16 @@ Every change except `change_type: "removed"` is converted — a `"removed"` entr
 
 A vulnerable change is converted regardless of its `scope` — a vulnerable `development`/build-time dependency is flagged exactly like a `runtime` one. That is deliberate and matches the default policy of blocking on any introduced vulnerability; scope-aware policy (à la dependency-review-action's `fail-on-scopes`) would belong with the per-tool configuration design in [#221](https://github.com/TomHennen/wrangle/issues/221).
 
+## Tool-error handling
+
+`continue-on-error: true` on the upstream step is required so the SARIF collection step runs even when dep-review exits non-zero on findings. `lib/check_results.sh` is the actual pass/fail gate via the produced SARIF.
+
+A tool error (Dependency Review API unavailable, Dependency Graph disabled, network failure) also surfaces as a non-zero upstream exit but with an empty `vulnerable-changes` output. The wrapper distinguishes the two cases:
+
+- Non-zero exit with a non-empty `vulnerable-changes` array → findings → SARIF contains the entries → `check_results.sh` fails on the SARIF count.
+- Non-zero exit with empty/`[]` `vulnerable-changes` → tool error → `mark_error.sh` writes an `error` marker into the metadata directory → `check_results.sh` fails closed on the marker (issue [#222](https://github.com/TomHennen/wrangle/issues/222)).
+
 ## Known limitations
 
-- The `continue-on-error: true` on the upstream step is required so the SARIF collection step runs even when dep-review exits non-zero on findings. `lib/check_results.sh` is the actual pass/fail gate via the produced SARIF.
 - License-policy findings (`invalid-license-changes`) and denied-package findings (`denied-changes`) are **not** currently converted to SARIF. Only `vulnerable-changes` flow into `output.sarif`. Adopters relying on license / deny-list policies should rely on the upstream action's own failure exit code; the wrangle wrapper preserves that exit semantics via `lib/check_results.sh` only for vulnerability findings.
-- The upstream action calls the GitHub Dependency Review API, which requires the PR's diff to be reachable. Forks of repositories that disable the GitHub Dependency Graph will not get useful output.
-- **A tool error fails open.** `continue-on-error: true` on the upstream step means an error (Dependency Review API unavailable, Dependency Graph disabled, network failure) produces an empty `vulnerable-changes` output — indistinguishable from "no vulnerable changes". The result is an empty SARIF and a passing `check_results.sh` gate, so a dep-review *failure* does not block a PR. This matches `zizmor`'s current behavior; tracked for a consistent cross-tool fix in [#222](https://github.com/TomHennen/wrangle/issues/222).
+- The upstream action calls the GitHub Dependency Review API, which requires the PR's diff to be reachable. Forks of repositories that disable the GitHub Dependency Graph will not get useful output, but the error marker above ensures this fails closed rather than fails open.

--- a/tools/dependency-review/action.yml
+++ b/tools/dependency-review/action.yml
@@ -62,17 +62,31 @@ runs:
 
     # Mark tool error so check_results.sh fails closed. The upstream step
     # uses continue-on-error: true so SARIF collection runs on findings,
-    # but that also swallows genuine errors (API unavailable, Dependency
-    # Graph disabled, network failure). Without this marker, an errored
-    # run produces an empty SARIF that is indistinguishable from "no
+    # but that also swallows genuine errors (API unavailable, network
+    # failure, malformed output). Without this marker, an errored run
+    # produces an empty SARIF that is indistinguishable from "no
     # vulnerable changes" — fail open. See issue #222.
     #
     # Disambiguating findings-exit from error-exit: the upstream action
     # populates the vulnerable-changes output even when it exits non-zero
     # on findings (fail-on-severity). When the action errors out it
-    # leaves vulnerable-changes empty. So `outcome == 'failure'` AND empty
-    # vulnerable-changes is a real tool error; non-empty means findings,
-    # which check_results.sh will catch via the SARIF count.
+    # leaves vulnerable-changes empty/null. So `outcome == 'failure'`
+    # AND empty vulnerable-changes is a real tool error; non-empty means
+    # findings, which check_results.sh will catch via the SARIF count.
+    # mark_error.sh's jq-based detection covers `''`, `[]`, `null`,
+    # whitespace, and parse failures uniformly.
+    #
+    # Known gap (raised in PR #262 review, deliberately deferred): the
+    # upstream action also has a `outcome=success` mode that produces
+    # nothing useful — e.g., Dependency Graph disabled on the repo, or
+    # a forked PR where the API can't reach the diff base. In that mode
+    # vulnerable-changes is also empty, and there is no signal from the
+    # upstream action to distinguish "Dependency Graph disabled" from
+    # the legitimate "no vulnerable changes introduced" happy path that
+    # every clean PR hits. Gating mark_error.sh on `always()` would
+    # therefore mark every clean PR as a tool error. The proper fix
+    # needs an upstream signal (or a wrangle-side probe of the
+    # Dependency Graph API state) and is tracked separately.
     - name: Mark dependency-review tool error
       if: always() && steps.depreview.outcome == 'failure'
       shell: bash

--- a/tools/dependency-review/action.yml
+++ b/tools/dependency-review/action.yml
@@ -90,6 +90,9 @@ runs:
     - name: Mark dependency-review tool error
       if: always() && steps.depreview.outcome == 'failure'
       shell: bash
+      # VULNERABLE_CHANGES is upstream JSON output (attacker-influenceable via
+      # PR contents); it must reach a parser, never a shell. mark_error.sh
+      # only pipes it into jq — preserve that invariant in future edits.
       env:
         TOOL_DIR: ${{ github.action_path }}
         METADATA_DIR: ${{ github.workspace }}/.wrangle/metadata/dependency-review

--- a/tools/dependency-review/action.yml
+++ b/tools/dependency-review/action.yml
@@ -60,39 +60,25 @@ runs:
       run: |
         "$TOOL_DIR/collect_outputs.sh" "${GITHUB_WORKSPACE}/.wrangle/metadata/dependency-review"
 
-    # Mark tool error so check_results.sh fails closed. The upstream step
-    # uses continue-on-error: true so SARIF collection runs on findings,
-    # but that also swallows genuine errors (API unavailable, network
-    # failure, malformed output). Without this marker, an errored run
-    # produces an empty SARIF that is indistinguishable from "no
-    # vulnerable changes" — fail open. See issue #222.
+    # Mark tool error so check_results.sh fails closed. continue-on-error
+    # above swallows genuine errors (API down, network failure) into the
+    # same outcome as findings; the upstream action distinguishes them by
+    # populating vulnerable-changes on findings and leaving it empty on
+    # error. mark_error.sh writes the marker on the latter. Without it,
+    # an errored run produces an empty SARIF indistinguishable from "no
+    # vulnerable changes" — fail open.
     #
-    # Disambiguating findings-exit from error-exit: the upstream action
-    # populates the vulnerable-changes output even when it exits non-zero
-    # on findings (fail-on-severity). When the action errors out it
-    # leaves vulnerable-changes empty/null. So `outcome == 'failure'`
-    # AND empty vulnerable-changes is a real tool error; non-empty means
-    # findings, which check_results.sh will catch via the SARIF count.
-    # mark_error.sh's jq-based detection covers `''`, `[]`, `null`,
-    # whitespace, and parse failures uniformly.
-    #
-    # Known gap (raised in PR #262 review, deliberately deferred): the
-    # upstream action also has a `outcome=success` mode that produces
-    # nothing useful — e.g., Dependency Graph disabled on the repo, or
-    # a forked PR where the API can't reach the diff base. In that mode
-    # vulnerable-changes is also empty, and there is no signal from the
-    # upstream action to distinguish "Dependency Graph disabled" from
-    # the legitimate "no vulnerable changes introduced" happy path that
-    # every clean PR hits. Gating mark_error.sh on `always()` would
-    # therefore mark every clean PR as a tool error. The proper fix
-    # needs an upstream signal (or a wrangle-side probe of the
-    # Dependency Graph API state) and is tracked separately.
+    # Known gap: the upstream action's `outcome=success` mode can also
+    # produce nothing useful (Dependency Graph disabled, forked PR without
+    # diff base) — same shape as a clean PR. Gating mark_error.sh on
+    # `always()` would mark every clean PR as error. The proper fix needs
+    # an upstream signal we don't currently have.
     - name: Mark dependency-review tool error
       if: always() && steps.depreview.outcome == 'failure'
       shell: bash
-      # VULNERABLE_CHANGES is upstream JSON output (attacker-influenceable via
-      # PR contents); it must reach a parser, never a shell. mark_error.sh
-      # only pipes it into jq — preserve that invariant in future edits.
+      # VULNERABLE_CHANGES is upstream JSON, attacker-influenceable via PR
+      # contents — it must reach a parser, never a shell. mark_error.sh
+      # only pipes it into jq; preserve that invariant in future edits.
       env:
         TOOL_DIR: ${{ github.action_path }}
         METADATA_DIR: ${{ github.workspace }}/.wrangle/metadata/dependency-review

--- a/tools/dependency-review/action.yml
+++ b/tools/dependency-review/action.yml
@@ -59,3 +59,27 @@ runs:
         VULNERABLE_CHANGES: ${{ steps.depreview.outputs.vulnerable-changes }}
       run: |
         "$TOOL_DIR/collect_outputs.sh" "${GITHUB_WORKSPACE}/.wrangle/metadata/dependency-review"
+
+    # Mark tool error so check_results.sh fails closed. The upstream step
+    # uses continue-on-error: true so SARIF collection runs on findings,
+    # but that also swallows genuine errors (API unavailable, Dependency
+    # Graph disabled, network failure). Without this marker, an errored
+    # run produces an empty SARIF that is indistinguishable from "no
+    # vulnerable changes" — fail open. See issue #222.
+    #
+    # Disambiguating findings-exit from error-exit: the upstream action
+    # populates the vulnerable-changes output even when it exits non-zero
+    # on findings (fail-on-severity). When the action errors out it
+    # leaves vulnerable-changes empty. So `outcome == 'failure'` AND empty
+    # vulnerable-changes is a real tool error; non-empty means findings,
+    # which check_results.sh will catch via the SARIF count.
+    - name: Mark dependency-review tool error
+      if: always() && steps.depreview.outcome == 'failure'
+      shell: bash
+      env:
+        TOOL_DIR: ${{ github.action_path }}
+        METADATA_DIR: ${{ github.workspace }}/.wrangle/metadata/dependency-review
+        OUTCOME: ${{ steps.depreview.outcome }}
+        VULNERABLE_CHANGES: ${{ steps.depreview.outputs.vulnerable-changes }}
+      run: |
+        "$TOOL_DIR/mark_error.sh"

--- a/tools/dependency-review/mark_error.sh
+++ b/tools/dependency-review/mark_error.sh
@@ -22,13 +22,38 @@ set -f  # disable globbing — processes external tool output
 #   OUTCOME             — the upstream step's outcome string (for context)
 #   VULNERABLE_CHANGES  — the upstream step's vulnerable-changes output
 #
-# Exit: 0 unconditionally — failure to write the marker is non-fatal here
-# because the surrounding step is purely a fail-closed hint.
+# Exit: 0 on success; non-zero on missing required env or an unwritable
+# marker path (set -euo pipefail propagates failures from the redirect
+# and the `: "${METADATA_DIR:?...}"` guard).
 
 : "${METADATA_DIR:?METADATA_DIR is required}"
 : "${OUTCOME:=failure}"
 
-if [[ -z "${VULNERABLE_CHANGES:-}" ]] || [[ "${VULNERABLE_CHANGES}" == "[]" ]]; then
+# Empty-array / unparseable / null detection via jq, so we don't depend
+# on the upstream serialisation (`[]` vs `[ ]` vs pretty-printed vs
+# `null`) staying byte-stable. `jq -e 'length == 0'` is true for `[]`
+# and `{}`, false for non-empty arrays, and exits non-zero on null or
+# parse failure — both of those are "no usable findings array" and
+# count as a tool error.
+should_mark=0
+if [[ -z "${VULNERABLE_CHANGES:-}" ]]; then
+    should_mark=1
+elif ! printf '%s' "${VULNERABLE_CHANGES}" | jq -e 'length == 0' >/dev/null 2>&1; then
+    # jq returns success (0) when length == 0 → empty, mark.
+    # jq returns failure (non-zero) when length != 0 (findings) OR
+    # when input is null/unparseable. Disambiguate by re-checking
+    # whether the input parses at all.
+    if ! printf '%s' "${VULNERABLE_CHANGES}" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+        # Not a non-empty array — null, unparseable, or wrong type.
+        # Treat as tool error.
+        should_mark=1
+    fi
+else
+    # jq succeeded → length == 0 → empty array, tool error.
+    should_mark=1
+fi
+
+if [[ "$should_mark" -eq 1 ]]; then
     mkdir -p "$METADATA_DIR"
     printf 'upstream dependency-review-action exited non-zero with no vulnerable-changes (outcome=%s)\n' \
         "$OUTCOME" > "$METADATA_DIR/error"

--- a/tools/dependency-review/mark_error.sh
+++ b/tools/dependency-review/mark_error.sh
@@ -31,25 +31,12 @@ set -f  # disable globbing — processes external tool output
 
 # Empty-array / unparseable / null detection via jq, so we don't depend
 # on the upstream serialisation (`[]` vs `[ ]` vs pretty-printed vs
-# `null`) staying byte-stable. `jq -e 'length == 0'` is true for `[]`
-# and `{}`, false for non-empty arrays, and exits non-zero on null or
-# parse failure — both of those are "no usable findings array" and
-# count as a tool error.
+# `null`) staying byte-stable. A single positive check ("is this a
+# non-empty array?") is true only for real findings; everything else
+# (empty array, null, parse failure, wrong type, missing env) falls
+# through to the marker.
 should_mark=0
-if [[ -z "${VULNERABLE_CHANGES:-}" ]]; then
-    should_mark=1
-elif ! printf '%s' "${VULNERABLE_CHANGES}" | jq -e 'length == 0' >/dev/null 2>&1; then
-    # jq returns success (0) when length == 0 → empty, mark.
-    # jq returns failure (non-zero) when length != 0 (findings) OR
-    # when input is null/unparseable. Disambiguate by re-checking
-    # whether the input parses at all.
-    if ! printf '%s' "${VULNERABLE_CHANGES}" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
-        # Not a non-empty array — null, unparseable, or wrong type.
-        # Treat as tool error.
-        should_mark=1
-    fi
-else
-    # jq succeeded → length == 0 → empty array, tool error.
+if ! printf '%s' "${VULNERABLE_CHANGES:-}" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
     should_mark=1
 fi
 

--- a/tools/dependency-review/mark_error.sh
+++ b/tools/dependency-review/mark_error.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — processes external tool output
+
+# mark_error.sh — write the dependency-review tool-error marker.
+#
+# Called from action.yml's "Mark dependency-review tool error" step when
+# the upstream action's outcome is 'failure'. The upstream step
+# populates the `vulnerable-changes` output when it exits non-zero on
+# findings, and leaves it empty/`[]` when it exits non-zero on a genuine
+# error (API down, Dependency Graph disabled, network failure).
+#
+# A non-empty array means findings — those flow through SARIF and are
+# caught by lib/check_results.sh. An empty array (or unset variable) is
+# the fail-open case from issue #222: an empty SARIF would be
+# indistinguishable from "no vulnerable changes", so we write the marker
+# so check_results.sh fails closed.
+#
+# Inputs (env):
+#   METADATA_DIR        — destination directory (e.g.,
+#                         $GITHUB_WORKSPACE/.wrangle/metadata/dependency-review)
+#   OUTCOME             — the upstream step's outcome string (for context)
+#   VULNERABLE_CHANGES  — the upstream step's vulnerable-changes output
+#
+# Exit: 0 unconditionally — failure to write the marker is non-fatal here
+# because the surrounding step is purely a fail-closed hint.
+
+: "${METADATA_DIR:?METADATA_DIR is required}"
+: "${OUTCOME:=failure}"
+
+if [[ -z "${VULNERABLE_CHANGES:-}" ]] || [[ "${VULNERABLE_CHANGES}" == "[]" ]]; then
+    mkdir -p "$METADATA_DIR"
+    printf 'upstream dependency-review-action exited non-zero with no vulnerable-changes (outcome=%s)\n' \
+        "$OUTCOME" > "$METADATA_DIR/error"
+fi

--- a/tools/dependency-review/mark_error.sh
+++ b/tools/dependency-review/mark_error.sh
@@ -4,43 +4,26 @@ set -f  # disable globbing — processes external tool output
 
 # mark_error.sh — write the dependency-review tool-error marker.
 #
-# Called from action.yml's "Mark dependency-review tool error" step when
-# the upstream action's outcome is 'failure'. The upstream step
-# populates the `vulnerable-changes` output when it exits non-zero on
-# findings, and leaves it empty/`[]` when it exits non-zero on a genuine
-# error (API down, Dependency Graph disabled, network failure).
-#
-# A non-empty array means findings — those flow through SARIF and are
-# caught by lib/check_results.sh. An empty array (or unset variable) is
-# the fail-open case from issue #222: an empty SARIF would be
-# indistinguishable from "no vulnerable changes", so we write the marker
-# so check_results.sh fails closed.
+# Hidden upstream contract: dependency-review-action populates the
+# vulnerable-changes output on findings exit but leaves it empty/`[]`
+# on genuine error (API down, Dependency Graph disabled). So
+# "outcome=failure AND vulnerable-changes non-empty" means findings;
+# everything else under outcome=failure is a tool error that would
+# otherwise look like "no vulnerable changes" to check_results.sh.
 #
 # Inputs (env):
-#   METADATA_DIR        — destination directory (e.g.,
-#                         $GITHUB_WORKSPACE/.wrangle/metadata/dependency-review)
-#   OUTCOME             — the upstream step's outcome string (for context)
-#   VULNERABLE_CHANGES  — the upstream step's vulnerable-changes output
-#
-# Exit: 0 on success; non-zero on missing required env or an unwritable
-# marker path (set -euo pipefail propagates failures from the redirect
-# and the `: "${METADATA_DIR:?...}"` guard).
+#   METADATA_DIR        — destination directory
+#   OUTCOME             — upstream step's outcome string (for context)
+#   VULNERABLE_CHANGES  — upstream step's vulnerable-changes output
 
 : "${METADATA_DIR:?METADATA_DIR is required}"
 : "${OUTCOME:=failure}"
 
-# Empty-array / unparseable / null detection via jq, so we don't depend
-# on the upstream serialisation (`[]` vs `[ ]` vs pretty-printed vs
-# `null`) staying byte-stable. A single positive check ("is this a
-# non-empty array?") is true only for real findings; everything else
-# (empty array, null, parse failure, wrong type, missing env) falls
-# through to the marker.
-should_mark=0
+# Single positive check via jq so we don't depend on serialisation form
+# (`[]` vs `[ ]` vs pretty-printed vs `null`) staying byte-stable.
+# Everything that isn't a non-empty array — empty, null, parse failure,
+# wrong type, missing env — falls through to the marker.
 if ! printf '%s' "${VULNERABLE_CHANGES:-}" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
-    should_mark=1
-fi
-
-if [[ "$should_mark" -eq 1 ]]; then
     mkdir -p "$METADATA_DIR"
     printf 'upstream dependency-review-action exited non-zero with no vulnerable-changes (outcome=%s)\n' \
         "$OUTCOME" > "$METADATA_DIR/error"

--- a/tools/dependency-review/mark_error.sh
+++ b/tools/dependency-review/mark_error.sh
@@ -4,27 +4,24 @@ set -f  # disable globbing — processes external tool output
 
 # mark_error.sh — write the dependency-review tool-error marker.
 #
-# Hidden upstream contract: dependency-review-action populates the
-# vulnerable-changes output on findings exit but leaves it empty/`[]`
-# on genuine error (API down, Dependency Graph disabled). So
-# "outcome=failure AND vulnerable-changes non-empty" means findings;
-# everything else under outcome=failure is a tool error that would
-# otherwise look like "no vulnerable changes" to check_results.sh.
-#
-# Inputs (env):
-#   METADATA_DIR        — destination directory
-#   OUTCOME             — upstream step's outcome string (for context)
-#   VULNERABLE_CHANGES  — upstream step's vulnerable-changes output
+# Hidden upstream contract: dependency-review-action populates
+# vulnerable-changes on findings but leaves it empty/`[]` on genuine
+# error (API down, Dependency Graph disabled). VULNERABLE_CHANGES is
+# attacker-influenced JSON, so the only check that touches it is a jq
+# parse — never a shell expansion.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../lib/write_tool_error_marker.sh
+source "$SCRIPT_DIR/../../lib/write_tool_error_marker.sh"
 
 : "${METADATA_DIR:?METADATA_DIR is required}"
 : "${OUTCOME:=failure}"
 
-# Single positive check via jq so we don't depend on serialisation form
-# (`[]` vs `[ ]` vs pretty-printed vs `null`) staying byte-stable.
-# Everything that isn't a non-empty array — empty, null, parse failure,
-# wrong type, missing env — falls through to the marker.
+# Single positive check via jq so serialisation form (`[]` vs `[ ]` vs
+# pretty-printed vs `null`) doesn't matter. Everything that isn't a
+# non-empty array — empty, null, parse failure, wrong type, missing
+# env — falls through to the marker.
 if ! printf '%s' "${VULNERABLE_CHANGES:-}" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
-    mkdir -p "$METADATA_DIR"
-    printf 'upstream dependency-review-action exited non-zero with no vulnerable-changes (outcome=%s)\n' \
-        "$OUTCOME" > "$METADATA_DIR/error"
+    wrangle_write_tool_error_marker "$METADATA_DIR" \
+        "upstream dependency-review-action exited non-zero with no vulnerable-changes (outcome=${OUTCOME})"
 fi

--- a/tools/dependency-review/test.bats
+++ b/tools/dependency-review/test.bats
@@ -78,6 +78,55 @@ teardown() {
     ! grep -Eq '^\s+(if|for|while) ' "$TOOL_DIR/action.yml"
 }
 
+# --- Tool-error marker (issue #222) ---
+
+@test "dependency-review: action.yml writes error marker gated on upstream outcome" {
+    # The fail-open fix from #222: write a marker the Check results step
+    # treats as failure when the upstream action errored out (as opposed
+    # to "found issues").
+    grep -q "steps.depreview.outcome == 'failure'" "$TOOL_DIR/action.yml"
+    grep -q 'mark_error.sh' "$TOOL_DIR/action.yml"
+}
+
+@test "dependency-review: mark_error.sh exists and is executable" {
+    [ -x "$TOOL_DIR/mark_error.sh" ]
+}
+
+@test "mark_error: empty VULNERABLE_CHANGES writes error marker" {
+    META="$TMP_DIR/meta-err-empty"
+    METADATA_DIR="$META" OUTCOME=failure VULNERABLE_CHANGES='' \
+        run "$TOOL_DIR/mark_error.sh"
+    [ "$status" -eq 0 ]
+    [ -f "$META/error" ]
+    grep -q 'outcome=failure' "$META/error"
+}
+
+@test "mark_error: literal [] VULNERABLE_CHANGES writes error marker" {
+    META="$TMP_DIR/meta-err-empty-arr"
+    METADATA_DIR="$META" OUTCOME=failure VULNERABLE_CHANGES='[]' \
+        run "$TOOL_DIR/mark_error.sh"
+    [ "$status" -eq 0 ]
+    [ -f "$META/error" ]
+}
+
+@test "mark_error: non-empty VULNERABLE_CHANGES does NOT write error marker" {
+    # Findings exit: dep-review populated vulnerable-changes. The SARIF
+    # produced by collect_outputs.sh already encodes the findings, so
+    # check_results.sh will fail on the SARIF count. Writing an error
+    # marker here would misreport findings as a tool error.
+    META="$TMP_DIR/meta-findings"
+    VC='[{"change_type":"added","manifest":"package.json","ecosystem":"npm","name":"x","version":"1","vulnerabilities":[{"severity":"high","advisory_ghsa_id":"GHSA-x","advisory_summary":"s","advisory_url":"u"}]}]'
+    METADATA_DIR="$META" OUTCOME=failure VULNERABLE_CHANGES="$VC" \
+        run "$TOOL_DIR/mark_error.sh"
+    [ "$status" -eq 0 ]
+    [ ! -f "$META/error" ]
+}
+
+@test "mark_error: missing METADATA_DIR exits non-zero" {
+    run env -u METADATA_DIR OUTCOME=failure VULNERABLE_CHANGES='' "$TOOL_DIR/mark_error.sh"
+    [ "$status" -ne 0 ]
+}
+
 @test "converter: empty array -> SARIF with zero results" {
     printf '[]' > "$TMP_DIR/in.json"
     run "$TOOL_DIR/vulnerable_changes_to_sarif.sh" "$TMP_DIR/in.json"

--- a/tools/dependency-review/test.bats
+++ b/tools/dependency-review/test.bats
@@ -109,6 +109,43 @@ teardown() {
     [ -f "$META/error" ]
 }
 
+# --- Robust empty detection (PR #262 review): defend against upstream
+#     swapping the wire format. The detection delegates to jq rather
+#     than literal string compare, so all of these must mark.
+
+@test "mark_error: whitespace-wrapped [] writes error marker" {
+    META="$TMP_DIR/meta-err-ws-arr"
+    METADATA_DIR="$META" OUTCOME=failure VULNERABLE_CHANGES='  [ ]  ' \
+        run "$TOOL_DIR/mark_error.sh"
+    [ "$status" -eq 0 ]
+    [ -f "$META/error" ]
+}
+
+@test "mark_error: pretty-printed empty [\\n] writes error marker" {
+    META="$TMP_DIR/meta-err-pretty-arr"
+    # shellcheck disable=SC2034
+    METADATA_DIR="$META" OUTCOME=failure VULNERABLE_CHANGES=$'[\n]' \
+        run "$TOOL_DIR/mark_error.sh"
+    [ "$status" -eq 0 ]
+    [ -f "$META/error" ]
+}
+
+@test "mark_error: literal null writes error marker" {
+    META="$TMP_DIR/meta-err-null"
+    METADATA_DIR="$META" OUTCOME=failure VULNERABLE_CHANGES='null' \
+        run "$TOOL_DIR/mark_error.sh"
+    [ "$status" -eq 0 ]
+    [ -f "$META/error" ]
+}
+
+@test "mark_error: unparseable JSON writes error marker (cannot trust upstream)" {
+    META="$TMP_DIR/meta-err-bad"
+    METADATA_DIR="$META" OUTCOME=failure VULNERABLE_CHANGES='not json' \
+        run "$TOOL_DIR/mark_error.sh"
+    [ "$status" -eq 0 ]
+    [ -f "$META/error" ]
+}
+
 @test "mark_error: non-empty VULNERABLE_CHANGES does NOT write error marker" {
     # Findings exit: dep-review populated vulnerable-changes. The SARIF
     # produced by collect_outputs.sh already encodes the findings, so

--- a/tools/zizmor/SPEC.md
+++ b/tools/zizmor/SPEC.md
@@ -9,7 +9,7 @@
 | SARIF upload | Handled by the upstream action (wrangle does not upload separately) |
 | Default policy | `:fail` — workflow security issues block the check |
 | Suppression | `.zizmor.yml` at repo root configures accepted findings. Suppress only documented false positives, not convenience silencing |
-| Tool-error handling | `continue-on-error: true` on the upstream step is required so the SARIF collection step can access outputs after zizmor finds issues (exit code 14). The collection step distinguishes "found issues" (SARIF present) from "tool error" (no SARIF output and upstream outcome is `failure`); the error case writes an `error` marker that `lib/check_results.sh` reads to fail closed for `:fail` policy. The "Check results" step in the scan action is the actual pass/fail gate. |
+| Tool-error handling | `continue-on-error: true` on the upstream step is required so the SARIF collection step can access outputs after zizmor finds issues (exit code 14). `collect_sarif.sh` disambiguates "found issues" from "tool error": when upstream outcome is `failure` and the SARIF is missing, empty, malformed, or reports zero results, it writes an `error` marker that `lib/check_results.sh` reads to fail closed for `:fail` policy. A parseable SARIF with `>0` results is preserved as findings so `:info` policy reports findings informationally rather than as an error. The "Check results" step in the scan action is the actual pass/fail gate. |
 
 ## Install paths
 

--- a/tools/zizmor/SPEC.md
+++ b/tools/zizmor/SPEC.md
@@ -9,7 +9,7 @@
 | SARIF upload | Handled by the upstream action (wrangle does not upload separately) |
 | Default policy | `:fail` — workflow security issues block the check |
 | Suppression | `.zizmor.yml` at repo root configures accepted findings. Suppress only documented false positives, not convenience silencing |
-| Known limitations | `continue-on-error: true` on the upstream step is required so the SARIF collection step can access outputs after zizmor finds issues (exit code 14). The "Check results" step in the scan action is the actual pass/fail gate. |
+| Tool-error handling | `continue-on-error: true` on the upstream step is required so the SARIF collection step can access outputs after zizmor finds issues (exit code 14). The collection step distinguishes "found issues" (SARIF present) from "tool error" (no SARIF output and upstream outcome is `failure`); the error case writes an `error` marker that `lib/check_results.sh` reads to fail closed for `:fail` policy. The "Check results" step in the scan action is the actual pass/fail gate. |
 
 ## Install paths
 

--- a/tools/zizmor/action.yml
+++ b/tools/zizmor/action.yml
@@ -41,16 +41,31 @@ runs:
     - name: Collect SARIF output
       if: always()
       shell: bash
-      # Route step output through env: to prevent expression injection
+      # Route step output through env: to prevent expression injection.
+      # OUTCOME lets us distinguish a real zizmor error (no SARIF produced)
+      # from "found issues" (zizmor exits 14 but writes valid SARIF first).
+      # See issue #222: without this, a tool error produces an empty SARIF
+      # that check_results.sh reads as "0 findings" — fail open.
       env:
         SARIF_SRC: ${{ steps.zizmor.outputs.output-file }}
+        OUTCOME: ${{ steps.zizmor.outcome }}
       run: |
         set -euo pipefail
-        SARIF_DST="${GITHUB_WORKSPACE}/.wrangle/metadata/zizmor/output.sarif"
+        META="${GITHUB_WORKSPACE}/.wrangle/metadata/zizmor"
+        SARIF_DST="$META/output.sarif"
         if [[ -n "$SARIF_SRC" ]] && [[ -f "$SARIF_SRC" ]]; then
             cp "$SARIF_SRC" "$SARIF_DST"
         else
-            # If no SARIF produced, create an empty one
+            # No SARIF produced. If the upstream step failed, this is a
+            # tool error (not "ran clean"): drop a marker so check_results.sh
+            # fails closed for :fail policy. Findings cause exit 14 *after*
+            # SARIF is written, so they take the cp branch above.
+            if [[ "$OUTCOME" == "failure" ]]; then
+                printf 'upstream zizmor-action exited non-zero with no SARIF output (outcome=%s)\n' \
+                    "$OUTCOME" > "$META/error"
+            fi
+            # Create an empty SARIF so the summary collector and Code
+            # Scanning upload still have a file to read.
             jq -n '{
                 "version": "2.1.0",
                 "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",

--- a/tools/zizmor/action.yml
+++ b/tools/zizmor/action.yml
@@ -41,11 +41,9 @@ runs:
     - name: Collect SARIF output
       if: always()
       shell: bash
-      # Route step output through env: to prevent expression injection.
-      # Logic lives in collect_sarif.sh, not inline here — see CLAUDE.md
-      # "Inline Shell in GitHub Actions". The script disambiguates a real
-      # tool error from "found issues" and writes the error marker that
-      # lib/check_results.sh consumes to fail closed (issue #222).
+      # Step output routed via env: to prevent expression injection.
+      # collect_sarif.sh disambiguates "found issues" from "tool error"
+      # and writes the marker check_results.sh consumes to fail closed.
       env:
         TOOL_DIR: ${{ github.action_path }}
         SARIF_SRC: ${{ steps.zizmor.outputs.output-file }}

--- a/tools/zizmor/action.yml
+++ b/tools/zizmor/action.yml
@@ -42,36 +42,16 @@ runs:
       if: always()
       shell: bash
       # Route step output through env: to prevent expression injection.
-      # OUTCOME lets us distinguish a real zizmor error (no SARIF produced)
-      # from "found issues" (zizmor exits 14 but writes valid SARIF first).
-      # See issue #222: without this, a tool error produces an empty SARIF
-      # that check_results.sh reads as "0 findings" — fail open.
+      # Logic lives in collect_sarif.sh, not inline here — see CLAUDE.md
+      # "Inline Shell in GitHub Actions". The script disambiguates a real
+      # tool error from "found issues" and writes the error marker that
+      # lib/check_results.sh consumes to fail closed (issue #222).
       env:
+        TOOL_DIR: ${{ github.action_path }}
         SARIF_SRC: ${{ steps.zizmor.outputs.output-file }}
         OUTCOME: ${{ steps.zizmor.outcome }}
       run: |
-        set -euo pipefail
-        META="${GITHUB_WORKSPACE}/.wrangle/metadata/zizmor"
-        SARIF_DST="$META/output.sarif"
-        if [[ -n "$SARIF_SRC" ]] && [[ -f "$SARIF_SRC" ]]; then
-            cp "$SARIF_SRC" "$SARIF_DST"
-        else
-            # No SARIF produced. If the upstream step failed, this is a
-            # tool error (not "ran clean"): drop a marker so check_results.sh
-            # fails closed for :fail policy. Findings cause exit 14 *after*
-            # SARIF is written, so they take the cp branch above.
-            if [[ "$OUTCOME" == "failure" ]]; then
-                printf 'upstream zizmor-action exited non-zero with no SARIF output (outcome=%s)\n' \
-                    "$OUTCOME" > "$META/error"
-            fi
-            # Create an empty SARIF so the summary collector and Code
-            # Scanning upload still have a file to read.
-            jq -n '{
-                "version": "2.1.0",
-                "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-                "runs": [{"tool": {"driver": {"name": "zizmor"}}, "results": []}]
-            }' > "$SARIF_DST"
-        fi
+        "$TOOL_DIR/collect_sarif.sh" "${GITHUB_WORKSPACE}/.wrangle/metadata/zizmor"
 
     - name: Generate human-readable output
       if: always()

--- a/tools/zizmor/collect_sarif.sh
+++ b/tools/zizmor/collect_sarif.sh
@@ -83,17 +83,23 @@ if [[ -n "$SARIF_SRC" ]] && [[ -f "$SARIF_SRC" ]] && [[ -s "$SARIF_SRC" ]]; then
     fi
 fi
 
-if [[ "$OUTCOME" == "failure" ]] && (( src_count <= 0 )); then
+if [[ "$OUTCOME" == "failure" ]] && [[ "$src_count" -le 0 ]]; then
     # Tool error: upstream failed and the SARIF either does not exist,
     # is empty, fails to parse, or contains zero results. None of these
     # correspond to "zizmor ran cleanly and found nothing" (that would
     # be outcome=success). Drop the marker so check_results.sh fails
     # closed for :fail and logs informatively for :info.
+    #
+    # `[[ -le ]]` (rather than `(( ))`) is deliberate: arithmetic
+    # contexts exit non-zero when the expression evaluates to 0, which
+    # under `set -e` could short-circuit before the marker write if
+    # a future edit broke the && chain. `[[ ]]` always returns the
+    # comparison result without side effects.
     printf 'upstream zizmor-action exited non-zero with no usable SARIF output (outcome=%s)\n' \
         "$OUTCOME" > "$ERROR_MARKER"
 fi
 
-if (( src_count >= 0 )); then
+if [[ "$src_count" -ge 0 ]]; then
     # SARIF parses — copy as-is. Note that for OUTCOME=failure with
     # src_count == 0 we have already written the marker above, so this
     # copy is purely so the step-summary collector and any Code Scanning

--- a/tools/zizmor/collect_sarif.sh
+++ b/tools/zizmor/collect_sarif.sh
@@ -2,32 +2,19 @@
 set -euo pipefail
 set -f  # disable globbing — processes external tool output
 
-# collect_sarif.sh — collect the zizmor SARIF into the wrangle metadata
-# directory and disambiguate "found issues" from "tool error" so
-# lib/check_results.sh can fail closed on real errors.
+# collect_sarif.sh — collect zizmor SARIF and disambiguate "found
+# issues" from "tool error" for lib/check_results.sh.
 #
-# Hidden upstream constraint: zizmorcore/zizmor-action pipes through
-# `tee` and always exports the output-file path, so SARIF_SRC is always
-# non-empty and the file always exists — even on image-pull failure or
-# mid-run crash, when its contents are empty/truncated/garbled. We
-# therefore can't infer success from "file present"; we must inspect it.
-#
-# Disambiguation: on OUTCOME == "failure", trust the SARIF only when it
-# parses AND contains at least one result. zizmor exits 14 (→
-# outcome=failure) only after writing a complete SARIF with findings;
-# everything else (missing, empty, malformed, or zero results with
-# outcome=failure) is a tool error and gets the marker. A partially-
-# truncated parseable SARIF is preserved so :fail still blocks via the
-# count — it may under-report, but never silently drops to zero.
-#
-# Inputs (env):
-#   SARIF_SRC — upstream action's output-file path
-#   OUTCOME   — upstream step's outcome string (success/failure/etc.)
-# Args: $1 — metadata directory.
-# Side effects: writes <metadata_dir>/output.sarif (real or synthesised
-# empty) and <metadata_dir>/error on tool error.
-# Exit: always 0 — the marker, not this script's exit code, is what
-# check_results.sh consumes.
+# Hidden upstream constraint: zizmor-action pipes through `tee`, so
+# SARIF_SRC always exists even on image-pull failure or mid-run crash
+# (then empty/truncated). File presence does not imply success — we
+# must inspect contents. zizmor exits 14 (→ outcome=failure) only after
+# writing a complete SARIF with findings; anything else under
+# outcome=failure is a tool error.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../lib/write_tool_error_marker.sh
+source "$SCRIPT_DIR/../../lib/write_tool_error_marker.sh"
 
 if [[ $# -ne 1 ]]; then
     printf 'Usage: collect_sarif.sh <metadata_dir>\n' >&2
@@ -38,9 +25,7 @@ METADATA_DIR="$1"
 mkdir -p "$METADATA_DIR"
 
 SARIF_DST="${METADATA_DIR}/output.sarif"
-ERROR_MARKER="${METADATA_DIR}/error"
 
-# Default missing env so set -u doesn't trip.
 : "${OUTCOME:=}"
 SARIF_SRC="${SARIF_SRC:-}"
 
@@ -58,8 +43,8 @@ fi
 # `[[ -le ]]` not `(( ))`: an arithmetic 0 exits non-zero, which under
 # set -e could short-circuit a future && chain before the marker write.
 if [[ "$OUTCOME" == "failure" ]] && [[ "$src_count" -le 0 ]]; then
-    printf 'upstream zizmor-action exited non-zero with no usable SARIF output (outcome=%s)\n' \
-        "$OUTCOME" > "$ERROR_MARKER"
+    wrangle_write_tool_error_marker "$METADATA_DIR" \
+        "upstream zizmor-action exited non-zero with no usable SARIF output (outcome=${OUTCOME})"
 fi
 
 if [[ "$src_count" -ge 0 ]]; then
@@ -74,5 +59,4 @@ else
     }' > "$SARIF_DST"
 fi
 
-# Always succeed: errors and findings are communicated via marker + SARIF.
 exit 0

--- a/tools/zizmor/collect_sarif.sh
+++ b/tools/zizmor/collect_sarif.sh
@@ -117,3 +117,9 @@ else
         "runs": [{"tool": {"driver": {"name": "zizmor"}}, "results": []}]
     }' > "$SARIF_DST"
 fi
+
+# Explicit exit 0: this script's role is to drop the marker and a SARIF
+# file for the downstream gate (check_results.sh) to consume. Whether
+# the upstream tool errored or found issues is communicated via those
+# artifacts, not our exit code, so we always succeed.
+exit 0

--- a/tools/zizmor/collect_sarif.sh
+++ b/tools/zizmor/collect_sarif.sh
@@ -3,55 +3,30 @@ set -euo pipefail
 set -f  # disable globbing — processes external tool output
 
 # collect_sarif.sh — collect the zizmor SARIF into the wrangle metadata
-# directory, and disambiguate "found issues" from "tool error" so
+# directory and disambiguate "found issues" from "tool error" so
 # lib/check_results.sh can fail closed on real errors.
 #
-# Background (issue #222):
-#   The upstream zizmorcore/zizmor-action runs `docker run … | tee
-#   "${output}"` and unconditionally exports the output-file path when
-#   `advanced-security: true`. That means:
-#     * `SARIF_SRC` is *always* non-empty in our config.
-#     * The file referenced by `SARIF_SRC` exists regardless of whether
-#       docker succeeded — `tee` creates it eagerly. On image-pull
-#       failure, OOM, or a mid-run crash, the file is empty or holds
-#       partial/garbled JSON.
-#   The previous implementation only wrote the tool-error marker on the
-#   "no SARIF" branch, which therefore never fired for the common error
-#   modes — check_results.sh would read the empty file as zero findings
-#   and fail open. See the discussion on PR #262.
+# Hidden upstream constraint: zizmorcore/zizmor-action pipes through
+# `tee` and always exports the output-file path, so SARIF_SRC is always
+# non-empty and the file always exists — even on image-pull failure or
+# mid-run crash, when its contents are empty/truncated/garbled. We
+# therefore can't infer success from "file present"; we must inspect it.
 #
-# Disambiguation strategy:
-#   On OUTCOME == "failure", trust the SARIF only when it parses AND
-#   contains at least one result. zizmor exits 14 (→ outcome=failure)
-#   only after writing a complete SARIF with findings, so a parseable
-#   SARIF with results correlates with "real findings". Everything else
-#   (file missing, empty, malformed, or zero results with outcome
-#   failure) is treated as a tool error: we write the marker so the
-#   downstream check_results.sh step fails closed for :fail policy and
-#   logs informatively for :info policy.
-#
-#   A SARIF that parses but is partially truncated (e.g., docker crashed
-#   mid-stream after some findings) is preserved and reported via the
-#   normal count path. That may under-report relative to what a clean
-#   run would have shown, but it never silently drops to zero — :fail
-#   policy still blocks because the count is > 0.
+# Disambiguation: on OUTCOME == "failure", trust the SARIF only when it
+# parses AND contains at least one result. zizmor exits 14 (→
+# outcome=failure) only after writing a complete SARIF with findings;
+# everything else (missing, empty, malformed, or zero results with
+# outcome=failure) is a tool error and gets the marker. A partially-
+# truncated parseable SARIF is preserved so :fail still blocks via the
+# count — it may under-report, but never silently drops to zero.
 #
 # Inputs (env):
-#   SARIF_SRC  — upstream action's output-file path (may point at a
-#                missing/empty/garbage file)
-#   OUTCOME    — upstream step's outcome string (success/failure/etc.)
-#
-# Args:
-#   $1 — metadata directory (e.g.,
-#        $GITHUB_WORKSPACE/.wrangle/metadata/zizmor)
-#
-# Side effects:
-#   * Writes <metadata_dir>/output.sarif (copy of upstream's SARIF, or
-#     a synthesised empty SARIF if upstream produced none/garbage).
-#   * Writes <metadata_dir>/error when the upstream step failed and the
-#     SARIF is not a parseable SARIF with at least one finding.
-#
-# Exit: 0 on success — the marker, not this script's exit code, is what
+#   SARIF_SRC — upstream action's output-file path
+#   OUTCOME   — upstream step's outcome string (success/failure/etc.)
+# Args: $1 — metadata directory.
+# Side effects: writes <metadata_dir>/output.sarif (real or synthesised
+# empty) and <metadata_dir>/error on tool error.
+# Exit: always 0 — the marker, not this script's exit code, is what
 # check_results.sh consumes.
 
 if [[ $# -ne 1 ]]; then
@@ -65,52 +40,33 @@ mkdir -p "$METADATA_DIR"
 SARIF_DST="${METADATA_DIR}/output.sarif"
 ERROR_MARKER="${METADATA_DIR}/error"
 
-# Default OUTCOME so missing env doesn't trigger set -u.
+# Default missing env so set -u doesn't trip.
 : "${OUTCOME:=}"
 SARIF_SRC="${SARIF_SRC:-}"
 
-# Inspect the upstream SARIF: does it parse, and does it report results?
-# `jq -e` exits non-zero on null/false/parse-failure, so a missing or
-# malformed file falls through to count=-1 and trips the error path.
+# src_count: -1 sentinel = "no usable SARIF" (missing / empty / unparseable /
+# non-numeric jq output). Any non-negative value is a real finding count.
 src_count=-1
 if [[ -n "$SARIF_SRC" ]] && [[ -f "$SARIF_SRC" ]] && [[ -s "$SARIF_SRC" ]]; then
     if parsed_count="$(jq '[.runs[]?.results[]?] | length' "$SARIF_SRC" 2>/dev/null)"; then
-        # Numeric sanity check — defend against jq returning something
-        # unexpected on weird inputs.
         if [[ "$parsed_count" =~ ^[0-9]+$ ]]; then
             src_count="$parsed_count"
         fi
     fi
 fi
 
+# `[[ -le ]]` not `(( ))`: an arithmetic 0 exits non-zero, which under
+# set -e could short-circuit a future && chain before the marker write.
 if [[ "$OUTCOME" == "failure" ]] && [[ "$src_count" -le 0 ]]; then
-    # Tool error: upstream failed and the SARIF either does not exist,
-    # is empty, fails to parse, or contains zero results. None of these
-    # correspond to "zizmor ran cleanly and found nothing" (that would
-    # be outcome=success). Drop the marker so check_results.sh fails
-    # closed for :fail and logs informatively for :info.
-    #
-    # `[[ -le ]]` (rather than `(( ))`) is deliberate: arithmetic
-    # contexts exit non-zero when the expression evaluates to 0, which
-    # under `set -e` could short-circuit before the marker write if
-    # a future edit broke the && chain. `[[ ]]` always returns the
-    # comparison result without side effects.
     printf 'upstream zizmor-action exited non-zero with no usable SARIF output (outcome=%s)\n' \
         "$OUTCOME" > "$ERROR_MARKER"
 fi
 
 if [[ "$src_count" -ge 0 ]]; then
-    # SARIF parses — copy as-is. Note that for OUTCOME=failure with
-    # src_count == 0 we have already written the marker above, so this
-    # copy is purely so the step-summary collector and any Code Scanning
-    # upload still see a file. For OUTCOME=failure with src_count > 0
-    # (real findings), no marker exists and the count flows through
-    # check_results.sh as findings, preserving :info-policy semantics.
     cp "$SARIF_SRC" "$SARIF_DST"
 else
-    # No usable upstream SARIF — synthesise an empty one so downstream
-    # consumers (summary collector, Code Scanning upload) have a file.
-    # The marker, if appropriate, was written above.
+    # Synthesise an empty SARIF so the summary collector and Code Scanning
+    # upload still have a file; the marker (if any) is the error signal.
     jq -n '{
         "version": "2.1.0",
         "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
@@ -118,8 +74,5 @@ else
     }' > "$SARIF_DST"
 fi
 
-# Explicit exit 0: this script's role is to drop the marker and a SARIF
-# file for the downstream gate (check_results.sh) to consume. Whether
-# the upstream tool errored or found issues is communicated via those
-# artifacts, not our exit code, so we always succeed.
+# Always succeed: errors and findings are communicated via marker + SARIF.
 exit 0

--- a/tools/zizmor/collect_sarif.sh
+++ b/tools/zizmor/collect_sarif.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — processes external tool output
+
+# collect_sarif.sh — collect the zizmor SARIF into the wrangle metadata
+# directory, and disambiguate "found issues" from "tool error" so
+# lib/check_results.sh can fail closed on real errors.
+#
+# Background (issue #222):
+#   The upstream zizmorcore/zizmor-action runs `docker run … | tee
+#   "${output}"` and unconditionally exports the output-file path when
+#   `advanced-security: true`. That means:
+#     * `SARIF_SRC` is *always* non-empty in our config.
+#     * The file referenced by `SARIF_SRC` exists regardless of whether
+#       docker succeeded — `tee` creates it eagerly. On image-pull
+#       failure, OOM, or a mid-run crash, the file is empty or holds
+#       partial/garbled JSON.
+#   The previous implementation only wrote the tool-error marker on the
+#   "no SARIF" branch, which therefore never fired for the common error
+#   modes — check_results.sh would read the empty file as zero findings
+#   and fail open. See the discussion on PR #262.
+#
+# Disambiguation strategy:
+#   On OUTCOME == "failure", trust the SARIF only when it parses AND
+#   contains at least one result. zizmor exits 14 (→ outcome=failure)
+#   only after writing a complete SARIF with findings, so a parseable
+#   SARIF with results correlates with "real findings". Everything else
+#   (file missing, empty, malformed, or zero results with outcome
+#   failure) is treated as a tool error: we write the marker so the
+#   downstream check_results.sh step fails closed for :fail policy and
+#   logs informatively for :info policy.
+#
+#   A SARIF that parses but is partially truncated (e.g., docker crashed
+#   mid-stream after some findings) is preserved and reported via the
+#   normal count path. That may under-report relative to what a clean
+#   run would have shown, but it never silently drops to zero — :fail
+#   policy still blocks because the count is > 0.
+#
+# Inputs (env):
+#   SARIF_SRC  — upstream action's output-file path (may point at a
+#                missing/empty/garbage file)
+#   OUTCOME    — upstream step's outcome string (success/failure/etc.)
+#
+# Args:
+#   $1 — metadata directory (e.g.,
+#        $GITHUB_WORKSPACE/.wrangle/metadata/zizmor)
+#
+# Side effects:
+#   * Writes <metadata_dir>/output.sarif (copy of upstream's SARIF, or
+#     a synthesised empty SARIF if upstream produced none/garbage).
+#   * Writes <metadata_dir>/error when the upstream step failed and the
+#     SARIF is not a parseable SARIF with at least one finding.
+#
+# Exit: 0 on success — the marker, not this script's exit code, is what
+# check_results.sh consumes.
+
+if [[ $# -ne 1 ]]; then
+    printf 'Usage: collect_sarif.sh <metadata_dir>\n' >&2
+    exit 1
+fi
+
+METADATA_DIR="$1"
+mkdir -p "$METADATA_DIR"
+
+SARIF_DST="${METADATA_DIR}/output.sarif"
+ERROR_MARKER="${METADATA_DIR}/error"
+
+# Default OUTCOME so missing env doesn't trigger set -u.
+: "${OUTCOME:=}"
+SARIF_SRC="${SARIF_SRC:-}"
+
+# Inspect the upstream SARIF: does it parse, and does it report results?
+# `jq -e` exits non-zero on null/false/parse-failure, so a missing or
+# malformed file falls through to count=-1 and trips the error path.
+src_count=-1
+if [[ -n "$SARIF_SRC" ]] && [[ -f "$SARIF_SRC" ]] && [[ -s "$SARIF_SRC" ]]; then
+    if parsed_count="$(jq '[.runs[]?.results[]?] | length' "$SARIF_SRC" 2>/dev/null)"; then
+        # Numeric sanity check — defend against jq returning something
+        # unexpected on weird inputs.
+        if [[ "$parsed_count" =~ ^[0-9]+$ ]]; then
+            src_count="$parsed_count"
+        fi
+    fi
+fi
+
+if [[ "$OUTCOME" == "failure" ]] && (( src_count <= 0 )); then
+    # Tool error: upstream failed and the SARIF either does not exist,
+    # is empty, fails to parse, or contains zero results. None of these
+    # correspond to "zizmor ran cleanly and found nothing" (that would
+    # be outcome=success). Drop the marker so check_results.sh fails
+    # closed for :fail and logs informatively for :info.
+    printf 'upstream zizmor-action exited non-zero with no usable SARIF output (outcome=%s)\n' \
+        "$OUTCOME" > "$ERROR_MARKER"
+fi
+
+if (( src_count >= 0 )); then
+    # SARIF parses — copy as-is. Note that for OUTCOME=failure with
+    # src_count == 0 we have already written the marker above, so this
+    # copy is purely so the step-summary collector and any Code Scanning
+    # upload still see a file. For OUTCOME=failure with src_count > 0
+    # (real findings), no marker exists and the count flows through
+    # check_results.sh as findings, preserving :info-policy semantics.
+    cp "$SARIF_SRC" "$SARIF_DST"
+else
+    # No usable upstream SARIF — synthesise an empty one so downstream
+    # consumers (summary collector, Code Scanning upload) have a file.
+    # The marker, if appropriate, was written above.
+    jq -n '{
+        "version": "2.1.0",
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+        "runs": [{"tool": {"driver": {"name": "zizmor"}}, "results": []}]
+    }' > "$SARIF_DST"
+fi

--- a/tools/zizmor/test.bats
+++ b/tools/zizmor/test.bats
@@ -1,14 +1,11 @@
 #!/usr/bin/env bats
 
-# Tests for tools/zizmor/ (action pattern)
+# Tests for tools/zizmor/ (action pattern).
 #
-# Action-pattern tools wrap an upstream GitHub Action, so there is no
-# install.sh or adapter.sh to unit-test. These tests validate the
-# action.yml structure plus the collect_sarif.sh helper which performs
-# the fail-closed disambiguation for issue #222.
-#
-# Full integration testing happens in CI when the scan action invokes
-# tools/zizmor/action.yml against the wrangle repo itself (dogfooding).
+# Action-pattern tools wrap an upstream GitHub Action; there's no
+# install.sh or adapter.sh to unit-test. These cover action.yml
+# structure plus collect_sarif.sh's fail-closed disambiguation. Full
+# integration testing happens via dogfooding in CI.
 
 setup() {
     export ORIG_DIR="$(pwd)"
@@ -118,7 +115,7 @@ make_sarif() {
     [ -x "$TOOL_DIR/collect_sarif.sh" ]
 }
 
-# --- collect_sarif.sh: fail-closed disambiguation (issue #222) ---
+# --- collect_sarif.sh: fail-closed disambiguation ---
 
 @test "collect_sarif: usage error when metadata dir arg missing" {
     run "$TOOL_DIR/collect_sarif.sh"
@@ -174,8 +171,8 @@ make_sarif() {
 }
 
 @test "collect_sarif: outcome=failure + empty SARIF file → marker written" {
-    # Reproduces the original #222 fail-open: upstream `tee` created the
-    # file but docker crashed before zizmor wrote anything.
+    # Upstream `tee` creates the file eagerly; docker crashing before
+    # zizmor writes anything leaves it empty. The original fail-open.
     META="$TMP_DIR/meta-empty"
     mkdir -p "$META"
     SRC="$TMP_DIR/src-empty.sarif"

--- a/tools/zizmor/test.bats
+++ b/tools/zizmor/test.bats
@@ -4,43 +4,68 @@
 #
 # Action-pattern tools wrap an upstream GitHub Action, so there is no
 # install.sh or adapter.sh to unit-test. These tests validate the
-# action.yml structure and that supporting files are correct.
+# action.yml structure plus the collect_sarif.sh helper which performs
+# the fail-closed disambiguation for issue #222.
 #
 # Full integration testing happens in CI when the scan action invokes
 # tools/zizmor/action.yml against the wrangle repo itself (dogfooding).
 
 setup() {
     export ORIG_DIR="$(pwd)"
+    export TOOL_DIR="$ORIG_DIR/tools/zizmor"
+    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/zizmor-bats-XXXXXX")"
+    export TMP_DIR
 }
 
+teardown() {
+    if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# Helper: write a SARIF fixture with $1 findings to $2.
+make_sarif() {
+    local count="$1"
+    local dst="$2"
+    local results="[]"
+    if [[ "$count" -gt 0 ]]; then
+        results="$(jq -n --argjson n "$count" '[range($n) | {"ruleId":"TEST-\(.)","message":{"text":"x"}}]')"
+    fi
+    jq -n --argjson r "$results" \
+        '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"zizmor"}},"results":$r}]}' \
+        > "$dst"
+}
+
+# --- action.yml structure ---
+
 @test "zizmor: action.yml exists and is valid YAML" {
-    [ -f "$ORIG_DIR/tools/zizmor/action.yml" ]
+    [ -f "$TOOL_DIR/action.yml" ]
 }
 
 @test "zizmor: action.yml pins upstream action to SHA" {
-    grep -q 'zizmorcore/zizmor-action@[0-9a-f]\{40\}' "$ORIG_DIR/tools/zizmor/action.yml"
+    grep -q 'zizmorcore/zizmor-action@[0-9a-f]\{40\}' "$TOOL_DIR/action.yml"
 }
 
 @test "zizmor: action.yml has version input" {
-    grep -q 'version:' "$ORIG_DIR/tools/zizmor/action.yml"
+    grep -q 'version:' "$TOOL_DIR/action.yml"
 }
 
 @test "zizmor: no install.sh exists (action pattern, not adapter)" {
-    [ ! -f "$ORIG_DIR/tools/zizmor/install.sh" ]
+    [ ! -f "$TOOL_DIR/install.sh" ]
 }
 
 @test "zizmor: no adapter.sh exists (action pattern, not adapter)" {
-    [ ! -f "$ORIG_DIR/tools/zizmor/adapter.sh" ]
+    [ ! -f "$TOOL_DIR/adapter.sh" ]
 }
 
 @test "zizmor: action.yml sets advanced-security to true" {
     # advanced-security: true is required for the upstream action to produce
     # SARIF output. See issue #109 and #114.
-    grep -q 'advanced-security: true' "$ORIG_DIR/tools/zizmor/action.yml"
+    grep -q 'advanced-security: true' "$TOOL_DIR/action.yml"
 }
 
 @test "zizmor: action.yml writes to wrangle metadata directory" {
-    grep -q '\.wrangle/metadata/zizmor' "$ORIG_DIR/tools/zizmor/action.yml"
+    grep -q '\.wrangle/metadata/zizmor' "$TOOL_DIR/action.yml"
 }
 
 @test "zizmor: requirements.txt and action.yml default agree on version" {
@@ -71,13 +96,158 @@ setup() {
     grep -qE '"/tools/(zizmor|\*\*)"' "$ORIG_DIR/.github/dependabot.yml"
 }
 
-@test "zizmor: action.yml writes error marker when upstream fails without SARIF" {
-    # Fail-open fix from issue #222: when the upstream step errors out
-    # (no SARIF produced) AND its outcome is failure, write an `error`
-    # marker file the Check results step treats as a hard failure.
-    # The collection step's else branch must reference both the outcome
-    # check and write to the error marker path.
-    grep -Fq 'OUTCOME: ${{ steps.zizmor.outcome }}' "$ORIG_DIR/tools/zizmor/action.yml"
-    grep -Fq '"$OUTCOME" == "failure"' "$ORIG_DIR/tools/zizmor/action.yml"
-    grep -Fq '/error"' "$ORIG_DIR/tools/zizmor/action.yml"
+@test "zizmor: action.yml delegates SARIF collection to a script, not inline shell" {
+    # Per CLAUDE.md, run: blocks with logic must be extracted to scripts.
+    # The collection step's run: block should just invoke collect_sarif.sh.
+    grep -q 'collect_sarif.sh' "$TOOL_DIR/action.yml"
+    # The "Collect SARIF output" run: block must contain no inline
+    # conditionals — extract everything to collect_sarif.sh. We scope this
+    # check to the collection step only; the small "Generate human-readable
+    # output" step retains its `[[ -f $SARIF ]]` guard.
+    run awk '/^    - name: Collect SARIF output/{flag=1;next} flag && /^    - name:/{flag=0} flag' "$TOOL_DIR/action.yml"
+    [ "$status" -eq 0 ]
+    ! printf '%s\n' "$output" | grep -Eq '^\s+(if|for|while) '
+}
+
+@test "zizmor: action.yml passes upstream output via env, not direct interpolation" {
+    # Belt-and-braces: run: blocks must not interpolate ${{ steps.* }}.
+    ! grep -E 'run:.*\$\{\{ *steps\.zizmor' "$TOOL_DIR/action.yml"
+}
+
+@test "zizmor: collect_sarif.sh exists and is executable" {
+    [ -x "$TOOL_DIR/collect_sarif.sh" ]
+}
+
+# --- collect_sarif.sh: fail-closed disambiguation (issue #222) ---
+
+@test "collect_sarif: usage error when metadata dir arg missing" {
+    run "$TOOL_DIR/collect_sarif.sh"
+    [ "$status" -eq 1 ]
+}
+
+@test "collect_sarif: outcome=success + valid SARIF → copy, no marker" {
+    # Clean run, zero findings.
+    META="$TMP_DIR/meta-clean"
+    mkdir -p "$META"
+    SRC="$TMP_DIR/src-clean.sarif"
+    make_sarif 0 "$SRC"
+
+    SARIF_SRC="$SRC" OUTCOME=success \
+        run "$TOOL_DIR/collect_sarif.sh" "$META"
+    [ "$status" -eq 0 ]
+    [ -f "$META/output.sarif" ]
+    [ ! -f "$META/error" ]
+    # The copied SARIF round-trips correctly.
+    jq -e '[.runs[].results[]] | length == 0' "$META/output.sarif" >/dev/null
+}
+
+@test "collect_sarif: outcome=failure + valid SARIF with findings → copy, no marker" {
+    # Findings exit (zizmor exit code 14 → upstream outcome=failure).
+    # SARIF is well-formed and reports >0 results, so we trust it.
+    # check_results.sh will fail-close via SARIF count for :fail; :info
+    # will report findings informationally (not as an error).
+    META="$TMP_DIR/meta-findings"
+    mkdir -p "$META"
+    SRC="$TMP_DIR/src-findings.sarif"
+    make_sarif 3 "$SRC"
+
+    SARIF_SRC="$SRC" OUTCOME=failure \
+        run "$TOOL_DIR/collect_sarif.sh" "$META"
+    [ "$status" -eq 0 ]
+    [ -f "$META/output.sarif" ]
+    [ ! -f "$META/error" ]
+    jq -e '[.runs[].results[]] | length == 3' "$META/output.sarif" >/dev/null
+}
+
+@test "collect_sarif: outcome=failure + missing SARIF → marker written" {
+    META="$TMP_DIR/meta-missing"
+    mkdir -p "$META"
+
+    SARIF_SRC="$TMP_DIR/does-not-exist.sarif" OUTCOME=failure \
+        run "$TOOL_DIR/collect_sarif.sh" "$META"
+    [ "$status" -eq 0 ]
+    [ -f "$META/error" ]
+    grep -q 'outcome=failure' "$META/error"
+    # Empty fallback SARIF written so downstream consumers have a file.
+    [ -f "$META/output.sarif" ]
+    jq -e '[.runs[].results[]] | length == 0' "$META/output.sarif" >/dev/null
+}
+
+@test "collect_sarif: outcome=failure + empty SARIF file → marker written" {
+    # Reproduces the original #222 fail-open: upstream `tee` created the
+    # file but docker crashed before zizmor wrote anything.
+    META="$TMP_DIR/meta-empty"
+    mkdir -p "$META"
+    SRC="$TMP_DIR/src-empty.sarif"
+    : > "$SRC"
+
+    SARIF_SRC="$SRC" OUTCOME=failure \
+        run "$TOOL_DIR/collect_sarif.sh" "$META"
+    [ "$status" -eq 0 ]
+    [ -f "$META/error" ]
+}
+
+@test "collect_sarif: outcome=failure + malformed SARIF → marker written" {
+    # docker crashed mid-stream and tee captured truncated/garbled JSON.
+    META="$TMP_DIR/meta-bad"
+    mkdir -p "$META"
+    SRC="$TMP_DIR/src-bad.sarif"
+    printf '{not valid json' > "$SRC"
+
+    SARIF_SRC="$SRC" OUTCOME=failure \
+        run "$TOOL_DIR/collect_sarif.sh" "$META"
+    [ "$status" -eq 0 ]
+    [ -f "$META/error" ]
+}
+
+@test "collect_sarif: outcome=failure + parseable SARIF with zero results → marker written" {
+    # Parseable but reports nothing — combined with outcome=failure this
+    # cannot be a clean findings exit (zizmor only exits 14 *with*
+    # findings), so we treat as tool error and fail closed.
+    META="$TMP_DIR/meta-zero"
+    mkdir -p "$META"
+    SRC="$TMP_DIR/src-zero.sarif"
+    make_sarif 0 "$SRC"
+
+    SARIF_SRC="$SRC" OUTCOME=failure \
+        run "$TOOL_DIR/collect_sarif.sh" "$META"
+    [ "$status" -eq 0 ]
+    [ -f "$META/error" ]
+}
+
+@test "collect_sarif: outcome=failure + empty SARIF_SRC env → marker written" {
+    # Defensive: if the upstream action ever stops exporting output-file,
+    # SARIF_SRC is empty. Combined with outcome=failure that's still a
+    # tool error.
+    META="$TMP_DIR/meta-emptyenv"
+    mkdir -p "$META"
+
+    SARIF_SRC='' OUTCOME=failure \
+        run "$TOOL_DIR/collect_sarif.sh" "$META"
+    [ "$status" -eq 0 ]
+    [ -f "$META/error" ]
+}
+
+@test "collect_sarif: outcome=success + missing SARIF → no marker, empty fallback" {
+    # Upstream succeeded but for some reason produced no file (e.g.,
+    # advanced-security: false path). Do not flag as error.
+    META="$TMP_DIR/meta-succ-nofile"
+    mkdir -p "$META"
+
+    SARIF_SRC="$TMP_DIR/does-not-exist.sarif" OUTCOME=success \
+        run "$TOOL_DIR/collect_sarif.sh" "$META"
+    [ "$status" -eq 0 ]
+    [ ! -f "$META/error" ]
+    [ -f "$META/output.sarif" ]
+}
+
+@test "collect_sarif: creates metadata directory if missing" {
+    META="$TMP_DIR/meta-fresh/zizmor"
+    SRC="$TMP_DIR/src-fresh.sarif"
+    make_sarif 0 "$SRC"
+
+    SARIF_SRC="$SRC" OUTCOME=success \
+        run "$TOOL_DIR/collect_sarif.sh" "$META"
+    [ "$status" -eq 0 ]
+    [ -f "$META/output.sarif" ]
 }

--- a/tools/zizmor/test.bats
+++ b/tools/zizmor/test.bats
@@ -70,3 +70,14 @@ setup() {
     grep -qE 'package-ecosystem: +"pip"' "$ORIG_DIR/.github/dependabot.yml"
     grep -qE '"/tools/(zizmor|\*\*)"' "$ORIG_DIR/.github/dependabot.yml"
 }
+
+@test "zizmor: action.yml writes error marker when upstream fails without SARIF" {
+    # Fail-open fix from issue #222: when the upstream step errors out
+    # (no SARIF produced) AND its outcome is failure, write an `error`
+    # marker file the Check results step treats as a hard failure.
+    # The collection step's else branch must reference both the outcome
+    # check and write to the error marker path.
+    grep -Fq 'OUTCOME: ${{ steps.zizmor.outcome }}' "$ORIG_DIR/tools/zizmor/action.yml"
+    grep -Fq '"$OUTCOME" == "failure"' "$ORIG_DIR/tools/zizmor/action.yml"
+    grep -Fq '/error"' "$ORIG_DIR/tools/zizmor/action.yml"
+}


### PR DESCRIPTION
Closes #222.

## Summary

Action-pattern tools (`zizmor`, `dependency-review`) run their upstream action with `continue-on-error: true` so SARIF collection still runs when the tool exits non-zero on findings. That same setting also swallows genuine **tool errors** (API unavailable, Dependency Graph disabled, network failure) — an errored tool produces an empty SARIF, `check_results.sh` sees 0 findings, and the gate passes. For a supply-chain security tool that is fail-open.

This change distinguishes "tool errored" from "tool found nothing" via an explicit per-tool error marker file (`metadata/<tool>/error`):

- `lib/check_results.sh` treats the marker as fail-closed for `:fail`-policy tools and as a logged-but-non-blocking event for `:info`-policy tools.
- The marker takes precedence over the SARIF count, so a fallback empty SARIF (synthesised so downstream Code Scanning upload / step summary always have a file to read) cannot mask the error.

## Per-tool disambiguation

The issue flagged that we cannot trust the upstream step's `outcome == failure` alone, because that is also `failure` when a tool exits on findings. Each tool gets its own signal:

- **zizmor.** Zizmor's upstream action propagates the underlying exit code. Exit 14 ("found issues") writes valid SARIF before exiting; other errors leave no SARIF. We piggy-back on the existing collection step's `if SARIF_SRC present / else fallback` split: in the `else` branch we now also check `OUTCOME == failure` and, when both, drop the error marker. This is more robust than parsing the exit code from outside the step (which the action does not expose).
- **dependency-review.** The upstream action populates the `vulnerable-changes` output on findings (exit non-zero) and leaves it empty/`[]` on a genuine error. A new `tools/dependency-review/mark_error.sh` writes the marker when `outcome == failure` AND `vulnerable-changes` is empty/`[]`.

Both upstream steps keep `continue-on-error: true` — that is still required so the SARIF collection / output conversion runs on findings.

## Files changed

- `lib/check_results.sh` — read `metadata/<tool>/error` marker; fail closed for `:fail`, log for `:info`; marker takes precedence over SARIF count.
- `tools/zizmor/action.yml` — write marker in the existing empty-SARIF-fallback path when upstream outcome is `failure`.
- `tools/dependency-review/action.yml` — add a `Mark dependency-review tool error` step gated on `outcome == 'failure'`, delegating to `mark_error.sh`.
- `tools/dependency-review/mark_error.sh` — new helper that disambiguates findings-exit from error-exit via `vulnerable-changes`.
- `tools/zizmor/SPEC.md`, `tools/dependency-review/SPEC.md` — replace the documented "fail-open known limitation" with the new tool-error contract.
- `test/test_check_results.bats` — 8 new tests covering marker behaviour, precedence over SARIF count, and `:fail`/`:info` policy interaction.
- `tools/dependency-review/test.bats` — 6 new tests covering the marker step in `action.yml` and `mark_error.sh` behaviour for empty / non-empty `vulnerable-changes` and missing inputs.
- `tools/zizmor/test.bats` — 1 new structural test verifying the marker logic is present in `action.yml`.

## Out of scope / known gaps

- If `collect_outputs.sh` (dep-review) fails with the upstream action succeeding (e.g., malformed JSON from a passing upstream), no marker is written and `check_results.sh` sees no SARIF -> the tool is treated as skipped. This is the same shape as a tool with no SARIF output (Scorecard on PRs) and is unchanged here.
- `scorecard` is `:info` and PR-skipped, so it is intentionally untouched.

## Test plan

- [x] `./test.sh shellcheck` — clean.
- [x] `./test.sh lint` (actionlint) — clean.
- [x] `./test.sh bats` — all 671 tests pass (8 new `check_results.sh` tests + 7 new tool-level tests).
- [x] Verified that the existing "0 findings -> PASS for `:fail` tools" path is unchanged (regression test added).
- [x] Verified the marker takes precedence over both empty SARIF (no double-counting) and a (defensive) findings SARIF.
- [ ] CI must pass on the PR — including the integration workflow.

[Issue #222](https://github.com/TomHennen/wrangle/issues/222)