### PR TITLE
fix(go): pin goreleaser to the triggering tag

### DIFF
--- a/build/actions/go/release/action.yml
+++ b/build/actions/go/release/action.yml
@@ -175,6 +175,12 @@ runs:
         # grants contents: write at startup. Harmless when not
         # publishing.
         GITHUB_TOKEN: ${{ github.token }}
+        # Pin goreleaser to the tag that triggered this run. When several
+        # tags point at the same commit, goreleaser's own resolution picks
+        # an arbitrary one and re-targets that tag's existing Release,
+        # failing the upload with 422 already_exists. Empty on non-tag
+        # (snapshot) builds, which goreleaser treats as unset.
+        GORELEASER_CURRENT_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
 
     - name: Resume workflow commands (end)
       if: always()

--- a/build/actions/go/test.bats
+++ b/build/actions/go/test.bats
@@ -455,6 +455,14 @@ func main() {}
     [[ "$status" -eq 0 ]]
 }
 
+@test "go.release: goreleaser is pinned to the triggering tag" {
+    # Several tags can point at one commit; without GORELEASER_CURRENT_TAG
+    # goreleaser picks an arbitrary one and re-targets that tag's existing
+    # Release (422 already_exists). Must be empty on non-tag builds.
+    run grep -E "GORELEASER_CURRENT_TAG: \\\$\\{\\{ startsWith\\(github\\.ref, 'refs/tags/'\\) && github\\.ref_name \\|\\| '' \\}\\}" "$RELEASE_ACTION"
+    [[ "$status" -eq 0 ]]
+}
+
 @test "go.checks: setup-go cache is gated by the cache input" {
     run grep -E "cache: \\\$\\{\\{ inputs\\.cache != 'disabled' \\}\\}" "$CHECKS_ACTION"
     [[ "$status" -eq 0 ]]


### PR DESCRIPTION
Fixes the cross-tag half of TomHennen/wrangle-test#27.

**Mechanism:** wrangle's release-showcase pushes one tracking tag per main-push, and they all point at the same wrangle-test commit (five tags on `1484f0f` right now). The go release action never told goreleaser which tag triggered the run, so goreleaser's own commit→tag resolution picked the same arbitrary (stale) tag every time, targeted *that* tag's existing Release, and re-uploaded identical asset names — `422 already_exists` on three consecutive tracking tags.

**Fix:** set `GORELEASER_CURRENT_TAG` to `github.ref_name` when the trigger is a tag — goreleaser's documented override "in cases where one git commit is referenced by multiple git tags" ([cookbook](https://goreleaser.com/cookbooks/set-a-custom-git-tag/)). On non-tag (snapshot) builds the env is empty, which goreleaser treats as unset (verified in source: `getFromEnv` ignores empty values). Any adopter who tags one commit multiple times (retag, parallel release trains) hits the same bug, so the fix belongs in the action, not the showcase fixture.

The same-tag re-run half (re-running one tag's workflow re-uploads to its own release) is a fixture concern — addressed in wrangle-test with `replace_existing_artifacts: true`.

Structural bats fingerprint added; `./test.sh quick` + zizmor pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)