### PR TITLE
docs: expand README with pipeline, update, and security details

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,39 @@ uses one of wrangle's reusable workflows.  With that single job developers get:
 The promise is that if developers use wrangle, wrangle will take care of drudgery, safely,
 and let developers focus on the features they want to ship.
 
+## Quick Start
+
+Developers can copy & adapt one of the ecosystem specific examples from [./gh_workflow_examples](gh_workflow_examples),
+putting it in their .github/workflows directory.
+
+This is what it looks like for go (which also needs a `.goreleaser.yml` — see the table below).
+
+```yaml
+name: Go Build
+
+on:
+  push:
+    branches: ["main"]  # source scan + snapshot build on main (no publish); drop to skip per-merge builds
+    tags: ["v*"]       # publish on version tags
+  pull_request:
+    branches: ["**"]   # build + test on PRs (no provenance, no publish)
+  workflow_dispatch:
+
+jobs:
+  build:
+    permissions:
+      contents: write         # goreleaser creates the Release; verify job attaches the VSA
+      id-token: write         # OIDC for Sigstore signing
+      attestations: write     # GitHub-issued SLSA provenance
+      actions: read           # source scan: Scorecard reads the Actions API
+      security-events: write  # source-scan SARIF -> Security tab
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.0
+    with:
+      path: "."
+```
+
+Once they've done this they'll get tests run, scanning, attestations, etc.
+
 ## How Wrangle Works
 
 You add **one workflow file** to your repo that calls a wrangle reusable workflow. From there,
@@ -37,9 +70,8 @@ don't have to wire them up, configure them, or keep them current yourself.
 
 Depending on the ecosystem you pick, a run moves through these stages:
 
-1. **Scan the source** — checks your dependencies for known vulnerabilities (OSV), lints your
-   GitHub Actions workflows for unsafe patterns (Zizmor), and assesses your repo's overall
-   security posture (Scorecard).
+1. **Scan the source** — checks your dependencies for known vulnerabilities (OSV) and lints your
+   GitHub Actions workflows for unsafe patterns (Zizmor).
 2. **Run your tests** — wrangle runs your existing test suite; it orchestrates your tests, it
    doesn't replace them.
 3. **Build the artifact** — compiles/packages your project using safe defaults for your
@@ -78,39 +110,6 @@ Wrangle is a supply-chain security tool, so its defaults lean toward safety:
 
 You don't have to be a security expert to get these properties; adopting wrangle is how you get
 them.
-
-## Quick Start
-
-Developers can copy & adapt one of the ecosystem specific examples from [./gh_workflow_examples](gh_workflow_examples),
-putting it in their .github/workflows directory.
-
-This is what it looks like for go (which also needs a `.goreleaser.yml` — see the table below).
-
-```yaml
-name: Go Build
-
-on:
-  push:
-    branches: ["main"]  # source scan + snapshot build on main (no publish); drop to skip per-merge builds
-    tags: ["v*"]       # publish on version tags
-  pull_request:
-    branches: ["**"]   # build + test on PRs (no provenance, no publish)
-  workflow_dispatch:
-
-jobs:
-  build:
-    permissions:
-      contents: write         # goreleaser creates the Release; verify job attaches the VSA
-      id-token: write         # OIDC for Sigstore signing
-      attestations: write     # GitHub-issued SLSA provenance
-      actions: read           # source scan: Scorecard reads the Actions API
-      security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.0
-    with:
-      path: "."
-```
-
-Once they've done this they'll get tests run, scanning, attestations, etc.
 
 ## Ecosystems
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,20 @@ Depending on the ecosystem you pick, a run moves through these stages:
 Source-only and shell projects run the checks without producing a published artifact; the other
 ecosystems run the whole pipeline. (The intro bullets above link out to each of these terms.)
 
-### Maintained for you
+### Staying up to date
 
 Because you reference wrangle's reusable workflows (rather than copying tool config into your
-repo), tool updates, new security checks, and fixes flow to you automatically. A security
-engineer can improve the defaults for everyone without every project having to change anything.
+repo), every new wrangle release ships freshly-pinned tool versions, new security checks, and
+fixes — and you adopt the whole bundle by bumping a single pin, not by re-plumbing anything. A
+security engineer can improve the defaults for everyone centrally.
+
+These updates do **not** apply themselves. You pin wrangle at a release tag (e.g.
+`@v0.2.0`), and you pick up new releases when that pin is bumped — so wrangle adoption is really
+**two files**: the workflow above, plus a [Dependabot config](gh_workflow_examples/dependabot.yml)
+(copy it to `.github/dependabot.yml`) that raises a PR whenever a newer wrangle tag is available.
+Without it your pin — and the security tooling behind it — silently goes stale. Review and merge
+those PRs yourself; **do not** enable auto-merge, so wrangle's ~7-day cooldown can let
+supply-chain attacks surface before you pull a new version in.
 
 ### Security is the point, not a feature
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,58 @@ uses one of wrangle's reusable workflows.  With that single job developers get:
 The promise is that if developers use wrangle, wrangle will take care of drudgery, safely,
 and let developers focus on the features they want to ship.
 
+## How Wrangle Works
+
+You add **one workflow file** to your repo that calls a wrangle reusable workflow. From there,
+wrangle runs your code through a pipeline of well-known security and supply-chain tools so you
+don't have to wire them up, configure them, or keep them current yourself.
+
+### The pipeline
+
+Depending on the ecosystem you pick, a run moves through these stages:
+
+1. **Scan the source** — checks your dependencies for known vulnerabilities (OSV), lints your
+   GitHub Actions workflows for unsafe patterns (Zizmor), and assesses your repo's overall
+   security posture (Scorecard).
+2. **Run your tests** — wrangle runs your existing test suite; it orchestrates your tests, it
+   doesn't replace them.
+3. **Build the artifact** — compiles/packages your project using safe defaults for your
+   ecosystem (Go, Python, npm, or a container image).
+4. **Describe what's inside** — generates an [SBOM](https://spdx.dev) (a bill of materials of
+   every dependency) and scans it for vulnerabilities.
+5. **Sign and attest** — signs the artifact and produces
+   [SLSA Build Level 3 provenance](https://slsa.dev/spec/v1.2/levels): tamper-evident proof of
+   exactly how and where it was built.
+6. **Verify before shipping** — checks that provenance against a policy and emits a
+   [VSA](https://slsa.dev/verification_summary/v1) so the people who consume your artifact can
+   verify it with a single command.
+
+Source-only and shell projects run the checks without producing a published artifact; the other
+ecosystems run the whole pipeline.
+
+### Maintained for you
+
+Because you reference wrangle's reusable workflows (rather than copying tool config into your
+repo), tool updates, new security checks, and fixes flow to you automatically. A security
+engineer can improve the defaults for everyone without every project having to change anything.
+
+### Security is the point, not a feature
+
+Wrangle is a supply-chain security tool, so its defaults lean toward safety:
+
+- **Fail-closed on security guarantees.** If signing or provenance generation fails, the release
+  is *blocked* — wrangle never ships an unsigned or unattested artifact, because a missing
+  guarantee is indistinguishable from an attack.
+- **Keyless signing.** Artifacts are signed with [Sigstore](https://www.sigstore.dev/) using
+  your GitHub Actions identity — there are no signing keys for you to manage or leak.
+- **Verifiable provenance.** The provenance ties each artifact back to the exact workflow that
+  built it, and the VSA lets downstream users confirm that without trusting you blindly.
+- **Least privilege.** Workflows request only the permissions they actually need — never
+  blanket write access.
+
+You don't have to be a security expert to get these properties; adopting wrangle is how you get
+them.
+
 ## Quick Start
 
 Developers can copy & adapt one of the ecosystem specific examples from [./gh_workflow_examples](gh_workflow_examples),

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Once they've done this they'll get tests run, scanning, attestations, etc.
 
 ## How Wrangle Works
 
-You add **one workflow file** to your repo that calls a wrangle reusable workflow. From there,
-wrangle runs your code through a pipeline of well-known security and supply-chain tools so you
-don't have to wire them up, configure them, or keep them current yourself.
+Behind that one workflow call, wrangle runs your code through a pipeline of well-known security
+and supply-chain tools so you don't have to wire them up, configure them, or keep them current
+yourself.
 
 ### The pipeline
 
@@ -76,17 +76,15 @@ Depending on the ecosystem you pick, a run moves through these stages:
    doesn't replace them.
 3. **Build the artifact** — compiles/packages your project using safe defaults for your
    ecosystem (Go, Python, npm, or a container image).
-4. **Describe what's inside** — generates an [SBOM](https://spdx.dev) (a bill of materials of
-   every dependency) and scans it for vulnerabilities.
-5. **Sign and attest** — signs the artifact and produces
-   [SLSA Build Level 3 provenance](https://slsa.dev/spec/v1.2/levels): tamper-evident proof of
-   exactly how and where it was built.
-6. **Verify before shipping** — checks that provenance against a policy and emits a
-   [VSA](https://slsa.dev/verification_summary/v1) so the people who consume your artifact can
-   verify it with a single command.
+4. **Describe what's inside** — generates an SBOM (a bill of materials of every dependency) and
+   scans it for vulnerabilities.
+5. **Sign and attest** — signs the artifact and produces SLSA Build Level 3 provenance:
+   tamper-evident proof of exactly how and where it was built.
+6. **Verify before shipping** — checks that provenance against a policy and emits a VSA so the
+   people who consume your artifact can verify it with a single command.
 
 Source-only and shell projects run the checks without producing a published artifact; the other
-ecosystems run the whole pipeline.
+ecosystems run the whole pipeline. (The intro bullets above link out to each of these terms.)
 
 ### Maintained for you
 
@@ -105,15 +103,19 @@ Wrangle is a supply-chain security tool, so its defaults lean toward safety:
   your GitHub Actions identity — there are no signing keys for you to manage or leak.
 - **Verifiable provenance.** The provenance ties each artifact back to the exact workflow that
   built it, and the VSA lets downstream users confirm that without trusting you blindly.
-- **Least privilege.** Workflows request only the permissions they actually need — never
-  blanket write access.
+- **Least privilege, job by job.** There is no workflow-wide permission grant. Each job inside a
+  reusable workflow declares its own minimal `permissions:` block, so the scan and test jobs run
+  read-only while only the publish, sign, and attest jobs hold write or token scopes
+  (`contents: write`, `packages: write`, `id-token: write`, `attestations: write`) — and only for
+  the length of that one job. GitHub enforces the ceiling too: a called job can narrow the
+  caller's grant but never widen it.
 
 You don't have to be a security expert to get these properties; adopting wrangle is how you get
 them.
 
 ## Ecosystems
 
-Go, Python, npm, and Container each produce a signed artifact — source scan, tests, SBOM, SLSA Build L3 provenance, and a VSA. Shell and source-only run checks without producing an artifact.
+Go, Python, npm, and Container each run the full pipeline and produce a signed, verifiable artifact; Shell and source-only run the checks only. Pick the row matching your project:
 
 | Ecosystem | README | Example |
 |-----------|--------|---------|

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ jobs:
 
 Once they've done this they'll get tests run, scanning, attestations, etc.
 
+Add one more file to keep wrangle current: copy
+[`gh_workflow_examples/dependabot.yml`](gh_workflow_examples/dependabot.yml) to
+`.github/dependabot.yml`. It raises a PR whenever a newer wrangle release is available so your
+pin (and the security tooling behind it) doesn't go stale — review and merge those yourself, and
+don't enable auto-merge (see [Staying up to date](#staying-up-to-date)).
+
 ## How Wrangle Works
 
 Behind that one workflow call, wrangle runs your code through a pipeline of well-known security


### PR DESCRIPTION
## What does this PR do?

Expands the README with three new sections that explain wrangle's core value proposition and adoption model:

1. **How Wrangle Works** — documents the six-stage security pipeline (source scanning, tests, build, SBOM, signing/attestation, verification) and clarifies which ecosystems run the full pipeline vs. checks-only.

2. **Staying up to date** — explains the pin-and-bump adoption model: wrangle is two files (workflow + Dependabot config), and new releases are adopted by bumping a single tag. Emphasizes that updates are manual (no auto-merge) to allow supply-chain attack detection during the ~7-day cooldown.

3. **Security is the point, not a feature** — documents four core security properties: fail-closed on guarantees, keyless signing via Sigstore, verifiable provenance, and least-privilege job-by-job permissions.

Also updates the Ecosystems intro to clarify the pipeline/checks distinction and improve readability.

These additions help adopters understand what wrangle does, why its defaults are strict, and how to keep it current without introducing risk.

## Checklist

- [x] Spec updated if contracts changed — no contract changes, documentation only
- [x] `make test` passes locally — N/A (documentation only)
- [x] CI passes on this PR — documentation changes only
- [x] No new `continue-on-error` — N/A
- [x] No `@main` refs in `uses:` lines — N/A
- [x] Tool `SPEC.md` exists/updated — N/A

https://claude.ai/code/session_01QHWTW1DtpmVD9B1tYXiQH6