### PR TITLE
chore: bump wrangle self-ref action pins to main (#305 follow-up)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -105,7 +105,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/preflight_guard@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
 
   gate:
     needs: [guard]
@@ -116,7 +116,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/release_gate@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -138,7 +138,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      uses: TomHennen/wrangle/build/actions/container@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -152,7 +152,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/preflight_guard@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
 
   gate:
     needs: [guard]
@@ -162,7 +162,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/release_gate@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -187,7 +187,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/build/actions/go/checks@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -245,7 +245,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/build/actions/go/release@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
         id: release
         with:
           path: ${{ inputs.path }}
@@ -316,7 +316,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/build/actions/go/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/go/verify@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/build/actions/go/verify@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
         with:
           dist-dir: dist
           provenance-path: provenance/${{ needs.provenance.outputs.provenance-name }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -125,7 +125,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/preflight_guard@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
 
   gate:
     needs: [guard]
@@ -136,7 +136,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/release_gate@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -160,7 +160,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/build/actions/npm@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
         id: build
         with:
           path: ${{ inputs.path }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -104,7 +104,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/preflight_guard@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -119,7 +119,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/release_gate@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -148,7 +148,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/build/actions/python@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
         id: build
         with:
           path: ${{ inputs.path }}
@@ -308,7 +308,7 @@ jobs:
       # yet. A nested self-ref is fetched from its pinned SHA, not the PR head, so
       # the integration test must point this at a branch SHA that carries them.
       # Re-bump to a main SHA post-merge — see docs/e2e_testing.md.
-      - uses: TomHennen/wrangle/actions/verify@400d43220997494ac4529b8fdd2ced3a4c2181b8 # feat/verify-python-provenance 2026-05-31
+      - uses: TomHennen/wrangle/actions/verify@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-v1.hjson

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -29,7 +29,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/preflight_guard@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
 
   shell-build:
     needs: [guard]
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+        uses: TomHennen/wrangle/build/actions/shell@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -20,7 +20,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/preflight_guard@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
 
   check-change:
     needs: [guard]
@@ -38,6 +38,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@e063cc9d26562d5e7f13da2f226a1bfebf95cfc9 # main 2026-05-31
+        uses: TomHennen/wrangle/actions/scan@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
         with:
           tools: ${{ inputs.tools }}


### PR DESCRIPTION
Completes the bootstrap-pin lifecycle for #305 (see [docs/e2e_testing.md](https://github.com/TomHennen/wrangle/blob/main/docs/e2e_testing.md)).

#305 was squash-merged, which orphaned the bootstrap pin `actions/verify@400d432` (a feature-branch SHA) and turned `check_pin_ancestry` **red on main**. This repoints it — and rolls the other self-ref pins forward from `e063cc9` — to the merged main SHA `5e5d4b1`, labeled `# main`. `check_pin_ancestry` is green again.

Pure pin bump (6 workflow files); no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)