### PR TITLE
chore: bump wrangle self-ref action pins to main (#310 follow-up)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -105,7 +105,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/preflight_guard@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
 
   gate:
     needs: [guard]
@@ -116,7 +116,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/release_gate@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -138,7 +138,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      uses: TomHennen/wrangle/build/actions/container@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -268,12 +268,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # actions/verify resolves a relative policy path against ITS OWN checkout
-      # (the pinned SHA), not the PR head — so the new container PolicySet only
-      # resolves once it is on the pinned ref. This pin needs a bootstrap bump
-      # to the PR branch SHA for the integration test, then back to main on merge.
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@bd69d445b9988d2f233779ec5b39da473c1885f6 # bootstrap: branch SHA carrying the container PolicySet + oci-target push; bump to main on merge
+      - uses: TomHennen/wrangle/actions/verify@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         with:
           subject: ${{ needs.build.outputs.digest }}
           policy: policies/wrangle-provenance-container-v1.hjson

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -152,7 +152,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/preflight_guard@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
 
   gate:
     needs: [guard]
@@ -162,7 +162,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/release_gate@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -187,7 +187,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/build/actions/go/checks@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -248,7 +248,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/build/actions/go/release@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -349,7 +349,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/build/actions/go/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/go/verify@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/build/actions/go/verify@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         with:
           dist-dir: dist
           provenance-path: provenance/${{ needs.provenance.outputs.provenance-name }}
@@ -389,7 +389,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/verify@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-v1.hjson

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -125,7 +125,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/preflight_guard@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
 
   gate:
     needs: [guard]
@@ -136,7 +136,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/release_gate@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -163,7 +163,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/build/actions/npm@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -312,7 +312,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/verify@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-v1.hjson

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -104,7 +104,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/preflight_guard@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -119,7 +119,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/release_gate@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -148,7 +148,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/build/actions/python@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -308,7 +308,7 @@ jobs:
       # yet. A nested self-ref is fetched from its pinned SHA, not the PR head, so
       # the integration test must point this at a branch SHA that carries them.
       # Re-bump to a main SHA post-merge — see docs/e2e_testing.md.
-      - uses: TomHennen/wrangle/actions/verify@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/verify@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-v1.hjson

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -29,7 +29,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/preflight_guard@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
 
   shell-build:
     needs: [guard]
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+        uses: TomHennen/wrangle/build/actions/shell@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -20,7 +20,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+      - uses: TomHennen/wrangle/actions/preflight_guard@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
 
   check-change:
     needs: [guard]
@@ -38,6 +38,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@5e5d4b1ae9aca432ffced21b83d7e56478d0e575 # main 2026-05-31
+        uses: TomHennen/wrangle/actions/scan@791a63abeeb5446fc32ead609c6c3767f9395e24 # main 2026-06-04
         with:
           tools: ${{ inputs.tools }}


### PR DESCRIPTION
Routine post-merge bump (the lifecycle in [`docs/e2e_testing.md`](../blob/main/docs/e2e_testing.md)). #310 squash-merged, so the container `actions/verify` **bootstrap pin** (a branch SHA, `bd69d44`) is no longer reachable from `main` — `check_pin_ancestry` is **red on main** until it's rolled forward, and the unattended showcase can't resolve that action.

- `tools/bump_action_pins.sh` rolls every `TomHennen/wrangle/...` self-ref pin (6 workflows) to the #310 merge SHA (`791a63a`), relabeled `# main 2026-06-04`.
- Drops the now-stale bootstrap-pin comment in `build_and_publish_container.yml` — the container PolicySet + the `oci-target` push are on `main` now, so `actions/verify` resolves the relative policy path from a normal main pin.

`check_pin_ancestry` passes again with this. No behavior change — pin SHAs + one comment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)