### PR TITLE
docs: add an adopter-facing-docs altitude rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,15 @@ Comments explain *why*, not *what*. Explain hidden constraints or non-obvious de
 
 **Describe what the code does now, not what it used to do.** When you change or remove something, rewrite the comment to stand on its own describing current behavior — never "replaces the old X", "previously the generator…", "this is the new path", or "X now does Y instead of Z". A reader who never saw the prior version is the audience. Migration rationale and "what changed and why" belong in the PR description or an inline PR comment to the reviewer — not in the committed code.
 
+## Adopter-facing docs
+
+The per-build-type READMEs, `docs/verifying_artifacts.md`, the top-level `README.md`, and the workflow examples are **quick-start docs, not specifications.** Keep them at the altitude of *what the adopter does*; mechanism, rationale, and exhaustive rules live in `SPEC.md` (or the relevant upstream spec) and get a *link*, not a reproduction. Match the top-level `README.md`'s voice: benefit-first, second person, no spec-annex walls.
+
+- **State the fact, link the spec — don't reproduce it.** "The name is PEP 503-normalized (link)" — not the normalization algorithm; "provenance covers `checksums.txt`" — not the subject-set derivation.
+- **Don't enumerate what a source of truth already lists.** Workflow inputs/outputs are documented in the workflow file — point to it, don't copy the list (copies drift).
+- **Cut anything the adopter doesn't act on** — internal job mechanics, threat-model derivations, "under the hood" asides.
+- **Unshipped work lives in issues, not docs.** Don't describe planned features or what hasn't been done yet.
+
 ## Shell scripts
 
 Every shell script MUST start with the exact preamble `set -euo pipefail` followed by `set -f` (disable globbing). Stricter supersets (`set -Eeuo pipefail`) and equivalent decompositions (`set -e -u -o pipefail`) are rejected — one canonical form. If you need ERR trap inheritance, add `set -E` on its own line after the preamble. Scripts that intentionally need globbing must wrap it in `set +f` / `set -f` with a comment, scoped as narrowly as possible. Sourced libs that toggle `set +f` MUST restore `set -f` before returning.


### PR DESCRIPTION
## What

Adds an **Adopter-facing docs** section to `CLAUDE.md` establishing a documentation-altitude rule: the per-build-type READMEs, `docs/verifying_artifacts.md`, the top-level `README.md`, and the workflow examples are quick-start docs, not specifications — state the fact and link the spec rather than reproducing mechanism inline.

## Why

The README reshape (#367) and its follow-ups kept surfacing the same reviewer correction by hand: docs drifting toward spec-level detail. Most recently on #374 — a doc change spelled out the full PEP 503 normalization algorithm where "the name is PEP 503-normalized (link)" was enough. Other recurrences across the review rounds: enumerating workflow outputs the workflow file already documents, narrating internal job mechanics, and describing unshipped work that belongs in issues.

There was no rule to point at — `CLAUDE.md` had `## Comments` but nothing for docs. This codifies the judgment reviewers were applying ad hoc, so it's enforceable by reference instead of re-derived each time.

## The rule

Four bullets, each generalizing a distinct recurring comment:
- State the fact, link the spec — don't reproduce it (the PEP 503 case is the worked example).
- Don't enumerate what a source of truth already lists (workflow inputs/outputs).
- Cut anything the adopter doesn't act on (internal mechanics, threat-model derivations, "under the hood" asides).
- Unshipped work lives in issues, not docs.

This is a prose convention by design — "too detailed" isn't mechanically lintable, which is exactly the kind of rule `CLAUDE.md` is for (rule 1).

https://claude.ai/code/session_01KNUqsBMWLLAobX6ASbA17f

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNUqsBMWLLAobX6ASbA17f)_