### PR TITLE
docs: point each build type at Dependabot setup

### DIFF
--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -27,6 +27,7 @@ Copy [`build_and_publish_containers.yml`](../../../gh_workflow_examples/build_an
 - **`pull_request_target` can't trigger this workflow** — that trigger (and `workflow_run` chained from it) is a common exploit vector, so wrangle blocks both at startup.
 - **Private repos aren't supported** — the `verify` job can't pull auth-gated provenance referrers ([#182](https://github.com/TomHennen/wrangle/issues/182)).
 - **Workflow outputs** are documented in [`build_and_publish_container.yml`](../../../.github/workflows/build_and_publish_container.yml) itself.
+- **Enable Dependabot too** — copy [`dependabot.yml`](../../../gh_workflow_examples/dependabot.yml) to `.github/` and uncomment the `docker` entry (base-image updates). Its `github-actions` entry also keeps your `uses: TomHennen/wrangle/...` pin current.
 
 ## Verifying what you shipped
 

--- a/build/actions/go/README.md
+++ b/build/actions/go/README.md
@@ -53,6 +53,7 @@ Push a `v`-prefixed semver tag (e.g. `v1.2.3`) and wrangle runs the full pipelin
 - **`pull_request_target` can't trigger this workflow** — that trigger (and `workflow_run` chained from it) is a common exploit vector, so wrangle blocks both at startup.
 - **`release-events`** (default: `tag-only`) controls which events run the full pipeline — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating".
 - **Workflow outputs** are documented in [`build_and_publish_go.yml`](../../../.github/workflows/build_and_publish_go.yml) itself.
+- **Enable Dependabot too** — copy [`dependabot.yml`](../../../gh_workflow_examples/dependabot.yml) to `.github/` and uncomment the `gomod` entry. Its `github-actions` entry also keeps your `uses: TomHennen/wrangle/...` pin current.
 
 ## Cross-compiling
 

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -75,6 +75,7 @@ Skip the gate and you publish on every non-PR event; skip verify-vsa and you may
 - **`release-events`** (default: `non-pull-request`; the example sets `tag-only`) controls when release-time actions run and what `should-release` reports — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating".
 - **`pull_request_target` can't trigger this workflow** — that trigger (and `workflow_run` chained from it) is a common exploit vector, so wrangle blocks both at startup.
 - **Workflow outputs** are documented in [`build_and_publish_npm.yml`](../../../.github/workflows/build_and_publish_npm.yml) itself.
+- **Enable Dependabot too** — copy [`dependabot.yml`](../../../gh_workflow_examples/dependabot.yml) to `.github/` and uncomment the `npm` entry. Its `github-actions` entry also keeps your `uses: TomHennen/wrangle/...` pin current.
 
 ## Verifying what you shipped
 

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -71,6 +71,7 @@ Skip the gate and you publish on every non-PR event; skip verify-vsa and you may
 - **`release-events`** (default: `non-pull-request`; the example sets `tag-only`) controls when release-time actions run and what `should-release` reports — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating".
 - **`pull_request_target` can't trigger this workflow** — that trigger (and `workflow_run` chained from it) is a common exploit vector, so wrangle blocks both at startup.
 - **Workflow outputs** are documented in [`build_and_publish_python.yml`](../../../.github/workflows/build_and_publish_python.yml) itself.
+- **Enable Dependabot too** — copy [`dependabot.yml`](../../../gh_workflow_examples/dependabot.yml) to `.github/` and uncomment the `pip` entry. Its `github-actions` entry also keeps your `uses: TomHennen/wrangle/...` pin current.
 
 ## Verifying what you shipped
 

--- a/gh_workflow_examples/dependabot.yml
+++ b/gh_workflow_examples/dependabot.yml
@@ -44,3 +44,12 @@ updates:
   #   open-pull-requests-limit: 5
   #   cooldown:
   #     default-days: 7
+
+  # - package-ecosystem: "docker"   # base-image updates (Dockerfile FROM lines)
+  #   directories:
+  #     - "/**"
+  #   schedule:
+  #     interval: "weekly"
+  #   open-pull-requests-limit: 5
+  #   cooldown:
+  #     default-days: 7


### PR DESCRIPTION
## What

Adds a one-line Dependabot pointer to each build-type README's "Good to know" section, and a commented `docker` ecosystem entry to the example.

## Why

The top-level `README.md` recommends enabling Dependabot, but the per-build-type READMEs never mentioned it — and an adopter wiring up `.github/` from, say, the Go README would never see the top-level note. The pointer belongs where the adopter is actually creating workflow files.

The per-type version also adds what the top-level note can't: the **exact ecosystem keyword** to uncomment (the top-level just says "customize for your ecosystem"), and the reminder that the example's `github-actions` entry is what keeps your `uses: TomHennen/wrangle/...` pin current — so it's part of wrangle's own update loop, not a tangent.

## Changes

- **Go / npm / Python / container READMEs** — one "Good to know" bullet each, naming the ecosystem keyword (`gomod` / `npm` / `pip` / `docker`).
- **`gh_workflow_examples/dependabot.yml`** — adds a commented `docker` entry (base-image / `FROM`-line updates) for the container case, which the example didn't ship.

Stays within the adopter-docs altitude rule (#376): a fact + link, not a reproduction of the top-level README's explanation or Dependabot's own docs.

## Note

Shell has no package ecosystem, so it's intentionally omitted — only the `github-actions` (pin-currency) half would apply there, and Shell's README is the thinnest of the set.

https://claude.ai/code/session_01KNUqsBMWLLAobX6ASbA17f

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNUqsBMWLLAobX6ASbA17f)_