### PR TITLE
chore: bump wrangle self-ref pins to main ahead of v0.2.0

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -97,7 +97,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/preflight_guard@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
 
   gate:
     needs: [guard]
@@ -108,7 +108,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/release_gate@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -130,7 +130,7 @@ jobs:
           persist-credentials: false
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/scan@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -153,7 +153,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      uses: TomHennen/wrangle/build/actions/container@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -250,7 +250,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/verify@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         with:
           subject: ${{ needs.build.outputs.digest }}
           policy: policies/wrangle-provenance-container-v1.hjson

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -130,7 +130,7 @@ jobs:
           persist-credentials: false
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/scan@ba74caf4d236992224c23b072879410228a88d09 # chore/bump-pins-pre-v0.2.0 2026-06-12 (bootstrap)
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -149,7 +149,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/preflight_guard@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
 
   gate:
     needs: [guard]
@@ -159,7 +159,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/release_gate@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -182,7 +182,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/scan@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -207,7 +207,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/build/actions/go/checks@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/build/actions/go/release@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         id: release
         with:
           path: ${{ inputs.path }}
@@ -405,7 +405,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/verify@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-go-v1.hjson

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -182,7 +182,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/scan@ba74caf4d236992224c23b072879410228a88d09 # chore/bump-pins-pre-v0.2.0 2026-06-12 (bootstrap)
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -124,7 +124,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/preflight_guard@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
 
   gate:
     needs: [guard]
@@ -135,7 +135,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/release_gate@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -158,7 +158,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/scan@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -188,7 +188,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/build/actions/npm@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -322,7 +322,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/verify@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-npm-v1.hjson

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -158,7 +158,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/scan@ba74caf4d236992224c23b072879410228a88d09 # chore/bump-pins-pre-v0.2.0 2026-06-12 (bootstrap)
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -139,7 +139,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/scan@ba74caf4d236992224c23b072879410228a88d09 # chore/bump-pins-pre-v0.2.0 2026-06-12 (bootstrap)
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/preflight_guard@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -116,7 +116,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/release_gate@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -139,7 +139,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/scan@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -169,7 +169,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/build/actions/python@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -313,7 +313,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/verify@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-python-v1.hjson

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -46,7 +46,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/preflight_guard@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -67,7 +67,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/scan@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -88,7 +88,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+        uses: TomHennen/wrangle/build/actions/shell@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/scan@ba74caf4d236992224c23b072879410228a88d09 # chore/bump-pins-pre-v0.2.0 2026-06-12 (bootstrap)
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -20,7 +20,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      - uses: TomHennen/wrangle/actions/preflight_guard@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
 
   check-change:
     needs: [guard]
@@ -38,6 +38,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+        uses: TomHennen/wrangle/actions/scan@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
         with:
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -38,6 +38,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+        uses: TomHennen/wrangle/actions/scan@ba74caf4d236992224c23b072879410228a88d09 # chore/bump-pins-pre-v0.2.0 2026-06-12 (bootstrap)
         with:
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -54,7 +54,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      uses: TomHennen/wrangle/tools/zizmor@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -62,7 +62,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      uses: TomHennen/wrangle/tools/scorecard@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -74,7 +74,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@15b64ecbe38ca59cd24964eb9403d428075ffa37 # main 2026-06-10
+      uses: TomHennen/wrangle/tools/dependency-review@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
 
     - name: Generate step summary
       if: always()


### PR DESCRIPTION
Routine pin → merge → bump cleanup ahead of v0.2.0, targeting `e0944de` (the #379 merge) — plus a fix the bump itself surfaced.

**What's here:**

1. `make bump-action-pins`: all workflow self-ref pins move from `15b64ec` (predates #366 ampel gate, #371 RESOURCE_URI validation, #374 pkg:pypi, #377, #379) to `e0944de`.
2. **Nested-pin fix**: the first CI run failed (`build-shell / scan` + the companion dispatch) with `Unknown version: v1.25.2`. Root cause: `actions/scan/action.yml`'s nested `tools/*` pins still pointed at `15b64ec`, where `tools/zizmor` declared zizmor v1.25.2 but pinned zizmor-action v0.5.2, which doesn't know it — the broken combo #365 fixed. `bump_action_pins` only walks `.github/workflows/`, so the workflow bump made scan@`e0944de` dispatch the broken zizmor@`15b64ec` for the first time. Fixed by bumping the three nested pins to `e0944de`.
3. **Bootstrap pin** (per docs/e2e_testing.md): the workflows' `actions/scan` refs point at this branch's `ba74caf` so CI fetches a scan that already carries the nested-pin fix — `e0944de`'s scan is broken on its own. All other refs stay at `e0944de`.

**Post-merge**: routine `tools/bump_action_pins.sh <main-sha>` to roll the bootstrap pin onto main — `check_pin_ancestry` enforces this (a merge commit keeps it green meanwhile; squash makes it red until the bump). The v0.2.0 tag should be cut at/after that final bump.

Supersedes Dependabot's #364 (targets the older `6017c85`), which can be closed.

Verified: containerized `./test.sh quick` green except the three pre-existing #378 failures (local `.wrangle/bin` shadowing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)