### PR TITLE
claude: Surface scan findings inline for diagnosis (#158)

### DIFF
--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -92,6 +92,12 @@ runs:
     # Log per-finding lines to the CI log so adopters (and AI agents)
     # can see WHAT each tool flagged without parsing raw SARIF. Purely
     # informational — never affects the build outcome (issue #158).
+    #
+    # STEP ORDERING IS LOAD-BEARING: this step MUST run before
+    # "Check results" so the per-finding context appears ABOVE the
+    # red X failure line in the CI log. Reordering would silently
+    # defeat the issue #158 use case (adopters needing to see WHAT
+    # failed without scrolling past the failure summary).
     - name: Log findings
       if: always()
       shell: bash

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -89,15 +89,9 @@ runs:
           "$WRANGLE_ROOT/lib/format_sarif_summary.sh" "$WRANGLE_METADATA_DIR" >> "$GITHUB_STEP_SUMMARY"
         fi
 
-    # Log per-finding lines to the CI log so adopters (and AI agents)
-    # can see WHAT each tool flagged without parsing raw SARIF. Purely
-    # informational — never affects the build outcome (issue #158).
-    #
-    # STEP ORDERING IS LOAD-BEARING: this step MUST run before
-    # "Check results" so the per-finding context appears ABOVE the
-    # red X failure line in the CI log. Reordering would silently
-    # defeat the issue #158 use case (adopters needing to see WHAT
-    # failed without scrolling past the failure summary).
+    # Per-finding CI-log lines. MUST run before "Check results" so the
+    # finding context appears above the failure line — reordering
+    # silently defeats issue #158.
     - name: Log findings
       if: always()
       shell: bash

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -89,6 +89,19 @@ runs:
           "$WRANGLE_ROOT/lib/format_sarif_summary.sh" "$WRANGLE_METADATA_DIR" >> "$GITHUB_STEP_SUMMARY"
         fi
 
+    # Log per-finding lines to the CI log so adopters (and AI agents)
+    # can see WHAT each tool flagged without parsing raw SARIF. Purely
+    # informational — never affects the build outcome (issue #158).
+    - name: Log findings
+      if: always()
+      shell: bash
+      env:
+        WRANGLE_ROOT: ${{ github.action_path }}/../..
+      run: |
+        # shellcheck source=../../lib/env.sh
+        source "$WRANGLE_ROOT/lib/env.sh"
+        "$WRANGLE_ROOT/lib/log_findings.sh" "$WRANGLE_METADATA_DIR"
+
     # Check results: fail the check if any :fail-policy tool reported
     # findings. Tools with :info policy are noted but don't block.
     - name: Check results

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -287,7 +287,8 @@ wrangle/
 │       └── test.bats
 ├── lib/                    # Shared helpers
 │   ├── download_verify.sh  # wrangle_download_verify(), wrangle_verify_provenance()
-│   ├── format_sarif_summary.sh  # SARIF → markdown summary
+│   ├── format_sarif_summary.sh  # SARIF → markdown summary (with sarif_to_md.sh fallback)
+│   ├── log_findings.sh     # Per-finding CI log lines (issue #158)
 │   ├── sanitize.sh         # wrangle_sanitize_output() — shared HTML stripping + truncation
 │   ├── sarif_to_md.sh      # SARIF → human-readable markdown (per-tool)
 │   └── tool_banner.sh      # Print visual banner for tool log attribution
@@ -898,7 +899,35 @@ All install scripts MUST use `wrangle_download_verify` rather than implementing 
 
 `lib/sanitize.sh` provides `wrangle_sanitize_output()`, a shared function that strips HTML tags and truncates output to `$WRANGLE_MAX_SUMMARY` (default 65536) characters. Sourced by `format_sarif_summary.sh` and `sarif_to_md.sh`. All tool output written to `$GITHUB_STEP_SUMMARY` MUST be passed through this function to prevent HTML/markdown injection.
 
-Action-pattern tools call these helpers from their own `action.yml`. The `format_sarif_summary.sh` script picks up `output.md` (or `output.txt`) to populate the expandable details section in the step summary.
+Action-pattern tools call these helpers from their own `action.yml`. The `format_sarif_summary.sh` script picks up `output.md` (or `output.txt`) to populate the expandable details section in the step summary. **Fallback:** if neither `output.md` nor `output.txt` is present for a tool but `output.sarif` is, `format_sarif_summary.sh` invokes `sarif_to_md.sh` to render the findings table directly. This makes the adapter-contract claim above (orchestrator generates `output.md` from SARIF) hold in the step summary, so adopters can see WHAT was found without opening the raw SARIF artifact. The fallback is skipped when SARIF reports zero findings — the top table already shows "No findings" for that tool. Note: the fallback path is bounded by `wrangle_sanitize_output` inside `sarif_to_md.sh`, so it shares a single `$WRANGLE_MAX_SUMMARY` (64 KB) budget; tools that ship their own `output.md` get a separate 64 KB budget on the `wrangle_sanitize_output < output.md` path.
+
+`lib/log_findings.sh` emits one CI-log line per finding so adopters (and AI agents) can see WHAT each tool flagged without parsing raw SARIF. Invoked once after all adapters by the scan composite action; runs before `lib/check_results.sh` so per-finding context appears above the failure line in the log.
+
+```
+# Usage: log_findings.sh <metadata_dir>
+# Output (one line per finding, to stdout):
+#   wrangle: <tool>[<i>/<n>] <ruleId> <uri>:<line> -- <truncated message>
+#
+# Environment:
+#   WRANGLE_MAX_FINDING_MESSAGE  Max bytes for per-finding message
+#                                (default 100). Truncation is byte-based;
+#                                a multibyte UTF-8 sequence at the
+#                                boundary may render as a replacement
+#                                char (consistent with wrangle_sanitize_output).
+#
+# Exit codes:
+#   0  Success — including malformed SARIF (silently skipped so this
+#      script does not double-report against check_results.sh, which
+#      is the pass/fail gate). Always exits 0 in the happy path so a
+#      missing/empty metadata dir does not break the composite action.
+#   2  Usage error (missing/extra args)
+#
+# All fields (ruleId, uri, message) are passed through
+# wrangle_sanitize_output (HTML strip + WRANGLE_MAX_SUMMARY truncate)
+# and have \r\n\t collapsed to spaces so each finding stays on one
+# log line. Only locations[0] (the SARIF-defined primary location) is
+# rendered — one log line per result, never N×M.
+```
 
 ### Sandboxing and Isolation
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -909,11 +909,10 @@ Action-pattern tools call these helpers from their own `action.yml`. The `format
 #   wrangle: <tool>[<i>/<n>] <ruleId> <uri>:<line> -- <truncated message>
 #
 # Environment:
-#   WRANGLE_MAX_FINDING_MESSAGE  Max bytes for per-finding message
-#                                (default 100). Truncation is byte-based;
-#                                a multibyte UTF-8 sequence at the
-#                                boundary may render as a replacement
-#                                char (consistent with wrangle_sanitize_output).
+#   WRANGLE_MAX_FINDING_MESSAGE  Max characters for per-finding message
+#                                (default 100). Truncation runs inside
+#                                jq, so it is char-based — multibyte
+#                                UTF-8 sequences stay intact.
 #
 # Exit codes:
 #   0  Success — including malformed SARIF (silently skipped so this

--- a/lib/format_sarif_summary.sh
+++ b/lib/format_sarif_summary.sh
@@ -74,11 +74,24 @@ while IFS= read -r -d '' dir; do
         # WHAT was found in the step summary (issue #158) without
         # opening the raw SARIF artifact. Silently skip on invalid SARIF
         # — the table above already flagged it as "Error (invalid SARIF)".
-        if md_table="$("$SCRIPT_DIR/sarif_to_md.sh" "${dir}/output.sarif" 2>/dev/null)"; then
-            printf '## %s Details\n' "$safe_tool"
-            # sarif_to_md.sh already sanitizes its output; pass through.
-            printf '%s\n' "$md_table"
-            printf '\n'
+        # Skip the fallback entirely when there are zero findings: the
+        # top table already shows "No findings" for this tool, and
+        # emitting a redundant "## <tool> Details\nNo findings." section
+        # adds noise without information.
+        # Note on truncation budget: this fallback path is bounded by
+        # wrangle_sanitize_output inside sarif_to_md.sh (so the section
+        # is capped at $WRANGLE_MAX_SUMMARY, 64 KB default) — a separate
+        # budget from the `wrangle_sanitize_output < output.md` path
+        # above. Tools that ship their own output.md effectively get a
+        # second 64 KB headroom. See docs/SPEC.md §Shared Tool Helpers.
+        if num_sarif_findings="$(jq '[.runs[].results[]] | length' "${dir}/output.sarif" 2>/dev/null)" \
+            && [[ "$num_sarif_findings" -gt 0 ]]; then
+            if md_table="$("$SCRIPT_DIR/sarif_to_md.sh" "${dir}/output.sarif" 2>/dev/null)"; then
+                printf '## %s Details\n' "$safe_tool"
+                # sarif_to_md.sh already sanitizes its output; pass through.
+                printf '%s\n' "$md_table"
+                printf '\n'
+            fi
         fi
     fi
 done < <(find "$METADATA_DIR" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)

--- a/lib/format_sarif_summary.sh
+++ b/lib/format_sarif_summary.sh
@@ -72,26 +72,20 @@ while IFS= read -r -d '' dir; do
         # Fallback: no tool-supplied human-readable output, but we have
         # SARIF. Render a findings table directly so adopters can see
         # WHAT was found in the step summary (issue #158) without
-        # opening the raw SARIF artifact. Silently skip on invalid SARIF
-        # — the table above already flagged it as "Error (invalid SARIF)".
-        # Skip the fallback entirely when there are zero findings: the
-        # top table already shows "No findings" for this tool, and
-        # emitting a redundant "## <tool> Details\nNo findings." section
-        # adds noise without information.
-        # Note on truncation budget: this fallback path is bounded by
-        # wrangle_sanitize_output inside sarif_to_md.sh (so the section
-        # is capped at $WRANGLE_MAX_SUMMARY, 64 KB default) — a separate
-        # budget from the `wrangle_sanitize_output < output.md` path
-        # above. Tools that ship their own output.md effectively get a
-        # second 64 KB headroom. See docs/SPEC.md §Shared Tool Helpers.
-        if num_sarif_findings="$(jq '[.runs[].results[]] | length' "${dir}/output.sarif" 2>/dev/null)" \
-            && [[ "$num_sarif_findings" -gt 0 ]]; then
-            if md_table="$("$SCRIPT_DIR/sarif_to_md.sh" "${dir}/output.sarif" 2>/dev/null)"; then
-                printf '## %s Details\n' "$safe_tool"
-                # sarif_to_md.sh already sanitizes its output; pass through.
-                printf '%s\n' "$md_table"
-                printf '\n'
-            fi
+        # opening the raw SARIF artifact. sarif_to_md.sh exits 2 on
+        # parse failure (already flagged "Error (invalid SARIF)" above)
+        # and prints the literal "No findings." string on zero findings;
+        # skip both cases — the top table already covers them and an
+        # empty "## <tool> Details" section is just noise.
+        # Truncation budget: bounded by wrangle_sanitize_output inside
+        # sarif_to_md.sh ($WRANGLE_MAX_SUMMARY, 64 KB default). See
+        # docs/SPEC.md §Shared Tool Helpers.
+        if md_table="$("$SCRIPT_DIR/sarif_to_md.sh" "${dir}/output.sarif" 2>/dev/null)" \
+            && [[ "$md_table" != "No findings." ]]; then
+            printf '## %s Details\n' "$safe_tool"
+            # sarif_to_md.sh already sanitizes its output; pass through.
+            printf '%s\n' "$md_table"
+            printf '\n'
         fi
     fi
 done < <(find "$METADATA_DIR" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)

--- a/lib/format_sarif_summary.sh
+++ b/lib/format_sarif_summary.sh
@@ -68,5 +68,17 @@ while IFS= read -r -d '' dir; do
         # Sanitize markdown output: strip HTML tags, truncate
         wrangle_sanitize_output < "${dir}/output.md"
         printf '\n'
+    elif [[ -f "${dir}/output.sarif" ]]; then
+        # Fallback: no tool-supplied human-readable output, but we have
+        # SARIF. Render a findings table directly so adopters can see
+        # WHAT was found in the step summary (issue #158) without
+        # opening the raw SARIF artifact. Silently skip on invalid SARIF
+        # — the table above already flagged it as "Error (invalid SARIF)".
+        if md_table="$("$SCRIPT_DIR/sarif_to_md.sh" "${dir}/output.sarif" 2>/dev/null)"; then
+            printf '## %s Details\n' "$safe_tool"
+            # sarif_to_md.sh already sanitizes its output; pass through.
+            printf '%s\n' "$md_table"
+            printf '\n'
+        fi
     fi
 done < <(find "$METADATA_DIR" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)

--- a/lib/log_findings.sh
+++ b/lib/log_findings.sh
@@ -16,14 +16,16 @@ set -f  # disable globbing — processes external input paths
 # from check_results.sh (which gates pass/fail) — this script always
 # exits 0 and never affects the build outcome.
 #
-# Finding fields are sanitized:
+# Finding fields are sanitized inside jq (one pass per SARIF file) so
+# we don't fork 4-5 subprocesses per finding on large reports:
 #   - ruleId, uri, and message have \r\n\t collapsed to spaces so a
-#     single finding stays on a single log line (line is numeric).
-#   - HTML tags are stripped via lib/sanitize.sh.
-#   - Messages are truncated to MAX_FINDING_MESSAGE bytes (default 100).
-#     Note: head -c is byte-based, not char-based, matching
-#     wrangle_sanitize_output's own truncation. A UTF-8 multibyte
-#     sequence at the boundary may render as a replacement char.
+#     single finding stays on one log line (line is numeric).
+#   - HTML tags are stripped via gsub (same regex as lib/sanitize.sh).
+#   - Messages are truncated to MAX_FINDING_MESSAGE characters
+#     (default 100). jq slicing is char-based, not byte-based, so a
+#     multibyte UTF-8 sequence at the boundary stays intact (no
+#     replacement char). The whole TSV stream is then piped through
+#     wrangle_sanitize_output once for the global $WRANGLE_MAX_SUMMARY cap.
 #
 # Exit codes:
 #   0  Success (including malformed SARIF — skipped silently so this
@@ -65,22 +67,23 @@ while IFS= read -r -d '' dir; do
 
     [[ -f "$sarif" ]] || continue
 
-    # Extract findings as TSV: ruleId<TAB>uri<TAB>line<TAB>message.
-    # Skip silently on parse errors — check_results.sh is the gate.
-    # Apply gsub("[\r\n\t]"; " ") to every string field (not just
-    # message) so each finding renders as one CI log line regardless
-    # of which attacker-controllable field contains a control char.
+    # Extract findings as TSV: ruleId<TAB>uri<TAB>line<TAB>message, with
+    # all string-field sanitization done inside jq (gsub for \r\n\t and
+    # HTML tags, message truncated to MAX_FINDING_MESSAGE). Skip silently
+    # on parse errors — check_results.sh is the gate.
     # We always read .locations[0] (the primary location per SARIF
     # spec); a single result with multiple locations stays one log line.
-    if ! findings="$(jq -r '
+    if ! findings="$(jq -r --argjson maxmsg "$MAX_FINDING_MESSAGE" '
+      def clean: gsub("[\r\n\t]"; " ") | gsub("<[^>]*>"; "");
       .runs[].results[] |
         [
-          ((.ruleId // "unknown-rule") | gsub("[\r\n\t]"; " ")),
-          ((.locations[0].physicalLocation.artifactLocation.uri // "unknown") | gsub("[\r\n\t]"; " ")),
+          ((.ruleId // "unknown-rule") | clean),
+          ((.locations[0].physicalLocation.artifactLocation.uri // "unknown") | clean),
           ((.locations[0].physicalLocation.region.startLine // "?") | tostring),
-          ((.message.text // "") | gsub("[\r\n\t]"; " "))
+          ((.message.text // "") | clean | .[0:$maxmsg])
         ] | @tsv
-    ' "$sarif" 2>/dev/null)"; then
+    ' "$sarif" 2>/dev/null \
+        | wrangle_sanitize_output)"; then
         continue
     fi
 
@@ -92,25 +95,18 @@ while IFS= read -r -d '' dir; do
     total="$(printf '%s\n' "$findings" | wc -l | tr -d ' ')"
     i=0
 
-    # Sanitize tool name once.
+    # Sanitize tool name once (jq didn't see it — it comes from the
+    # directory name, not the SARIF).
     safe_tool="$(printf '%s' "$tool" | wrangle_sanitize_output)"
 
     # Use a here-string so the while loop runs in the current shell —
     # otherwise `i` would be lost in a subshell on each iteration.
+    # Fields are already sanitized inside jq, so no per-field forking.
     while IFS=$'\t' read -r rule uri line message; do
         i=$((i + 1))
-        # Sanitize each field. wrangle_sanitize_output strips HTML and
-        # truncates to MAX_SUMMARY_LENGTH — apply to each field rather
-        # than the whole line so the message budget is independent.
-        safe_rule="$(printf '%s' "$rule" | wrangle_sanitize_output)"
-        safe_uri="$(printf '%s' "$uri" | wrangle_sanitize_output)"
-        safe_line="$(printf '%s' "$line" | wrangle_sanitize_output)"
-        safe_message="$(printf '%s' "$message" \
-            | wrangle_sanitize_output \
-            | head -c "$MAX_FINDING_MESSAGE")"
         printf 'wrangle: %s[%d/%d] %s %s:%s -- %s\n' \
             "$safe_tool" "$i" "$total" \
-            "$safe_rule" "$safe_uri" "$safe_line" "$safe_message"
+            "$rule" "$uri" "$line" "$message"
     done <<< "$findings"
 done < <(find "$METADATA_DIR" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)
 

--- a/lib/log_findings.sh
+++ b/lib/log_findings.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — processes external input paths
+
+# lib/log_findings.sh — Print one-line CI log summaries per finding.
+#
+# Usage: log_findings.sh <metadata_dir>
+#
+# For each tool/output.sarif under <metadata_dir>, emits one line per
+# finding to stdout in the form:
+#
+#   wrangle: <tool>[<i>/<n>] <ruleId> <uri>:<line> -- <message>
+#
+# This is informational output for CI logs so adopters (and AI agents)
+# can see WHAT was found without parsing raw SARIF. It is decoupled
+# from check_results.sh (which gates pass/fail) — this script always
+# exits 0 and never affects the build outcome.
+#
+# Finding fields are sanitized:
+#   - ruleId, uri, line, and message have newlines collapsed and any
+#     character that would break the log line (control chars, pipes
+#     in ruleId/uri to keep them parseable) collapsed to spaces.
+#   - HTML tags are stripped via lib/sanitize.sh.
+#   - Messages are truncated to MAX_FINDING_MESSAGE chars (default 100).
+#
+# Malformed SARIF is silently skipped — check_results.sh is the place
+# that fails on invalid SARIF; this script is purely informational.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=sanitize.sh
+source "$SCRIPT_DIR/sanitize.sh"
+
+# Maximum characters for a per-finding message in the log line.
+MAX_FINDING_MESSAGE="${WRANGLE_MAX_FINDING_MESSAGE:-100}"
+
+if [[ $# -ne 1 ]]; then
+    printf 'Usage: log_findings.sh <metadata_dir>\n' >&2
+    exit 1
+fi
+
+METADATA_DIR="$1"
+
+if [[ ! -d "$METADATA_DIR" ]]; then
+    # Not an error — adapters may not have produced any output (e.g.,
+    # all tools were skipped). Stay silent so this can be called
+    # unconditionally from action.yml.
+    exit 0
+fi
+
+# Iterate tools deterministically by sorting the tool directories.
+while IFS= read -r -d '' dir; do
+    tool="$(basename "$dir")"
+    sarif="${dir}/output.sarif"
+
+    [[ -f "$sarif" ]] || continue
+
+    # Extract findings as TSV: ruleId<TAB>uri<TAB>line<TAB>message.
+    # Skip silently on parse errors — check_results.sh is the gate.
+    if ! findings="$(jq -r '
+      .runs[].results[] |
+        [
+          (.ruleId // "unknown-rule"),
+          (.locations[0].physicalLocation.artifactLocation.uri // "unknown"),
+          ((.locations[0].physicalLocation.region.startLine // "?") | tostring),
+          ((.message.text // "") | gsub("[\r\n\t]"; " "))
+        ] | @tsv
+    ' "$sarif" 2>/dev/null)"; then
+        continue
+    fi
+
+    [[ -n "$findings" ]] || continue
+
+    total="$(printf '%s\n' "$findings" | wc -l | tr -d ' ')"
+    i=0
+
+    # Sanitize tool name once.
+    safe_tool="$(printf '%s' "$tool" | wrangle_sanitize_output)"
+
+    # Use a here-string so the while loop runs in the current shell —
+    # otherwise `i` would be lost in a subshell on each iteration.
+    while IFS=$'\t' read -r rule uri line message; do
+        i=$((i + 1))
+        # Sanitize each field. wrangle_sanitize_output strips HTML and
+        # truncates to MAX_SUMMARY_LENGTH — apply to each field rather
+        # than the whole line so the message budget is independent.
+        safe_rule="$(printf '%s' "$rule" | wrangle_sanitize_output)"
+        safe_uri="$(printf '%s' "$uri" | wrangle_sanitize_output)"
+        safe_line="$(printf '%s' "$line" | wrangle_sanitize_output)"
+        safe_message="$(printf '%s' "$message" \
+            | wrangle_sanitize_output \
+            | head -c "$MAX_FINDING_MESSAGE")"
+        printf 'wrangle: %s[%d/%d] %s %s:%s -- %s\n' \
+            "$safe_tool" "$i" "$total" \
+            "$safe_rule" "$safe_uri" "$safe_line" "$safe_message"
+    done <<< "$findings"
+done < <(find "$METADATA_DIR" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)
+
+exit 0

--- a/lib/log_findings.sh
+++ b/lib/log_findings.sh
@@ -17,11 +17,19 @@ set -f  # disable globbing — processes external input paths
 # exits 0 and never affects the build outcome.
 #
 # Finding fields are sanitized:
-#   - ruleId, uri, line, and message have newlines collapsed and any
-#     character that would break the log line (control chars, pipes
-#     in ruleId/uri to keep them parseable) collapsed to spaces.
+#   - ruleId, uri, and message have \r\n\t collapsed to spaces so a
+#     single finding stays on a single log line (line is numeric).
 #   - HTML tags are stripped via lib/sanitize.sh.
-#   - Messages are truncated to MAX_FINDING_MESSAGE chars (default 100).
+#   - Messages are truncated to MAX_FINDING_MESSAGE bytes (default 100).
+#     Note: head -c is byte-based, not char-based, matching
+#     wrangle_sanitize_output's own truncation. A UTF-8 multibyte
+#     sequence at the boundary may render as a replacement char.
+#
+# Exit codes:
+#   0  Success (including malformed SARIF — skipped silently so this
+#      script does not double-report against check_results.sh, which
+#      is the pass/fail gate)
+#   2  Usage error (missing/extra args)
 #
 # Malformed SARIF is silently skipped — check_results.sh is the place
 # that fails on invalid SARIF; this script is purely informational.
@@ -36,7 +44,9 @@ MAX_FINDING_MESSAGE="${WRANGLE_MAX_FINDING_MESSAGE:-100}"
 
 if [[ $# -ne 1 ]]; then
     printf 'Usage: log_findings.sh <metadata_dir>\n' >&2
-    exit 1
+    # Exit 2 for usage error to match sibling lib/ scripts
+    # (sarif_to_md.sh, check_results.sh).
+    exit 2
 fi
 
 METADATA_DIR="$1"
@@ -57,11 +67,16 @@ while IFS= read -r -d '' dir; do
 
     # Extract findings as TSV: ruleId<TAB>uri<TAB>line<TAB>message.
     # Skip silently on parse errors — check_results.sh is the gate.
+    # Apply gsub("[\r\n\t]"; " ") to every string field (not just
+    # message) so each finding renders as one CI log line regardless
+    # of which attacker-controllable field contains a control char.
+    # We always read .locations[0] (the primary location per SARIF
+    # spec); a single result with multiple locations stays one log line.
     if ! findings="$(jq -r '
       .runs[].results[] |
         [
-          (.ruleId // "unknown-rule"),
-          (.locations[0].physicalLocation.artifactLocation.uri // "unknown"),
+          ((.ruleId // "unknown-rule") | gsub("[\r\n\t]"; " ")),
+          ((.locations[0].physicalLocation.artifactLocation.uri // "unknown") | gsub("[\r\n\t]"; " ")),
           ((.locations[0].physicalLocation.region.startLine // "?") | tostring),
           ((.message.text // "") | gsub("[\r\n\t]"; " "))
         ] | @tsv
@@ -71,6 +86,9 @@ while IFS= read -r -d '' dir; do
 
     [[ -n "$findings" ]] || continue
 
+    # Count findings. $(jq ...) stripped the trailing newline, so for
+    # N findings $findings has N-1 embedded newlines. The printf '%s\n'
+    # wrapper adds the final newline so `wc -l` returns N, not N-1.
     total="$(printf '%s\n' "$findings" | wc -l | tr -d ' ')"
     i=0
 

--- a/lib/sarif_to_md.sh
+++ b/lib/sarif_to_md.sh
@@ -43,11 +43,11 @@ fi
 if ! results="$(jq -r '
   [.runs[].results[] |
     {
-      ruleId: .ruleId,
+      ruleId: ((.ruleId // "unknown-rule") | gsub("\n"; " ") | gsub("\\|"; "/")),
       level: (.level // "warning"),
-      uri: (.locations[0].physicalLocation.artifactLocation.uri // "unknown"),
+      uri: ((.locations[0].physicalLocation.artifactLocation.uri // "unknown") | gsub("\n"; " ") | gsub("\\|"; "/")),
       line: (.locations[0].physicalLocation.region.startLine // "?"),
-      message: (.message.text | gsub("\n"; " ") | gsub("\\|"; "/"))
+      message: ((.message.text // "") | gsub("\n"; " ") | gsub("\\|"; "/"))
     }
   ]' "$SARIF_FILE" 2>/dev/null)"; then
     printf 'Error: failed to parse SARIF results\n' >&2

--- a/test/test_log_findings.bats
+++ b/test/test_log_findings.bats
@@ -90,6 +90,22 @@ teardown() {
     [[ "$output" != *"bad["* ]]
 }
 
+@test "log_findings: silently-skipped malformed SARIF still fails check_results" {
+    # Pins the invariant the silent-skip relies on: the same fixture
+    # that log_findings ignores MUST cause check_results (the gate) to
+    # exit non-zero. If check_results ever softens, log_findings' silent
+    # behaviour becomes a hole and this test should fail loudly.
+    mkdir -p "$METADATA/bad"
+    cp "$ORIG_DIR/test/fixtures/malformed.sarif" "$METADATA/bad/output.sarif"
+
+    run "$SCRIPT" "$METADATA"
+    [ "$status" -eq 0 ]
+
+    run "$ORIG_DIR/lib/check_results.sh" "$METADATA" "bad"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"invalid SARIF"* ]]
+}
+
 @test "log_findings: not-json SARIF is silently skipped" {
     mkdir -p "$METADATA/bad"
     echo "not json" > "$METADATA/bad/output.sarif"

--- a/test/test_log_findings.bats
+++ b/test/test_log_findings.bats
@@ -1,0 +1,183 @@
+#!/usr/bin/env bats
+
+# Tests for lib/log_findings.sh
+
+setup() {
+    export TEST_DIR="$(mktemp -d)"
+    export ORIG_DIR="$(pwd)"
+    export SCRIPT="$ORIG_DIR/lib/log_findings.sh"
+    export METADATA="$TEST_DIR/metadata"
+    mkdir -p "$METADATA"
+}
+
+teardown() {
+    cd "$ORIG_DIR"
+    rm -rf "$TEST_DIR"
+}
+
+@test "log_findings: requires metadata_dir argument" {
+    run "$SCRIPT"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "log_findings: silent on nonexistent metadata directory" {
+    # The action invokes us unconditionally — missing metadata is fine.
+    run "$SCRIPT" "$TEST_DIR/missing"
+
+    [ "$status" -eq 0 ]
+    [[ -z "$output" ]]
+}
+
+@test "log_findings: empty metadata directory produces no output" {
+    run "$SCRIPT" "$METADATA"
+
+    [ "$status" -eq 0 ]
+    [[ -z "$output" ]]
+}
+
+@test "log_findings: tool with no SARIF is silently skipped" {
+    mkdir -p "$METADATA/scorecard"
+    run "$SCRIPT" "$METADATA"
+
+    [ "$status" -eq 0 ]
+    [[ -z "$output" ]]
+}
+
+@test "log_findings: tool with empty findings produces no log lines" {
+    mkdir -p "$METADATA/clean"
+    cp "$ORIG_DIR/test/fixtures/empty.sarif" "$METADATA/clean/output.sarif"
+
+    run "$SCRIPT" "$METADATA"
+
+    [ "$status" -eq 0 ]
+    [[ -z "$output" ]]
+}
+
+@test "log_findings: emits one line per finding with tool, ruleId, location, message" {
+    mkdir -p "$METADATA/zizmor"
+    cp "$ORIG_DIR/test/fixtures/findings.sarif" "$METADATA/zizmor/output.sarif"
+
+    run "$SCRIPT" "$METADATA"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wrangle: zizmor[1/2] TEST-001 src/main.c:10"* ]]
+    [[ "$output" == *"wrangle: zizmor[2/2] TEST-001 src/utils.c:42"* ]]
+    [[ "$output" == *"A test vulnerability was found"* ]]
+    [[ "$output" == *"Another test finding"* ]]
+}
+
+@test "log_findings: emits exactly N lines for N findings" {
+    mkdir -p "$METADATA/zizmor"
+    cp "$ORIG_DIR/test/fixtures/findings.sarif" "$METADATA/zizmor/output.sarif"
+
+    line_count=$("$SCRIPT" "$METADATA" | wc -l | tr -d ' ')
+
+    [[ "$line_count" -eq 2 ]]
+}
+
+@test "log_findings: malformed SARIF is silently skipped (check_results gates)" {
+    mkdir -p "$METADATA/bad"
+    cp "$ORIG_DIR/test/fixtures/malformed.sarif" "$METADATA/bad/output.sarif"
+
+    run "$SCRIPT" "$METADATA"
+
+    # Script must not fail — check_results.sh is the failure gate. We
+    # stay silent so it doesn't double-report on the same bad SARIF.
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"bad["* ]]
+}
+
+@test "log_findings: not-json SARIF is silently skipped" {
+    mkdir -p "$METADATA/bad"
+    echo "not json" > "$METADATA/bad/output.sarif"
+
+    run "$SCRIPT" "$METADATA"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"bad["* ]]
+}
+
+@test "log_findings: HTML tags in messages are stripped" {
+    mkdir -p "$METADATA/injected"
+    cp "$ORIG_DIR/test/fixtures/injection.sarif" "$METADATA/injected/output.sarif"
+
+    run "$SCRIPT" "$METADATA"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"INJECT-001"* ]]
+    [[ "$output" != *"<img"* ]]
+    [[ "$output" != *"<script>"* ]]
+    [[ "$output" != *"onerror"* ]]
+}
+
+@test "log_findings: long messages are truncated" {
+    export WRANGLE_MAX_FINDING_MESSAGE=20
+    mkdir -p "$METADATA/zizmor"
+    # Build SARIF with a long message
+    jq -n '{
+      "version":"2.1.0",
+      "runs":[{
+        "tool":{"driver":{"name":"zizmor"}},
+        "results":[{
+          "ruleId":"long-msg",
+          "message":{"text":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+          "locations":[{"physicalLocation":{"artifactLocation":{"uri":"x.yml"},"region":{"startLine":1}}}]
+        }]
+      }]
+    }' > "$METADATA/zizmor/output.sarif"
+
+    run env WRANGLE_MAX_FINDING_MESSAGE=20 "$SCRIPT" "$METADATA"
+
+    [ "$status" -eq 0 ]
+    # Pull the trailing message portion (after " -- ") and verify it's <= 20 chars.
+    msg="${output##* -- }"
+    [[ ${#msg} -le 20 ]]
+}
+
+@test "log_findings: iterates tools deterministically (sorted)" {
+    mkdir -p "$METADATA/b-tool" "$METADATA/a-tool"
+    cp "$ORIG_DIR/test/fixtures/findings.sarif" "$METADATA/b-tool/output.sarif"
+    cp "$ORIG_DIR/test/fixtures/findings.sarif" "$METADATA/a-tool/output.sarif"
+
+    output="$("$SCRIPT" "$METADATA")"
+
+    # a-tool lines must appear before b-tool lines
+    a_line=$(printf '%s\n' "$output" | grep -n 'a-tool\[' | head -1 | cut -d: -f1)
+    b_line=$(printf '%s\n' "$output" | grep -n 'b-tool\[' | head -1 | cut -d: -f1)
+    [[ "$a_line" -lt "$b_line" ]]
+}
+
+@test "log_findings: finding without location uses defaults" {
+    mkdir -p "$METADATA/no-loc"
+    jq -n '{
+      "version":"2.1.0",
+      "runs":[{
+        "tool":{"driver":{"name":"no-loc"}},
+        "results":[{"ruleId":"R1","message":{"text":"no location info"}}]
+      }]
+    }' > "$METADATA/no-loc/output.sarif"
+
+    run "$SCRIPT" "$METADATA"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no-loc[1/1] R1 unknown:?"* ]]
+}
+
+@test "log_findings: finding without ruleId uses unknown-rule" {
+    mkdir -p "$METADATA/no-rule"
+    jq -n '{
+      "version":"2.1.0",
+      "runs":[{
+        "tool":{"driver":{"name":"no-rule"}},
+        "results":[{"message":{"text":"no rule id"},
+          "locations":[{"physicalLocation":{"artifactLocation":{"uri":"a.yml"},"region":{"startLine":3}}}]}]
+      }]
+    }' > "$METADATA/no-rule/output.sarif"
+
+    run "$SCRIPT" "$METADATA"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no-rule[1/1] unknown-rule a.yml:3"* ]]
+}

--- a/test/test_log_findings.bats
+++ b/test/test_log_findings.bats
@@ -18,7 +18,8 @@ teardown() {
 @test "log_findings: requires metadata_dir argument" {
     run "$SCRIPT"
 
-    [ "$status" -eq 1 ]
+    # Exit 2 matches sibling lib/ scripts (sarif_to_md.sh, check_results.sh).
+    [ "$status" -eq 2 ]
     [[ "$output" == *"Usage"* ]]
 }
 
@@ -131,9 +132,12 @@ teardown() {
     run env WRANGLE_MAX_FINDING_MESSAGE=20 "$SCRIPT" "$METADATA"
 
     [ "$status" -eq 0 ]
-    # Pull the trailing message portion (after " -- ") and verify it's <= 20 chars.
+    # Pull the trailing message portion (after " -- ") and verify it's
+    # truncated to exactly 20 bytes. Pinning -eq (not just -le) catches
+    # the regression where truncation becomes too aggressive (e.g.,
+    # head -c swapped for cut -c1-N with an off-by-one).
     msg="${output##* -- }"
-    [[ ${#msg} -le 20 ]]
+    [[ ${#msg} -eq 20 ]]
 }
 
 @test "log_findings: iterates tools deterministically (sorted)" {
@@ -180,4 +184,36 @@ teardown() {
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"no-rule[1/1] unknown-rule a.yml:3"* ]]
+}
+
+@test "log_findings: result with multiple locations emits exactly one line (primary only)" {
+    # SARIF allows multiple locations[] per result; the primary is
+    # locations[0]. Pin that we always render one log line per result,
+    # not N×M, in case someone "helpfully" switches to .locations[].
+    mkdir -p "$METADATA/multi-loc"
+    jq -n '{
+      "version":"2.1.0",
+      "runs":[{
+        "tool":{"driver":{"name":"multi-loc"}},
+        "results":[{
+          "ruleId":"MULTI-1",
+          "message":{"text":"finding with multiple locations"},
+          "locations":[
+            {"physicalLocation":{"artifactLocation":{"uri":"primary.yml"},"region":{"startLine":1}}},
+            {"physicalLocation":{"artifactLocation":{"uri":"secondary.yml"},"region":{"startLine":2}}},
+            {"physicalLocation":{"artifactLocation":{"uri":"tertiary.yml"},"region":{"startLine":3}}}
+          ]
+        }]
+      }]
+    }' > "$METADATA/multi-loc/output.sarif"
+
+    line_count=$("$SCRIPT" "$METADATA" | wc -l | tr -d ' ')
+    [[ "$line_count" -eq 1 ]]
+
+    run "$SCRIPT" "$METADATA"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"multi-loc[1/1] MULTI-1 primary.yml:1"* ]]
+    # secondary/tertiary must NOT appear — only locations[0] is rendered.
+    [[ "$output" != *"secondary.yml"* ]]
+    [[ "$output" != *"tertiary.yml"* ]]
 }

--- a/test/test_sanitized_summary.bats
+++ b/test/test_sanitized_summary.bats
@@ -133,3 +133,62 @@ teardown() {
     [[ "$output" != *"<pre>"* ]]
     [[ "$output" != *"<code>"* ]]
 }
+
+# --- Findings rendering (issue #158) ---
+
+@test "sanitized summary: SARIF-only tool falls back to rendering findings table" {
+    # Tool produced SARIF but no human-readable output.md/output.txt —
+    # the summary must still show WHAT was found (issue #158).
+    mkdir -p "$TEST_DIR/metadata/raw-tool"
+    cp "$ORIG_DIR/test/fixtures/findings.sarif" "$TEST_DIR/metadata/raw-tool/output.sarif"
+
+    output=$("$FORMATTER" "$TEST_DIR/metadata")
+
+    # Details section header is present
+    [[ "$output" == *"## raw-tool Details"* ]]
+    # Rule ID and location appear (sourced from SARIF via sarif_to_md.sh)
+    [[ "$output" == *"TEST-001"* ]]
+    [[ "$output" == *"src/main.c:10"* ]]
+    [[ "$output" == *"src/utils.c:42"* ]]
+    [[ "$output" == *"A test vulnerability was found"* ]]
+}
+
+@test "sanitized summary: SARIF-only tool with no findings produces no findings rows" {
+    mkdir -p "$TEST_DIR/metadata/clean"
+    cp "$ORIG_DIR/test/fixtures/empty.sarif" "$TEST_DIR/metadata/clean/output.sarif"
+
+    output=$("$FORMATTER" "$TEST_DIR/metadata")
+
+    # Status row still shows "No findings"
+    [[ "$output" == *"No findings"* ]]
+    # No table header rendered (no findings to show)
+    [[ "$output" != *"| Severity | Rule | Location | Message |"* ]]
+}
+
+@test "sanitized summary: output.md takes precedence over SARIF fallback" {
+    # When a tool supplies its own output.md (e.g., zizmor/OSV), use it
+    # rather than the generic SARIF fallback.
+    mkdir -p "$TEST_DIR/metadata/with-md"
+    cp "$ORIG_DIR/test/fixtures/findings.sarif" "$TEST_DIR/metadata/with-md/output.sarif"
+    printf '%s' "Tool-specific markdown content" > "$TEST_DIR/metadata/with-md/output.md"
+
+    output=$("$FORMATTER" "$TEST_DIR/metadata")
+
+    [[ "$output" == *"Tool-specific markdown content"* ]]
+    # Generic findings table would include "TEST-001" rows — must not appear.
+    [[ "$output" != *"TEST-001"* ]]
+}
+
+@test "sanitized summary: SARIF fallback sanitizes injection content" {
+    mkdir -p "$TEST_DIR/metadata/injected"
+    cp "$ORIG_DIR/test/fixtures/injection.sarif" "$TEST_DIR/metadata/injected/output.sarif"
+
+    output=$("$FORMATTER" "$TEST_DIR/metadata")
+
+    # The injection fixture has 1 finding with HTML in the message
+    [[ "$output" == *"INJECT-001"* ]]
+    # HTML tags from message must be stripped
+    [[ "$output" != *"<img"* ]]
+    [[ "$output" != *"<script>"* ]]
+    [[ "$output" != *"onerror"* ]]
+}


### PR DESCRIPTION
Closes #158.

## Summary

Adopters debugging a failed wrangle scan currently see only a count (`zizmor reported 3 finding(s)`) and have to grep raw SARIF in the step summary or artifact to learn WHAT was flagged. This PR surfaces finding details at three layers:

- **Step summary** (`lib/format_sarif_summary.sh`): when a tool didn't supply `output.md` or `output.txt`, fall back to rendering the SARIF findings table via `sarif_to_md.sh`, so the `## Details` section always answers "what was found?"
- **CI log** (`lib/log_findings.sh`, new): emits one line per finding in the form
  ```
  wrangle: <tool>[<i>/<n>] <ruleId> <uri>:<line> -- <truncated message>
  ```
  invoked from a new "Log findings" step in `actions/scan/action.yml`. Purely informational (always exits 0); the pass/fail gate (`check_results.sh`) is untouched.
- **`sarif_to_md.sh`**: now sanitizes pipe characters in `ruleId` and `uri` too, not only `message`, so a malicious filename like `evil|name.yml` can't break the findings table.

## Safety

All SARIF content is attacker-controllable (file names, message text in any branch). Every embedded field passes through `wrangle_sanitize_output` (HTML strip + 64 KB truncate). Per-finding messages are independently capped to `WRANGLE_MAX_FINDING_MESSAGE` (default 100). Malformed SARIF is silently skipped in the log path (no double-reporting against `check_results.sh`, which remains the failure gate).

## Test plan

- [x] `./test.sh` passes (674 → 692 tests)
- [x] New tests cover: empty SARIF, malformed SARIF, HTML injection, missing location/ruleId defaults, message truncation, deterministic per-tool ordering, output.md precedence over fallback
- [x] `shellcheck` clean
- [ ] Verify in CI step summary & logs on the PR itself (dogfooding)