### PR TITLE
fix(zizmor): bump zizmor-action pin to v0.5.6 so it knows zizmor v1.25.2

### DIFF
--- a/tools/zizmor/action.yml
+++ b/tools/zizmor/action.yml
@@ -32,7 +32,7 @@ runs:
       # the SARIF to the metadata dir for the step summary collector.
       # continue-on-error ensures SARIF collection runs even when zizmor
       # finds issues (exit code 14).
-      uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+      uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
       continue-on-error: true
       with:
         version: ${{ inputs.version }}


### PR DESCRIPTION
## Problem

`build-shell / scan` fails on PR #364 with:

```
##[error]Unknown version: v1.25.2
wrangle: zizmor errored: upstream zizmor-action exited non-zero with no usable SARIF output (outcome=failure)
```

`zizmorcore/zizmor-action` resolves the requested zizmor version against a static `support/versions` digest manifest baked into the action at its pinned ref. Our pin, v0.5.2 (released 2026-03-09), predates zizmor v1.25.2 (released 2026-05-16), so the manifest lookup fails and wrangle's fail-closed handling correctly fails the job.

The breakage was introduced in #276, which bumped the default zizmor version from v1.23.1 to v1.25.2 without bumping the zizmor-action pin — the two are coupled. It stayed latent because the self-pin chain still routed through `tools/zizmor@68b1cae` (default v1.23.1); dependabot's pin bump in #364 is the first thing to pull the v1.25.2 default through the chain.

## Fix

Bump the `zizmorcore/zizmor-action` pin v0.5.2 → v0.5.6 (`5f14fd0`, released 2026-05-16 — past the 7-day adoption delay). Its manifest includes 1.24.x and 1.25.x.

Upstream diff v0.5.2..v0.5.6 is minimal: the versions manifest additions plus an internal `codeql-action/upload-sarif` bump. The interface `collect_sarif.sh` depends on (`version` / `advanced-security` inputs, `output-file` output, exit-code semantics, the `tee` pipe) is unchanged.

After merge, #364 will stay red until a new main SHA containing this fix flows through the pin chain (dependabot re-bump or retarget).

## Testing

`./test.sh` passes locally (full suite incl. zizmor, no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)