### PR TITLE
container: emit a Docker tag on non-semver tag pushes (#292)

### DIFF
--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -97,9 +97,10 @@ runs:
         tags: |
           type=ref,event=branch
           type=ref,event=pr
-          # Non-semver tags (the vYYYYMMDD-<sha> tracking tags the showcase
-          # pushes) match no semver rule; emit a tag from the ref so the push
-          # doesn't fail with "tag is needed when pushing to registry" (#292).
+          # Adopters who version with non-semver tags (CalVer, date-sha,
+          # git-describe) match no type=semver rule below; without a tag from
+          # the ref the push fails with "tag is needed when pushing to
+          # registry" (#292). Part of metadata-action's default tag set.
           type=ref,event=tag
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -97,6 +97,10 @@ runs:
         tags: |
           type=ref,event=branch
           type=ref,event=pr
+          # Non-semver tags (the vYYYYMMDD-<sha> tracking tags the showcase
+          # pushes) match no semver rule; emit a tag from the ref so the push
+          # doesn't fail with "tag is needed when pushing to registry" (#292).
+          type=ref,event=tag
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Problem

The wrangle-test showcase container jobs fail on every run (#292; run 26693944337) with:

> ERROR: failed to build: tag is needed when pushing to registry

## Root cause

The showcase pushes a **non-semver** tracking tag (`vYYYYMMDD-<sha>`). `docker/metadata-action`'s tag rules here cover only branch / PR / semver / `main`-`latest` — all of which miss on such a tag — so `steps.meta.outputs.tags` comes out empty, and the next step's unconditional `push: true` aborts. (The `provenance` job that genuinely needs a semver tag is never reached; the `build` job isn't release-gated, so it runs and hits buildx.)

## Fix

Add `type=ref,event=tag` so any tag ref yields a usable image tag (`…:vYYYYMMDD-<sha>`). On a real semver tag it fires alongside `type=semver` (a harmless extra `v`-prefixed tag).

Found by a dedicated investigation of #292. The same run also had three **unrelated** failures (PyPI trusted-publishing not configured, an npm publish error, and a `release-assets` step missing `actions/checkout` → "not a git repository") — out of scope for this PR.

Fixes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)
