### PR TITLE
claude: bump self-reference pins to main (propagate #297)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -105,7 +105,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/actions/preflight_guard@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
 
   gate:
     needs: [guard]
@@ -116,7 +116,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/actions/release_gate@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -138,7 +138,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      uses: TomHennen/wrangle/build/actions/container@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -152,7 +152,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/actions/preflight_guard@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
 
   gate:
     needs: [guard]
@@ -162,7 +162,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/actions/release_gate@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -187,7 +187,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/build/actions/go/checks@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -245,7 +245,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/build/actions/go/release@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
         id: release
         with:
           path: ${{ inputs.path }}
@@ -316,7 +316,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/build/actions/go/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/go/verify@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/build/actions/go/verify@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
         with:
           dist-dir: dist
           provenance-path: provenance/${{ needs.provenance.outputs.provenance-name }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -125,7 +125,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/actions/preflight_guard@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
 
   gate:
     needs: [guard]
@@ -136,7 +136,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/actions/release_gate@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -160,7 +160,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/build/actions/npm@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -104,7 +104,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/actions/preflight_guard@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -119,7 +119,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/actions/release_gate@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/build/actions/python@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -29,7 +29,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/actions/preflight_guard@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
 
   shell-build:
     needs: [guard]
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+        uses: TomHennen/wrangle/build/actions/shell@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -20,7 +20,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+      - uses: TomHennen/wrangle/actions/preflight_guard@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
 
   check-change:
     needs: [guard]
@@ -38,6 +38,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@152ddef7189664d507ecb5d7356c84e7a64029d9 # main 2026-05-24
+        uses: TomHennen/wrangle/actions/scan@ecd5780c4c8e968d8db5d12be4d5c50d13fc3429 # main 2026-05-31
         with:
           tools: ${{ inputs.tools }}


### PR DESCRIPTION
## Why

After #297 merged, the showcase on `wrangle-test` still failed its container jobs with the original `tag is needed when pushing to registry` error — even though the fix is in `main`'s tree and the #297 integration test passed.

Root cause: the companion's `showcase.yml` calls `build_and_publish_container.yml@main`, and that reusable workflow SHA-pins the container composite to `152ddef` (`# main 2026-05-24`) — *before* the fix. So the showcase ran the unfixed composite.

## What

Ran `tools/bump_action_pins.sh` (target = current `main` HEAD `ecd5780`, which carries the #297 fix). Bumps all 18 `TomHennen/wrangle/...@<sha>` self-reference pins across 6 reusable workflows from `152ddef` → `ecd5780`.

```
build_and_publish_container.yml
build_and_publish_go.yml
build_and_publish_npm.yml
build_and_publish_python.yml
build_shell.yml
check_source_change.yml
```

Mechanical, comment-date-and-SHA-only diff. Once merged, the next showcase run should clear the container jobs.

No 7-day adoption delay applies: that gate is for third-party upstreams; self-reference bumps are the intended propagation mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)