### PR TITLE
fix(test): don't probe Sigstore reachability in CI — let the real tool decide

### DIFF
--- a/test/consumer/verify_consumer_vsa.bats
+++ b/test/consumer/verify_consumer_vsa.bats
@@ -51,8 +51,11 @@ setup() {
 
 teardown() { rm -rf "$TMP"; }
 
-# Sigstore must be reachable for keyless verification; fail-not-skip under CI.
+# Sigstore reachability decides the local skip only. In CI the verification
+# command itself is the arbiter — a one-shot probe blip must not fail a job
+# the real tool (with its own retries and TUF cache) would pass.
 require_sigstore() {
+    if in_ci; then return 0; fi
     curl -fsS -m 10 -o /dev/null https://rekor.sigstore.dev/api/v1/log 2>/dev/null \
         || skip_or_fail "rekor.sigstore.dev unreachable"
 }

--- a/test/lib/bats_helpers.bash
+++ b/test/lib/bats_helpers.bash
@@ -3,11 +3,18 @@
 # executed on its own), so it carries no script preamble. Not a *.bats file, so
 # the suite's glob doesn't run it as a test.
 
+# in_ci: true under CI (CI/GITHUB_ACTIONS set). The single definition of
+# "are we in CI" for test helpers — skip policy and preflight probes must
+# agree on it.
+in_ci() {
+    [[ -n "${CI:-}${GITHUB_ACTIONS:-}" ]]
+}
+
 # skip_or_fail <reason>: under CI the real binary + network are present, so a
-# skip means the test silently degraded — fail instead. Locally (CI/
-# GITHUB_ACTIONS unset) skip, so sandboxed dev isn't blocked.
+# skip means the test silently degraded — fail instead. Locally skip, so
+# sandboxed dev isn't blocked.
 skip_or_fail() {
-    if [[ -n "${CI:-}${GITHUB_ACTIONS:-}" ]]; then
+    if in_ci; then
         printf 'FATAL: %s (skip not allowed in CI)\n' "$1" >&2
         exit 1
     fi


### PR DESCRIPTION
The `require_sigstore` preflight in `test/consumer/verify_consumer_vsa.bats` is a one-shot `curl -m 10` against rekor. Its purpose is the **local** half of `skip_or_fail` — give sandboxed dev a clean skip instead of a baffling cosign network trace. But it also ran in CI, where it's strictly more fragile than the command it guards: today a transient blip on that single curl failed `build-shell / shell-build` on PR #374 (test 76), while the very next Sigstore-hitting test passed seconds later. The probe can only produce false failures in CI — if Sigstore is genuinely down, the real `cosign`/`ampel` invocation reports that itself, with retries and TUF caching the probe doesn't have.

- `require_sigstore` now returns immediately in CI; the verification command is the arbiter there. Locally unchanged: probe → skip when unreachable.
- The CI condition is extracted into a shared `in_ci` helper in `test/lib/bats_helpers.bash` (the same `CI`/`GITHUB_ACTIONS` check `skip_or_fail` uses), so the skip policy and the preflight gate can't drift.
- The fallback stays `skip_or_fail` rather than plain `skip`: if the early return is ever removed, the helper fails closed in CI instead of silently skipping.

This complements #361 (retries around `ampel`/`bnd` in the verify path) — same transient-Sigstore family (#354), different victim.

Verified: `run_shellcheck.sh .` clean; containerized `./test.sh quick` green except the three pre-existing #378 failures (local `.wrangle/bin` ampel shadowing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)