### PR TITLE
claude: Make set -f the default for all shell scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,27 +6,7 @@ Read `docs/SPEC.md` before contributing. It is the source of truth for architect
 
 ## Shell Script Safety
 
-Every shell script MUST start with these two lines:
-
-```bash
-set -euo pipefail
-set -f
-```
-
-`set -f` (disable filename globbing) is included by default because unquoted expansions containing `*` / `?` / `[…]` are a recurring source of subtle bugs and shell-injection vectors (e.g., a variable holding `*` expanding to every file in a directory). Wrangle is a supply-chain security tool and defaults to the safer flag rather than relying on every contributor to reason about whether their script "needs" it.
-
-Scripts that genuinely need globbing — e.g., `for f in *.txt; do …` — must wrap the glob in `set +f` / `set -f` with a comment explaining why, scoped as narrowly as possible:
-
-```bash
-# set +f: this loop intentionally expands the glob
-set +f
-for f in *.txt; do
-  process "$f"
-done
-set -f
-```
-
-Sourced libraries (`lib/*.sh`) that change shell options affect their callers. `set -f` leaking from a sourced lib is intentional — callers want the same protection — but a lib that temporarily `set +f`s MUST restore `set -f` before returning.
+Every shell script MUST start with `set -euo pipefail` and `set -f` (disable globbing). Scripts that intentionally need globbing must wrap it in `set +f` / `set -f` with a comment, scoped as narrowly as possible. Sourced libs that toggle `set +f` MUST restore `set -f` before returning.
 
 All variable expansions MUST be double-quoted: `"$var"`, `"${var}"`, `"$@"`. The only exception is intentional word-splitting with a documented comment explaining why it is safe (e.g., `$WRANGLE_TOOLS` in the composite action, which is validated by the orchestrator's regex).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,27 @@ Read `docs/SPEC.md` before contributing. It is the source of truth for architect
 
 ## Shell Script Safety
 
-Every shell script MUST start with `set -euo pipefail`. Scripts that process arguments from external input MUST also `set -f` (disable globbing) before processing those arguments.
+Every shell script MUST start with these two lines:
+
+```bash
+set -euo pipefail
+set -f
+```
+
+`set -f` (disable filename globbing) is included by default because unquoted expansions containing `*` / `?` / `[…]` are a recurring source of subtle bugs and shell-injection vectors (e.g., a variable holding `*` expanding to every file in a directory). Wrangle is a supply-chain security tool and defaults to the safer flag rather than relying on every contributor to reason about whether their script "needs" it.
+
+Scripts that genuinely need globbing — e.g., `for f in *.txt; do …` — must wrap the glob in `set +f` / `set -f` with a comment explaining why, scoped as narrowly as possible:
+
+```bash
+# set +f: this loop intentionally expands the glob
+set +f
+for f in *.txt; do
+  process "$f"
+done
+set -f
+```
+
+Sourced libraries (`lib/*.sh`) that change shell options affect their callers. `set -f` leaking from a sourced lib is intentional — callers want the same protection — but a lib that temporarily `set +f`s MUST restore `set -f` before returning.
 
 All variable expansions MUST be double-quoted: `"$var"`, `"${var}"`, `"$@"`. The only exception is intentional word-splitting with a documented comment explaining why it is safe (e.g., `$WRANGLE_TOOLS` in the composite action, which is validated by the orchestrator's regex).
 


### PR DESCRIPTION
## Summary
- Tightens CLAUDE.md "Shell Script Safety" so `set -f` is required as the second line of every shell script, not just scripts that process external input.
- The escape hatch is an explicitly-commented `set +f` / `set -f` wrap around the smallest possible scope, modeled on how `# shellcheck disable` already works.
- Adds a note about sourced-library leakage being intentional (callers want the same protection).

## Why now

Surfaced in PR #243 review (https://github.com/TomHennen/wrangle/pull/243#pullrequestreview-4351699820):

> Setting `set -f` (disable globbing) globally alongside `set -euo pipefail` is a fantastic, highly secure default. Unless a specific script actively needs to expand wildcards … globbing is a massive source of subtle bugs and security vulnerabilities.

Wrangle is a supply-chain security tool. Defaulting to the safer flag and requiring an explicit, commented opt-out for globbing is a better posture than asking every contributor to judge whether their script "needs" `set -f."

## Scope and follow-ups

This PR is **spec-only**. It does **not**:
- Audit and update existing scripts to add `set -f` — that lands together with #243's `wrangle-shell-lint` rewrite (WSL002 will enforce this rule and the bulk script update will be in the same atomic change).
- Touch `tools/wrangle-shell-lint/` — that's #243's surface.

For the brief window between this PR merging and #243 landing, several existing scripts will be out of compliance with the new rule. That's a known intentional gap: the spec change is small enough to land independently and the linter that enforces it is in flight.

## Test plan
- [ ] CLAUDE.md renders correctly on GitHub
- [ ] No new code paths to test
- [ ] CI passes (no shell or code changed)