### PR TITLE
dependency-review: disable upstream license + scorecard noise (#294)

### DIFF
--- a/tools/dependency-review/action.yml
+++ b/tools/dependency-review/action.yml
@@ -46,6 +46,12 @@ runs:
       with:
         fail-on-severity: ${{ inputs.fail-on-severity }}
         comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
+        # wrangle gates only on vulnerabilities (the SARIF below), not licenses,
+        # so disable the upstream license + scorecard channels — otherwise they
+        # emit a noisy "could not detect a license" list for gomod deps whose
+        # license GitHub's dependency graph doesn't surface (#294).
+        license-check: false
+        show-openssf-scorecard: false
 
     - name: Collect dependency review output
       if: always()

--- a/tools/dependency-review/action.yml
+++ b/tools/dependency-review/action.yml
@@ -47,9 +47,10 @@ runs:
         fail-on-severity: ${{ inputs.fail-on-severity }}
         comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
         # wrangle gates only on vulnerabilities (the SARIF below), not licenses,
-        # so disable the upstream license + scorecard channels — otherwise they
-        # emit a noisy "could not detect a license" list for gomod deps whose
-        # license GitHub's dependency graph doesn't surface (#294).
+        # so disable the upstream license + scorecard channels. Beyond being
+        # unused, the license check is unreliable: it emits a noisy "could not
+        # detect a license" list — lots of false positives — for gomod deps
+        # whose license GitHub's dependency graph doesn't surface (#294).
         license-check: false
         show-openssf-scorecard: false
 


### PR DESCRIPTION
## Problem

`dependency-review` looks "too aggressive" and inconsistent (#294): it prints a long *"could not detect a license"* list for ~75 Go modules that **do** have licenses, while the wrangle "dependency-review Details" section on the same summary says **No findings**.

## Root cause (the run never actually failed — it was green)

- wrangle sets **no** license policy, but the upstream `dependency-review-action`'s `license-check` **defaults to `true`**, so it runs and prints an *informational* "could not detect a license" list. Those entries are GitHub dependency-graph **metadata gaps for gomod**, not real violations — and informational only (they never call `setFailed`). `show-openssf-scorecard` (also default-`true`) adds the parallel `Score: undefined` noise.
- The "No findings" below it is **correct**: wrangle's SARIF is vulnerability-only by design, and zero vulnerabilities were introduced. It just sits jarringly beneath the upstream license list — two writers to the same `$GITHUB_STEP_SUMMARY` page.

## Fix

wrangle doesn't gate on licenses, so disable the upstream channels it doesn't consume: `license-check: false` and `show-openssf-scorecard: false`. This removes the false-positive list **and** the contradicting top-of-page content — one change resolves both symptoms, with no change to the SARIF pipeline.

Fixes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)
