### PR TITLE
docs: DEP_MGMT.md — dependency-management strategy + decision tree (#284)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,13 +48,13 @@ Don't `curl | sh` — all binary downloads go through `lib/download_verify.sh`. 
 
 Required pin format per context (third-party actions, the SLSA-generator tag exception, self-references, examples), the `@main` prohibition, and how self-references are bumped: see [DEP_MGMT.md](DEP_MGMT.md).
 
-## Install method and verification (see SPEC.md §Install Script Interface for the full contract)
+## Installing and verifying tools
 
-The decision tree for choosing an install method and verification tier (canonical-package-manager strong default, the integrity-tier ladder, never-downgrade-for-convenience, minimal footprint) and the per-category verification mechanisms are in [DEP_MGMT.md](DEP_MGMT.md). Install-script mechanics (`lib/download_verify.sh`, `$WRANGLE_BIN_DIR`, idempotency, atomic `mv`) are the Install Script Interface contract in SPEC.md.
+How to choose an install method and verification tier — the decision tree, the integrity-tier ladder, and the freshness-first rule — is in [DEP_MGMT.md](DEP_MGMT.md). Install-script mechanics (`lib/download_verify.sh`, `$WRANGLE_BIN_DIR`, idempotency, atomic `mv`) are the Install Script Interface contract in SPEC.md.
 
 ## Pins drift across files
 
-How wrangle keeps the same pin literal in more than one file from drifting (single-source or a divergence-fail test): see [DEP_MGMT.md § Drift risks and mitigations](DEP_MGMT.md).
+Prevent the same pin literal drifting across files (single-source or a divergence-fail test): see [DEP_MGMT.md § Drift](DEP_MGMT.md#drift).
 
 ## Adapter contract (see SPEC.md §Adapter Script Interface for the full contract)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ Don't `curl | sh` — all binary downloads go through `lib/download_verify.sh`. 
 
 ## Install method and verification (see SPEC.md §Install Script Interface for the full contract)
 
+See [DEP_MGMT.md](DEP_MGMT.md) for the full per-category dependency-management strategy and a decision tree for choosing how to install and verify a new dependency.
+
 **Strong default: use the canonical package manager.** If upstream publishes via pip / cargo / npm / go install / brew with adequate verification, use it. Binary + attestation and binary + sha256 are fallbacks for tools that publish no package-manager release, not alternatives to choose between. When upstream offers multiple package managers, prefer in order: (1) the one upstream's install docs recommend first, (2) the one with attestation support, (3) the one that doesn't add transitive runtime deps to the test image.
 
 **Integrity tier (within whichever install method):** SLSA provenance > GitHub release attestation > Sigstore signature > hash-pinned package manager (`--require-hashes`, lockfile) > hardcoded SHA-256 against a downloaded binary. NEVER fall back to a weaker tier if a stronger one fails.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,43 +46,15 @@ Don't `curl | sh` — all binary downloads go through `lib/download_verify.sh`. 
 
 ## Action reference pinning
 
-| Context | Required format |
-|---|---|
-| Third-party actions | Full commit SHA with version comment: `uses: actions/checkout@<sha> # v4.2.2` |
-| SLSA generator (exception) | Release tag only: `@v2.1.0` ([slsa-verifier#12](https://github.com/slsa-framework/slsa-verifier/issues/12)) |
-| Wrangle's own actions in examples | Release tag: `@v0.1.0` |
-| Wrangle internal cross-references in reusable workflows | Full SHA with `# main` or `# vX.Y.Z` comment (never a branch name — zizmor flags it). Temporary — see #136 |
-| Wrangle internal cross-references elsewhere | Relative path: `./actions/scan` |
-
-`@main` MUST NOT appear in any `uses:` line, including examples and docs. Dependabot manages third-party action updates; tool binary versions are manual. After merging a PR (or a batch) that changes a referenced composite action, bump the SHA in any reusable-workflow self-references — `tools/bump_action_pins.sh` (or `make bump-action-pins`) handles this and writes the `# main` comment correctly.
+Required pin format per context (third-party actions, the SLSA-generator tag exception, self-references, examples), the `@main` prohibition, and how self-references are bumped: see [DEP_MGMT.md](DEP_MGMT.md).
 
 ## Install method and verification (see SPEC.md §Install Script Interface for the full contract)
 
-See [DEP_MGMT.md](DEP_MGMT.md) for the full per-category dependency-management strategy and a decision tree for choosing how to install and verify a new dependency.
-
-**Strong default: use the canonical package manager.** If upstream publishes via pip / cargo / npm / go install / brew with adequate verification, use it. Binary + attestation and binary + sha256 are fallbacks for tools that publish no package-manager release, not alternatives to choose between. When upstream offers multiple package managers, prefer in order: (1) the one upstream's install docs recommend first, (2) the one with attestation support, (3) the one that doesn't add transitive runtime deps to the test image.
-
-**Integrity tier (within whichever install method):** SLSA provenance > GitHub release attestation > Sigstore signature > hash-pinned package manager (`--require-hashes`, lockfile) > hardcoded SHA-256 against a downloaded binary. NEVER fall back to a weaker tier if a stronger one fails.
-
-**Python tools:** pin via `tools/<tool>/requirements.txt` (`package==version --hash=sha256:...` for the direct dep plus all transitives), install into a `python3 -m venv` with `pip install --require-hashes`, and let Dependabot's `pip` ecosystem bump version + hashes atomically.
-
-**Go modules via `go install`.** Accepted only when no upstream binary release exists: pin to a specific semver tag, install the Go toolchain itself via `lib/download_verify.sh`, and assert `GOPROXY=https://proxy.golang.org,direct GOSUMDB=sum.golang.org` at the install site so [sum.golang.org](https://sum.golang.org/) verification isn't environment-conditional. Note: the sumdb attests immutability of the first-seen `(module, version)`, NOT publisher authenticity.
-
-**Convenience is not a fallback justification.** "We'd have to install one more tool in the image" or "the attestation flow is awkward at build time" are NOT reasons to drop to a weaker tier. The fallback rule is "stronger verification is genuinely unavailable upstream" — document *why* the stronger tier doesn't exist, not why it'd be inconvenient.
-
-All downloads in custom install scripts go through `lib/download_verify.sh`. Install to `$WRANGLE_BIN_DIR`, never `/usr/local/bin`. Be idempotent. Use atomic `mv` (not `cp`).
-
-**Don't add heavyweight runtimes for single-use tasks.** Use the smallest dependency that does the job — `unzip` over `python3` for archives, `jq` over a python script for JSON, etc. Adding a language runtime to the test image just to run a one-liner expands the supply-chain surface for no gain.
+The decision tree for choosing an install method and verification tier (canonical-package-manager strong default, the integrity-tier ladder, never-downgrade-for-convenience, minimal footprint) and the per-category verification mechanisms are in [DEP_MGMT.md](DEP_MGMT.md). Install-script mechanics (`lib/download_verify.sh`, `$WRANGLE_BIN_DIR`, idempotency, atomic `mv`) are the Install Script Interface contract in SPEC.md.
 
 ## Pins drift across files
 
-If a version, checksum, SHA, or other pin literal lives in more than one file, either consolidate to a single source or add a regression test that diffs the locations and fails on divergence. This applies to:
-
-- A tool version pinned in both the local install path (e.g. `tools/<name>/requirements.txt`, `test/Dockerfile`) and `tools/<name>/action.yml`
-- A version default in a reusable workflow, its composite, and an env coalesce
-- An adapter helper duplicated across multiple per-tool install scripts
-
-Don't rely on humans remembering to update both places.
+How wrangle keeps the same pin literal in more than one file from drifting (single-source or a divergence-fail test): see [DEP_MGMT.md § Drift risks and mitigations](DEP_MGMT.md).
 
 ## Adapter contract (see SPEC.md §Adapter Script Interface for the full contract)
 

--- a/DEP_MGMT.md
+++ b/DEP_MGMT.md
@@ -8,11 +8,8 @@ carries the one-line rules and points here.
 
 The goal is to declare tool versions in real package manifests:
 `tools/<tool>/requirements.txt` for the pip dev tools (today), and a `tools/go.mod`
-`tool` manifest for the Go tools (**being introduced** — the Go-tool migration is
-in flight), with per-tool install scripts only for what no package manager ships.
-<!-- TODO: when the Go-tool migration lands, drop the "being introduced / in
-flight" qualifier here, the "today" / "added alongside the Go-tool manifest"
-notes under Keeping things current, and the "once #247 adds it" note in branch 2. -->
+`tool` manifest for the Go tools (pending completion of #247), with per-tool
+install scripts only for what no package manager ships.
 
 ## Choosing how to install a dependency
 

--- a/DEP_MGMT.md
+++ b/DEP_MGMT.md
@@ -25,9 +25,11 @@ What are you adding?
 │
 ├─ A GitHub Action you `uses:` ?
 │    ├─ a wrangle self-reference (TomHennen/wrangle/…)
-│    │     → pin  @<40-hex sha> # main YYYY-MM-DD ;
+│    │     → in a reusable workflow: pin  @<40-hex sha> # main YYYY-MM-DD ;
 │    │       bump with `make bump-action-pins` (and BY HAND if it lives outside
 │    │       .github/workflows/ — the bumper doesn't reach those yet; see Drift).
+│    │       From one composite action to a sibling: use a relative path
+│    │       `./actions/…` instead of a pin.
 │    ├─ the SLSA generator reusable workflow
 │    │     → tag-pin  @vX.Y.Z  + inline `# zizmor: ignore[unpinned-uses]`.
 │    │       The ONLY sanctioned tag-only ref: its OIDC identity verification
@@ -43,7 +45,15 @@ What are you adding?
 │       (wrangle's product is shell; today this is only the pip *dev* tools.)
 │
 ├─ A CLI tool / binary fetched at install or build time ?   ← the common case.
-│  Walk the tiers; STOP at the first the publisher supports:
+│  First — is there a canonical package-manager release (pip / cargo / npm /
+│  go install / brew) whose verification is at least as strong as any binary
+│  option? If so, USE THE PACKAGE MANAGER — it is the strong default. When
+│  several exist, prefer (1) the one upstream's docs recommend, (2) the one with
+│  attestation support, (3) the one adding the fewest transitive runtime deps to
+│  the image. Binary + attestation and binary + sha256 below are FALLBACKS for
+│  tools with no adequately-verified PM release — not free-choice alternatives.
+│
+│  Otherwise, walk the verification tiers; STOP at the first the publisher supports:
 │
 │     1. Ships SLSA provenance?  → curl binary + provenance, verify, STOP:
 │          • attest-build-provenance sigstore bundle → `gh attestation verify`
@@ -90,7 +100,13 @@ What are you adding?
 
 Whatever the branch: per CLAUDE.md, a PR adopting a new tool must state what
 upstream install paths and verification mechanisms exist and why the chosen one
-was picked.
+was picked. And keep the footprint minimal — use the smallest tool that does the
+job (`unzip` over `python3`, `jq` over a Python script); don't add a language
+runtime to the image for a one-liner.
+
+Operational install-script mechanics (route downloads through
+`lib/download_verify.sh`, install to `$WRANGLE_BIN_DIR`, be idempotent, atomic
+`mv`) are the Install Script Interface contract — see `SPEC.md`.
 
 ## Dependency categories
 

--- a/DEP_MGMT.md
+++ b/DEP_MGMT.md
@@ -1,0 +1,216 @@
+# Dependency management
+
+How wrangle pins, verifies, and upgrades every kind of dependency it consumes.
+This is the canonical strategy; [`CLAUDE.md`](CLAUDE.md) holds the one-line rules
+and points here for the rationale and per-category detail.
+
+Wrangle's product runtime is shell — composite GitHub Actions, `lib/*.sh`, and
+`run.sh`. There is no `go.mod`, `package.json`, `Cargo.toml`, or `pyproject.toml`
+in the tree. (`tools/osv/testdata/vulnerable_go.mod` is a deliberately-vulnerable
+scanner *test fixture*, not a project manifest — never onboard it to Dependabot.)
+So wrangle's real dependency surface is **upstream tool references and binaries
+pulled at install/build time**, each verified at an integrity tier defined in
+[`CLAUDE.md` § Install method and verification](CLAUDE.md).
+
+## Decision tree: how to install and verify a new dependency
+
+Work top-down and stop at the first branch that matches. The governing rule is
+CLAUDE.md's integrity-tier ladder: **use the strongest tier the publisher
+actually supports, and never drop to a weaker one for convenience** — "we'd have
+to install one more tool" is not a justification; "the stronger tier is genuinely
+unavailable upstream" is (and must be documented in the PR).
+
+```
+What are you adding?
+│
+├─ A GitHub Action you `uses:` ?
+│    ├─ a wrangle self-reference (TomHennen/wrangle/…)
+│    │     → pin  @<40-hex sha> # main YYYY-MM-DD ;
+│    │       bump with `make bump-action-pins` (and BY HAND if it lives outside
+│    │       .github/workflows/ — the bumper doesn't reach those yet; see Drift).
+│    ├─ the SLSA generator reusable workflow
+│    │     → tag-pin  @vX.Y.Z  + inline `# zizmor: ignore[unpinned-uses]`.
+│    │       The ONLY sanctioned tag-only ref: its OIDC identity verification
+│    │       keys off the tag, so a SHA pin is impossible (slsa-verifier#12).
+│    └─ any other third-party action
+│          → pin  @<40-hex sha> # vX ;  Dependabot (github-actions) bumps it;
+│            zizmor (unpinned-uses / impostor-commit) enforces the SHA pin.
+│
+├─ A language/package dependency (belongs in a real manifest — go.mod,
+│  package.json, requirements.txt) ?
+│     → use the package manager + its lockfile/hashes; declare the ecosystem in
+│       .github/dependabot.yml so the version AND hashes bump together.
+│       (wrangle's product is shell; today this is only the pip *dev* tools.)
+│
+├─ A CLI tool / binary fetched at install or build time ?   ← the common case.
+│  Walk the tiers; STOP at the first the publisher supports:
+│
+│     1. Ships SLSA provenance?  → curl binary + provenance, verify, STOP:
+│          • attest-build-provenance sigstore bundle → `gh attestation verify`
+│              (--signer-workflow pins the builder identity).
+│              [introduced by the Ampel verify integration, #247]
+│          • slsa-github-generator provenance        → `slsa-verifier verify-artifact`
+│              (osv-scanner, via lib/download_verify.sh `wrangle_verify_provenance`)
+│          • a bnd-style multi-line attestations.jsonl bundle → verify against
+│              THAT format; confirm the release's shape before reusing another
+│              tool's invocation — it is not the same as a single *.provenance.json.
+│
+│     2. Else ships a sigstore signature over a checksums file?
+│          → `cosign verify-blob` the checksums against the publisher identity,
+│            then sha256 the binary against the verified checksums.
+│            (syft — Anchore publishes no provenance; `wrangle_verify_signature`)
+│
+│     3. Else a pure-Go tool that ships NO provenance/signature?
+│          → `go install module@vX.Y.Z` (sum.golang.org) is acceptable AS ITS
+│            NATIVE TIER; track it as a go.mod `tool` directive to gain Dependabot
+│            coverage.  (govulncheck)
+│            ✗ Do NOT use `go install` for a tool that DOES ship provenance or a
+│              signature — sum.golang.org attests first-seen immutability, not
+│              publisher authenticity, so it would DOWNGRADE the tier.
+│
+│     4. Else (nothing published)?
+│          → hardcoded SHA-256 from a trusted out-of-band source, pinned in the
+│            installer, with a comment explaining why nothing stronger exists.
+│            Last resort.
+│
+│     Then, for every binary regardless of tier:
+│       • the installer FAILS CLOSED and never falls back to a weaker tier at
+│         runtime (a failed check may be an attack, not a glitch);
+│       • single-source the version (the `VERSION="${1:-X}"` default in the one
+│         install.sh; the actions invoke it with no version arg so the literal
+│         isn't duplicated). If a version literal must repeat across files, add a
+│         divergence-fail test;
+│       • freshness is MANUAL today — Dependabot can't read install scripts, and
+│         `go install` would downgrade the tier (#264 tracks automating this).
+│
+└─ An OS/apt package, or a container base image (test/build image only) ?
+      → pin the apt package version (don't rely on the base image alone); pin the
+        base image by @sha256: digest. Dev/CI-only; manual upgrade.
+```
+
+Whatever the branch: per CLAUDE.md, a PR adopting a new tool must state what
+upstream install paths and verification mechanisms exist and why the chosen one
+was picked.
+
+## Dependency categories
+
+| # | Category | Where | Pin format |
+|---|---|---|---|
+| 1 | Third-party GitHub Actions | `.github/workflows/`, `actions/`, `build/actions/`, `tools/*/action.yml` | `@<40-hex sha> # vX` |
+| 2 | SLSA generator reusable workflows | `build_and_publish_{python,npm,go,container}.yml` | tag only `@vX.Y.Z` (sanctioned exception) |
+| 3 | Wrangle self-refs in `.github/workflows/` | reusable workflows | `@<sha> # main YYYY-MM-DD` |
+| 4 | Wrangle self-refs outside workflows | e.g. `actions/scan/action.yml` | `@<sha> # main YYYY-MM-DD` |
+| 5 | Upstream `main`-tracking workflow | `compute_slsa_source.yml` | `@<sha> # main` |
+| 6 | Wrangle action refs in examples/docs | `*/README.md` | release tag `@vX.Y.Z` |
+| 7 | pip dev/CI tools | `tools/{zizmor,wrangle-shell-lint}/requirements.txt` | `==ver --hash=sha256:` |
+| 8 | Script-installed release binaries | `tools/{osv,syft}/install.sh` | `VERSION="${1:-X}"` default |
+| 9 | Dockerfile-installed tools | `test/Dockerfile` (actionlint, Go, govulncheck) | ARG + hardcoded SHA-256 / `go install` |
+| 10 | apt packages | `test/Dockerfile` (bats, shellcheck) | unpinned |
+| 11 | Test base image | `test/Dockerfile` | OCI `@sha256:` digest |
+
+> **Incoming with the Ampel verify integration ([#247](https://github.com/TomHennen/wrangle/issues/247)):**
+> a script-installed `ampel` binary verified via `gh attestation verify` (SLSA
+> provenance tier — slsa-verifier deliberately not used, as it doesn't accept
+> ampel's `attest-build-provenance` bundle shape), and a new category — **Ampel
+> policy content**, referenced as SHA-pinned `git+https://…@<commit>` VCS
+> locators in `policies/*.hjson` and divergence-guarded by the policy test
+> harness. Fold these into the tables above when that work lands.
+
+## How integrity is verified
+
+Verification follows the tier ladder in
+[`CLAUDE.md` § Install method and verification](CLAUDE.md) — that file is the
+single source for the ladder; this section maps each category onto it.
+
+| Category | Tier | Mechanism |
+|---|---|---|
+| osv-scanner | **SLSA provenance** (top) | `wrangle_verify_provenance` → `slsa-verifier verify-artifact` against OSV's published provenance |
+| SLSA generator workflows | **SLSA provenance** (generator) | OIDC identity verification (tag-bound) |
+| syft | **Sigstore signature** | `cosign verify-blob` of `checksums.txt`, then SHA-256 of the tarball against the cosign-trusted checksums (Anchore ships no provenance — documented in `tools/syft/install.sh`) |
+| pip tools (zizmor, ast-grep-cli) | **hash-pinned package manager** | `pip install --require-hashes` |
+| actionlint, Go (test image) | **hardcoded SHA-256** | `sha256sum -c` against ARG-pinned checksums |
+| govulncheck | Go sumdb (first-seen immutability, *not* publisher authenticity) | `go install` with `GOPROXY`/`GOSUMDB` asserted |
+| Actions (third-party + self-refs) | commit-SHA immutability | SHA pin; `zizmor` `unpinned-uses` + `impostor-commit` enforce live (`make zizmor`, CI); `test.bats` assert `@[0-9a-f]{40}` |
+| base image | OCI digest | `@sha256:` digest pins layer content and anchors the otherwise-unpinned apt packages |
+
+All custom install scripts abort on verification failure and **never** fall back
+to a weaker tier.
+
+## How upgrades happen
+
+Two automated tracks; the rest manual.
+
+**Automated — Dependabot** (`.github/dependabot.yml`): weekly, capped PR count,
+**no auto-merge**, with a default cooldown that implements CLAUDE.md's "adopt
+after a delay" rule.
+- `github-actions` over the repo — every **third-party** action SHA; new
+  composites are auto-discovered by the glob. Dependabot does **not** open PRs
+  for wrangle's own `TomHennen/wrangle/…@<sha>` self-references — those go through
+  `bump-action-pins` below.
+- `pip` over `/tools/**` — bumps `requirements.txt` version **and** hashes
+  atomically.
+
+**Semi-automated — `make bump-action-pins`** (`tools/bump_action_pins.sh`):
+rewrites every `TomHennen/wrangle/…@<sha>` self-reference **in
+`.github/workflows/`** to a target SHA and refreshes the `# main DATE` comment.
+Run by a human after merging a PR that changes a referenced composite. Its glob
+is **non-recursive over `.github/workflows/`**, so self-refs inside `actions/`
+(e.g. `actions/scan/action.yml`) are **not** covered — see Drift.
+
+**Manual** (hand-edit, no automation): script-installed binary versions
+(`tools/*/install.sh`); Dockerfile tools (actionlint, Go, govulncheck) and the
+base-image digest (no `docker` ecosystem is declared, and it would only touch
+`FROM`, never in-`RUN` `curl` installs); the SLSA generator tag; example/doc
+tags; and `compute_slsa_source.yml`'s upstream-`main` SHA.
+
+> `make update-tool` is currently a **non-functional stub** — tool-binary
+> upgrades are manual today. (Where docs describe it as a working helper, that is
+> doc drift to correct.)
+
+## Drift risks and mitigations
+
+CLAUDE.md § "Pins drift across files" requires every pin that lives in more than
+one file to be **single-sourced** *or* guarded by a **divergence-fail test**.
+Current structural status (specific live instances are tracked as issues, not
+pinned here, since exact versions churn):
+
+| Pin class | Status |
+|---|---|
+| Same third-party action pinned in several files (e.g. the artifact-upload and cosign-installer actions) | Can drift transiently because Dependabot opens **per-directory** PRs that land asynchronously. A *hard* divergence test would fight that window — consolidating the duplicated steps into a shared composite is the durable fix. |
+| The `slsa-verifier` installer action across multiple workflow files | Consistent today but **unguarded** (the self-ref bumper doesn't touch it). Add a divergence-fail `bats` test (stable literal — safe to hard-guard). |
+| `govulncheck` in `test/Dockerfile` ↔ the go checks action default | **Unguarded** — the exact pair CLAUDE.md names; the Dockerfile comment asserts parity but nothing enforces it. Add a divergence-fail test. |
+| Wrangle self-refs **outside** `.github/workflows/` (e.g. `actions/scan/action.yml`) | **No updater owns them** — outside the `bump_action_pins.sh` glob and tagless for Dependabot, so they go stale. Sharpest live gap; extend the bumper to cover `actions/`. |
+| Version comment vs SHA (`# vX`) | Unverified — a wrong comment passes `actionlint`/`zizmor`. Treated as decorative; the SHA is the contract. |
+
+Precedent to build on: the `pip` deps are single-sourced; `zizmor`'s
+requirements-vs-`action.yml` default has a `bats` divergence guard. Mirror that
+pattern to close the unguarded pairs above.
+
+## For reviewers
+
+When reviewing a dependency change, check:
+
+1. **Format.** Third-party action → `@<40-hex> # vX`. Self-ref → `@<sha> # main DATE`.
+   No bare `@main` anywhere (incl. examples/docs). The SLSA generator tag is the
+   only sanctioned tag-only ref and must keep its `# zizmor: ignore` justification.
+2. **Tier not weakened.** A change must not drop to a weaker integrity tier
+   without a documented reason that the stronger tier is genuinely unavailable
+   upstream (per the decision tree). Convenience is not a reason.
+3. **No undocumented drift.** If a pin literal you touched also appears elsewhere
+   (`grep` it), the copies must move together or a divergence guard must exist.
+   Watch the known unguarded pairs (`slsa-verifier`, `govulncheck`).
+4. **Self-refs are fresh.** After merging a composite change, confirm
+   `make bump-action-pins` ran; remember it does **not** cover `actions/` self-refs.
+5. **No auto-merge.** Dependency-update PRs wait out the cooldown and get a human review.
+
+## Tracking items
+
+[#264](https://github.com/TomHennen/wrangle/issues/264) (centralized `tools.lock`
++ freshness automation for the manual binary surface),
+[#277](https://github.com/TomHennen/wrangle/issues/277) (install-method audit),
+[#136](https://github.com/TomHennen/wrangle/issues/136) (`$\{{}}` same-repo
+syntax — simplifies categories 3–4),
+[#218](https://github.com/TomHennen/wrangle/issues/218) (self-ref impostor-commit
+/ advisory-check gap),
+[#247](https://github.com/TomHennen/wrangle/issues/247) (Ampel verify integration
+— adds the gh-attestation tier and the policy-content category).

--- a/DEP_MGMT.md
+++ b/DEP_MGMT.md
@@ -1,232 +1,137 @@
 # Dependency management
 
-How wrangle pins, verifies, and upgrades every kind of dependency it consumes.
-This is the canonical strategy; [`CLAUDE.md`](CLAUDE.md) holds the one-line rules
-and points here for the rationale and per-category detail.
+wrangle's product is shell, but its real dependency surface is the **upstream
+tools it pulls at install and build time** — the policy / scan / SBOM binaries it
+runs and the GitHub Actions it composes. This file is the **authoritative**
+strategy for how those are chosen, pinned, verified, and kept current; `CLAUDE.md`
+carries the one-line rules and points here.
 
-Wrangle's product runtime is shell — composite GitHub Actions, `lib/*.sh`, and
-`run.sh`. There is no `go.mod`, `package.json`, `Cargo.toml`, or `pyproject.toml`
-in the tree. (`tools/osv/testdata/vulnerable_go.mod` is a deliberately-vulnerable
-scanner *test fixture*, not a project manifest — never onboard it to Dependabot.)
-So wrangle's real dependency surface is **upstream tool references and binaries
-pulled at install/build time**, each verified at an integrity tier defined in
-[`CLAUDE.md` § Install method and verification](CLAUDE.md).
+The goal is to declare tool versions in real package manifests:
+`tools/<tool>/requirements.txt` for the pip dev tools (today), and a `tools/go.mod`
+`tool` manifest for the Go tools (**being introduced** — the Go-tool migration is
+in flight), with per-tool install scripts only for what no package manager ships.
 
-## Decision tree: how to install and verify a new dependency
+## Choosing how to install a dependency
 
-Work top-down and stop at the first branch that matches. The governing rule is
-CLAUDE.md's integrity-tier ladder: **use the strongest tier the publisher
-actually supports, and never drop to a weaker one for convenience** — "we'd have
-to install one more tool" is not a justification; "the stronger tier is genuinely
-unavailable upstream" is (and must be documented in the PR).
+The dominant risk in practice isn't a forged download — it's **running something
+stale** with a known CVE. So wrangle weights **freshness first**, as a deliberate
+tradeoff: an automatically-patched install from a slightly-less-attested channel
+beats a marginally-stronger one that a human has to remember to update.
+
+Before anything else — **is the dependency worth trusting at all?** Provenance and
+signatures prove a binary is authentically built from source repo X; they do
+*not* prove X is benign. Vet the project first: who maintains it, how widely it's
+used, its release history, and that the module/path is the canonical one (not a
+typo-squat or fork).
+
+Then:
 
 ```
 What are you adding?
-│
-├─ A GitHub Action you `uses:` ?
-│    ├─ a wrangle self-reference (TomHennen/wrangle/…)
-│    │     → in a reusable workflow: pin  @<40-hex sha> # main YYYY-MM-DD ;
-│    │       bump with `make bump-action-pins` (and BY HAND if it lives outside
-│    │       .github/workflows/ — the bumper doesn't reach those yet; see Drift).
-│    │       From one composite action to a sibling: use a relative path
-│    │       `./actions/…` instead of a pin.
-│    ├─ the SLSA generator reusable workflow
-│    │     → tag-pin  @vX.Y.Z  + inline `# zizmor: ignore[unpinned-uses]`.
-│    │       The ONLY sanctioned tag-only ref: its OIDC identity verification
-│    │       keys off the tag, so a SHA pin is impossible (slsa-verifier#12).
-│    └─ any other third-party action
-│          → pin  @<40-hex sha> # vX ;  Dependabot (github-actions) bumps it;
-│            zizmor (unpinned-uses / impostor-commit) enforces the SHA pin.
-│
-├─ A language/package dependency (belongs in a real manifest — go.mod,
-│  package.json, requirements.txt) ?
-│     → use the package manager + its lockfile/hashes; declare the ecosystem in
-│       .github/dependabot.yml so the version AND hashes bump together.
-│       (wrangle's product is shell; today this is only the pip *dev* tools.)
-│
-├─ A CLI tool / binary fetched at install or build time ?   ← the common case.
-│  First — is there a canonical package-manager release (pip / cargo / npm /
-│  go install / brew) whose verification is at least as strong as any binary
-│  option? If so, USE THE PACKAGE MANAGER — it is the strong default. When
-│  several exist, prefer (1) the one upstream's docs recommend, (2) the one with
-│  attestation support, (3) the one adding the fewest transitive runtime deps to
-│  the image. Binary + attestation and binary + sha256 below are FALLBACKS for
-│  tools with no adequately-verified PM release — not free-choice alternatives.
-│
-│  Otherwise, walk the verification tiers; STOP at the first the publisher supports:
-│
-│     1. Ships SLSA provenance?  → curl binary + provenance, verify, STOP:
-│          • attest-build-provenance sigstore bundle → `gh attestation verify`
-│              (--signer-workflow pins the builder identity).
-│              [introduced by the Ampel verify integration, #247]
-│          • slsa-github-generator provenance        → `slsa-verifier verify-artifact`
-│              (osv-scanner, via lib/download_verify.sh `wrangle_verify_provenance`)
-│          • a bnd-style multi-line attestations.jsonl bundle → verify against
-│              THAT format; confirm the release's shape before reusing another
-│              tool's invocation — it is not the same as a single *.provenance.json.
-│
-│     2. Else ships a sigstore signature over a checksums file?
-│          → `cosign verify-blob` the checksums against the publisher identity,
-│            then sha256 the binary against the verified checksums.
-│            (syft — Anchore publishes no provenance; `wrangle_verify_signature`)
-│
-│     3. Else a pure-Go tool that ships NO provenance/signature?
-│          → `go install module@vX.Y.Z` (sum.golang.org) is acceptable AS ITS
-│            NATIVE TIER; track it as a go.mod `tool` directive to gain Dependabot
-│            coverage.  (govulncheck)
-│            ✗ Do NOT use `go install` for a tool that DOES ship provenance or a
-│              signature — sum.golang.org attests first-seen immutability, not
-│              publisher authenticity, so it would DOWNGRADE the tier.
-│
-│     4. Else (nothing published)?
-│          → hardcoded SHA-256 from a trusted out-of-band source, pinned in the
-│            installer, with a comment explaining why nothing stronger exists.
-│            Last resort.
-│
-│     Then, for every binary regardless of tier:
-│       • the installer FAILS CLOSED and never falls back to a weaker tier at
-│         runtime (a failed check may be an attack, not a glitch);
-│       • single-source the version (the `VERSION="${1:-X}"` default in the one
-│         install.sh; the actions invoke it with no version arg so the literal
-│         isn't duplicated). If a version literal must repeat across files, add a
-│         divergence-fail test;
-│       • freshness is MANUAL today — Dependabot can't read install scripts, and
-│         `go install` would downgrade the tier (#264 tracks automating this).
-│
-└─ An OS/apt package, or a container base image (test/build image only) ?
-      → pin the apt package version (don't rely on the base image alone); pin the
-        base image by @sha256: digest. Dev/CI-only; manual upgrade.
+
+1. Installable from a package manager Dependabot supports
+   (go install / pip / npm / cargo), from a reputable, canonical source?
+     → USE THAT. Dependabot keeps it patched (after the cooldown) — the bigger
+       real-world security win. This is the default.
+         • Go tools     → a `tool` directive in tools/go.mod, installed with
+                          `go install` / `go build` at the pinned version
+                          (sum.golang.org pins the bytes; Dependabot bumps it).
+         • Python tools → tools/<tool>/requirements.txt (==version + --hash),
+                          a venv + `pip install --require-hashes` (Dependabot
+                          bumps version and hashes together).
+
+2. Not package-manager-installable, but the publisher ships SLSA provenance or a
+   sigstore signature?
+     → download the binary and verify it through lib/download_verify.sh
+       (slsa-verifier or cosign today; `gh attestation verify` once #247 adds it).
+       Freshness is then MANUAL — flag it against the #264 automation.
+
+3. Neither?
+     → hardcoded SHA-256 from a trusted out-of-band source, pinned in the
+       installer, with a comment explaining why nothing stronger exists.
+       Last resort.
 ```
 
-Whatever the branch: per CLAUDE.md, a PR adopting a new tool must state what
-upstream install paths and verification mechanisms exist and why the chosen one
-was picked. And keep the footprint minimal — use the smallest tool that does the
-job (`unzip` over `python3`, `jq` over a Python script); don't add a language
-runtime to the image for a one-liner.
+A GitHub Action (a `uses:` reference) is a separate case — see [Pinning](#pinning).
 
-Operational install-script mechanics (route downloads through
-`lib/download_verify.sh`, install to `$WRANGLE_BIN_DIR`, be idempotent, atomic
-`mv`) are the Install Script Interface contract — see `SPEC.md`.
+Keep the footprint minimal: the smallest tool that does the job (`unzip` over
+`python3`, `jq` over a Python script); don't add a language runtime for a
+one-liner.
 
-## Dependency categories
+## Integrity tiers
 
-| # | Category | Where | Pin format |
-|---|---|---|---|
-| 1 | Third-party GitHub Actions | `.github/workflows/`, `actions/`, `build/actions/`, `tools/*/action.yml` | `@<40-hex sha> # vX` |
-| 2 | SLSA generator reusable workflows | `build_and_publish_{python,npm,go,container}.yml` | tag only `@vX.Y.Z` (sanctioned exception) |
-| 3 | Wrangle self-refs in `.github/workflows/` | reusable workflows | `@<sha> # main YYYY-MM-DD` |
-| 4 | Wrangle self-refs outside workflows | e.g. `actions/scan/action.yml` | `@<sha> # main YYYY-MM-DD` |
-| 5 | Upstream `main`-tracking workflow | `compute_slsa_source.yml` | `@<sha> # main` |
-| 6 | Wrangle action refs in examples/docs | `*/README.md` | release tag `@vX.Y.Z` |
-| 7 | pip dev/CI tools | `tools/{zizmor,wrangle-shell-lint}/requirements.txt` | `==ver --hash=sha256:` |
-| 8 | Script-installed release binaries | `tools/{osv,syft}/install.sh` | `VERSION="${1:-X}"` default |
-| 9 | Dockerfile-installed tools | `test/Dockerfile` (actionlint, Go, govulncheck) | ARG + hardcoded SHA-256 / `go install` |
-| 10 | apt packages | `test/Dockerfile` (bats, shellcheck) | unpinned |
-| 11 | Test base image | `test/Dockerfile` | OCI `@sha256:` digest |
+When you download-and-verify (branch 2/3 above), use the strongest tier the
+publisher offers, and never drop to a weaker one **for convenience** — "we'd have
+to install one more tool" is not a reason; "the stronger tier is genuinely
+unavailable upstream" is (and the PR must say which):
 
-> **Incoming with the Ampel verify integration ([#247](https://github.com/TomHennen/wrangle/issues/247)):**
-> a script-installed `ampel` binary verified via `gh attestation verify` (SLSA
-> provenance tier — slsa-verifier deliberately not used, as it doesn't accept
-> ampel's `attest-build-provenance` bundle shape), and a new category — **Ampel
-> policy content**, referenced as SHA-pinned `git+https://…@<commit>` VCS
-> locators in `policies/*.hjson` and divergence-guarded by the policy test
-> harness. Fold these into the tables above when that work lands.
+> **SLSA provenance > GitHub release attestation > sigstore signature >
+> hash-pinned package manager (lockfile / `--require-hashes` / sum.golang.org) >
+> hardcoded SHA-256.**
 
-## How integrity is verified
+This interacts with the freshness-first rule deliberately. A package manager sits
+at the "hash-pinned" rung, but its **Dependabot auto-patching is what earns it the
+default slot** — freshness is treated as part of the security posture, not just
+convenience. And for a Go tool from its canonical module path, `go install`
+(build-from-source, sum.golang.org, your own verified toolchain) is **not** a
+meaningful downgrade from binary+provenance: there is no foreign prebuilt binary
+to attest, and a compromise of the upstream repo would defeat build provenance
+just the same. So `go install` is a first-class choice, not a fallback.
 
-Verification follows the tier ladder in
-[`CLAUDE.md` § Install method and verification](CLAUDE.md) — that file is the
-single source for the ladder; this section maps each category onto it.
+## Pinning
 
-| Category | Tier | Mechanism |
-|---|---|---|
-| osv-scanner | **SLSA provenance** (top) | `wrangle_verify_provenance` → `slsa-verifier verify-artifact` against OSV's published provenance |
-| SLSA generator workflows | **SLSA provenance** (generator) | OIDC identity verification (tag-bound) |
-| syft | **Sigstore signature** | `cosign verify-blob` of `checksums.txt`, then SHA-256 of the tarball against the cosign-trusted checksums (Anchore ships no provenance — documented in `tools/syft/install.sh`) |
-| pip tools (zizmor, ast-grep-cli) | **hash-pinned package manager** | `pip install --require-hashes` |
-| actionlint, Go (test image) | **hardcoded SHA-256** | `sha256sum -c` against ARG-pinned checksums |
-| govulncheck | Go sumdb (first-seen immutability, *not* publisher authenticity) | `go install` with `GOPROXY`/`GOSUMDB` asserted |
-| Actions (third-party + self-refs) | commit-SHA immutability | SHA pin; `zizmor` `unpinned-uses` + `impostor-commit` enforce live (`make zizmor`, CI); `test.bats` assert `@[0-9a-f]{40}` |
-| base image | OCI digest | `@sha256:` digest pins layer content and anchors the otherwise-unpinned apt packages |
-
-All custom install scripts abort on verification failure and **never** fall back
-to a weaker tier.
-
-## How upgrades happen
-
-Two automated tracks; the rest manual.
-
-**Automated — Dependabot** (`.github/dependabot.yml`): weekly, capped PR count,
-**no auto-merge**, with a default cooldown that implements CLAUDE.md's "adopt
-after a delay" rule.
-- `github-actions` over the repo — every **third-party** action SHA; new
-  composites are auto-discovered by the glob. Dependabot does **not** open PRs
-  for wrangle's own `TomHennen/wrangle/…@<sha>` self-references — those go through
-  `bump-action-pins` below.
-- `pip` over `/tools/**` — bumps `requirements.txt` version **and** hashes
-  atomically.
-
-**Semi-automated — `make bump-action-pins`** (`tools/bump_action_pins.sh`):
-rewrites every `TomHennen/wrangle/…@<sha>` self-reference **in
-`.github/workflows/`** to a target SHA and refreshes the `# main DATE` comment.
-Run by a human after merging a PR that changes a referenced composite. Its glob
-is **non-recursive over `.github/workflows/`**, so self-refs inside `actions/`
-(e.g. `actions/scan/action.yml`) are **not** covered — see Drift.
-
-**Manual** (hand-edit, no automation): script-installed binary versions
-(`tools/*/install.sh`); Dockerfile tools (actionlint, Go, govulncheck) and the
-base-image digest (no `docker` ecosystem is declared, and it would only touch
-`FROM`, never in-`RUN` `curl` installs); the SLSA generator tag; example/doc
-tags; and `compute_slsa_source.yml`'s upstream-`main` SHA.
-
-> `make update-tool` is currently a **non-functional stub** — tool-binary
-> upgrades are manual today. (Where docs describe it as a working helper, that is
-> doc drift to correct.)
-
-## Drift risks and mitigations
-
-CLAUDE.md § "Pins drift across files" requires every pin that lives in more than
-one file to be **single-sourced** *or* guarded by a **divergence-fail test**.
-Current structural status (specific live instances are tracked as issues, not
-pinned here, since exact versions churn):
-
-| Pin class | Status |
+| Dependency | Pin format |
 |---|---|
-| Same third-party action pinned in several files (e.g. the artifact-upload and cosign-installer actions) | Can drift transiently because Dependabot opens **per-directory** PRs that land asynchronously. A *hard* divergence test would fight that window — consolidating the duplicated steps into a shared composite is the durable fix. |
-| The `slsa-verifier` installer action across multiple workflow files | Consistent today but **unguarded** (the self-ref bumper doesn't touch it). Add a divergence-fail `bats` test (stable literal — safe to hard-guard). |
-| `govulncheck` in `test/Dockerfile` ↔ the go checks action default | **Unguarded** — the exact pair CLAUDE.md names; the Dockerfile comment asserts parity but nothing enforces it. Add a divergence-fail test. |
-| Wrangle self-refs **outside** `.github/workflows/` (e.g. `actions/scan/action.yml`) | **No updater owns them** — outside the `bump_action_pins.sh` glob and tagless for Dependabot, so they go stale. Sharpest live gap; extend the bumper to cover `actions/`. |
-| Version comment vs SHA (`# vX`) | Unverified — a wrong comment passes `actionlint`/`zizmor`. Treated as decorative; the SHA is the contract. |
+| Third-party GitHub Action | `@<40-hex sha> # vX` |
+| SLSA generator reusable workflow | tag only `@vX.Y.Z` + `# zizmor: ignore[unpinned-uses]` (sanctioned exception — its OIDC verification keys off the tag) |
+| Wrangle self-ref in a reusable workflow | `@<sha> # main YYYY-MM-DD` |
+| Wrangle composite → sibling composite | relative path `./actions/…` |
+| Wrangle action in examples/docs | release tag `@vX.Y.Z` |
+| Go tool | `tool` directive + pinned `require` in `tools/go.mod` (+ `go.sum`) |
+| Python tool | `==version --hash=sha256:` in `requirements.txt` |
+| Binary with no package manager | version pinned in the install script |
+| Container base image | OCI `@sha256:` digest |
 
-Precedent to build on: the `pip` deps are single-sourced; `zizmor`'s
-requirements-vs-`action.yml` default has a `bats` divergence guard. Mirror that
-pattern to close the unguarded pairs above.
+`@main` MUST NOT appear in any `uses:` line, anywhere — including examples and docs.
+
+## Keeping things current
+
+- **Dependabot** (`.github/dependabot.yml`) — weekly, no auto-merge, with a
+  cooldown that implements the 7-day "adopt after a delay" rule. It covers
+  `github-actions` (third-party action SHAs) and `pip` (the dev-tool requirements)
+  today; `gomod` is added alongside the Go-tool manifest. This automatic patching
+  is *why* branch 1 is the default.
+- **`make bump-action-pins`** rewrites wrangle's own self-references after a
+  composite changes (it currently reaches only `.github/workflows/` — see #287).
+- **Manual today:** the binary+provenance installs (branch 2) and the base-image
+  digest. Automating that surface — ideally one mechanism that also covers
+  wrangle's own self-references — is #264.
+
+## Drift
+
+A pin literal (version, SHA, checksum) that lives in more than one file must be
+**single-sourced or guarded by a divergence-fail test** — never left to humans to
+update in lockstep. The pip versions are single-sourced by `requirements.txt` (the Go tools likewise,
+once the `go.mod` manifest lands); the existing `tools/zizmor`
+requirements↔`action.yml` `bats` guard is the pattern to copy for the rest. Known unguarded duplicates are tracked in #286.
 
 ## For reviewers
 
-When reviewing a dependency change, check:
+1. **Reputable?** Is the dependency itself worth trusting — maintained, adopted,
+   on its canonical path? Verification proves *authenticity*, not *benignity*.
+2. **Fresh?** Prefer a Dependabot-covered package manager. If it's a manual binary
+   install, is that justified (no PM release, or a stronger tier genuinely needed)?
+3. **Tier not weakened for convenience.**
+4. **Pinned correctly** — `# vX` SHA for third-party actions, `# main DATE` for
+   self-refs, no bare `@main`; a pinned version in the manifest or script.
+5. **No undocumented drift** — a pin literal you touched that also appears
+   elsewhere must move together or be guarded.
+6. **No auto-merge** — dependency updates wait out the cooldown and get a human review.
 
-1. **Format.** Third-party action → `@<40-hex> # vX`. Self-ref → `@<sha> # main DATE`.
-   No bare `@main` anywhere (incl. examples/docs). The SLSA generator tag is the
-   only sanctioned tag-only ref and must keep its `# zizmor: ignore` justification.
-2. **Tier not weakened.** A change must not drop to a weaker integrity tier
-   without a documented reason that the stronger tier is genuinely unavailable
-   upstream (per the decision tree). Convenience is not a reason.
-3. **No undocumented drift.** If a pin literal you touched also appears elsewhere
-   (`grep` it), the copies must move together or a divergence guard must exist.
-   Watch the known unguarded pairs (`slsa-verifier`, `govulncheck`).
-4. **Self-refs are fresh.** After merging a composite change, confirm
-   `make bump-action-pins` ran; remember it does **not** cover `actions/` self-refs.
-5. **No auto-merge.** Dependency-update PRs wait out the cooldown and get a human review.
+## Tracking
 
-## Tracking items
-
-[#264](https://github.com/TomHennen/wrangle/issues/264) (centralized `tools.lock`
-+ freshness automation for the manual binary surface),
-[#277](https://github.com/TomHennen/wrangle/issues/277) (install-method audit),
-[#136](https://github.com/TomHennen/wrangle/issues/136) (`$\{{}}` same-repo
-syntax — simplifies categories 3–4),
-[#218](https://github.com/TomHennen/wrangle/issues/218) (self-ref impostor-commit
-/ advisory-check gap),
-[#247](https://github.com/TomHennen/wrangle/issues/247) (Ampel verify integration
-— adds the gh-attestation tier and the policy-content category).
+#264 (automate the manual binary surface, ideally covering wrangle's own refs too),
+#277 (install-method audit), #286 (divergence guards), #287 (self-ref bump scope),
+#136 (`$/` same-repo syntax), #218 (self-ref impostor-commit gap),
+#247 (Ampel verify — adds the `gh attestation verify` path to
+`lib/download_verify.sh`; fold it into branch 2 once merged).

--- a/DEP_MGMT.md
+++ b/DEP_MGMT.md
@@ -10,6 +10,9 @@ The goal is to declare tool versions in real package manifests:
 `tools/<tool>/requirements.txt` for the pip dev tools (today), and a `tools/go.mod`
 `tool` manifest for the Go tools (**being introduced** — the Go-tool migration is
 in flight), with per-tool install scripts only for what no package manager ships.
+<!-- TODO: when the Go-tool migration lands, drop the "being introduced / in
+flight" qualifier here, the "today" / "added alongside the Go-tool manifest"
+notes under Keeping things current, and the "once #247 adds it" note in branch 2. -->
 
 ## Choosing how to install a dependency
 
@@ -66,7 +69,7 @@ to install one more tool" is not a reason; "the stronger tier is genuinely
 unavailable upstream" is (and the PR must say which):
 
 > **SLSA provenance > GitHub release attestation > sigstore signature >
-> hash-pinned package manager (lockfile / `--require-hashes` / sum.golang.org) >
+> hash-pinned package manager (lockfile, `--require-hashes`) >
 > hardcoded SHA-256.**
 
 This interacts with the freshness-first rule deliberately. A package manager sits


### PR DESCRIPTION
Closes #284.

Adds **`DEP_MGMT.md`** — the canonical dependency-management strategy — and links it from `CLAUDE.md` (§ Install method and verification) so reviewers are directed to it.

## What's in it
- **A decision tree** (the centerpiece) for choosing how to install + verify a *new* dependency: GitHub Action vs. language/package dep vs. CLI binary vs. OS/base-image, and for binaries, walking the integrity-tier ladder (SLSA provenance → sigstore signature → `go install`/sumdb only for pure-Go-no-provenance tools → hardcoded SHA-256 last resort), with the "never downgrade for convenience" rule.
- The 11 current dependency categories, how each is pinned, the per-category verification tier, and how upgrades happen (Dependabot tracks vs. the manual binary surface).
- Drift risks as **strategy + structural status** (single-source-or-divergence-guard), with specific live instances tracked as issues rather than pinned into the doc (they churn).
- A "For reviewers" checklist.

## Scope notes
- **Written against `main`.** The Ampel verify work (#247 / its in-flight PR) introduces the `gh attestation verify` provenance tier and a new *policy-content* (VCS-locator SHA) category — these are marked **incoming**, to fold into the tables when that lands.
- This PR is the **documentation** half of #284. The "consider fixing anything we're worried about" half is being filed as separate tracked issues (divergence guards for the unguarded duplicate pins, the self-ref bumper's scope gap, pinning bats/shellcheck, the `go.mod` tool-directive win for govulncheck, and the `update-tool` doc drift).