### PR TITLE
chore: bump wrangle self-ref pins to main after #343

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -97,7 +97,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/preflight_guard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
 
   gate:
     needs: [guard]
@@ -108,7 +108,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/release_gate@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -130,7 +130,7 @@ jobs:
           persist-credentials: false
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/scan@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -153,7 +153,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      uses: TomHennen/wrangle/build/actions/container@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -250,7 +250,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/verify@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         with:
           subject: ${{ needs.build.outputs.digest }}
           policy: policies/wrangle-provenance-container-v1.hjson

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -149,7 +149,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/preflight_guard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
 
   gate:
     needs: [guard]
@@ -159,7 +159,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/release_gate@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -182,7 +182,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/scan@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -207,7 +207,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/build/actions/go/checks@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/build/actions/go/release@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         id: release
         with:
           path: ${{ inputs.path }}
@@ -405,7 +405,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/verify@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-go-v1.hjson

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -121,7 +121,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/preflight_guard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
 
   gate:
     needs: [guard]
@@ -132,7 +132,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/release_gate@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -155,7 +155,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/scan@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -182,7 +182,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/build/actions/npm@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         id: build
         with:
           path: ${{ inputs.path }}
@@ -316,7 +316,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/verify@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-npm-v1.hjson

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -98,7 +98,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/preflight_guard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -113,7 +113,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/release_gate@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -136,7 +136,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/scan@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -165,7 +165,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/build/actions/python@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         id: build
         with:
           path: ${{ inputs.path }}
@@ -295,7 +295,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/verify@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-python-v1.hjson

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -46,7 +46,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/preflight_guard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -67,7 +67,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/scan@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -88,7 +88,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+        uses: TomHennen/wrangle/build/actions/shell@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -20,7 +20,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/preflight_guard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
 
   check-change:
     needs: [guard]
@@ -38,6 +38,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@0ed04fbdbd47aa3b85b9cf726c1589dafee6aba1 # main 2026-06-10
+        uses: TomHennen/wrangle/actions/scan@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
         with:
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -54,7 +54,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+      uses: TomHennen/wrangle/tools/zizmor@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -62,7 +62,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@68b1caea47c1dc2c3210d4313d6871eb5a631b12 # main 2026-05-17
+      uses: TomHennen/wrangle/tools/scorecard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -74,10 +74,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      # Bootstrap pin (docs/e2e_testing.md): the wrapper gained native
-      # config-file threading this PR; main's pin predates it. Bump to
-      # main post-merge via tools/bump_action_pins.sh.
-      uses: TomHennen/wrangle/tools/dependency-review@b89692aa71d1dfd42eef4a8f7f1e7fb6add2583d # claude/wrangle-build-shell-workflow-72lpca 2026-06-09
+      uses: TomHennen/wrangle/tools/dependency-review@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
 
     - name: Generate step summary
       if: always()


### PR DESCRIPTION
Unbreaks `build-shell / scan` on main (red since #343 merged, and inherited by every PR).

#343's bootstrap pin in `actions/scan/action.yml` points at `b89692aa` — a commit on the squash-merged PR branch, so zizmor's impostor-commit audit correctly flags "uses a commit that doesn't belong to the specified org/repo" now that the work landed as a different SHA on main. This is the documented pin → merge → bump lifecycle (docs/e2e_testing.md); this PR is the bump step. All self-ref pins move to main HEAD `15b64ec`, and the bootstrap comment (which described the pre-merge state) is dropped.

Process note: the bootstrap comment said to bump via `tools/bump_action_pins.sh`, but the tool's default walk only covers `.github/workflows/` (non-recursive glob) — composite-action pins need an explicit `WRANGLE_PINS_DIR=actions/scan`. Worth either widening the tool's default walk or making `check_pin_ancestry` fail on merged-branch (not just unreachable) pins; happy to file/fix as a follow-up.

`./test.sh quick` and `check_pin_ancestry` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)