### PR TITLE
docs: correct signing and SBOM-scanning claims to match shipped behavior

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,7 +15,7 @@ Wrangle's own workflows all have filenames that start with `local_`.
 
 ## build_and_publish_*.yml
 
-`build_and_publish_container.yml`, `build_and_publish_python.yml`, `build_and_publish_npm.yml`, `build_and_publish_go.yml`, and `build_shell.yml` let callers build and publish with a minimum of fuss, following best practices: SLSA provenance, SBOMs, signing, and a source scan up front.
+`build_and_publish_container.yml`, `build_and_publish_python.yml`, `build_and_publish_npm.yml`, and `build_and_publish_go.yml` let callers build and publish with a minimum of fuss, following best practices: signed SLSA provenance, SBOMs, a signed VSA, and a source scan up front. `build_shell.yml` runs the same scan/build/test flow for shell projects but produces no artifact.
 
 **Embedded source scan.** Each of these workflows runs a `scan` job (the `actions/scan` composite) before building, so adopters get scanning *and* build/publish from one workflow — no separate `check_source_change.yml` needed.
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ A run typically moves through these stages:
 2. **Run your tests** — runs your existing test suite.
 3. **Build the artifact** — compiles/packages your project using safe defaults for your
    ecosystem
-4. **Describe what's inside** — generates an SBOM and
-   scans it for vulnerabilities.
-5. **Sign and attest** — signs the artifact and produces provenance signed by Wrangle.
+4. **Describe what's inside** — generates an SBOM for the artifact.
+5. **Attest** — produces Sigstore-signed SLSA provenance tying the artifact to the exact
+   workflow run that built it.
 6. **Verify before shipping** — checks that provenance against a policy and emits a VSA so the
    people who consume your artifact can verify it with a single command.
 
@@ -109,7 +109,7 @@ Wrangle is a supply-chain security tool, so its defaults lean toward safety:
 
 ## Ecosystems
 
-Go, Python, npm, and Container each run the full pipeline and produce a signed, verifiable artifact; Shell and source-only run the checks only. Pick the row matching your project:
+Go, Python, npm, and Container each run the full pipeline and produce an attested, verifiable artifact; Shell and source-only run the checks only. Pick the row matching your project:
 
 | Ecosystem | README | Example |
 |-----------|--------|---------|

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ A run typically moves through these stages:
 3. **Build the artifact** — compiles/packages your project using safe defaults for your
    ecosystem
 4. **Describe what's inside** — generates an SBOM for the artifact.
-5. **Attest** — produces Sigstore-signed SLSA provenance tying the artifact to the exact
-   workflow run that built it.
+5. **Attest** — produces Sigstore-signed SLSA provenance tying the artifact to the
+   workflow that built it.
 6. **Verify before shipping** — checks that provenance against a policy and emits a VSA so the
    people who consume your artifact can verify it with a single command.
 

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -1,6 +1,6 @@
 # Wrangle Build Container
 
-Build and publish a container image to ghcr.io with an SBOM, Cosign signature, and SLSA L3 provenance.
+Build and publish a container image to ghcr.io with an SBOM, SLSA L3 provenance, and a signed VSA.
 
 ## Quick-start
 

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -1,8 +1,10 @@
 name: Docker image builder
 description: |
   Build and push a Docker image with BuildKit SBOM and provenance.
-  Cosign signing, SLSA L3 provenance, and SBOM vulnerability scanning
-  are planned but not yet implemented (see implementation plan PR 9).
+  SLSA L3 provenance and the signed VSA come from the
+  build_and_publish_container.yml reusable workflow, not this action.
+  Cosign signing of the image digest and SBOM vulnerability scanning
+  are planned but not yet implemented.
 
 inputs:
   path:

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -3,8 +3,6 @@ description: |
   Build and push a Docker image with BuildKit SBOM and provenance.
   SLSA L3 provenance and the signed VSA come from the
   build_and_publish_container.yml reusable workflow, not this action.
-  Cosign signing of the image digest and SBOM vulnerability scanning
-  are planned but not yet implemented.
 
 inputs:
   path:


### PR DESCRIPTION
Audit of the README (and adjacent docs) against shipped behavior turned up claims that overstate what wrangle does today:

- **"Sign and attest — signs the artifact"** (README pipeline step 5): no artifact is directly signed anywhere — there is no `cosign sign`/`sign-blob` in the repo (for Go this is a deliberate decision, `build/actions/go/SPEC.md` §signing). What's signed are the attestations: Sigstore-signed SLSA provenance and the keyless-signed VSA. Reworded to "Attest".
- **"generates an SBOM and scans it for vulnerabilities"** (step 4): SBOMs are produced for all four publishing ecosystems but nothing scans them yet (`build/actions/container/README.md` lists this explicitly as unshipped). The osv vulnerability scan runs against *source* in step 1. Step 4 now just claims the SBOM.
- **"signed, verifiable artifact"** (Ecosystems) → "attested, verifiable artifact".
- **Container action description** was stale in both directions: it claimed SLSA L3 provenance was "planned but not yet implemented" (it ships via `build_and_publish_container.yml`) while its README's line 3 claimed a "Cosign signature" that its own not-yet-shipped list at line 38 contradicts. Both now describe current behavior; also drops a "see PR 9" reference.
- **`.github/workflows/README.md`** lumped `build_shell.yml` in with the publish workflows as providing "SLSA provenance, SBOMs, signing" — shell produces no artifact. Now described separately.

Docs-only; `./test.sh quick` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)