### PR TITLE
fix(python): emit pkg:pypi VSA resourceUri, not pkg:generic (#373)

### DIFF
--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -156,9 +156,6 @@ jobs:
       hashes: ${{ steps.build.outputs.hashes }}
       name: ${{ steps.build.outputs.name }}
       version: ${{ steps.build.outputs.version }}
-      # Single composition site for the purl (PEP 503-normalized in `purl`):
-      # the verify job bakes this into the VSA's resourceUri and the workflow
-      # re-exports it for publish gates.
       resource-uri: ${{ steps.purl.outputs.resource-uri }}
       shortname: ${{ steps.build.outputs.shortname }}
       dist-artifact-name: ${{ steps.names.outputs.dist }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -71,7 +71,7 @@ on:
         description: "The package version that was built"
         value: ${{ jobs.build.outputs.version }}
       resource-uri:
-        description: "The purl the VSA's resourceUri names (pkg:generic/<name>@<version>). Pipe into actions/verify-vsa's resource-uri input."
+        description: "The purl the VSA's resourceUri names (pkg:pypi/<name>@<version>, name PEP 503-normalized). Pipe into actions/verify-vsa's resource-uri input."
         value: ${{ jobs.build.outputs.resource-uri }}
       dist-artifact-name:
         description: "Name of the uploaded dist/ artifact (download with this name to publish)"
@@ -156,9 +156,10 @@ jobs:
       hashes: ${{ steps.build.outputs.hashes }}
       name: ${{ steps.build.outputs.name }}
       version: ${{ steps.build.outputs.version }}
-      # Single composition site for the purl: the verify job bakes this into
-      # the VSA's resourceUri and the workflow re-exports it for publish gates.
-      resource-uri: pkg:generic/${{ steps.build.outputs.name }}@${{ steps.build.outputs.version }}
+      # Single composition site for the purl (PEP 503-normalized in `purl`):
+      # the verify job bakes this into the VSA's resourceUri and the workflow
+      # re-exports it for publish gates.
+      resource-uri: ${{ steps.purl.outputs.resource-uri }}
       shortname: ${{ steps.build.outputs.shortname }}
       dist-artifact-name: ${{ steps.names.outputs.dist }}
       metadata-artifact-name: ${{ steps.names.outputs.metadata }}
@@ -184,6 +185,20 @@ jobs:
           # fast iteration; they produce no provenance, so cache poisoning
           # is not an L3 concern at that layer.
           cache: ${{ needs.gate.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
+
+      # Compose the VSA resourceUri purl. PyPI's purl type normalizes the
+      # name per PEP 503 (lowercase; runs of . _ - collapse to -), so the
+      # identity matches what ecosystem-aware tooling derives from the
+      # published package.
+      - id: purl
+        shell: bash
+        env:
+          NAME: ${{ steps.build.outputs.name }}
+          VERSION: ${{ steps.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          normalized="$(printf '%s' "$NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[._-]+/-/g')"
+          printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
 
       # Namespace artifact names by the path-derived shortname so multiple
       # python builds in one workflow don't collide.
@@ -306,9 +321,9 @@ jobs:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-python-v1.hjson
           collector: jsonl:provenance/provenance.jsonl
-          # resourceUri names the package the VSA covers (pkg:generic, matching
-          # the policy harness — pypi purl normalization isn't load-bearing while
-          # no consumer reads it). The subject digest is the cryptographic bind.
+          # resourceUri names the package the VSA covers (pkg:pypi, PEP
+          # 503-normalized); the consumer/gate check pins it. The subject
+          # digest is the cryptographic bind.
           context: buildPoint:git+https://github.com/${{ github.repository }},vsa.resourceUri:${{ needs.build.outputs.resource-uri }}
           artifact-name: ${{ matrix.artifact }}
           fail: "true"

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -80,11 +80,11 @@ Downstream users verify a dist file with one command. Download the wheel (or sdi
 ampel verify --subject <dist-file> \
   --policy git+https://github.com/TomHennen/wrangle@v0.2.0#policies/wrangle-vsa-consumer-v1.hjson \
   --attestation <dist-file>.intoto.jsonl \
-  --context expectedResourceUri:pkg:generic/<name>@<version> \
+  --context expectedResourceUri:pkg:pypi/<name>@<version> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>
 ```
 
-That single command checks — fail-closed — the signature, wrangle's signer identity, that the build ran in *your* repo, and that policy passed at SLSA Build L3. No ampel? See the [artifact verification guide](../../../docs/verifying_artifacts.md) for an equivalent cosign recipe, the PEP 740 path, and the full trust model.
+That single command checks — fail-closed — the signature, wrangle's signer identity, that the build ran in *your* repo, and that policy passed at SLSA Build L3. The `<name>` is [PEP 503-normalized](https://peps.python.org/pep-0503/#normalized-names) (lowercase; runs of `.`, `_`, `-` collapse to `-`), matching the published PyPI project. No ampel? See the [artifact verification guide](../../../docs/verifying_artifacts.md) for an equivalent cosign recipe, the PEP 740 path, and the full trust model.
 
 ## Further reading
 

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -84,7 +84,7 @@ ampel verify --subject <dist-file> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>
 ```
 
-That single command checks — fail-closed — the signature, wrangle's signer identity, that the build ran in *your* repo, and that policy passed at SLSA Build L3. The `<name>` is [PEP 503-normalized](https://peps.python.org/pep-0503/#normalized-names) (lowercase; runs of `.`, `_`, `-` collapse to `-`), matching the published PyPI project. No ampel? See the [artifact verification guide](../../../docs/verifying_artifacts.md) for an equivalent cosign recipe, the PEP 740 path, and the full trust model.
+That single command checks — fail-closed — the signature, wrangle's signer identity, that the build ran in *your* repo, and that policy passed at SLSA Build L3. The `<name>` is [PEP 503-normalized](https://peps.python.org/pep-0503/#normalized-names). No ampel? See the [artifact verification guide](../../../docs/verifying_artifacts.md) for an equivalent cosign recipe, the PEP 740 path, and the full trust model.
 
 ## Further reading
 

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -22,7 +22,7 @@ you trust one signature instead of re-running the policy engine.
 | Build type | VSA location | `resourceUri` to expect | Signing workflow |
 |---|---|---|---|
 | Go | GitHub release, `<archive>.intoto.jsonl` | `pkg:golang/<module-path>@<version>` (the `module` directive in `go.mod`) | `build_and_publish_go.yml` |
-| Python | GitHub release, `<dist-file>.intoto.jsonl` (wheel or sdist) | `pkg:pypi/<name>@<version>` (name [PEP 503-normalized](https://peps.python.org/pep-0503/#normalized-names): lowercase, runs of `.`/`_`/`-` → `-`) | `build_and_publish_python.yml` |
+| Python | GitHub release, `<dist-file>.intoto.jsonl` (wheel or sdist) | `pkg:pypi/<name>@<version>` (name [PEP 503-normalized](https://peps.python.org/pep-0503/#normalized-names)) | `build_and_publish_python.yml` |
 | npm | GitHub release, `<tarball>.intoto.jsonl` | `pkg:npm/<name>@<version>` (scoped names verbatim, e.g. `pkg:npm/@scope/pkg@1.2.3`) | `build_and_publish_npm.yml` |
 | Container | OCI referrer on the image digest | `<imagename>@sha256:<digest>` | `build_and_publish_container.yml` |
 

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -22,7 +22,7 @@ you trust one signature instead of re-running the policy engine.
 | Build type | VSA location | `resourceUri` to expect | Signing workflow |
 |---|---|---|---|
 | Go | GitHub release, `<archive>.intoto.jsonl` | `pkg:golang/<module-path>@<version>` (the `module` directive in `go.mod`) | `build_and_publish_go.yml` |
-| Python | GitHub release, `<dist-file>.intoto.jsonl` (wheel or sdist) | `pkg:generic/<name>@<version>` | `build_and_publish_python.yml` |
+| Python | GitHub release, `<dist-file>.intoto.jsonl` (wheel or sdist) | `pkg:pypi/<name>@<version>` (name [PEP 503-normalized](https://peps.python.org/pep-0503/#normalized-names): lowercase, runs of `.`/`_`/`-` → `-`) | `build_and_publish_python.yml` |
 | npm | GitHub release, `<tarball>.intoto.jsonl` | `pkg:npm/<name>@<version>` (scoped names verbatim, e.g. `pkg:npm/@scope/pkg@1.2.3`) | `build_and_publish_npm.yml` |
 | Container | OCI referrer on the image digest | `<imagename>@sha256:<digest>` | `build_and_publish_container.yml` |
 

--- a/test/consumer/verify_consumer_vsa.bats
+++ b/test/consumer/verify_consumer_vsa.bats
@@ -25,8 +25,11 @@ SIGNER_REPO="TomHennen/wrangle-test"
 ISSUER="https://token.actions.githubusercontent.com"
 VSA_PREDICATE="https://slsa.dev/verification_summary/v1"
 # A real PYTHON VSA (wheel subject) from run 26991037293 — same cosign
-# verify-blob-attestation shape as npm, but a distinct signer workflow and a
-# pkg:generic resourceUri, so it can drift independently of the npm path.
+# verify-blob-attestation shape as npm, but a distinct signer workflow. This
+# capture predates the pkg:pypi migration (#373), and a keyless-signed VSA
+# can't be re-resourced without re-signing, so its resourceUri stays the old
+# pkg:generic form; releases now emit pkg:pypi (PEP 503-normalized). Re-capture
+# from a post-migration release to flip this.
 PY_RESOURCE_URI="pkg:generic/wrangle_test_fixture@0.0.1.dev26991037293"
 PY_SIGNER_REGEX='^https://github\.com/TomHennen/wrangle/\.github/workflows/build_and_publish_python\.yml@'
 # A real CONTAINER VSA (digest subject) from the same run — covers the
@@ -94,8 +97,9 @@ require_sigstore() {
 
 # --- Path A (python): the python README's verify-blob-attestation command ---
 # Same shape as npm, exercised against a real python wheel + its VSA so the
-# python README's literals (signer workflow, pkg:generic resourceUri) can't
-# drift unnoticed.
+# python README's signer-workflow literal can't drift unnoticed. The
+# resourceUri here is the fixture's pre-#373 pkg:generic value (see above),
+# not the pkg:pypi form releases now emit.
 
 @test "consumer A (python): cosign verify-blob-attestation verifies the wheel's signer + subject" {
     [[ -x "$COSIGN_BIN" ]] || skip_or_fail "real cosign not available"
@@ -121,7 +125,7 @@ require_sigstore() {
     [[ "$status" -ne 0 ]]
 }
 
-@test "consumer A (python): predicate fields decode to PASSED / pkg:generic resourceUri / L3" {
+@test "consumer A (python): predicate fields decode to PASSED / resourceUri / L3" {
     payload="$(jq -r '.dsseEnvelope.payload' "$PY_VSA" | base64 -d)"
     [[ "$(jq -r '.predicate.verificationResult' <<<"$payload")" == "PASSED" ]]
     [[ "$(jq -r '.predicate.resourceUri' <<<"$payload")" == "$PY_RESOURCE_URI" ]]


### PR DESCRIPTION
Closes #373. The Python build type emitted `pkg:generic/<name>@<version>` for the VSA `resourceUri`; purl has a first-class PyPI type, so this switches to `pkg:pypi/<name>@<version>` with PEP 503 name normalization — making the identity match what any ecosystem-aware tool derives from the published project.

## Change

- **`build_and_publish_python.yml`** — new `purl` step composes the resourceUri as the single source the VSA context (`verify` job) and the `resource-uri` workflow output both consume. Name normalized per [PEP 503](https://peps.python.org/pep-0503/#normalized-names) (`tr '[:upper:]' '[:lower:]' | sed -E 's/[._-]+/-/g'` — lowercase; runs of `.`/`_`/`-` → `-`). Version is used verbatim (PEP 440). Validated locally: `wrangle_test_fixture` → `pkg:pypi/wrangle-test-fixture@…`, `My.Cool__Package` → `my-cool-package`.
- **Docs** — `build/actions/python/README.md` and `docs/verifying_artifacts.md` now show `pkg:pypi` and explain the normalization.

## Breaking change (called out in #373)

Consumers running the documented `--context expectedResourceUri:pkg:generic/...` against an **old** VSA still need the old value; VSAs from releases after this change carry `pkg:pypi`. Worth landing before the v0.2.0 tag so the first tagged consumer command matches what tagged releases emit.

## The fixture, honestly

`test/consumer/fixtures/python-vsa.intoto.jsonl` is a real keyless-signed VSA — its `resourceUri` can't be changed to `pkg:pypi` without re-signing (cosign verifies the payload signature in `consumer A (python)`). So it stays `pkg:generic`, now annotated as a pre-migration capture; the test still validates the cosign decode path. Re-capturing it from a post-#373 python release (an integration/showcase run) is the follow-up that locks `pkg:pypi` into the offline drift-detector.

## Coverage note

The new emission is exercised end-to-end by the next integration/showcase python run (real build → `pkg:pypi` VSA → verify). There's no offline assertion of the `pkg:pypi` string yet — the consumer fixture (frozen above) is the offline drift-detector and lags until re-capture. A `verify-python-vsa-gate` in wrangle-test (mirroring the npm gate from wrangle-test#29) would assert it per-dispatch; happy to follow up if you want that.

`./test.sh` full green, zizmor clean, actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)