### PR TITLE
fix(test): single-source local shellcheck with CI's shell build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 # exclude .claude/ separately, since ./test.sh mounts the repo at runtime.)
 .claude/
 .beads/
+.wrangle/

--- a/Makefile
+++ b/Makefile
@@ -31,15 +31,10 @@ workflowstyle:
 	@echo "=== wrangle-workflow-lint ==="
 	@./tools/wrangle-workflow-lint/lint.sh
 
-# Lint all shell scripts
+# Lint all shell scripts (.sh and .bats) via the same script CI's dogfooded
+# shell build runs, so the local and CI shellcheck surfaces can't drift (#368).
 shellcheck:
-	@echo "=== shellcheck ==="
-	@SCRIPTS=$$(find . -name '*.sh' -not -path './.git/*' -not -path './.beads/*' -not -path './.claude/*'); \
-	if [ -n "$$SCRIPTS" ]; then \
-		echo $$SCRIPTS | xargs shellcheck -x --source-path=SCRIPTDIR; \
-	else \
-		echo "No shell scripts to check"; \
-	fi
+	@./build/actions/shell/run_shellcheck.sh .
 
 # Run bats tests
 bats:

--- a/build/actions/shell/run_shellcheck.sh
+++ b/build/actions/shell/run_shellcheck.sh
@@ -41,9 +41,15 @@ fi
 # findings still fail the step. -x --source-path=SCRIPTDIR follows
 # `source`d libs relative to each script's own directory, so findings in
 # sourced helpers surface instead of being masked by SC1091 "not following".
+# .claude and .beads hold local development state (worktrees with full repo
+# copies, tracker data) — git-ignored, so absent from CI checkouts, but
+# present when the Makefile runs this against a dev checkout mounted into
+# the test container.
 find "$SCAN_PATH" -name '*.sh' \
     -not -path '*/.git/*' \
     -not -path '*/node_modules/*' \
+    -not -path '*/.claude/*' \
+    -not -path '*/.beads/*' \
     -print0 | xargs -0 -r "$GUARD" run shellcheck -x --source-path=SCRIPTDIR
 
 # .bats files (bash syntax) exclude the codes that misfire on core bats
@@ -57,5 +63,7 @@ find "$SCAN_PATH" -name '*.sh' \
 find "$SCAN_PATH" -name '*.bats' \
     -not -path '*/.git/*' \
     -not -path '*/node_modules/*' \
+    -not -path '*/.claude/*' \
+    -not -path '*/.beads/*' \
     -print0 | xargs -0 -r "$GUARD" run shellcheck -x --source-path=SCRIPTDIR --exclude=SC2030,SC2031,SC2016,SC2314
 printf 'shellcheck: all scripts under %s passed\n' "$SCAN_PATH"

--- a/test.sh
+++ b/test.sh
@@ -13,7 +13,7 @@ set -f
 #   `quick`               Inner-loop iteration: skip zizmor for fast feedback
 #   `bats`                Bats tests only
 #   `lint`                actionlint only
-#   `shellcheck`          ShellCheck against all *.sh
+#   `shellcheck`          ShellCheck against all *.sh and *.bats (same script CI runs)
 #   `shellstyle`          wrangle-shell-lint (ast-grep WSL rules)
 #   `workflowstyle`       wrangle-workflow-lint (python3 + PyYAML WWL rules)
 #   `zizmor`              Zizmor workflow security linter only


### PR DESCRIPTION
Fixes #368.

`./test.sh` could be green while CI's `build-shell / shell-build` job failed, because the Makefile `shellcheck` target only checked `*.sh` while the dogfooded shell build's `run_shellcheck.sh` also checks `*.bats` (this bit #366 on SC2034). Per the issue's preferred option, this single-sources the invocation:

- **Makefile**: the `shellcheck` target now runs `build/actions/shell/run_shellcheck.sh .` — byte-identical to CI, so the surfaces can't drift again (DEP_MGMT §Drift). The bats-idiom exclude list now has one home.
- **run_shellcheck.sh**: adds `.claude/` and `.beads/` to the find excludes. These are git-ignored local dev state (`.claude/worktrees/` holds full repo copies) that CI checkouts never contain but that `test.sh`'s repo mount exposes locally. No-op in CI.
- **test.sh**: usage text updated to mention `.bats` coverage.
- **.dockerignore**: adds `.wrangle/` — 305MB of locally installed tool binaries that were being sent into every test-container build context (and filled my docker disk). Not needed by the image build.

No new test: single-sourcing is itself the drift enforcement, and the action's existing bats (delegation, guard usage, path validation) still cover `run_shellcheck.sh`.

Verified locally: `make shellcheck` now flags `.bats` findings (and passes on current main), and the containerized `./test.sh quick` suite passes — except three pre-existing `actions/verify-vsa/test.bats` failures that also reproduce on clean `origin/main` when a real `ampel` sits in `.wrangle/bin` (local-only shim shadowing; filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)