### PR TITLE
feat: mechanically enforce 5 CLAUDE.md GitHub Actions/shell conventions (#273)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ metadata/
 .wrangle/
 .claude/
 CLAUDE.local.md
+
+# Python bytecode cache from tools/wrangle-workflow-lint/lint.py
+__pycache__/
+*.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,11 @@ Every shell script MUST start with the exact preamble `set -euo pipefail` follow
 
 All variable expansions MUST be double-quoted. All scripts MUST pass `shellcheck` — no `# shellcheck disable` without a justifying comment. Use `$(command)` not backticks. Use `[[ ]]` not `[ ]` for conditionals. Use `printf` not `echo` for output that may contain user data.
 
-Don't `curl | sh` — all binary downloads go through `lib/download_verify.sh`. These rules are mechanically enforced by `tools/wrangle-shell-lint/` (WSL001–005).
+Don't `curl | sh` — all binary downloads go through `lib/download_verify.sh`. These rules are mechanically enforced by `tools/wrangle-shell-lint/` (WSL001–007; `curl | sh` is WSL006, `set +f` outside a subshell is WSL007).
 
 ## GitHub Actions
 
-- **Inline shell ≤ ~5 lines.** Longer or anything with logic → extract to a script.
+- **Inline shell ≤ 10 physical lines** (preamble, blanks, and comments all count). Longer or anything with logic → extract to a script. Enforced by `tools/wrangle-workflow-lint/` (WWL001).
 - **No expression injection.** NEVER interpolate `${{ inputs.* }}`, `${{ github.event.* }}`, or any attacker-controllable expression directly in a `run:` block — always thread through `env:` first.
 - **No copy-paste across workflows.** If the same `run:` block or step sequence appears in more than two workflow files, extract to a composite or shared script. Drift between copies is a class of bug, not a one-off.
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: all test lint shellcheck shellstyle bats zizmor bump-action-pins
+.PHONY: all test lint shellcheck shellstyle workflowstyle bats zizmor bump-action-pins
 
 # Default target
 all: test
 
 # Run all local checks
-test: lint shellcheck shellstyle bats zizmor
+test: lint shellcheck shellstyle workflowstyle bats zizmor
 
 # Validate all workflow and action YAML files
 lint:
@@ -15,6 +15,12 @@ lint:
 shellstyle:
 	@echo "=== wrangle-shell-lint ==="
 	@./tools/wrangle-shell-lint/lint.sh
+
+# Run wrangle-specific workflow style linter (CLAUDE.md GitHub Actions rules:
+# run-block length, expression injection, continue-on-error justification)
+workflowstyle:
+	@echo "=== wrangle-workflow-lint ==="
+	@./tools/wrangle-workflow-lint/lint.sh
 
 # Lint all shell scripts
 shellcheck:

--- a/build/actions/go/release/generate_summary.sh
+++ b/build/actions/go/release/generate_summary.sh
@@ -23,11 +23,6 @@ INPUT_PATH="$1"
 VERSION="$2"
 PUBLISHED="$3"
 
-# Re-enable globbing locally for the for-loop below. The script
-# disabled it at the top to make positional-arg handling safe; here
-# we want to glob dist/* explicitly.
-set +f
-
 if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
     printf 'Note: GITHUB_STEP_SUMMARY not set; printing to stdout instead.\n'
     OUT=/dev/stdout
@@ -42,10 +37,16 @@ fi
     printf '| **Version** | %s |\n' "$VERSION"
     printf '| **Published** | %s |\n' "$PUBLISHED"
     printf '| **Artifacts** | |\n'
-    for f in "$INPUT_PATH"/dist/*; do
-        if [[ -f "$f" ]]; then
-            # shellcheck disable=SC2016 # backticks here are human-readable markdown, not command substitution
-            printf '| | `%s` |\n' "$(basename "$f")"
-        fi
-    done
+    # Expand dist/* inside a subshell so globbing is restored on every
+    # exit path — a bare `set +f` here would leak glob-enabled state to
+    # the rest of the script if the loop aborted under set -e.
+    (
+        set +f
+        for f in "$INPUT_PATH"/dist/*; do
+            if [[ -f "$f" ]]; then
+                # shellcheck disable=SC2016 # backticks here are human-readable markdown, not command substitution
+                printf '| | `%s` |\n' "$(basename "$f")"
+            fi
+        done
+    )
 } >> "$OUT"

--- a/build/actions/npm/action.yml
+++ b/build/actions/npm/action.yml
@@ -185,19 +185,19 @@ runs:
       env:
         INPUT_PATH: ${{ inputs.path }}
         METADATA_DIR: ${{ steps.metadata.outputs.metadata-dir }}
+      # syft over the project source. Same tool wrangle's python build
+      # type uses; OWASP-known-conformant for SPDX. (Earlier SPEC drafts
+      # picked the npm-CLI's in-tree SBOM command, but its conformance
+      # was publicly criticized; switching to syft removes the question.)
+      # Adopters consuming wrangle-attested packages with bundled native
+      # code SHOULD layer binary scanners (Trivy, Grype) against installed
+      # node_modules/ for full coverage — wrangle's source-tree SBOM does
+      # not see compiled C/C++ artifacts that prebuild-install fetches at
+      # consumer install time.
       run: |
         set -euo pipefail
         SBOM_PATH="${METADATA_DIR}/sbom.spdx.json"
         BIN_DIR="${WRANGLE_BIN_DIR:-${RUNNER_TEMP:-.}/.wrangle/bin}"
-        # syft over the project source. Same tool wrangle's python build
-        # type uses; OWASP-known-conformant for SPDX. (Earlier SPEC drafts
-        # picked the npm-CLI's in-tree SBOM command, but its conformance
-        # was publicly criticized; switching to syft removes the question.)
-        # Adopters consuming wrangle-attested packages with bundled native
-        # code SHOULD layer binary scanners (Trivy, Grype) against installed
-        # node_modules/ for full coverage — wrangle's source-tree SBOM does
-        # not see compiled C/C++ artifacts that prebuild-install fetches at
-        # consumer install time.
         "$BIN_DIR/syft" dir:"$INPUT_PATH" -o spdx-json > "$SBOM_PATH"
         printf 'SBOM written to %s\n' "$SBOM_PATH"
 

--- a/build/actions/python/action.yml
+++ b/build/actions/python/action.yml
@@ -155,27 +155,7 @@ runs:
         INPUT_PATH: ${{ inputs.path }}
       run: |
         set -euo pipefail
-        SHORTNAME="${INPUT_PATH////_}"
-        METADATA_DIR="metadata/python/${SHORTNAME}"
-        mkdir -p "$METADATA_DIR"
-        printf 'shortname=%s\n' "$SHORTNAME" >> "$GITHUB_OUTPUT"
-        printf 'metadata-dir=%s\n' "$METADATA_DIR" >> "$GITHUB_OUTPUT"
-
-        # Extract version from the built wheel filename. nullglob avoids
-        # the pipefail abort that `ls dist/*.whl | head` triggers when no
-        # wheel exists — we want to surface a friendly message instead.
-        cd "$INPUT_PATH"
-        shopt -s nullglob
-        wheels=(dist/*.whl)
-        if (( ${#wheels[@]} > 0 )); then
-            # Wheel filename format: {name}-{version}-{tags}.whl
-            VERSION="$(basename "${wheels[0]}" | sed 's/^[^-]*-\([^-]*\)-.*/\1/')"
-            printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
-            printf 'Package version: %s\n' "$VERSION"
-        else
-            printf 'Warning: no wheel found in dist/\n'
-            printf 'version=unknown\n' >> "$GITHUB_OUTPUT"
-        fi
+        "${{ github.action_path }}/extract_metadata.sh" "$INPUT_PATH"
 
     - name: Compute artifact hashes
       id: hash
@@ -221,15 +201,4 @@ runs:
         VERSION: ${{ steps.metadata.outputs.version }}
       run: |
         set -euo pipefail
-        {
-            printf '## Python Build Results\n\n'
-            printf '| | |\n|---|---|\n'
-            printf '| **Package** | %s |\n' "$INPUT_PATH"
-            printf '| **Version** | %s |\n' "$VERSION"
-            printf '| **Artifacts** | |\n'
-            for f in "$INPUT_PATH"/dist/*; do
-                if [[ -f "$f" ]]; then
-                    printf '| | `%s` |\n' "$(basename "$f")"
-                fi
-            done
-        } >> "$GITHUB_STEP_SUMMARY"
+        "${{ github.action_path }}/generate_summary.sh" "$INPUT_PATH" "$VERSION"

--- a/build/actions/python/extract_metadata.sh
+++ b/build/actions/python/extract_metadata.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# Extract Python package metadata for the build composite: a filesystem-
+# safe shortname, the per-package metadata directory, and the wheel
+# version. Writes `shortname`, `metadata-dir`, and `version` to
+# $GITHUB_OUTPUT for downstream steps.
+#
+# Usage: extract_metadata.sh <input_path>
+
+if [[ $# -ne 1 ]]; then
+    printf 'Usage: extract_metadata.sh <input_path>\n' >&2
+    exit 1
+fi
+
+INPUT_PATH="$1"
+SHORTNAME="${INPUT_PATH////_}"
+METADATA_DIR="metadata/python/${SHORTNAME}"
+mkdir -p "$METADATA_DIR"
+printf 'shortname=%s\n' "$SHORTNAME" >> "$GITHUB_OUTPUT"
+printf 'metadata-dir=%s\n' "$METADATA_DIR" >> "$GITHUB_OUTPUT"
+
+# Extract the version from the built wheel filename. The glob runs in a
+# subshell so `set +f` cannot leak glob-enabled state to the rest of the
+# script (a bare toggle would not restore under set -e); nullglob makes
+# the no-wheel case expand to nothing rather than the literal pattern.
+# Wheel name format: {name}-{version}-{tags}.whl
+VERSION="$(
+    set +f
+    shopt -s nullglob
+    cd "$INPUT_PATH"
+    wheels=(dist/*.whl)
+    if (( ${#wheels[@]} > 0 )); then
+        basename "${wheels[0]}" | sed 's/^[^-]*-\([^-]*\)-.*/\1/'
+    fi
+)"
+
+if [[ -n "$VERSION" ]]; then
+    printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
+    printf 'Package version: %s\n' "$VERSION"
+else
+    printf 'Warning: no wheel found in dist/\n'
+    printf 'version=unknown\n' >> "$GITHUB_OUTPUT"
+fi

--- a/build/actions/python/extract_metadata.sh
+++ b/build/actions/python/extract_metadata.sh
@@ -14,6 +14,9 @@ if [[ $# -ne 1 ]]; then
     exit 1
 fi
 
+# input_path is the action's inputs.path, already constrained by
+# validate_inputs.sh (lib/validate_path.sh) — the composite's first step,
+# which runs before this one; no untrusted value reaches the cd / glob below.
 INPUT_PATH="$1"
 SHORTNAME="${INPUT_PATH////_}"
 METADATA_DIR="metadata/python/${SHORTNAME}"

--- a/build/actions/python/generate_summary.sh
+++ b/build/actions/python/generate_summary.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# Writes the GitHub Actions step summary for the Python build composite.
+# Renders a markdown table with package / version, plus a list of every
+# file in <input_path>/dist/.
+#
+# Usage: generate_summary.sh <input_path> <version>
+#
+#   input_path: project directory (the "Package" label and dist/ root).
+#   version:    the package version (or "unknown").
+
+if [[ $# -ne 2 ]]; then
+    printf 'Usage: generate_summary.sh <input_path> <version>\n' >&2
+    exit 1
+fi
+
+INPUT_PATH="$1"
+VERSION="$2"
+
+if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    printf 'Note: GITHUB_STEP_SUMMARY not set; printing to stdout instead.\n'
+    OUT=/dev/stdout
+else
+    OUT="$GITHUB_STEP_SUMMARY"
+fi
+
+{
+    printf '## Python Build Results\n\n'
+    printf '| | |\n|---|---|\n'
+    printf '| **Package** | %s |\n' "$INPUT_PATH"
+    printf '| **Version** | %s |\n' "$VERSION"
+    printf '| **Artifacts** | |\n'
+    # Expand dist/* inside a subshell so globbing is restored on every
+    # exit path — a bare `set +f` here would leak glob-enabled state to
+    # the rest of the script if the loop aborted under set -e.
+    (
+        set +f
+        for f in "$INPUT_PATH"/dist/*; do
+            if [[ -f "$f" ]]; then
+                # shellcheck disable=SC2016 # backticks here are human-readable markdown, not command substitution
+                printf '| | `%s` |\n' "$(basename "$f")"
+            fi
+        done
+    )
+} >> "$OUT"

--- a/build/actions/python/generate_summary.sh
+++ b/build/actions/python/generate_summary.sh
@@ -16,6 +16,9 @@ if [[ $# -ne 2 ]]; then
     exit 1
 fi
 
+# input_path is the action's inputs.path, already constrained by
+# validate_inputs.sh (lib/validate_path.sh) — the composite's first step,
+# which runs before this one; no untrusted value reaches the dist/* glob below.
 INPUT_PATH="$1"
 VERSION="$2"
 

--- a/build/actions/shell/action.yml
+++ b/build/actions/shell/action.yml
@@ -46,56 +46,23 @@ runs:
         fi
         printf 'bats version: %s\n' "$(bats --version)"
 
-    # shellcheck echoes excerpts of the source lines it diagnoses, and
-    # the source files under scan-path are caller-controlled. A `.sh`
-    # file containing a line that starts with `::add-mask::` or
-    # `::set-output::` could therefore reach the step log via shellcheck's
-    # output. stop_commands_guard.sh wraps the shellcheck invocation so a
-    # workflow command on stdout is neutralized — see
-    # docs/SLSA_L3_AUDIT.md Finding 3. The guard re-enables command
-    # processing on exit, before the final "scripts passed" line.
+    # shellcheck echoes excerpts of caller-controlled source lines in its
+    # diagnostics, so the invocation must run under stop_commands_guard.sh
+    # to neutralize workflow commands on stdout (#225 / SLSA_L3_AUDIT.md
+    # Finding 3). The scan-path validation and guard wiring live in
+    # run_shellcheck.sh.
     - name: Run shellcheck
       shell: bash
       env:
         SCAN_PATH: ${{ inputs.scan-path }}
       run: |
         set -euo pipefail
-        printf '=== shellcheck ===\n'
+        "${{ github.action_path }}/run_shellcheck.sh" "$SCAN_PATH"
 
-        # Validate scan-path: must be a relative path with only safe
-        # characters. Reject absolute paths and path traversal.
-        if [[ "$SCAN_PATH" == /* ]]; then
-          printf 'shellcheck: absolute paths not allowed in scan-path: %s\n' "$SCAN_PATH" >&2
-          exit 1
-        fi
-        if [[ "$SCAN_PATH" == *..* ]]; then
-          printf 'shellcheck: path traversal not allowed in scan-path: %s\n' "$SCAN_PATH" >&2
-          exit 1
-        fi
-        if [[ ! "$SCAN_PATH" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
-          printf 'shellcheck: invalid characters in scan-path: %s\n' "$SCAN_PATH" >&2
-          exit 1
-        fi
-        if [[ ! -d "$SCAN_PATH" ]]; then
-          printf 'shellcheck: scan-path does not exist: %s\n' "$SCAN_PATH" >&2
-          exit 1
-        fi
-
-        # Use find -print0 + xargs -0 for safe filename handling.
-        # shellcheck also supports .bats files (bash syntax). Each xargs
-        # batch is one guarded invocation; the guard preserves shellcheck's
-        # exit status so findings still fail the step.
-        find "$SCAN_PATH" \( -name '*.sh' -o -name '*.bats' \) \
-          -not -path '*/.git/*' \
-          -not -path '*/node_modules/*' \
-          -print0 | xargs -0 -r "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run shellcheck
-        printf 'shellcheck: all scripts under %s passed\n' "$SCAN_PATH"
-
-    # bats EXECUTES caller-supplied .bats files (arbitrary bash), which
-    # is a direct workflow-command-injection path: a test that printfs
-    # `::add-mask::SECRET` would hijack the build job. Both invocation
-    # paths (explicit BATS_PATH and auto-detected .bats files) run under
-    # stop_commands_guard.sh — see docs/SLSA_L3_AUDIT.md Finding 3.
+    # bats EXECUTES caller-supplied .bats files (arbitrary bash), a direct
+    # workflow-command-injection path. Both invocation paths (explicit
+    # bats-path and auto-detected files) run under stop_commands_guard.sh
+    # inside run_bats.sh — see SLSA_L3_AUDIT.md Finding 3.
     - name: Run bats tests
       shell: bash
       env:
@@ -103,35 +70,4 @@ runs:
         SCAN_PATH: ${{ inputs.scan-path }}
       run: |
         set -euo pipefail
-        printf '=== bats ===\n'
-
-        # Validate bats-path if provided: must be a relative path with
-        # only safe characters. Reject absolute paths and path traversal.
-        if [[ -n "$BATS_PATH" ]]; then
-          if [[ "$BATS_PATH" == /* ]]; then
-            printf 'bats: absolute paths not allowed: %s\n' "$BATS_PATH" >&2
-            exit 1
-          fi
-          if [[ "$BATS_PATH" == *..* ]]; then
-            printf 'bats: path traversal not allowed: %s\n' "$BATS_PATH" >&2
-            exit 1
-          fi
-          if [[ ! "$BATS_PATH" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
-            printf 'bats: invalid characters in bats-path: %s\n' "$BATS_PATH" >&2
-            exit 1
-          fi
-          "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run bats "$BATS_PATH"
-        else
-          # Auto-detect: find all .bats files under scan-path.
-          # scan-path was validated by the shellcheck step above.
-          bats_files=()
-          while IFS= read -r -d '' f; do
-            bats_files+=("$f")
-          done < <(find "$SCAN_PATH" -name '*.bats' -not -path '*/.git/*' -print0 2>/dev/null)
-
-          if [[ ${#bats_files[@]} -gt 0 ]]; then
-            "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run bats "${bats_files[@]}"
-          else
-            printf 'bats: no .bats files found under %s, skipping\n' "$SCAN_PATH"
-          fi
-        fi
+        "${{ github.action_path }}/run_bats.sh" "$BATS_PATH" "$SCAN_PATH"

--- a/build/actions/shell/run_bats.sh
+++ b/build/actions/shell/run_bats.sh
@@ -22,26 +22,17 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GUARD="$SCRIPT_DIR/../../../lib/stop_commands_guard.sh"
+VALIDATE_PATH="$SCRIPT_DIR/../../../lib/validate_path.sh"
 BATS_PATH="$1"
 SCAN_PATH="$2"
 
 printf '=== bats ===\n'
 
-# Validate bats-path if provided: must be a relative path with only safe
-# characters. Reject absolute paths and path traversal.
+# Validate bats-path if provided via the shared allowlist (relative, no
+# traversal, safe charset); lib/validate_path.sh exits non-zero and set -e
+# aborts here. scan-path is validated by run_shellcheck.sh, which runs first.
 if [[ -n "$BATS_PATH" ]]; then
-    if [[ "$BATS_PATH" == /* ]]; then
-        printf 'bats: absolute paths not allowed: %s\n' "$BATS_PATH" >&2
-        exit 1
-    fi
-    if [[ "$BATS_PATH" == *..* ]]; then
-        printf 'bats: path traversal not allowed: %s\n' "$BATS_PATH" >&2
-        exit 1
-    fi
-    if [[ ! "$BATS_PATH" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
-        printf 'bats: invalid characters in bats-path: %s\n' "$BATS_PATH" >&2
-        exit 1
-    fi
+    "$VALIDATE_PATH" "$BATS_PATH"
     "$GUARD" run bats "$BATS_PATH"
 else
     # Auto-detect: find all .bats files under scan-path. scan-path was

--- a/build/actions/shell/run_bats.sh
+++ b/build/actions/shell/run_bats.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# Run bats tests, either against an explicit <bats-path> or by
+# auto-detecting .bats files under <scan-path>.
+#
+# bats EXECUTES caller-supplied .bats files (arbitrary bash), a direct
+# workflow-command-injection path: a test that printfs `::add-mask::SECRET`
+# would hijack the build job. Both invocation paths run under
+# stop_commands_guard.sh — see #225 / docs/SLSA_L3_AUDIT.md Finding 3.
+#
+# Usage: run_bats.sh <bats-path> <scan-path>
+#   bats-path:  explicit path to .bats files, or "" to auto-detect.
+#   scan-path:  subtree to auto-detect .bats files under (already
+#               validated by run_shellcheck.sh, which runs first).
+
+if [[ $# -ne 2 ]]; then
+    printf 'Usage: run_bats.sh <bats-path> <scan-path>\n' >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/../../../lib/stop_commands_guard.sh"
+BATS_PATH="$1"
+SCAN_PATH="$2"
+
+printf '=== bats ===\n'
+
+# Validate bats-path if provided: must be a relative path with only safe
+# characters. Reject absolute paths and path traversal.
+if [[ -n "$BATS_PATH" ]]; then
+    if [[ "$BATS_PATH" == /* ]]; then
+        printf 'bats: absolute paths not allowed: %s\n' "$BATS_PATH" >&2
+        exit 1
+    fi
+    if [[ "$BATS_PATH" == *..* ]]; then
+        printf 'bats: path traversal not allowed: %s\n' "$BATS_PATH" >&2
+        exit 1
+    fi
+    if [[ ! "$BATS_PATH" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
+        printf 'bats: invalid characters in bats-path: %s\n' "$BATS_PATH" >&2
+        exit 1
+    fi
+    "$GUARD" run bats "$BATS_PATH"
+else
+    # Auto-detect: find all .bats files under scan-path. scan-path was
+    # validated by run_shellcheck.sh, which runs first.
+    bats_files=()
+    while IFS= read -r -d '' f; do
+        bats_files+=("$f")
+    done < <(find "$SCAN_PATH" -name '*.bats' -not -path '*/.git/*' -print0 2>/dev/null)
+
+    if [[ ${#bats_files[@]} -gt 0 ]]; then
+        "$GUARD" run bats "${bats_files[@]}"
+    else
+        printf 'bats: no .bats files found under %s, skipping\n' "$SCAN_PATH"
+    fi
+fi

--- a/build/actions/shell/run_shellcheck.sh
+++ b/build/actions/shell/run_shellcheck.sh
@@ -21,24 +21,16 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GUARD="$SCRIPT_DIR/../../../lib/stop_commands_guard.sh"
+VALIDATE_PATH="$SCRIPT_DIR/../../../lib/validate_path.sh"
 SCAN_PATH="$1"
 
 printf '=== shellcheck ===\n'
 
-# Validate scan-path: must be a relative path with only safe characters.
-# Reject absolute paths and path traversal.
-if [[ "$SCAN_PATH" == /* ]]; then
-    printf 'shellcheck: absolute paths not allowed in scan-path: %s\n' "$SCAN_PATH" >&2
-    exit 1
-fi
-if [[ "$SCAN_PATH" == *..* ]]; then
-    printf 'shellcheck: path traversal not allowed in scan-path: %s\n' "$SCAN_PATH" >&2
-    exit 1
-fi
-if [[ ! "$SCAN_PATH" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
-    printf 'shellcheck: invalid characters in scan-path: %s\n' "$SCAN_PATH" >&2
-    exit 1
-fi
+# Enforce the shared path allowlist (relative, no traversal, safe charset)
+# via lib/validate_path.sh; it exits non-zero and set -e aborts here. The
+# existence check is shellcheck-specific — validate_path.sh is pure string
+# validation, and a missing scan-path is caller error, not a no-op.
+"$VALIDATE_PATH" "$SCAN_PATH"
 if [[ ! -d "$SCAN_PATH" ]]; then
     printf 'shellcheck: scan-path does not exist: %s\n' "$SCAN_PATH" >&2
     exit 1

--- a/build/actions/shell/run_shellcheck.sh
+++ b/build/actions/shell/run_shellcheck.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# Run shellcheck over every .sh / .bats file under <scan-path>.
+#
+# Its diagnostics echo excerpts of the source lines they flag, and the
+# source files under scan-path are caller-controlled. A `.sh` file with a
+# line starting `::add-mask::` or `::set-output::` could otherwise reach
+# the step log via that output. The invocation runs under
+# stop_commands_guard.sh, which neutralizes workflow commands on stdout
+# and re-enables command processing before the final "scripts passed"
+# line — see #225 / docs/SLSA_L3_AUDIT.md Finding 3.
+#
+# Usage: run_shellcheck.sh <scan-path>
+
+if [[ $# -ne 1 ]]; then
+    printf 'Usage: run_shellcheck.sh <scan-path>\n' >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/../../../lib/stop_commands_guard.sh"
+SCAN_PATH="$1"
+
+printf '=== shellcheck ===\n'
+
+# Validate scan-path: must be a relative path with only safe characters.
+# Reject absolute paths and path traversal.
+if [[ "$SCAN_PATH" == /* ]]; then
+    printf 'shellcheck: absolute paths not allowed in scan-path: %s\n' "$SCAN_PATH" >&2
+    exit 1
+fi
+if [[ "$SCAN_PATH" == *..* ]]; then
+    printf 'shellcheck: path traversal not allowed in scan-path: %s\n' "$SCAN_PATH" >&2
+    exit 1
+fi
+if [[ ! "$SCAN_PATH" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
+    printf 'shellcheck: invalid characters in scan-path: %s\n' "$SCAN_PATH" >&2
+    exit 1
+fi
+if [[ ! -d "$SCAN_PATH" ]]; then
+    printf 'shellcheck: scan-path does not exist: %s\n' "$SCAN_PATH" >&2
+    exit 1
+fi
+
+# find -print0 + xargs -0 for safe filename handling. shellcheck also
+# supports .bats files (bash syntax). Each xargs batch is one guarded
+# invocation; the guard preserves shellcheck's exit status so findings
+# still fail the step.
+find "$SCAN_PATH" \( -name '*.sh' -o -name '*.bats' \) \
+    -not -path '*/.git/*' \
+    -not -path '*/node_modules/*' \
+    -print0 | xargs -0 -r "$GUARD" run shellcheck
+printf 'shellcheck: all scripts under %s passed\n' "$SCAN_PATH"

--- a/build/actions/shell/test.bats
+++ b/build/actions/shell/test.bats
@@ -89,7 +89,7 @@ setup() {
 @test "shell: run_shellcheck.sh rejects an absolute scan-path" {
     run "$ACTION_DIR/run_shellcheck.sh" "/etc"
     [ "$status" -eq 1 ]
-    [[ "$output" == *"absolute paths not allowed"* ]]
+    [[ "$output" == *"path must be relative"* ]]
 }
 
 @test "shell: run_shellcheck.sh rejects path traversal in scan-path" {
@@ -113,7 +113,7 @@ setup() {
 @test "shell: run_bats.sh rejects an absolute bats-path" {
     run "$ACTION_DIR/run_bats.sh" "/etc" "."
     [ "$status" -eq 1 ]
-    [[ "$output" == *"absolute paths not allowed"* ]]
+    [[ "$output" == *"path must be relative"* ]]
 }
 
 @test "shell: run_bats.sh skips cleanly when no .bats files are found" {

--- a/build/actions/shell/test.bats
+++ b/build/actions/shell/test.bats
@@ -26,36 +26,106 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+# --- Delegation to extracted scripts ----------------------------------------
+
+@test "shell: run_shellcheck.sh and run_bats.sh exist and are executable" {
+    [[ -x "$ACTION_DIR/run_shellcheck.sh" ]]
+    [[ -x "$ACTION_DIR/run_bats.sh" ]]
+}
+
+@test "shell: action.yml delegates the shellcheck step to run_shellcheck.sh" {
+    run grep -F 'run_shellcheck.sh' "$ACTION_DIR/action.yml"
+    [ "$status" -eq 0 ]
+}
+
+@test "shell: action.yml delegates the bats step to run_bats.sh" {
+    run grep -F 'run_bats.sh' "$ACTION_DIR/action.yml"
+    [ "$status" -eq 0 ]
+}
+
 # --- Workflow-command-injection guard (#225 / SLSA_L3_AUDIT.md Finding 3) ---
 
 @test "shell: stop-commands guard helper exists and is executable" {
     [[ -x "$REPO_ROOT/lib/stop_commands_guard.sh" ]]
 }
 
-@test "shell: shellcheck runs under the stop-commands guard" {
+@test "shell: run_shellcheck.sh runs shellcheck under the stop-commands guard" {
     # shellcheck echoes excerpts of source lines in its diagnostics, and
     # the source files come from the caller's repo. A `.sh` file with a
     # line starting `::add-mask::` could reach the step log unguarded.
-    # The xargs invocation must spawn the guard, not bare shellcheck.
-    run grep -F 'xargs -0 -r "${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run shellcheck' "$ACTION_DIR/action.yml"
+    # GUARD must resolve to lib/stop_commands_guard.sh and the xargs
+    # invocation must spawn it, not bare shellcheck.
+    run grep -F 'GUARD="$SCRIPT_DIR/../../../lib/stop_commands_guard.sh"' "$ACTION_DIR/run_shellcheck.sh"
+    [[ "$status" -eq 0 ]]
+    run grep -F 'xargs -0 -r "$GUARD" run shellcheck' "$ACTION_DIR/run_shellcheck.sh"
     [[ "$status" -eq 0 ]]
     # The unguarded `xargs -0 -r shellcheck` form must not creep back.
-    run grep -E '^[[:space:]]*-print0[[:space:]]*\|[[:space:]]*xargs -0 -r shellcheck[[:space:]]*$' "$ACTION_DIR/action.yml"
+    run grep -E 'xargs -0 -r shellcheck([[:space:]]|$)' "$ACTION_DIR/run_shellcheck.sh"
     [[ "$status" -ne 0 ]]
 }
 
-@test "shell: both bats invocation paths run under the stop-commands guard" {
+@test "shell: run_bats.sh runs both invocation paths under the stop-commands guard" {
     # bats executes arbitrary user .bats files — a direct injection path
     # via printf '::add-mask::...'. BOTH branches (explicit bats-path
     # and auto-detected file list) must run under the guard.
-    run grep -F '"${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run bats "$BATS_PATH"' "$ACTION_DIR/action.yml"
+    run grep -F 'GUARD="$SCRIPT_DIR/../../../lib/stop_commands_guard.sh"' "$ACTION_DIR/run_bats.sh"
     [[ "$status" -eq 0 ]]
-    run grep -F '"${{ github.action_path }}/../../../lib/stop_commands_guard.sh" run bats "${bats_files[@]}"' "$ACTION_DIR/action.yml"
+    run grep -F '"$GUARD" run bats "$BATS_PATH"' "$ACTION_DIR/run_bats.sh"
+    [[ "$status" -eq 0 ]]
+    run grep -F '"$GUARD" run bats "${bats_files[@]}"' "$ACTION_DIR/run_bats.sh"
     [[ "$status" -eq 0 ]]
     # Bare `bats "$BATS_PATH"` / `bats "${bats_files[@]}"` (no guard)
     # must not creep back.
-    run bash -c "grep -E '^[[:space:]]+bats[[:space:]]+\"\\\$BATS_PATH\"[[:space:]]*\$' \"$ACTION_DIR/action.yml\""
+    run grep -E '^[[:space:]]+bats[[:space:]]+"\$BATS_PATH"[[:space:]]*$' "$ACTION_DIR/run_bats.sh"
     [[ "$status" -ne 0 ]]
-    run bash -c "grep -E '^[[:space:]]+bats[[:space:]]+\"\\\${bats_files\\[@\\]}\"[[:space:]]*\$' \"$ACTION_DIR/action.yml\""
+    run grep -E '^[[:space:]]+bats[[:space:]]+"\$\{bats_files\[@\]}"[[:space:]]*$' "$ACTION_DIR/run_bats.sh"
     [[ "$status" -ne 0 ]]
+}
+
+# --- run_shellcheck.sh / run_bats.sh behavioral validation ------------------
+# The path-validation rejections run before any tool is invoked, so they
+# need neither shellcheck nor bats on PATH.
+
+@test "shell: run_shellcheck.sh rejects an absolute scan-path" {
+    run "$ACTION_DIR/run_shellcheck.sh" "/etc"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"absolute paths not allowed"* ]]
+}
+
+@test "shell: run_shellcheck.sh rejects path traversal in scan-path" {
+    run "$ACTION_DIR/run_shellcheck.sh" "../evil"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"path traversal not allowed"* ]]
+}
+
+@test "shell: run_shellcheck.sh rejects a nonexistent scan-path" {
+    run "$ACTION_DIR/run_shellcheck.sh" "no_such_dir_xyz"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"does not exist"* ]]
+}
+
+@test "shell: run_shellcheck.sh usage error with no args" {
+    run "$ACTION_DIR/run_shellcheck.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "shell: run_bats.sh rejects an absolute bats-path" {
+    run "$ACTION_DIR/run_bats.sh" "/etc" "."
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"absolute paths not allowed"* ]]
+}
+
+@test "shell: run_bats.sh skips cleanly when no .bats files are found" {
+    local empty="$BATS_TEST_TMPDIR/empty"
+    mkdir -p "$empty"
+    run "$ACTION_DIR/run_bats.sh" "" "$empty"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no .bats files found"* ]]
+}
+
+@test "shell: run_bats.sh usage error with wrong arg count" {
+    run "$ACTION_DIR/run_bats.sh" "only-one"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage:"* ]]
 }

--- a/test.sh
+++ b/test.sh
@@ -3,18 +3,19 @@ set -euo pipefail
 set -f
 
 # Run all tests in a container — no local tool installation required.
-# Usage: ./test.sh [all|ci|quick|test|bats|lint|shellcheck|shellstyle|zizmor]
+# Usage: ./test.sh [all|ci|quick|test|bats|lint|shellcheck|shellstyle|workflowstyle|zizmor]
 #
-# Builds a test container with actionlint, shellcheck, ast-grep, bats-core,
-# and zizmor, then runs the specified test suite (default: all).
+# Builds a test container with actionlint, shellcheck, ast-grep, PyYAML,
+# bats-core, and zizmor, then runs the specified test suite (default: all).
 #
 # Targets:
-#   `all`|`test`|`ci`     Full suite: lint + shellcheck + shellstyle + bats + zizmor (default)
+#   `all`|`test`|`ci`     Full suite: lint + shellcheck + shellstyle + workflowstyle + bats + zizmor (default)
 #   `quick`               Inner-loop iteration: skip zizmor for fast feedback
 #   `bats`                Bats tests only
 #   `lint`                actionlint only
 #   `shellcheck`          ShellCheck against all *.sh
 #   `shellstyle`          wrangle-shell-lint (ast-grep WSL rules)
+#   `workflowstyle`       wrangle-workflow-lint (python3 + PyYAML WWL rules)
 #   `zizmor`              Zizmor workflow security linter only
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -24,8 +25,8 @@ TEST_TARGET="${1:-all}"
 # Validate test target. `ci` is an alias for `all` so CI configs and humans
 # can use the same name. `quick` runs the inner-loop subset (no zizmor).
 case "$TEST_TARGET" in
-    all|test|ci|quick|bats|lint|shellcheck|shellstyle|zizmor) ;;
-    *) printf 'Usage: %s [all|ci|quick|test|bats|lint|shellcheck|shellstyle|zizmor]\n' "$0" >&2; exit 1 ;;
+    all|test|ci|quick|bats|lint|shellcheck|shellstyle|workflowstyle|zizmor) ;;
+    *) printf 'Usage: %s [all|ci|quick|test|bats|lint|shellcheck|shellstyle|workflowstyle|zizmor]\n' "$0" >&2; exit 1 ;;
 esac
 
 # Check Docker is available
@@ -43,7 +44,7 @@ docker build -t "$IMAGE_NAME" -f "$SCRIPT_DIR/test/Dockerfile" "$SCRIPT_DIR"
 # leaning on word-splitting (and the SC2086 disable that used to require).
 case "$TEST_TARGET" in
     ci)    MAKE_TARGETS=(all) ;;
-    quick) MAKE_TARGETS=(lint shellcheck shellstyle bats) ;;
+    quick) MAKE_TARGETS=(lint shellcheck shellstyle workflowstyle bats) ;;
     *)     MAKE_TARGETS=("$TEST_TARGET") ;;
 esac
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -13,12 +13,19 @@ RUN apt-get update -q && \
         libc6-dev \
         python3 \
         python3-venv \
+        python3-yaml \
     && rm -rf /var/lib/apt/lists/*
 
 # python3 + python3-venv host the isolated venvs that both zizmor and
 # ast-grep install into (each tool gets its own venv via tools/<tool>/
 # requirements.txt with --require-hashes). See pypa/pipx#712 for why
 # pipx + --require-hashes isn't viable.
+#
+# python3-yaml (PyYAML) backs tools/wrangle-workflow-lint/lint.py. It's a
+# pure-Python parser shipped by the Ubuntu base repo, so it rides the same
+# apt trust model as the python3 interpreter itself — no separate
+# hash-pinned venv (a library import for an internal script is not a
+# wrapped third-party tool like zizmor / ast-grep). See DEP_MGMT.md.
 
 # gcc + libc6-dev are pulled in for `go test -race` (cgo needs a C toolchain).
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -13,19 +13,13 @@ RUN apt-get update -q && \
         libc6-dev \
         python3 \
         python3-venv \
-        python3-yaml \
     && rm -rf /var/lib/apt/lists/*
 
-# python3 + python3-venv host the isolated venvs that both zizmor and
-# ast-grep install into (each tool gets its own venv via tools/<tool>/
-# requirements.txt with --require-hashes). See pypa/pipx#712 for why
-# pipx + --require-hashes isn't viable.
-#
-# python3-yaml (PyYAML) backs tools/wrangle-workflow-lint/lint.py. It's a
-# pure-Python parser shipped by the Ubuntu base repo, so it rides the same
-# apt trust model as the python3 interpreter itself — no separate
-# hash-pinned venv (a library import for an internal script is not a
-# wrapped third-party tool like zizmor / ast-grep). See DEP_MGMT.md.
+# python3 + python3-venv host the isolated, hash-pinned venvs that zizmor,
+# ast-grep, and wrangle-workflow-lint's PyYAML each install into (each tool
+# gets its own venv via tools/<tool>/requirements.txt with --require-hashes,
+# Dependabot-covered). See pypa/pipx#712 for why pipx + --require-hashes
+# isn't viable.
 
 # gcc + libc6-dev are pulled in for `go test -race` (cgo needs a C toolchain).
 
@@ -103,5 +97,18 @@ RUN set -euo pipefail && \
         --require-hashes -r /tmp/ast-grep-requirements.txt && \
     ln -s /opt/ast-grep/bin/ast-grep /usr/local/bin/ast-grep && \
     rm /tmp/ast-grep-requirements.txt
+
+# wrangle-workflow-lint's PyYAML — same hash-pinned venv pattern. PyYAML is
+# a library, not a CLI, so there is no entrypoint to symlink onto PATH:
+# lint.sh runs lint.py under /opt/wrangle-workflow-lint/bin/python3 directly
+# (a venv python can't be symlinked out of its bin dir — it locates
+# site-packages via the adjacent pyvenv.cfg). With no yaml in the base
+# python, the lint.sh interpreter fallback fails closed here.
+COPY tools/wrangle-workflow-lint/requirements.txt /tmp/wwl-requirements.txt
+RUN set -euo pipefail && \
+    python3 -m venv /opt/wrangle-workflow-lint && \
+    /opt/wrangle-workflow-lint/bin/pip install --no-cache-dir \
+        --require-hashes -r /tmp/wwl-requirements.txt && \
+    rm /tmp/wwl-requirements.txt
 
 WORKDIR /wrangle

--- a/test/test_build_guard_coverage.bats
+++ b/test/test_build_guard_coverage.bats
@@ -48,10 +48,12 @@ is_exempt() {
 }
 
 @test "build-guard-coverage: every build composite references the stop-commands guard" {
-    # Enumerate build/actions/<name>/action.yml. For each non-exempt
-    # composite, the action.yml MUST reference lib/stop_commands_guard.sh
-    # at least once. New composites added without wiring in the guard
-    # fail here — the test does not need to be updated for new build
+    # Enumerate build/actions/<name>/. For each non-exempt composite, the
+    # composite MUST reference lib/stop_commands_guard.sh at least once —
+    # either directly in action.yml or in a script it delegates to (the
+    # action.yml -> script extraction pattern CLAUDE.md requires for any
+    # run: block with logic). New composites added without wiring in the
+    # guard fail here — the test does not need to be updated for new build
     # types, only for new exemptions (which require updating the
     # EXEMPT_COMPOSITES allowlist above with a rationale).
     local missing=()
@@ -64,7 +66,11 @@ is_exempt() {
             continue
         fi
 
-        if ! grep -qF "$GUARD" "$action_yml"; then
+        # Search the whole composite directory: action.yml plus any sibling
+        # scripts it shells out to. The per-composite test.bats (asserted by
+        # the next test) is what pins the guard to the actual tool
+        # invocation rather than an inert reference.
+        if ! grep -rqF "$GUARD" "$composite_dir"; then
             missing+=("$composite_name")
         fi
     done < <(find "$REPO_ROOT/build/actions" -mindepth 2 -maxdepth 2 \

--- a/tools/scorecard/action.yml
+++ b/tools/scorecard/action.yml
@@ -34,18 +34,11 @@ runs:
     - name: Ensure SARIF exists
       if: always()
       shell: bash
+      env:
+        SCORECARD_DIR: ${{ github.action_path }}
       run: |
         set -euo pipefail
-        SARIF_FILE="${GITHUB_WORKSPACE}/.wrangle/metadata/scorecard/output.sarif"
-        if [[ ! -f "$SARIF_FILE" ]]; then
-          # Scorecard didn't produce output (e.g., failed on PR event).
-          # Create empty SARIF so downstream summary steps don't fail.
-          jq -n '{
-            "version": "2.1.0",
-            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-            "runs": [{"tool": {"driver": {"name": "scorecard"}}, "results": []}]
-          }' > "$SARIF_FILE"
-        fi
+        "$SCORECARD_DIR/ensure_sarif.sh" "${GITHUB_WORKSPACE}/.wrangle/metadata/scorecard/output.sarif"
 
     - name: Format results
       if: always()

--- a/tools/scorecard/ensure_sarif.sh
+++ b/tools/scorecard/ensure_sarif.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# Ensure a Scorecard SARIF file exists at <sarif_file>.
+#
+# Scorecard commonly produces no output — it needs a GITHUB_TOKEN with
+# specific scopes and only fully works on default-branch pushes, so it
+# fails on most PR events. Downstream summary/collector steps need a
+# well-formed SARIF to consume; when Scorecard wrote none, this emits a
+# valid empty SARIF 2.1.0 so those steps don't fail.
+#
+# Usage: ensure_sarif.sh <sarif_file>
+
+if [[ $# -ne 1 ]]; then
+    printf 'Usage: ensure_sarif.sh <sarif_file>\n' >&2
+    exit 1
+fi
+
+SARIF_FILE="$1"
+
+if [[ ! -f "$SARIF_FILE" ]]; then
+    jq -n '{
+        "version": "2.1.0",
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+        "runs": [{"tool": {"driver": {"name": "scorecard"}}, "results": []}]
+    }' > "$SARIF_FILE"
+fi

--- a/tools/scorecard/test.bats
+++ b/tools/scorecard/test.bats
@@ -43,6 +43,31 @@ teardown() {
     [ ! -f "$ORIG_DIR/tools/scorecard/adapter.sh" ]
 }
 
+# --- ensure_sarif.sh behavioral tests ---
+
+@test "ensure_sarif: writes a valid empty SARIF when the file is missing" {
+    run "$ORIG_DIR/tools/scorecard/ensure_sarif.sh" "$TMP_DIR/out.sarif"
+    [ "$status" -eq 0 ]
+    [ -f "$TMP_DIR/out.sarif" ]
+    run jq -e '.version == "2.1.0" and (.runs[0].results | length) == 0' "$TMP_DIR/out.sarif"
+    [ "$status" -eq 0 ]
+}
+
+@test "ensure_sarif: leaves an existing SARIF untouched" {
+    printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"scorecard"}},"results":[{"ruleId":"R"}]}]}' > "$TMP_DIR/out.sarif"
+    run "$ORIG_DIR/tools/scorecard/ensure_sarif.sh" "$TMP_DIR/out.sarif"
+    [ "$status" -eq 0 ]
+    # The pre-existing result must survive — the script must not overwrite.
+    run jq -e '.runs[0].results[0].ruleId == "R"' "$TMP_DIR/out.sarif"
+    [ "$status" -eq 0 ]
+}
+
+@test "ensure_sarif: usage error with no args" {
+    run "$ORIG_DIR/tools/scorecard/ensure_sarif.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
 @test "scorecard: action.yml writes to wrangle metadata directory" {
     grep -q '\.wrangle/metadata/scorecard' "$ORIG_DIR/tools/scorecard/action.yml"
 }

--- a/tools/wrangle-shell-lint/fixtures/bad_wsl006.sh
+++ b/tools/wrangle-shell-lint/fixtures/bad_wsl006.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — processes external input
+
+# WSL006 positive fixture: a network download piped straight into a
+# shell interpreter, executing unverified remote code. Real downloads
+# must go through lib/download_verify.sh.
+curl -fsSL https://example.com/install.sh | sh

--- a/tools/wrangle-shell-lint/fixtures/bad_wsl007.sh
+++ b/tools/wrangle-shell-lint/fixtures/bad_wsl007.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — processes external input
+
+# WSL007 positive fixture: a top-level `set +f` with no subshell. Under
+# set -e, an abort before the restoring `set -f` leaks glob-enabled
+# state to the rest of the script. The compliant form confines the glob
+# to a `( … )` subshell.
+set +f
+shopt -s nullglob
+for f in ./*.conf; do
+    printf '%s\n' "$f"
+done
+set -f

--- a/tools/wrangle-shell-lint/lint.sh
+++ b/tools/wrangle-shell-lint/lint.sh
@@ -4,7 +4,7 @@ set -f
 
 # tools/wrangle-shell-lint/lint.sh — Wrangle shell-style linter.
 #
-# Thin wrapper around `ast-grep scan` with the WSL001-005 rules under
+# Thin wrapper around `ast-grep scan` with the WSL001-007 rules under
 # `tools/wrangle-shell-lint/rules/`. The rules enforce CLAUDE.md shell
 # conventions that shellcheck does not cover:
 #
@@ -13,16 +13,17 @@ set -f
 #   WSL003  echo with variable expansion — use printf instead
 #   WSL004  [ ] or `test` used as a conditional — use [[ ]] instead
 #   WSL005  # shellcheck disable=... without an inline justification
+#   WSL006  network download (curl/wget/fetch) piped into a shell
+#   WSL007  `set +f` outside a subshell (exception-safety)
 #
 # Rules already enforced by shellcheck (NOT re-implemented):
 #   SC2006  backtick command substitution
 #   SC2086  unquoted variable expansions
 #
-# Out of scope (CLAUDE.md rules NOT enforced by this linter):
-#   - "Inline Shell in GitHub Actions" length cap
-#   - "GitHub Actions Expression Injection" — actionlint does not flag
-#     ${{ inputs.* }} interpolated into run: blocks by default
-#   Tracked in issue #273.
+# The YAML-level GitHub Actions conventions (run-block length, expression
+# injection, continue-on-error justification) live in the sibling
+# wrangle-workflow-lint, which parses workflow structure rather than
+# shell AST.
 #
 # Usage:
 #   lint.sh                   walk the repo (excludes the linter's own fixtures)

--- a/tools/wrangle-shell-lint/rules/wsl006.yml
+++ b/tools/wrangle-shell-lint/rules/wsl006.yml
@@ -1,0 +1,66 @@
+# WSL006 — never pipe a network download straight into a shell
+#
+# CLAUDE.md: "Don't `curl | sh` — all binary downloads go through
+# lib/download_verify.sh." Supply-chain rule: piping a fetched script
+# into an interpreter executes whatever the server returns, with no
+# checksum, signature, or pin — the canonical supply-chain foothold.
+#
+# AST-aware match: a `pipeline` node that contains BOTH a download
+# command (curl / wget / fetch) AND a shell interpreter command
+# (sh / bash / dash / zsh). Matching on the pipeline-as-a-whole rather
+# than strict left/right position is deliberate: tree-sitter-bash gives
+# pipeline stages no positional field, and `sh | curl` is nonsensical,
+# so "a downloader and an interpreter in the same pipeline" is precisely
+# the dangerous shape (including the `curl x | tar | bash` middle-stage
+# variants).
+#
+# The interpreter stage is matched whether the shell is the command name
+# (`| sh`) or an argument to a privilege/env wrapper (`| sudo bash`,
+# `| env bash`, `| xargs sh -s`) — `curl | sudo bash` is the canonical
+# installer shape and must not slip through.
+#
+# Because the matcher is structural, textual decoys don't fire it:
+#   - `# curl x | sh` in a comment — comments are not pipeline nodes.
+#   - `printf 'curl x | sh'` — literal string, no pipeline.
+#   - `curl x | jq` — no interpreter stage, not matched.
+#   - `curl x | grep bash` — `bash` is grep's pattern arg, grep is not a
+#     wrapper, not matched.
+#   - `cat f | sh` — no downloader stage, not matched.
+#
+# Out of scope (not a pipeline): exec-from-substitution like
+# `bash <(curl …)` / `source <(curl …)`. zizmor and review cover those.
+
+id: wsl006-curl-pipe-shell
+severity: error
+language: bash
+rule:
+  kind: pipeline
+  all:
+    - has:
+        kind: command
+        stopBy: end
+        has:
+          field: name
+          regex: '^(curl|wget|fetch)$'
+    - any:
+        - has:
+            kind: command
+            stopBy: end
+            has:
+              field: name
+              regex: '^(sh|bash|dash|zsh)$'
+        - has:
+            kind: command
+            stopBy: end
+            all:
+              - has:
+                  field: name
+                  regex: '^(sudo|env|command|exec|nohup|timeout|nice|time|setsid|stdbuf|xargs)$'
+              - has:
+                  kind: word
+                  regex: '^(sh|bash|dash|zsh)$'
+message: |
+  WSL006: piping a network download into a shell interpreter
+  (curl/wget/fetch | sh/bash/dash/zsh) executes unverified remote code.
+  Route binary/script downloads through lib/download_verify.sh
+  (checksum/signature/pin verification). See CLAUDE.md "Supply chain".

--- a/tools/wrangle-shell-lint/rules/wsl007.yml
+++ b/tools/wrangle-shell-lint/rules/wsl007.yml
@@ -1,0 +1,46 @@
+# WSL007 — `set +f` must be confined to a subshell (exception-safety)
+#
+# CLAUDE.md: "Scripts that intentionally need globbing must wrap it in
+# `set +f` / `set -f`, scoped as narrowly as possible." The robust scope
+# is a subshell: under `set -e`, a bare `set +f; …; set -f` pair leaks
+# glob-enabled state to the rest of the script if anything between the
+# toggles exits non-zero (the restoring `set -f` never runs). Confining
+# `set +f` to a `( … )` subshell (or a command/process substitution,
+# which are themselves subshells) makes restoration automatic on every
+# exit path — see #244 / #258.
+#
+# Policy A — purely structural: a `set +f` is acceptable ONLY when it is
+# lexically inside a subshell / command_substitution / process_substitution.
+# A function body is NOT treated as safe: a function with a restore-trap
+# could be exception-safe, but that property is not structurally
+# expressible, so the rule does not try to recognize it. Wrap the glob in
+# a subshell instead.
+#
+# AST-aware match: a `command` node named `set` whose argument is `+f`,
+# with no subshell-class ancestor. Textual decoys (a `# set +f` comment,
+# a `'set +f'` string) are not `command` nodes and never match.
+
+id: wsl007-set-f-outside-subshell
+severity: error
+language: bash
+rule:
+  kind: command
+  all:
+    - has:
+        field: name
+        regex: '^set$'
+    - has:
+        kind: word
+        regex: '^\+f$'
+  not:
+    inside:
+      stopBy: end
+      any:
+        - kind: subshell
+        - kind: command_substitution
+        - kind: process_substitution
+message: |
+  WSL007: `set +f` outside a subshell leaks glob-enabled state if the
+  code before the restoring `set -f` exits (set -e). Wrap the glob in a
+  `( … )` subshell so globbing is restored on every exit path. A function
+  body does not count — use a subshell. See CLAUDE.md "Shell scripts".

--- a/tools/wrangle-shell-lint/rules/wsl007.yml
+++ b/tools/wrangle-shell-lint/rules/wsl007.yml
@@ -29,9 +29,19 @@ rule:
     - has:
         field: name
         regex: '^set$'
-    - has:
-        kind: word
-        regex: '^\+f$'
+    # Any form that re-enables globbing: `+f`, a combined short-flag word
+    # containing f (`+fx`, `+xf`), or the long form `+o noglob`.
+    - any:
+        - has:
+            kind: word
+            regex: '^\+[a-z]*f[a-z]*$'
+        - all:
+            - has:
+                kind: word
+                regex: '^\+o$'
+            - has:
+                kind: word
+                regex: '^noglob$'
   not:
     inside:
       stopBy: end

--- a/tools/wrangle-shell-lint/test.bats
+++ b/tools/wrangle-shell-lint/test.bats
@@ -544,6 +544,34 @@ SCRIPT
     [[ "$output" == *"WSL007"* ]]
 }
 
+@test "WSL007: combined-flag 'set +fx' outside a subshell is reported" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\nset +fx\nshopt -s nullglob\nprintf "%%s\\n" ./*.conf\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WSL007"* ]]
+}
+
+@test "WSL007: long-form 'set +o noglob' outside a subshell is reported" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\nset +o noglob\nshopt -s nullglob\nprintf "%%s\\n" ./*.conf\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WSL007"* ]]
+}
+
+@test "WSL007: enabling 'set -o noglob' is not flagged" {
+    # `-o` enables (does not disable) globbing — not the leak this rule targets.
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\nset -o noglob\nprintf done\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WSL007"* ]]
+}
+
 @test "WSL007: 'set +f' in a comment is not flagged" {
     tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
     printf '#!/bin/bash\nset -euo pipefail\nset -f\n# remember to set +f around the glob\nprintf done\n' > "$tmp"

--- a/tools/wrangle-shell-lint/test.bats
+++ b/tools/wrangle-shell-lint/test.bats
@@ -131,27 +131,29 @@ teardown() {
 }
 
 @test "WSL002: an internal set +f wrap is not flagged (escape hatch)" {
-    # The escape hatch is `set +f` / `set -f` wrapped around a glob.
-    # The wrap appears INSIDE the script, never at position 2, so the
-    # WSL002 rule does not flag it. The preamble line at position 2 is
-    # still required and present here.
+    # The escape hatch is `set +f` confined to a subshell around a glob
+    # (the WSL007-compliant form). The wrap appears INSIDE the script,
+    # never at position 2, so WSL002 does not flag it; the subshell keeps
+    # WSL007 quiet too. The preamble at position 2 is still present.
     tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
     cat > "$tmp" << 'SCRIPT'
 #!/bin/bash
 set -euo pipefail
 set -f
-# set +f: this loop intentionally expands the glob
-set +f
-shopt -s nullglob
-for f in /etc/*.conf; do
-    printf '%s\n' "$f"
-done
-set -f
+# Expand the glob inside a subshell so set +f can't leak (WSL007).
+(
+    set +f
+    shopt -s nullglob
+    for f in /etc/*.conf; do
+        printf '%s\n' "$f"
+    done
+)
 SCRIPT
     run "$LINTER" "$tmp"
     rm -f "$tmp"
     [ "$status" -eq 0 ]
     [[ "$output" != *"WSL002"* ]]
+    [[ "$output" != *"WSL007"* ]]
 }
 
 # --- WSL003: echo with variable interpolation --------------------------------
@@ -408,6 +410,147 @@ SCRIPT
     rm -f "$tmp"
     [ "$status" -eq 0 ]
     [[ "$output" != *"WSL005"* ]]
+}
+
+# --- WSL006: curl | sh (network download piped to a shell) ------------------
+
+@test "WSL006: curl | sh fixture is reported" {
+    run "$LINTER" "$FIXTURES/bad_wsl006.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WSL006"* ]]
+}
+
+@test "WSL006: clean script is not flagged" {
+    run "$LINTER" "$FIXTURES/good.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WSL006"* ]]
+}
+
+@test "WSL006: wget | bash and fetch | dash are reported" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\nwget -qO- https://x | bash -s -- --arg\nfetch -o - https://y | dash\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WSL006"* ]]
+}
+
+@test "WSL006: curl piped through a middle stage into bash is reported" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\ncurl -fsSL https://x | tar xz | bash\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WSL006"* ]]
+}
+
+@test "WSL006: curl piped into a wrapped interpreter (sudo/env/xargs bash) is reported" {
+    # `curl | sudo bash` is the canonical installer shape — the shell is
+    # an argument to a wrapper, not the command name.
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\ncurl -fsSL https://x | sudo bash\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WSL006"* ]]
+}
+
+@test "WSL006: curl into 'grep bash' (interpreter name as a pattern arg) is not flagged" {
+    # grep is not a wrapper, so `bash` here is just a search pattern.
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\ncurl -fsSL https://x | grep bash\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WSL006"* ]]
+}
+
+@test "WSL006: curl into a non-interpreter (jq) is not flagged" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\ncurl -fsSL https://x | jq .\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WSL006"* ]]
+}
+
+@test "WSL006: a non-download command piped to sh is not flagged" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\ncat ./script.sh | sh\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WSL006"* ]]
+}
+
+@test "WSL006: 'curl x | sh' inside a string is not flagged" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\nprintf "%%s\\n" "curl x | sh"\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WSL006"* ]]
+}
+
+@test "WSL006: 'curl | sh' in a comment is not flagged" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\n# do not curl https://x | sh here\nprintf done\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WSL006"* ]]
+}
+
+# --- WSL007: `set +f` outside a subshell (exception-safety) -----------------
+
+@test "WSL007: top-level set +f fixture is reported" {
+    run "$LINTER" "$FIXTURES/bad_wsl007.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WSL007"* ]]
+}
+
+@test "WSL007: clean script is not flagged" {
+    run "$LINTER" "$FIXTURES/good.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WSL007"* ]]
+}
+
+@test "WSL007: set +f inside a subshell is not flagged" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\n( set +f; shopt -s nullglob; printf "%%s\\n" ./*.conf; set -f )\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WSL007"* ]]
+}
+
+@test "WSL007: set +f inside a command substitution is not flagged" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\nfiles="$(set +f; printf "%%s" ./*.conf)"\nprintf "%%s\\n" "$files"\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WSL007"* ]]
+}
+
+@test "WSL007: set +f inside a function (no subshell) is reported (Policy A)" {
+    # A function body is NOT a structurally-safe scope. The compliant
+    # form wraps the glob in a subshell, even inside a function.
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\nf() {\n  set +f\n  shopt -s nullglob\n  printf "%%s\\n" ./*.conf\n  set -f\n}\nf\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WSL007"* ]]
+}
+
+@test "WSL007: 'set +f' in a comment is not flagged" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\nset -f\n# remember to set +f around the glob\nprintf done\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WSL007"* ]]
 }
 
 # --- Output format -----------------------------------------------------------

--- a/tools/wrangle-workflow-lint/fixtures/bad_r1_composite.yml
+++ b/tools/wrangle-workflow-lint/fixtures/bad_r1_composite.yml
@@ -1,0 +1,24 @@
+# WWL001 positive fixture (composite-action form): a runs.steps[] run
+# block longer than 10 physical lines. Pins that the scanner walks
+# runs.steps[], not only jobs.*.steps[]. Named *.yml (not action.yml) so
+# zizmor's tools/ scan ignores it; the parser keys off `runs.steps`.
+name: bad-r1-composite
+description: fixture
+runs:
+  using: composite
+  steps:
+    - name: Oversized composite run block
+      shell: bash
+      run: |
+        set -euo pipefail
+        printf 'a\n'
+        printf 'b\n'
+        printf 'c\n'
+        printf 'd\n'
+        printf 'e\n'
+        printf 'f\n'
+        printf 'g\n'
+        printf 'h\n'
+        printf 'i\n'
+        printf 'j\n'
+        printf 'k\n'

--- a/tools/wrangle-workflow-lint/fixtures/bad_r1_workflow.yml
+++ b/tools/wrangle-workflow-lint/fixtures/bad_r1_workflow.yml
@@ -1,0 +1,21 @@
+# WWL001 positive fixture (workflow form): a jobs.*.steps[] run block
+# longer than 10 physical lines (preamble + blanks + comments all count).
+name: bad-r1-workflow
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Oversized run block
+        run: |
+          set -euo pipefail
+          # line 2
+          # line 3
+          printf 'line 4\n'
+          printf 'line 5\n'
+          printf 'line 6\n'
+          printf 'line 7\n'
+          printf 'line 8\n'
+          printf 'line 9\n'
+          printf 'line 10\n'
+          printf 'line 11\n'

--- a/tools/wrangle-workflow-lint/fixtures/bad_r2.yml
+++ b/tools/wrangle-workflow-lint/fixtures/bad_r2.yml
@@ -1,0 +1,15 @@
+# WWL002 positive fixture: attacker-influenced expressions interpolated
+# directly into run: bodies. The compliant form threads each value
+# through env: and references it as a shell variable.
+name: bad-r2
+on: pull_request
+jobs:
+  inject:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inject a typed input
+        run: |
+          set -euo pipefail
+          printf 'building %s\n' "${{ inputs.path }}"
+      - name: Inject the event payload
+        run: echo "${{ github.event.pull_request.title }}"

--- a/tools/wrangle-workflow-lint/fixtures/bad_r4.yml
+++ b/tools/wrangle-workflow-lint/fixtures/bad_r4.yml
@@ -1,0 +1,16 @@
+# WWL003 positive fixture: a verification-class step (name matches the
+# verify|attestation|provenance|slsa|cosign|install keyword set) that
+# swallows failures with continue-on-error: true and no adjacent
+# justification comment. Silently tolerating a verification failure can
+# mask a supply-chain attack.
+name: bad-r4
+on: push
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify provenance attestation
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          slsa-verifier verify-artifact "$ARTIFACT"

--- a/tools/wrangle-workflow-lint/fixtures/good.yml
+++ b/tools/wrangle-workflow-lint/fixtures/good.yml
@@ -1,0 +1,25 @@
+# Negative fixture: a workflow that complies with every workflow-lint
+# rule. The linter must produce no findings.
+#   - run: blocks stay at or under 10 physical lines
+#   - inputs / event values are threaded through env:, never interpolated
+#     into a run: body
+#   - the continue-on-error verification step carries a justification
+name: good
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Short run, input via env
+        env:
+          INPUT_PATH: ${{ inputs.path }}
+        run: |
+          set -euo pipefail
+          printf 'building %s\n' "$INPUT_PATH"
+      - name: Verify provenance
+        # continue-on-error: provenance verification is advisory in this
+        # fixture; the justification comment makes the exception explicit.
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          printf 'verifying\n'

--- a/tools/wrangle-workflow-lint/lint.py
+++ b/tools/wrangle-workflow-lint/lint.py
@@ -9,8 +9,9 @@ ast-grep cannot express and that actionlint / zizmor do not cover:
                and comments included).
   WWL002 (R2)  no `${{ inputs.* }}` / `${{ github.event.* }}` interpolated
                literally inside a `run:` body (blanket ban — thread through
-               `env:` first). zizmor fails closed on the dangerous subset;
-               this closes the typed-inputs / safe-context gap.
+               `env:` first). Enforces the typed-input (`inputs.*`) and webhook
+               (`github.event.*`, `github.head_ref`, `github.ref_name`)
+               contexts; zizmor fails closed on its own overlapping subset.
   WWL003 (R4)  a verification-class step (name/id/uses matching
                verify|attestation|provenance|slsa|cosign|install) that sets
                `continue-on-error: true` must carry an adjacent justification
@@ -46,16 +47,51 @@ MAX_RUN_LINES = 10
 # rejects a leading `.` or word char) so sibling contexts that merely end in
 # `inputs` — `${{ matrix.inputs }}`, `${{ steps.x.outputs.inputs }}` — are not
 # false-flagged. `inputs` must be followed by `.`/`[` (a typed-input access).
+# `github.head_ref` / `github.ref_name` are attacker-influenced refs (the
+# classic pull_request_target injection vector), so they are flagged too.
 INJECTION_RE = re.compile(
-    r"\$\{\{[^}]*?(?<![.\w])(?:inputs\s*[.\[]|github\.event\b)"
+    r"\$\{\{[^}]*?(?<![.\w])"
+    r"(?:inputs\s*[.\[]|github\.(?:event\b|head_ref\b|ref_name\b))"
 )
 
 # R4: steps whose purpose is verifying provenance / attestations / signatures /
-# installing toolchains — the places where silently swallowing a failure is a
-# security regression, not a convenience.
-VERIFY_KEYWORDS = re.compile(
-    r"verify|attestation|provenance|slsa|cosign|install", re.IGNORECASE
+# installing toolchains — where silently swallowing a failure is a security
+# regression, not a convenience. Best-effort keyword sets (not exhaustive).
+#
+# IDENTITY set scans name/id/uses: `install` is meaningful here ("Install
+# Cosign", cosign-installer) — it names a tool-install step.
+IDENTITY_KEYWORDS = re.compile(
+    r"verify|attestation|provenance|slsa|cosign|sigstore|rekor|"
+    r"notation|gitsign|in-?toto|gpg|install",
+    re.IGNORECASE,
 )
+# RUN set scans the run: body — inline `run: cosign verify …` /
+# `gh attestation verify …` is the repo's dominant style. Narrower than the
+# identity set: `install` / `gpg` are dropped because a run body is dominated
+# by routine package installs (`npm install`) that are not verification steps.
+RUN_VERIFY_KEYWORDS = re.compile(
+    r"verify|attestation|provenance|slsa|cosign|sigstore|rekor|"
+    r"notation|gitsign|in-?toto",
+    re.IGNORECASE,
+)
+
+
+def tolerates_failure(coe_node):
+    """True if continue-on-error is set to anything that can evaluate true.
+
+    Literal `true`, or any `${{ … }}` expression we cannot statically prove
+    false. Literal `false` (the default) does not tolerate failure. This closes
+    the `continue-on-error: ${{ true }}` bypass of a literal-only check.
+    """
+    if coe_node is None:
+        return False
+    val = scalar_text(coe_node).strip()
+    low = val.lower()
+    if low == "false":
+        return False
+    if low == "true":
+        return True
+    return val.startswith("${{")
 
 
 class Finding:
@@ -163,22 +199,30 @@ def check_run_rules(path, run_node, raw_lines, findings):
             )
 
 
-def has_adjacent_justification(step, coe_node, raw_lines):
-    """True if a justification comment sits with the continue-on-error key.
+def has_adjacent_justification(coe_node, raw_lines):
+    """True if a justification comment is bound to the continue-on-error key.
 
-    Accepts any comment line (non-empty after `#`) from the line directly
-    above the step through the continue-on-error line — the band where an
-    author documents why failure is tolerated. Mirrors WSL005: whitespace
-    after `#` is not a justification.
+    Like WSL005, the justification must sit ON the directive: either a trailing
+    inline comment on the `continue-on-error:` line, or the contiguous block of
+    comment lines immediately above it. An incidental comment elsewhere in the
+    step does not count. Whitespace after `#` is not a justification.
     """
-    top = step.start_mark.line - 1  # allow a comment immediately above the step
-    bottom = coe_node.start_mark.line
-    for i in range(max(top, 0), bottom + 1):
-        if i >= len(raw_lines):
-            break
-        stripped = raw_lines[i].lstrip()
-        if stripped.startswith("#") and stripped[1:].strip():
+    coe_line = coe_node.start_mark.line
+    # Trailing inline comment on the continue-on-error line itself. The value is
+    # `true`/`false`/`${{ … }}` (no literal `#`), so a `#` here starts a comment.
+    if coe_line < len(raw_lines):
+        hash_idx = raw_lines[coe_line].find("#")
+        if hash_idx != -1 and raw_lines[coe_line][hash_idx + 1:].strip():
             return True
+    # Contiguous comment block directly above the continue-on-error line.
+    i = coe_line - 1
+    while i >= 0:
+        stripped = raw_lines[i].lstrip()
+        if not stripped.startswith("#"):
+            break
+        if stripped[1:].strip():
+            return True
+        i -= 1
     return False
 
 
@@ -187,26 +231,36 @@ def check_step_rules(path, step, raw_lines, findings):
     if "run" in sub and isinstance(sub["run"], yaml.ScalarNode):
         check_run_rules(path, sub["run"], raw_lines, findings)
 
-    # R4 — continue-on-error on a verification-class step needs justification.
+    # R4 — failure-tolerating continue-on-error on a verification-class step
+    # needs a justification. `tolerates_failure` covers the `${{ true }}`
+    # expression form, not only the literal.
     coe = sub.get("continue-on-error")
-    if coe is None or scalar_text(coe).strip().lower() != "true":
+    if not tolerates_failure(coe):
         return
     identity = " ".join(
         scalar_text(sub[k]) for k in ("name", "id", "uses") if k in sub
     )
-    if not VERIFY_KEYWORDS.search(identity):
+    run_body = (
+        scalar_text(sub["run"])
+        if "run" in sub and isinstance(sub["run"], yaml.ScalarNode)
+        else ""
+    )
+    if not (
+        IDENTITY_KEYWORDS.search(identity) or RUN_VERIFY_KEYWORDS.search(run_body)
+    ):
         return
-    if not has_adjacent_justification(step, coe, raw_lines):
+    if not has_adjacent_justification(coe, raw_lines):
         findings.append(
             Finding(
                 path,
                 coe.start_mark.line + 1,
                 "WWL003",
-                "continue-on-error: true on a verification-class step "
-                "(name/id/uses matches verify|attestation|provenance|slsa|"
-                "cosign|install) without an adjacent justification comment. "
-                "Swallowing a verification failure can mask a supply-chain "
-                "attack; document why it is safe here.",
+                "continue-on-error tolerates failure on a verification-class "
+                "step (name/id/uses/run matches verify|attestation|provenance|"
+                "slsa|cosign|sigstore|... or install) without a justification "
+                "comment on the continue-on-error line. Swallowing a "
+                "verification failure can mask a supply-chain attack; document "
+                "why it is safe here.",
             )
         )
 

--- a/tools/wrangle-workflow-lint/lint.py
+++ b/tools/wrangle-workflow-lint/lint.py
@@ -2,8 +2,9 @@
 """wrangle-workflow-lint — YAML-level CLAUDE.md conventions for GitHub Actions.
 
 Enforces the rules that operate on workflow / composite-action *structure*
-(run-block line spans, step-sibling keys) rather than shell AST — those that
-ast-grep cannot express and that actionlint / zizmor do not cover:
+(run-block line spans, step-sibling keys, comment adjacency) that actionlint
+and zizmor do not cover. PyYAML over ast-grep is a deliberate, researched
+choice — see the "Why PyYAML" note below:
 
   WWL001 (R1)  a `run:` block is at most 10 physical lines (preamble, blanks,
                and comments included).
@@ -20,6 +21,15 @@ ast-grep cannot express and that actionlint / zizmor do not cover:
 The sibling shell-AST rules live in wrangle-shell-lint: R3 (curl|sh) is WSL006
 and R5 (`set +f` outside a subshell) is WSL007.
 
+Why PyYAML, not ast-grep (which wrangle already runs for the shell rules):
+ast-grep does support YAML and expresses WWL002 cleanly (a `run:` pattern plus
+a regex constraint), but it has no line-count constraint for WWL001 (a block
+scalar's physical span) and reaches comments only through brittle relational
+matching for WWL003's adjacent-justification rule. A small PyYAML pass gets
+node line ranges and raw-line access for both directly, making it the more
+maintainable home for these three rules; WWL002 stays alongside them rather
+than splitting one rule out into a second tool.
+
 Inputs are file paths (workflows under .github/workflows and composite
 action.yml files). Both `jobs.*.steps[]` and `runs.steps[]` are walked.
 
@@ -34,8 +44,8 @@ try:
 except ImportError:
     sys.stderr.write(
         "wrangle-workflow-lint: PyYAML not available for this python3.\n"
-        "Install it (the test image apt-installs python3-yaml; locally: "
-        "`pip install pyyaml` or `apt-get install python3-yaml`).\n"
+        "Install the pinned version in tools/wrangle-workflow-lint/"
+        "requirements.txt into a venv (see test/Dockerfile).\n"
     )
     raise SystemExit(2)
 

--- a/tools/wrangle-workflow-lint/lint.py
+++ b/tools/wrangle-workflow-lint/lint.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""wrangle-workflow-lint — YAML-level CLAUDE.md conventions for GitHub Actions.
+
+Enforces the rules that operate on workflow / composite-action *structure*
+(run-block line spans, step-sibling keys) rather than shell AST — those that
+ast-grep cannot express and that actionlint / zizmor do not cover:
+
+  WWL001 (R1)  a `run:` block is at most 10 physical lines (preamble, blanks,
+               and comments included).
+  WWL002 (R2)  no `${{ inputs.* }}` / `${{ github.event.* }}` interpolated
+               literally inside a `run:` body (blanket ban — thread through
+               `env:` first). zizmor fails closed on the dangerous subset;
+               this closes the typed-inputs / safe-context gap.
+  WWL003 (R4)  a verification-class step (name/id/uses matching
+               verify|attestation|provenance|slsa|cosign|install) that sets
+               `continue-on-error: true` must carry an adjacent justification
+               comment — mirrors WSL005's documented-exception mechanism.
+
+The sibling shell-AST rules live in wrangle-shell-lint: R3 (curl|sh) is WSL006
+and R5 (`set +f` outside a subshell) is WSL007.
+
+Inputs are file paths (workflows under .github/workflows and composite
+action.yml files). Both `jobs.*.steps[]` and `runs.steps[]` are walked.
+
+Exit: 0 clean, 1 violations found, 2 tool/usage error (fail closed).
+"""
+
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write(
+        "wrangle-workflow-lint: PyYAML not available for this python3.\n"
+        "Install it (the test image apt-installs python3-yaml; locally: "
+        "`pip install pyyaml` or `apt-get install python3-yaml`).\n"
+    )
+    raise SystemExit(2)
+
+MAX_RUN_LINES = 10
+
+# R2: an interpolation of a typed input or the webhook event payload. These are
+# attacker-influenced and must never be spliced into a shell command directly.
+# `inputs` / `github` are matched only as expression roots (the lookbehind
+# rejects a leading `.` or word char) so sibling contexts that merely end in
+# `inputs` — `${{ matrix.inputs }}`, `${{ steps.x.outputs.inputs }}` — are not
+# false-flagged. `inputs` must be followed by `.`/`[` (a typed-input access).
+INJECTION_RE = re.compile(
+    r"\$\{\{[^}]*?(?<![.\w])(?:inputs\s*[.\[]|github\.event\b)"
+)
+
+# R4: steps whose purpose is verifying provenance / attestations / signatures /
+# installing toolchains — the places where silently swallowing a failure is a
+# security regression, not a convenience.
+VERIFY_KEYWORDS = re.compile(
+    r"verify|attestation|provenance|slsa|cosign|install", re.IGNORECASE
+)
+
+
+class Finding:
+    __slots__ = ("path", "line", "rule", "message")
+
+    def __init__(self, path, line, rule, message):
+        self.path = path
+        self.line = line
+        self.rule = rule
+        self.message = message
+
+    def __str__(self):
+        return f"{self.path}:{self.line}: {self.rule}: {self.message}"
+
+
+def mapping_items(node):
+    """Yield (key_string, value_node) for a MappingNode, or nothing."""
+    if isinstance(node, yaml.MappingNode):
+        for key, value in node.value:
+            if isinstance(key, yaml.ScalarNode):
+                yield key.value, value
+
+
+def find_steps(node):
+    """Yield every step MappingNode reachable through any `steps:` sequence.
+
+    Covers both `jobs.<id>.steps[]` (workflows) and `runs.steps[]` (composite
+    actions) because both attach the step list under a `steps` key.
+    """
+    if isinstance(node, yaml.MappingNode):
+        for key, value in mapping_items(node):
+            if key == "steps" and isinstance(value, yaml.SequenceNode):
+                for item in value.value:
+                    if isinstance(item, yaml.MappingNode):
+                        yield item
+            yield from find_steps(value)
+    elif isinstance(node, yaml.SequenceNode):
+        for item in node.value:
+            yield from find_steps(item)
+
+
+def run_body_physical_lines(node, raw_lines):
+    """Physical source-line count of a `run:` scalar body.
+
+    Counts the lines the shell occupies as written — preamble, blank lines,
+    and comments all count (a 10-line cap on the *body*, per CLAUDE.md). Uses
+    raw source lines rather than the parsed value so folded (`>`) scalars,
+    whose newlines collapse to spaces in the value, are still measured by
+    physical extent.
+    """
+    start = node.start_mark.line  # 0-indexed line of the value indicator
+    end = node.end_mark.line
+    if node.style in ("|", ">"):
+        body = raw_lines[start + 1 : end]
+        # Trailing blank lines are chomped from the value and are YAML
+        # formatting, not shell — don't count them against the cap.
+        while body and body[-1].strip() == "":
+            body.pop()
+        return len(body)
+    # Plain or quoted scalar: physical span (single line in the common case).
+    return (end - start) + 1
+
+
+def step_sub(step):
+    """Return {key_string: value_node} for a step's immediate keys."""
+    return {k: v for k, v in mapping_items(step)}
+
+
+def scalar_text(node):
+    return node.value if isinstance(node, yaml.ScalarNode) else ""
+
+
+def check_run_rules(path, run_node, raw_lines, findings):
+    # R1 — run-block length.
+    n = run_body_physical_lines(run_node, raw_lines)
+    if n > MAX_RUN_LINES:
+        findings.append(
+            Finding(
+                path,
+                run_node.start_mark.line + 1,
+                "WWL001",
+                f"run: block is {n} physical lines (max {MAX_RUN_LINES}). "
+                "Extract the logic to a script under tools/<name>/ or "
+                "build/actions/ and call it. See CLAUDE.md 'GitHub Actions'.",
+            )
+        )
+
+    # R2 — expression injection inside a run body. node.value holds the
+    # literal shell text for block scalars; search it line by line so the
+    # report points at the offending line, not the run: indicator.
+    body = scalar_text(run_node)
+    base = run_node.start_mark.line + (1 if run_node.style in ("|", ">") else 0)
+    for offset, text in enumerate(body.splitlines()):
+        if INJECTION_RE.search(text):
+            findings.append(
+                Finding(
+                    path,
+                    base + offset + 1,
+                    "WWL002",
+                    "`${{ inputs.* }}` / `${{ github.event.* }}` interpolated "
+                    "into a run: body. Thread the value through `env:` and "
+                    "reference it as a shell variable. See CLAUDE.md "
+                    "'No expression injection'.",
+                )
+            )
+
+
+def has_adjacent_justification(step, coe_node, raw_lines):
+    """True if a justification comment sits with the continue-on-error key.
+
+    Accepts any comment line (non-empty after `#`) from the line directly
+    above the step through the continue-on-error line — the band where an
+    author documents why failure is tolerated. Mirrors WSL005: whitespace
+    after `#` is not a justification.
+    """
+    top = step.start_mark.line - 1  # allow a comment immediately above the step
+    bottom = coe_node.start_mark.line
+    for i in range(max(top, 0), bottom + 1):
+        if i >= len(raw_lines):
+            break
+        stripped = raw_lines[i].lstrip()
+        if stripped.startswith("#") and stripped[1:].strip():
+            return True
+    return False
+
+
+def check_step_rules(path, step, raw_lines, findings):
+    sub = step_sub(step)
+    if "run" in sub and isinstance(sub["run"], yaml.ScalarNode):
+        check_run_rules(path, sub["run"], raw_lines, findings)
+
+    # R4 — continue-on-error on a verification-class step needs justification.
+    coe = sub.get("continue-on-error")
+    if coe is None or scalar_text(coe).strip().lower() != "true":
+        return
+    identity = " ".join(
+        scalar_text(sub[k]) for k in ("name", "id", "uses") if k in sub
+    )
+    if not VERIFY_KEYWORDS.search(identity):
+        return
+    if not has_adjacent_justification(step, coe, raw_lines):
+        findings.append(
+            Finding(
+                path,
+                coe.start_mark.line + 1,
+                "WWL003",
+                "continue-on-error: true on a verification-class step "
+                "(name/id/uses matches verify|attestation|provenance|slsa|"
+                "cosign|install) without an adjacent justification comment. "
+                "Swallowing a verification failure can mask a supply-chain "
+                "attack; document why it is safe here.",
+            )
+        )
+
+
+def lint_file(path):
+    """Return a list of Findings for one YAML file (may be empty)."""
+    with open(path, "r", encoding="utf-8") as fh:
+        content = fh.read()
+    raw_lines = content.splitlines()
+    try:
+        root = yaml.compose(content)
+    except yaml.YAMLError as exc:
+        # A file we cannot parse is a tool error, not a pass — fail closed.
+        raise RuntimeError(f"{path}: YAML parse error: {exc}") from exc
+    findings = []
+    if root is not None:
+        for step in find_steps(root):
+            check_step_rules(path, step, raw_lines, findings)
+    return findings
+
+
+def main(argv):
+    paths = argv[1:]
+    if not paths:
+        return 0
+    findings = []
+    try:
+        for path in paths:
+            findings.extend(lint_file(path))
+    except (OSError, RuntimeError) as exc:
+        sys.stderr.write(f"wrangle-workflow-lint: {exc}\n")
+        sys.stderr.write("wrangle-workflow-lint: failing closed.\n")
+        return 2
+    if findings:
+        findings.sort(key=lambda f: (f.path, f.line, f.rule))
+        for finding in findings:
+            print(finding)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/wrangle-workflow-lint/lint.sh
+++ b/tools/wrangle-workflow-lint/lint.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# tools/wrangle-workflow-lint/lint.sh — Wrangle workflow-style linter.
+#
+# Thin wrapper around lint.py (python3 + PyYAML) that enforces the
+# CLAUDE.md GitHub Actions conventions operating on YAML *structure*
+# rather than shell AST:
+#
+#   WWL001  a run: block is at most 10 physical lines
+#   WWL002  no ${{ inputs.* }} / ${{ github.event.* }} inside a run: body
+#   WWL003  unjustified continue-on-error on a verification-class step
+#
+# The shell-AST conventions (curl|sh, `set +f` outside a subshell) live in
+# the sibling wrangle-shell-lint as WSL006 / WSL007.
+#
+# python3 + PyYAML are provided by the test image's apt packages (python3,
+# python3-yaml) — the same trust model as the python3 interpreter itself,
+# kept current by the base-image rebuild. No separate hash-pinned venv: a
+# pure-Python parser in the base distro is not a wrapped third-party tool
+# like zizmor / ast-grep (see DEP_MGMT.md footprint rule).
+#
+# Usage:
+#   lint.sh                walk the repo (workflows + composite action.yml)
+#   lint.sh <file> [...]   lint specific YAML files only
+#
+# Exit: 0 clean, 1 violations found, 2 tool error (fail closed).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LINT_PY="${SCRIPT_DIR}/lint.py"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    printf 'wrangle-workflow-lint: python3 not found on PATH.\n' >&2
+    exit 2
+fi
+
+# Collect target files. Explicit args are used verbatim; otherwise walk the
+# repo for workflow files and every composite action.yml, skipping this
+# linter's own fixtures (intentionally-bad YAML that must not fail the repo
+# walk or the zizmor scan).
+declare -a targets=()
+if [[ $# -gt 0 ]]; then
+    targets=("$@")
+else
+    repo_root="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)" || \
+        repo_root="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    while IFS= read -r -d '' f; do
+        targets+=("$f")
+    done < <(find "$repo_root" \
+        \( -path '*/.git/*' -o -path '*/.beads/*' \
+           -o -path '*/wrangle-workflow-lint/fixtures/*' \) -prune -o \
+        -type f \( \
+            -path '*/.github/workflows/*.yml' -o \
+            -path '*/.github/workflows/*.yaml' -o \
+            -name 'action.yml' -o \
+            -name 'action.yaml' \
+        \) -print0 | sort -z)
+fi
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+    exit 0
+fi
+
+exec python3 "$LINT_PY" "${targets[@]}"

--- a/tools/wrangle-workflow-lint/lint.sh
+++ b/tools/wrangle-workflow-lint/lint.sh
@@ -15,11 +15,10 @@ set -f
 # The shell-AST conventions (curl|sh, `set +f` outside a subshell) live in
 # the sibling wrangle-shell-lint as WSL006 / WSL007.
 #
-# python3 + PyYAML are provided by the test image's apt packages (python3,
-# python3-yaml) — the same trust model as the python3 interpreter itself,
-# kept current by the base-image rebuild. No separate hash-pinned venv: a
-# pure-Python parser in the base distro is not a wrapped third-party tool
-# like zizmor / ast-grep (see DEP_MGMT.md footprint rule).
+# PyYAML is hash-pinned in tools/wrangle-workflow-lint/requirements.txt and
+# installed into an isolated venv (Dependabot-covered, like zizmor /
+# ast-grep — see DEP_MGMT.md). Being a library rather than a CLI it has no
+# PATH entrypoint, so this wrapper runs lint.py under the venv's python.
 #
 # Usage:
 #   lint.sh                walk the repo (workflows + composite action.yml)
@@ -30,8 +29,18 @@ set -f
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LINT_PY="${SCRIPT_DIR}/lint.py"
 
-if ! command -v python3 >/dev/null 2>&1; then
-    printf 'wrangle-workflow-lint: python3 not found on PATH.\n' >&2
+# Resolve the interpreter that can import yaml. Prefer the managed venv the
+# test image builds; fall back to a system python3 that already has PyYAML
+# (a local dev convenience). In the image the base python has no yaml, so
+# this fallback fails closed there rather than masking a broken venv.
+VENV_PYTHON="/opt/wrangle-workflow-lint/bin/python3"
+if [[ -x "$VENV_PYTHON" ]]; then
+    PYTHON="$VENV_PYTHON"
+elif command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+    PYTHON="python3"
+else
+    printf 'wrangle-workflow-lint: no python3 with PyYAML found.\n' >&2
+    printf 'wrangle-workflow-lint: install the pinned version in tools/wrangle-workflow-lint/requirements.txt into a venv (see test/Dockerfile).\n' >&2
     exit 2
 fi
 
@@ -39,6 +48,11 @@ fi
 # repo for workflow files and every composite action.yml, skipping this
 # linter's own fixtures (intentionally-bad YAML that must not fail the repo
 # walk or the zizmor scan).
+#
+# Targets are trusted developer input — git-discovered repo files or a dev's
+# explicit file list run from `make test` — not attacker-controlled
+# workflow_call inputs, so no path allowlisting is applied here (unlike the
+# build actions, whose inputs.* flow through lib/validate_path.sh).
 declare -a targets=()
 if [[ $# -gt 0 ]]; then
     targets=("$@")
@@ -62,4 +76,4 @@ if [[ ${#targets[@]} -eq 0 ]]; then
     exit 0
 fi
 
-exec python3 "$LINT_PY" "${targets[@]}"
+exec "$PYTHON" "$LINT_PY" "${targets[@]}"

--- a/tools/wrangle-workflow-lint/requirements.txt
+++ b/tools/wrangle-workflow-lint/requirements.txt
@@ -1,0 +1,31 @@
+# PyYAML — YAML parser backing tools/wrangle-workflow-lint/lint.py.
+#
+# Installed via `pip install --require-hashes` into an isolated venv
+# (see test/Dockerfile and DEP_MGMT.md "Choosing how to install"). A
+# library import, not a CLI: lint.sh runs lint.py under this venv's
+# python rather than symlinking an entrypoint onto PATH.
+#
+# Hashes cover every wheel pip might select on a supported platform
+# (cp311-cp313, linux x86_64/aarch64 + macOS x86_64/arm64) plus the
+# sdist fallback; pip refuses any artifact whose sha256 isn't listed.
+#
+# Dependabot manages version bumps (pip ecosystem watches this directory).
+# When you bump the version manually, run:
+#   pip download PyYAML==<new> --no-deps --dest /tmp/yaml \
+#     && python3 -m pip hash /tmp/yaml/*
+# and replace every hash below in the same commit.
+
+PyYAML==6.0.3 \
+    --hash=sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e \
+    --hash=sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824 \
+    --hash=sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c \
+    --hash=sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d \
+    --hash=sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196 \
+    --hash=sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0 \
+    --hash=sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28 \
+    --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc \
+    --hash=sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8 \
+    --hash=sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1 \
+    --hash=sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c \
+    --hash=sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6 \
+    --hash=sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f

--- a/tools/wrangle-workflow-lint/test.bats
+++ b/tools/wrangle-workflow-lint/test.bats
@@ -1,0 +1,246 @@
+#!/usr/bin/env bats
+
+# Tests for tools/wrangle-workflow-lint/lint.sh — the python3 + PyYAML
+# linter for CLAUDE.md GitHub Actions conventions that operate on workflow
+# structure (run-block line spans, step-sibling keys) rather than shell AST.
+#
+# Layout:
+#   - One committed fixture per rule under fixtures/ (named *.yml, never
+#     action.yml, so zizmor's tools/ scan ignores them — the parser keys
+#     off jobs.*.steps / runs.steps, not the filename).
+#   - good.yml is the negative fixture — must pass cleanly.
+#   - Inline tmp fixtures cover boundaries (exactly 10 lines), folded
+#     scalars, env-threaded inputs, and the continue-on-error exception.
+
+setup() {
+    ORIG_DIR="$(pwd)"
+    LINTER="$ORIG_DIR/tools/wrangle-workflow-lint/lint.sh"
+    FIXTURES="$ORIG_DIR/tools/wrangle-workflow-lint/fixtures"
+    export ORIG_DIR LINTER FIXTURES
+
+    # Fail loud if python3 / PyYAML is missing. The linter is mandatory in
+    # CI and in the test image (apt python3 + python3-yaml); a silent skip
+    # would let a broken image ship green.
+    if ! command -v python3 >/dev/null 2>&1; then
+        printf 'python3 not on PATH — run via ./test.sh (the Docker image provides it)\n' >&2
+        return 1
+    fi
+    if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+        printf 'PyYAML not importable — the test image apt-installs python3-yaml\n' >&2
+        return 1
+    fi
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+}
+
+# --- Negative fixture --------------------------------------------------------
+
+@test "clean workflow: no violations reported" {
+    run "$LINTER" "$FIXTURES/good.yml"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# --- WWL001 (R1): run-block length cap --------------------------------------
+
+@test "WWL001: oversized workflow run block is reported" {
+    run "$LINTER" "$FIXTURES/bad_r1_workflow.yml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL001"* ]]
+}
+
+@test "WWL001: oversized composite (runs.steps) run block is reported" {
+    # Pins that the scanner walks runs.steps[], not only jobs.*.steps[].
+    run "$LINTER" "$FIXTURES/bad_r1_composite.yml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL001"* ]]
+}
+
+@test "WWL001: a run block of exactly 10 lines passes (boundary)" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    {
+        printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n'
+        printf '      - run: |\n'
+        for i in $(seq 1 10); do printf '          printf "line %s\\n"\n' "$i"; done
+    } > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WWL001"* ]]
+}
+
+@test "WWL001: a run block of 11 lines fails (boundary)" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    {
+        printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n'
+        printf '      - run: |\n'
+        for i in $(seq 1 11); do printf '          printf "line %s\\n"\n' "$i"; done
+    } > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL001"* ]]
+}
+
+@test "WWL001: comments and blank lines count toward the cap" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: |\n          set -euo pipefail\n          # c\n\n          # c\n\n          # c\n\n          # c\n\n          # c\n\n          printf done\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL001"* ]]
+}
+
+@test "WWL001: a short run block is not flagged" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: |\n          set -euo pipefail\n          printf done\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WWL001"* ]]
+}
+
+# --- WWL002 (R2): expression injection into a run body ----------------------
+
+@test "WWL002: inputs.* interpolated into a run body is reported" {
+    run "$LINTER" "$FIXTURES/bad_r2.yml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL002"* ]]
+}
+
+@test "WWL002: an input threaded through env: is not flagged" {
+    # The safe pattern: inputs.* appears in env:, referenced as $VAR in the
+    # run body. R2 must scan only run: bodies, not env:/with:/if:.
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - env:\n          P: ${{ inputs.path }}\n        run: |\n          set -euo pipefail\n          printf "%%s" "$P"\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WWL002"* ]]
+}
+
+@test "WWL002: a sibling context ending in 'inputs' is not flagged" {
+    # ${{ matrix.inputs }} / ${{ steps.x.outputs.inputs }} are not typed-
+    # input interpolations — `inputs` is only a path segment. The rule
+    # anchors `inputs` as an expression root, so these must not fire.
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ matrix.inputs }}"\n      - run: echo "${{ steps.foo.outputs.inputs }}"\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WWL002"* ]]
+}
+
+@test "WWL002: inputs['x'] bracket access in a run body is reported" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ inputs['\''x'\''] }}"\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL002"* ]]
+}
+
+@test "WWL002: github.event.* interpolated into a run body is reported" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ github.event.issue.title }}"\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL002"* ]]
+}
+
+@test "WWL002: a safe context (github.sha) in a run body is not flagged" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: printf "%%s" "${{ github.sha }}"\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WWL002"* ]]
+}
+
+# --- WWL003 (R4): continue-on-error on a verification-class step ------------
+
+@test "WWL003: unjustified continue-on-error on a verify step is reported" {
+    run "$LINTER" "$FIXTURES/bad_r4.yml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL003"* ]]
+}
+
+@test "WWL003: a justification comment above continue-on-error exempts it" {
+    run "$LINTER" "$FIXTURES/good.yml"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WWL003"* ]]
+}
+
+@test "WWL003: keyword match on uses: triggers the rule" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: sigstore/cosign-installer@v3\n        continue-on-error: true\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL003"* ]]
+}
+
+@test "WWL003: continue-on-error on a non-verification step is not flagged" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - name: Upload artifact\n        uses: actions/upload-artifact@v4\n        continue-on-error: true\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WWL003"* ]]
+}
+
+@test "WWL003: a verification step without continue-on-error is not flagged" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - name: Verify provenance\n        run: slsa-verifier verify-artifact x\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WWL003"* ]]
+}
+
+@test "WWL003: a whitespace-only comment is not a justification" {
+    # Mirrors WSL005: an empty `#` is not an explanation.
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - name: Verify provenance\n        #\n        continue-on-error: true\n        run: slsa-verifier verify-artifact x\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL003"* ]]
+}
+
+# --- Tool-error handling -----------------------------------------------------
+
+@test "malformed YAML fails closed (exit 2)" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n   - bad: [unclosed\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 2 ]
+}
+
+# --- Output format -----------------------------------------------------------
+
+@test "output format includes path, line, and rule id" {
+    run "$LINTER" "$FIXTURES/bad_r1_workflow.yml"
+    [ "$status" -eq 1 ]
+    found=false
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^[^:]+:[0-9]+:\ WWL[0-9]+: ]]; then
+            found=true
+            break
+        fi
+    done <<< "$output"
+    [ "$found" = true ]
+}
+
+# --- Dogfood: linter passes on the entire wrangle repo ----------------------
+
+@test "dogfood: workflow-lint passes on the entire wrangle repo (exit 0)" {
+    cd "$ORIG_DIR"
+    run "$LINTER"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}

--- a/tools/wrangle-workflow-lint/test.bats
+++ b/tools/wrangle-workflow-lint/test.bats
@@ -151,6 +151,16 @@ teardown() {
     [[ "$output" == *"WWL002"* ]]
 }
 
+@test "WWL002: github.head_ref interpolated into a run body is reported" {
+    # The classic pull_request_target injection vector.
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ github.head_ref }}"\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL002"* ]]
+}
+
 @test "WWL002: a safe context (github.sha) in a run body is not flagged" {
     tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
     printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: printf "%%s" "${{ github.sha }}"\n' > "$tmp"
@@ -199,6 +209,55 @@ teardown() {
     rm -f "$tmp"
     [ "$status" -eq 0 ]
     [[ "$output" != *"WWL003"* ]]
+}
+
+@test "WWL003: expression-form continue-on-error (\${{ true }}) is reported" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - name: cosign verify\n        continue-on-error: ${{ true }}\n        run: cosign verify x\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL003"* ]]
+}
+
+@test "WWL003: an unnamed inline 'run: ... verify' step is reported (run body in identity)" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: gh attestation verify x\n        continue-on-error: true\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL003"* ]]
+}
+
+@test "WWL003: a routine 'run: npm install' is not flagged (install dropped from run set)" {
+    # `install` matches a step name/uses but NOT a run body, so package
+    # installs do not false-flag.
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: npm install\n        continue-on-error: true\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WWL003"* ]]
+}
+
+@test "WWL003: a trailing inline justification comment exempts it" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - name: verify provenance\n        continue-on-error: true  # advisory in this context\n        run: slsa-verifier verify x\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WWL003"* ]]
+}
+
+@test "WWL003: an incidental comment elsewhere in the step does not exempt it" {
+    # Tightened (WSL005-style): only a comment bound to the continue-on-error
+    # line counts, not an unrelated comment elsewhere in the step.
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - name: verify provenance\n        # TODO: rename this step\n        id: v\n        continue-on-error: true\n        run: slsa-verifier verify x\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL003"* ]]
 }
 
 @test "WWL003: a whitespace-only comment is not a justification" {

--- a/tools/wrangle-workflow-lint/test.bats
+++ b/tools/wrangle-workflow-lint/test.bats
@@ -18,15 +18,20 @@ setup() {
     FIXTURES="$ORIG_DIR/tools/wrangle-workflow-lint/fixtures"
     export ORIG_DIR LINTER FIXTURES
 
-    # Fail loud if python3 / PyYAML is missing. The linter is mandatory in
-    # CI and in the test image (apt python3 + python3-yaml); a silent skip
-    # would let a broken image ship green.
-    if ! command -v python3 >/dev/null 2>&1; then
+    # Fail loud if no python3 with PyYAML is reachable. The linter is
+    # mandatory in CI and in the test image; a silent skip would let a broken
+    # image ship green. Mirror lint.sh's interpreter discovery — the managed
+    # venv in the image, or a system python3 with PyYAML for local dev.
+    if [[ -x /opt/wrangle-workflow-lint/bin/python3 ]]; then
+        PY=/opt/wrangle-workflow-lint/bin/python3
+    elif command -v python3 >/dev/null 2>&1; then
+        PY=python3
+    else
         printf 'python3 not on PATH — run via ./test.sh (the Docker image provides it)\n' >&2
         return 1
     fi
-    if ! python3 -c 'import yaml' >/dev/null 2>&1; then
-        printf 'PyYAML not importable — the test image apt-installs python3-yaml\n' >&2
+    if ! "$PY" -c 'import yaml' >/dev/null 2>&1; then
+        printf 'PyYAML not importable — install tools/wrangle-workflow-lint/requirements.txt into a venv (see test/Dockerfile)\n' >&2
         return 1
     fi
 }
@@ -303,3 +308,11 @@ teardown() {
     [ "$status" -eq 0 ]
     [ -z "$output" ]
 }
+
+# --- Dockerfile / requirements.txt drift guard ------------------------------
+# PyYAML's version lives only in tools/wrangle-workflow-lint/requirements.txt;
+# the Dockerfile COPYs that file and installs it with --require-hashes into a
+# venv. As with wrangle-shell-lint, requirements.txt IS the sole pinned-version
+# source, so drift is impossible by construction and no drift-guard test is
+# needed. Hash well-formedness is enforced by pip --require-hashes at image
+# build time (a missing hash fails the build), exercised by every ./test.sh run.


### PR DESCRIPTION
claude: opening on behalf of @TomHennen.

Fixes #273.

## What

Closes the mechanical-enforcement gap for five CLAUDE.md conventions that
shellcheck / actionlint / zizmor don't cover, wired into `make test`.

**New `tools/wrangle-workflow-lint/`** (python3 + PyYAML) — YAML-structure rules,
walking both `jobs.*.steps[]` (workflows) and `runs.steps[]` (composite actions):
- **WWL001 (R1)** — a `run:` block is at most **10 physical lines** (preamble,
  blanks, and comments all count). Counts physical source extent, so folded
  (`>`) scalars are measured correctly too.
- **WWL002 (R2)** — no `${{ inputs.* }}` / `${{ github.event.* }}` interpolated
  literally inside a `run:` body (blanket ban; thread through `env:` first).
  `inputs`/`github.event` are matched only as expression roots, so sibling
  contexts like `${{ matrix.inputs }}` are not false-flagged. This closes the
  typed-input / safe-context gap that zizmor (which fails closed only on the
  dangerous subset) leaves open.
- **WWL003 (R4)** — `continue-on-error: true` on a verification-class step
  (name/id/uses matching `verify|attestation|provenance|slsa|cosign|install`)
  needs an adjacent justification comment, mirroring WSL005's documented-exception
  mechanism. Silently swallowing a verification failure can mask a supply-chain attack.

**`tools/wrangle-shell-lint/`** gains two ast-grep rules:
- **WSL006 (R3)** — a network download (`curl`/`wget`/`fetch`) piped into a shell
  interpreter (`sh`/`bash`/`dash`/`zsh`), including via a wrapper
  (`curl | sudo bash`, `| env bash`, `| xargs sh -s`).
- **WSL007 (R5)** — `set +f` outside a subshell / command-substitution /
  process-substitution (**Policy A**: a function body is not a structurally
  exception-safe scope; a subshell is the only acceptable wrap, because a bare
  `set +f … set -f` leaks glob-enabled state if the middle aborts under `set -e`).

## Existing violations fixed

The audit in the issue found two; **the new linter found six** R1 violations (all
five `build/actions/*/action.yml` oversized blocks were missed). Per maintainer
direction, all are fixed so the repo passes with the rules enforced:

- **WSL007** — `build/actions/go/release/generate_summary.sh`: the bare `set +f`
  (never restored) is now a subshell-wrapped glob.
- **WWL001** — six oversized `run:` blocks resolved by extracting logic to scripts
  (or, for npm's SBOM step, relocating the rationale comment above `run:`):
  `tools/scorecard/ensure_sarif.sh`, `build/actions/python/{extract_metadata,generate_summary}.sh`,
  `build/actions/shell/{run_shellcheck,run_bats}.sh`. The extractions preserve exact
  behavior, including the `stop_commands_guard.sh` wrapping in **both** branches of
  the bats runner (#225 / SLSA_L3_AUDIT Finding 3); each new script has test coverage.

## Why PyYAML, not ast-grep (tooling)

wrangle already runs ast-grep for the shell rules, so the natural question is whether
these YAML rules belong there too. Researched: ast-grep **does** support YAML, and
**WWL002** maps cleanly to it (a `run:` pattern + a regex constraint). But the other
two don't: ast-grep has **no line-count constraint** for **WWL001** (a block scalar's
physical span), and reaches comments only through brittle relational matching for
**WWL003**'s adjacent-justification rule. A small PyYAML pass gets node line ranges and
raw-line access for both directly, so it's the more maintainable home for the three
rules — and WWL002 stays alongside them rather than splitting one rule into a second
tool. Recorded in `lint.py`'s module docstring.

## Install method (PyYAML)

PyYAML is installed the DEP_MGMT branch-1 way its Dockerfile neighbors (zizmor,
ast-grep) already use: a **hash-pinned venv** via `tools/wrangle-workflow-lint/`
`requirements.txt` (`PyYAML==6.0.3`, `pip install --require-hashes`), **Dependabot-
covered** by the existing `pip` `/tools/**` glob so version + hashes bump atomically.
Because PyYAML is a library, not a CLI, there's no entrypoint to symlink onto PATH:
`lint.sh` resolves the venv python (`/opt/wrangle-workflow-lint/bin/python3`) and runs
`lint.py` under it, falling back to a system `python3` that has PyYAML for local dev.
The image's base `python3` carries no yaml, so that fallback **fails closed** in CI
rather than masking a broken venv; `test.bats` setup mirrors the same discovery so a
broken image fails loud instead of silently skipping. Version is single-sourced in
`requirements.txt` (the Dockerfile COPYs it), so no drift guard is needed — same as
wrangle-shell-lint.

## Review feedback addressed

Follow-up commit responding to @TomHennen's review threads:
- **Reuse** — `run_shellcheck.sh` / `run_bats.sh` re-implemented the relative /
  no-traversal / safe-charset allowlist that `lib/validate_path.sh` already provides;
  both now call the shared helper (run_shellcheck keeps its own `-d` existence check).
- **Install** — PyYAML moved off apt `python3-yaml` onto the hash-pinned venv described
  above (the original apt rationale didn't hold: the footprint rule is about not
  *adding* a runtime, and python3 is already required).
- **Validation** — the python-action scripts receive an `inputs.path` already gated by
  `validate_inputs.sh` (the composite's first step); the workflow-lint targets are
  trusted developer input (git-discovered or an explicit file list), not
  `workflow_call` inputs. No redundant validation added — documented with pointer
  comments, mirroring the `run_bats.sh` precedent.

## Other changes

- `CLAUDE.md`: inline-shell cap reconciled `~5` → `10 physical lines`.
- `test/test_build_guard_coverage.bats`: greps the whole composite dir instead of just
  `action.yml`, since the guard now lives in a delegated script — exactly the
  extraction pattern this PR enforces. Per-composite test.bats still pin the guard to
  the actual tool invocation.
- Wired `workflowstyle` into the `Makefile` `test:` target and `test.sh` `quick`;
  the wrangle-workflow-lint PyYAML venv added to the test image.

## Validation

`./test.sh all` passes (actionlint, shellcheck, wrangle-shell-lint WSL001–007,
wrangle-workflow-lint WWL001–003, full bats suite, zizmor — zizmor does not scan the
generically-named lint fixtures). Both linters report 0 violations across the whole
repo after the fixes; each rule has good/bad fixtures proving it fails on bad input.
The image rebuild installs PyYAML via `--require-hashes` and the linter runs under the
venv python (verified the base python3 has no yaml, so the fallback can't mask it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
