### PR TITLE
fix(verify): retry ampel and bnd once on transient Sigstore failures (#354)

### DIFF
--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -32,6 +32,21 @@ wrangle_resolve_policy() {
     esac
 }
 
+# Run a command and, on failure, run it once more. Sigstore I/O inside ampel
+# and bnd fails intermittently (an identity check on one tenet, the DSSE
+# signing stream) on runs that pass identically seconds later; re-evaluating
+# the same attestations against the same policy is deterministic, so a retry
+# can only flip a transient failure, never a real verdict. $1 is the stdout
+# capture file, truncated per attempt so a retry can't append to a partial
+# report.
+wrangle_retry_once() {
+    local out="$1"; shift
+    if "$@" > "$out"; then return 0; fi
+    local rc=$?
+    printf 'wrangle: %s failed (exit %s); retrying once for transient Sigstore I/O\n' "$1" "$rc" >&2
+    "$@" > "$out"
+}
+
 # Build the ampel verify argument vector from the environment. One argument per
 # line so callers (and tests) read it into an array with mapfile.
 wrangle_ampel_verify_args() {
@@ -85,7 +100,7 @@ wrangle_verify_emit_vsa() {
     # straight into the truncating sanitizer would let a >MAX_SUMMARY report
     # SIGPIPE the pipeline and flip a PASS into a blocked release.
     report="$(mktemp)"
-    ampel "${args[@]}" > "$report" || rc=$?
+    wrangle_retry_once "$report" ampel "${args[@]}" || rc=$?
     wrangle_sanitize_output < "$report" >> "$GITHUB_STEP_SUMMARY"
     # On a FAILED verdict the report (which tenet failed, missing attestation,
     # etc.) is the operator's only signal for why the release was blocked, and
@@ -105,7 +120,7 @@ wrangle_sign_vsa() {
     local args
     mapfile -t args < <(wrangle_bnd_sign_args "$VSA.unsigned")
     mv "$VSA" "$VSA.unsigned"
-    bnd "${args[@]}" > "$VSA"
+    wrangle_retry_once "$VSA" bnd "${args[@]}"
     rm -f "$VSA.unsigned"
 }
 

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -38,12 +38,15 @@ wrangle_resolve_policy() {
 # the same attestations against the same policy is deterministic, so a retry
 # can only flip a transient failure, never a real verdict. $1 is the stdout
 # capture file, truncated per attempt so a retry can't append to a partial
-# report.
+# report. WRANGLE_RETRY_DELAY (seconds) spaces the attempts so a brief
+# Sigstore blip has time to clear; an immediate retry tends to hit the same
+# failing connection. Tests set it to 0.
 wrangle_retry_once() {
     local out="$1"; shift
-    if "$@" > "$out"; then return 0; fi
+    "$@" > "$out" && return 0
     local rc=$?
     printf 'wrangle: %s failed (exit %s); retrying once for transient Sigstore I/O\n' "$1" "$rc" >&2
+    sleep "${WRANGLE_RETRY_DELAY:-5}"
     "$@" > "$out"
 }
 

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -34,6 +34,8 @@ setup() {
     export CONTEXT=""
     export ATTESTATION=""
     export OCI_TARGET=""
+    # No real Sigstore here, so the inter-attempt backoff is pure dead time.
+    export WRANGLE_RETRY_DELAY=0
 
     # shellcheck source=run_verify.sh
     source "$SCRIPT"
@@ -396,6 +398,8 @@ SHIM
     [[ "$status" -eq 0 ]]
     [[ "$(wc -l < "$shim.calls")" -eq 2 ]]
     [[ "$output" == *"retrying once"* ]]
+    # The notice carries the first attempt's real exit code, not a stale $?.
+    [[ "$output" == *"(exit 1)"* ]]
     # Truncated per attempt: no 'partial' residue from the failed first try.
     [[ "$(cat "$TEST_DIR/out")" == "good" ]]
 }

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -359,3 +359,55 @@ SHIM
     if grep -q "release create" "$GH_LOG"; then return 1; fi
     if grep -q "release upload" "$GH_LOG"; then return 1; fi
 }
+
+# --- wrangle_retry_once -----------------------------------------------------
+
+# Shim whose first invocation fails after partial output and whose second
+# succeeds — the transient-Sigstore shape the retry exists for.
+make_flaky() {
+    local mode="$1" shim="$TEST_DIR/flaky"
+    cat > "$shim" <<SHIM
+#!/usr/bin/env bash
+calls="\$0.calls"
+printf 'x\n' >> "\$calls"
+n="\$(wc -l < "\$calls")"
+case "$mode" in
+    pass)       printf 'good\n'; exit 0 ;;
+    fail-once)  if [[ "\$n" -eq 1 ]]; then printf 'partial\n'; exit 1; fi
+                printf 'good\n'; exit 0 ;;
+    fail-always) printf 'broken\n'; exit 1 ;;
+esac
+SHIM
+    chmod +x "$shim"
+    printf '%s\n' "$shim"
+}
+
+@test "retry: passing command runs exactly once" {
+    shim="$(make_flaky pass)"
+    run wrangle_retry_once "$TEST_DIR/out" "$shim"
+    [[ "$status" -eq 0 ]]
+    [[ "$(wc -l < "$shim.calls")" -eq 1 ]]
+    [[ "$(cat "$TEST_DIR/out")" == "good" ]]
+}
+
+@test "retry: transient failure retries once and the capture holds only the retry's output" {
+    shim="$(make_flaky fail-once)"
+    run wrangle_retry_once "$TEST_DIR/out" "$shim"
+    [[ "$status" -eq 0 ]]
+    [[ "$(wc -l < "$shim.calls")" -eq 2 ]]
+    [[ "$output" == *"retrying once"* ]]
+    # Truncated per attempt: no 'partial' residue from the failed first try.
+    [[ "$(cat "$TEST_DIR/out")" == "good" ]]
+}
+
+@test "retry: deterministic failure still fails closed after the second attempt" {
+    shim="$(make_flaky fail-always)"
+    run wrangle_retry_once "$TEST_DIR/out" "$shim"
+    [[ "$status" -ne 0 ]]
+    [[ "$(wc -l < "$shim.calls")" -eq 2 ]]
+}
+
+@test "retry: ampel and bnd invocations both route through wrangle_retry_once" {
+    grep -q 'wrangle_retry_once "$report" ampel' "$SCRIPT"
+    grep -q 'wrangle_retry_once "$VSA" bnd' "$SCRIPT"
+}

--- a/tools/syft/install.sh
+++ b/tools/syft/install.sh
@@ -103,6 +103,8 @@ wrangle_cosign_verify_checksums() {
 # distinguishable from network trouble.
 if ! verify_err="$(wrangle_cosign_verify_checksums 2>&1)"; then
     printf 'wrangle: cosign verify-blob failed; retrying once for transient Sigstore I/O\n' >&2
+    # Spaced so a brief Sigstore blip has time to clear; tests set 0.
+    sleep "${WRANGLE_RETRY_DELAY:-5}"
     if ! verify_err="$(wrangle_cosign_verify_checksums 2>&1)"; then
         printf '%s\n' "$verify_err" >&2
         printf 'wrangle: FATAL: Cosign signature verification failed for syft %s\n' "$VERSION" >&2

--- a/tools/syft/install.sh
+++ b/tools/syft/install.sh
@@ -88,15 +88,27 @@ fi
 # and publishes"), so the OIDC certificate's workflow_ref claim is
 # `@refs/heads/main`, not `@refs/tags/v...`. Locking to release.yaml on main
 # is the strongest claim available given how Anchore releases.
-if ! cosign verify-blob "$CHECKSUMS_PATH" \
-    --certificate "$PEM_PATH" \
-    --signature "$SIG_PATH" \
-    --certificate-identity 'https://github.com/anchore/syft/.github/workflows/release.yaml@refs/heads/main' \
-    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-    >/dev/null 2>&1; then
-    printf 'wrangle: FATAL: Cosign signature verification failed for syft %s\n' "$VERSION" >&2
-    printf 'wrangle: this may indicate a supply chain attack — aborting\n' >&2
-    exit 1
+wrangle_cosign_verify_checksums() {
+    cosign verify-blob "$CHECKSUMS_PATH" \
+        --certificate "$PEM_PATH" \
+        --signature "$SIG_PATH" \
+        --certificate-identity 'https://github.com/anchore/syft/.github/workflows/release.yaml@refs/heads/main' \
+        --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+}
+
+# Verification is deterministic over the downloaded files; only cosign's
+# Sigstore I/O (TUF root refresh) is flaky, so a retry can only flip a
+# transient failure — a forged signature fails both attempts. On the final
+# failure, surface cosign's own stderr so a real signature mismatch is
+# distinguishable from network trouble.
+if ! verify_err="$(wrangle_cosign_verify_checksums 2>&1)"; then
+    printf 'wrangle: cosign verify-blob failed; retrying once for transient Sigstore I/O\n' >&2
+    if ! verify_err="$(wrangle_cosign_verify_checksums 2>&1)"; then
+        printf '%s\n' "$verify_err" >&2
+        printf 'wrangle: FATAL: Cosign signature verification failed for syft %s\n' "$VERSION" >&2
+        printf 'wrangle: this may indicate a supply chain attack — aborting\n' >&2
+        exit 1
+    fi
 fi
 
 # Extract the tarball's SHA-256 from the now-trusted checksums file.

--- a/tools/syft/test.bats
+++ b/tools/syft/test.bats
@@ -145,3 +145,26 @@ MOCK
     run grep 'WRANGLE_BIN_DIR' "$ORIG_DIR/tools/syft/install.sh"
     [ "$status" -eq 0 ]
 }
+
+@test "install: cosign verification retries once and surfaces cosign stderr on final failure" {
+    # A cosign shim is required: real verify-blob needs network and the real
+    # syft release blobs; the retry/diagnostic contract is what's under test.
+    cat > "$TEST_DIR/bin/curl" << 'MOCK'
+#!/usr/bin/env bash
+exit 0
+MOCK
+    chmod +x "$TEST_DIR/bin/curl"
+    cat > "$TEST_DIR/bin/cosign" << 'MOCK'
+#!/usr/bin/env bash
+printf 'x\n' >> "$TEST_DIR/cosign.calls"
+printf 'tuf: timeout fetching trusted root\n' >&2
+exit 1
+MOCK
+    chmod +x "$TEST_DIR/bin/cosign"
+    PATH="$TEST_DIR/bin:$PATH" run "$ORIG_DIR/tools/syft/install.sh" "1.42.4"
+    [[ "$status" -ne 0 ]]
+    [[ "$(wc -l < "$TEST_DIR/cosign.calls")" -eq 2 ]]
+    [[ "$output" == *"retrying once"* ]]
+    [[ "$output" == *"tuf: timeout fetching trusted root"* ]]
+    [[ "$output" == *"FATAL"* ]]
+}

--- a/tools/syft/test.bats
+++ b/tools/syft/test.bats
@@ -9,6 +9,8 @@ setup() {
     export TEST_DIR ORIG_DIR
     mkdir -p "$TEST_DIR/bin" "$TEST_DIR/install_bin"
     export WRANGLE_BIN_DIR="$TEST_DIR/install_bin"
+    # No real Sigstore here, so the inter-attempt backoff is pure dead time.
+    export WRANGLE_RETRY_DELAY=0
 }
 
 teardown() {


### PR DESCRIPTION
Mitigates #354 — the intermittent verify-job failures seen three times on diffs that couldn&#39;t affect the verify path, in two flavors: ampel reporting &#34;no attestations matched a recognized signer identity&#34; on a single tenet (siblings passing identity on the same bundle), and bnd dying mid-DSSE-signing with an HTTP/2 `INTERNAL_ERROR` from Sigstore.

**Why retry-once is fail-closed-safe:**
- ampel re-evaluates the same attestations against the same policy — deterministic, so a genuine FAILED verdict fails identically on the retry; only a transient can flip. Cost on real failures: one extra evaluation on an already release-blocking event.
- bnd signing has no verdict semantics; it either produces the signed VSA or errors.
- The stdout capture is truncated per attempt, so a retry can never append to a partial report/VSA (regression-tested).

One `wrangle_retry_once` helper wraps both call sites, covering both observed flavors (and any future transient in either binary) rather than pattern-matching ampel&#39;s identity-error text, which varies per occurrence.

4 new bats tests (single-run on success, retry-then-pass with capture-truncation assertion, fail-closed after two failures, structural routing). `./test.sh quick` + zizmor pass.

I&#39;d keep #354 open after merge until a few weeks of companion runs confirm the flake stops surfacing, then close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Update (a369606):** a fourth occurrence surfaced a third flavor — `tools/syft/install.sh`&#39;s `cosign verify-blob` failing transiently with the generic supply-chain-attack message (identical verification passed 16 min earlier; see #354). The same retry-once treatment is applied there, and the install script now surfaces cosign&#39;s stderr on final failure instead of swallowing it — a TUF timeout and a real signature mismatch were previously indistinguishable. 10/10 syft bats pass.

**Update (6f00634):** review caught that the retry notice always printed `exit 0` — `$?` was read after the `if` statement, which bash resets when the condition fails with no else branch. Restructured so the first attempt's real exit code reaches the log (now asserted in bats). Also added a `WRANGLE_RETRY_DELAY` pause (default 5s) between attempts at both retry sites — an immediate retry tends to hit the same failing connection during a Sigstore blip; tests set it to 0. Both bats suites (35 tests), shellcheck, and wrangle-shell-lint pass.