### PR TITLE
docs: reconcile Go SLSA Build L3 status across SPEC, audit, and README

### DIFF
--- a/build/actions/go/README.md
+++ b/build/actions/go/README.md
@@ -108,7 +108,7 @@ Source-stage `gofmt` / `golangci-lint` is tracked in [#194](https://github.com/T
 
 ## Build Track level
 
-Consumed through wrangle's reusable workflow (`build_and_publish_go.yml`), the Go build targets **SLSA v1.2 Build L3**. Two conditions narrow it:
+Consumed through wrangle's reusable workflow (`build_and_publish_go.yml`), the Go build meets **SLSA v1.2 Build L3**. Two conditions narrow it:
 
 - **Reusable consumption only.** Calling the `build/actions/go/*` composites directly from a workflow you author yourself forfeits the build-vs-sign job separation and is **not** a supported L3 path.
 - **GitHub-hosted runners only.** Self-hosted runners invalidate the build-environment isolation the L3 verdict assumes.

--- a/docs/SLSA_L3_AUDIT.md
+++ b/docs/SLSA_L3_AUDIT.md
@@ -29,12 +29,22 @@ adopter consuming wrangle through one of wrangle's **reusable workflows**:
 | python path (pip sub-path) | **Build L3** | — |
 | python path (uv sub-path) | **Build L2** | Build L3 (Finding 1) |
 | container path | **Build L2** | Build L3 (Finding 2) |
+| Go path | **Build L3** [^go] | — |
 | shell path | **N/A** — no provenance produced | — |
 
 [^npmci]: Conditional on the install command being `npm ci`, which re-verifies
     each cached tarball's SHA against `package-lock.json` on every install.
     `npm ci` is the command wrangle invokes, so the precondition holds
     by-construction; full detail at [npm path (npm sub-path)](#npm-path-npm-sub-path).
+
+[^go]: The Go build type landed after this audit's 2026-05-14 date, so it has
+    no point-in-time row; this row reflects its current state. Go meets Build L3
+    by the same generic-generator isolation as the other paths, with the
+    release-vs-PR cache asymmetry applied to `actions/setup-go`'s module + build
+    caches (the module cache is `npm ci`-like — re-verified against `go.sum`; the
+    build cache is disabled on release builds). Per-builder analysis lives in
+    [`build/actions/go/SPEC.md`](../build/actions/go/SPEC.md) "Cache isolation",
+    not in this historical document.
 
 > **Update — 2026-05-17.** Findings 1 and 2 are now **resolved** by
 > [PR #226](https://github.com/TomHennen/wrangle/pull/226) (issue

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -230,7 +230,7 @@ Why opt-out exists. Some adopters run custom verification policies (different `-
 
 ### Build Track level
 
-Every wrangle build-type reusable workflow that produces provenance — `build_and_publish_npm.yml` (npm and pnpm), `build_and_publish_python.yml` (pip and uv), and `build_and_publish_container.yml` — meets **SLSA v1.2 Build L3**. `build_shell.yml` produces no artifact and no provenance, so no Build Track level applies to it.
+Every wrangle build-type reusable workflow that produces provenance — `build_and_publish_npm.yml` (npm and pnpm), `build_and_publish_python.yml` (pip and uv), `build_and_publish_container.yml`, and `build_and_publish_go.yml` — meets **SLSA v1.2 Build L3**. `build_shell.yml` produces no artifact and no provenance, so no Build Track level applies to it.
 
 Wrangle's user-facing docs claim exactly **one** Build Track level per workflow — Build L2 or Build L3 — and never a finer-grained, requirement-by-requirement breakdown. An adopter should not have to reason about individual SLSA L3 requirements ("Provenance is Unforgeable" versus "Isolated") to know what a workflow delivers; the single Build Track level is the claim. The full per-builder analysis behind the L3 verdicts is [`docs/SLSA_L3_AUDIT.md`](SLSA_L3_AUDIT.md).
 


### PR DESCRIPTION
## Summary

The docs disagreed with themselves about whether the Go build type meets SLSA v1.2 Build L3. This reconciles them. No code change — docs only.

**Verdict: Go meets Build L3**, by the same mechanism as npm/python/container:

- Provenance is generated by `slsa-framework/.../generator_generic_slsa3.yml@v2.1.0` in its own isolated reusable workflow (`build_and_publish_go.yml:278`) — the build-vs-sign separation that earns L3.
- Release builds disable both Go caches via `actions/setup-go`'s `cache: false`, gated on `should-release` — the same release-vs-PR cache asymmetry as the python-uv and container paths (`build_and_publish_go.yml:191,246`).
- `lib/stop_commands_guard.sh` wraps `go test` / `govulncheck` (checks composite) and goreleaser (release composite) — the Finding 3 mitigation.
- The same two narrowing conditions (reusable-consumption-only, GitHub-hosted-runners-only) are documented.

## The inconsistency

`docs/SPEC.md` contradicted itself: the **cache-isolation paragraph** (§"Build Track level") already lists "the Go path's `actions/setup-go` module + build caches" as one of the three release-cache-disabled **L3 paths**, but the **headline L3 list** in the same section omitted `build_and_publish_go.yml`. Separately, `build/actions/go/README.md` said the Go build "targets" L3 while the other build types say "meets". And the `SLSA_L3_AUDIT.md` verdict table had no Go row — exactly the gap `build/actions/go/SPEC.md` predicted ("the audit doc gets a per-builder verdict update when the Go implementation lands").

## Changes

- **`docs/SPEC.md`** — add `build_and_publish_go.yml` to the Build L3 list so it matches the cache-isolation paragraph two sentences down.
- **`docs/SLSA_L3_AUDIT.md`** — add a Go row to the "Build Track level today" verdict table, with a footnote that's honest about Go postdating the 2026-05-14 audit and points to `build/actions/go/SPEC.md` "Cache isolation" for the per-builder analysis (rather than retrofitting a full historical section into a point-in-time document).
- **`build/actions/go/README.md`** — "targets" → "meets" Build L3, matching python/npm/container phrasing.

## Test plan

- [x] No test asserts the L3 workflow list or the audit verdict table (`grep` across `test/`).
- [x] Changes are markdown-only — no shell/YAML/test surface touched.
- [ ] **CI must run the full suite** — I could not run `./test.sh` locally (it builds a Docker test container, and Docker was unavailable in my environment; no local `bats`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0183Hb4vrEqxSVxTjukkcA9a)_