### PR TITLE
docs(examples): run the embedded scan on pushes to main (go/python/npm)

### DIFF
--- a/gh_workflow_examples/build_go.yml
+++ b/gh_workflow_examples/build_go.yml
@@ -22,6 +22,7 @@ name: Go Build
 
 on:
   push:
+    branches: ["main"]  # source scan + snapshot build on main (no publish); drop to skip per-merge builds
     tags: ["v*"]       # publish on version tags
   pull_request:
     branches: ["**"]   # build + test on PRs (no provenance, no publish)

--- a/gh_workflow_examples/build_npm.yml
+++ b/gh_workflow_examples/build_npm.yml
@@ -35,6 +35,7 @@ name: npm Build
 
 on:
   push:
+    branches: ["main"]  # source scan + snapshot build on main (no publish); drop to skip per-merge builds
     tags: ["v*"]       # publish on version tags
   pull_request:
     branches: ["**"]   # build + test on PRs (no publish)

--- a/gh_workflow_examples/build_python.yml
+++ b/gh_workflow_examples/build_python.yml
@@ -32,6 +32,7 @@ name: Python Build
 
 on:
   push:
+    branches: ["main"]  # source scan + snapshot build on main (no publish); drop to skip per-merge builds
     tags: ["v*"]       # publish on version tags
   pull_request:
     branches: ["**"]   # build + test on PRs (no publish)


### PR DESCRIPTION
claude: follow-up to #335. The `build_shell` and `build_and_publish_containers` examples already trigger on push to `main`, but `build_go` / `build_python` / `build_npm` triggered only on tags + PRs — so their **embedded source scan never ran on the default branch**.

Now that a build workflow is the *only* workflow for build-type adopters (no separate `check_source_change.yml`), that loses what the standalone scan used to provide on `main`:
- **Scorecard** — it's push-only (skipped on PRs), so without a `main` trigger it ran only at release time.
- **Code-scanning baseline** — the Security tab's baseline is the default branch; PR-only scans never establish it.
- **osv/zizmor on merges** to `main`.

This adds `push: branches: ["main"]` to the three examples. It also runs a **snapshot** build per merge to `main` (no publish — the examples keep `release-events: tag-only`), which doubles as early build-break detection; the inline comment notes adopters can drop the trigger if they don't want per-merge builds.

**Pinning left as tags (not SHA), deliberately:** Dependabot already bumps tag-pinned `uses:` refs, and the consumer VSA-verification command in each build-type README pins the signer identity with `@refs/tags/v` — a SHA-pinned wrangle ref would make the VSA cert SAN unmatchable, breaking consumer verification. (Per DEP_MGMT.md: examples pin the wrangle ref by tag; genuine third-party actions in the examples are already SHA-pinned.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)