### PR TITLE
chore: bump self-ref action pins to main after #326

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -89,7 +89,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/actions/preflight_guard@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
 
   gate:
     needs: [guard]
@@ -100,7 +100,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/actions/release_gate@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -122,7 +122,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      uses: TomHennen/wrangle/build/actions/container@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -219,7 +219,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@24e24b114e45e5ed1c9a2cd31c8b5ba5c521ecc9 # feat/attest-build-provenance-316 2026-06-06
+      - uses: TomHennen/wrangle/actions/verify@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         with:
           subject: ${{ needs.build.outputs.digest }}
           policy: policies/wrangle-provenance-container-v1.hjson

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -141,7 +141,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/actions/preflight_guard@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
 
   gate:
     needs: [guard]
@@ -151,7 +151,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/actions/release_gate@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -176,7 +176,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -237,7 +237,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/build/actions/go/release@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         id: release
         with:
           path: ${{ inputs.path }}
@@ -373,7 +373,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@24e24b114e45e5ed1c9a2cd31c8b5ba5c521ecc9 # feat/attest-build-provenance-316 2026-06-06
+      - uses: TomHennen/wrangle/actions/verify@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-go-v1.hjson

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -113,7 +113,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/actions/preflight_guard@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
 
   gate:
     needs: [guard]
@@ -124,7 +124,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/actions/release_gate@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -151,7 +151,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/build/actions/npm@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         id: build
         with:
           path: ${{ inputs.path }}
@@ -284,7 +284,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@24e24b114e45e5ed1c9a2cd31c8b5ba5c521ecc9 # feat/attest-build-provenance-316 2026-06-06
+      - uses: TomHennen/wrangle/actions/verify@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-npm-v1.hjson

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -90,7 +90,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/actions/preflight_guard@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -105,7 +105,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/actions/release_gate@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -134,7 +134,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/build/actions/python@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         id: build
         with:
           path: ${{ inputs.path }}
@@ -263,7 +263,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@24e24b114e45e5ed1c9a2cd31c8b5ba5c521ecc9 # feat/attest-build-provenance-316 2026-06-06
+      - uses: TomHennen/wrangle/actions/verify@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-python-v1.hjson

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -29,7 +29,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/actions/preflight_guard@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
 
   shell-build:
     needs: [guard]
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)
-        uses: TomHennen/wrangle/build/actions/shell@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+        uses: TomHennen/wrangle/build/actions/shell@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -20,7 +20,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+      - uses: TomHennen/wrangle/actions/preflight_guard@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
 
   check-change:
     needs: [guard]
@@ -38,6 +38,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@cb043076b426c1e22b1305e39b7a59dc3a696f98 # main 2026-06-04
+        uses: TomHennen/wrangle/actions/scan@5b79a1ca848b761ae5bd5524e80af70bb42207c9 # main 2026-06-07
         with:
           tools: ${{ inputs.tools }}


### PR DESCRIPTION
claude: Post-merge pin bump for #326. Rolls actions/verify (the bootstrap pin) + the other wrangle self-refs to the #326 merge commit so check_pin_ancestry is green on main and the showcase resolves actions/verify. Mechanical; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)