### PR TITLE
deps: bump Go toolchain 1.26.3 → 1.26.4 (stdlib CVE fixes)

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -49,9 +49,9 @@ RUN set -euo pipefail && \
 # tests don't need Go; cost is ~80MB on the image but avoids the
 # cross-repo wrangle-test dispatch loop for catching regressions in
 # run_checks.sh and friends.
-ARG GO_VERSION=1.26.3
-ARG GO_CHECKSUM_ARM64=9d89a3ea57d141c2b22d70083f2c8459ba3890f2d9e818e7e933b75614936565
-ARG GO_CHECKSUM_AMD64=2b2cfc7148493da5e73981bffbf3353af381d5f93e789c82c79aff64962eb556
+ARG GO_VERSION=1.26.4
+ARG GO_CHECKSUM_ARM64=ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768
+ARG GO_CHECKSUM_AMD64=1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f
 RUN set -euo pipefail && \
     ARCH="$(uname -m)" && \
     case "$ARCH" in \

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/TomHennen/wrangle/tools
 
-go 1.26.3
+go 1.26.4
 
 tool (
 	github.com/carabiner-dev/ampel/cmd/ampel


### PR DESCRIPTION
osv-scanner's source scan flags the pinned Go stdlib (`1.26.3`) for three CVEs, failing `check-change` on every PR and on `main` right now:

- `CVE-2026-27145` (GO-2026-5037) — quadratic-time `crypto/x509` hostname verification
- `CVE-2026-42504` (GO-2026-5038)
- `CVE-2026-42507` (GO-2026-5039)

**go1.26.4** is the patched release (per the advisory, affected = `from go1.26.0-0 before go1.26.4`; fixed in go1.26.4 / go1.25.11).

This bumps, in one atomic commit (version + checksums together, per the supply-chain rules):
- `tools/go.mod` `go 1.26.3` → `1.26.4` (the directive osv reads; also the `go-version-file` source for the integration job)
- `test/Dockerfile` pinned `GO_VERSION` + both hardcoded `sha256` checksums (linux amd64 / arm64), taken from go.dev/dl

Clears the wrangle-side `check-change` red. **The companion repo's `scan/go.mod` (`stdlib@1.25.10`) needs the parallel bump to `go1.25.11` to clear the `dispatch` red** — separate PR on `TomHennen/wrangle-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)