### PR TITLE
chore: bump wrangle self-ref pins to main after #381

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -97,7 +97,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/preflight_guard@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
 
   gate:
     needs: [guard]
@@ -108,7 +108,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/release_gate@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -130,7 +130,7 @@ jobs:
           persist-credentials: false
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ba74caf4d236992224c23b072879410228a88d09 # chore/bump-pins-pre-v0.2.0 2026-06-12 (bootstrap)
+      - uses: TomHennen/wrangle/actions/scan@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -153,7 +153,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      uses: TomHennen/wrangle/build/actions/container@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -250,7 +250,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/verify@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         with:
           subject: ${{ needs.build.outputs.digest }}
           policy: policies/wrangle-provenance-container-v1.hjson

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -149,7 +149,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/preflight_guard@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
 
   gate:
     needs: [guard]
@@ -159,7 +159,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/release_gate@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -182,7 +182,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ba74caf4d236992224c23b072879410228a88d09 # chore/bump-pins-pre-v0.2.0 2026-06-12 (bootstrap)
+      - uses: TomHennen/wrangle/actions/scan@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -207,7 +207,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/build/actions/go/checks@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/build/actions/go/release@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         id: release
         with:
           path: ${{ inputs.path }}
@@ -405,7 +405,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/verify@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-go-v1.hjson

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -124,7 +124,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/preflight_guard@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
 
   gate:
     needs: [guard]
@@ -135,7 +135,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/release_gate@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -158,7 +158,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ba74caf4d236992224c23b072879410228a88d09 # chore/bump-pins-pre-v0.2.0 2026-06-12 (bootstrap)
+      - uses: TomHennen/wrangle/actions/scan@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -188,7 +188,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/build/actions/npm@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -322,7 +322,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/verify@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-npm-v1.hjson

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/preflight_guard@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -116,7 +116,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/release_gate@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -139,7 +139,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ba74caf4d236992224c23b072879410228a88d09 # chore/bump-pins-pre-v0.2.0 2026-06-12 (bootstrap)
+      - uses: TomHennen/wrangle/actions/scan@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -169,7 +169,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/build/actions/python@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -313,7 +313,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/verify@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-python-v1.hjson

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -46,7 +46,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/preflight_guard@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -67,7 +67,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@ba74caf4d236992224c23b072879410228a88d09 # chore/bump-pins-pre-v0.2.0 2026-06-12 (bootstrap)
+      - uses: TomHennen/wrangle/actions/scan@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -88,7 +88,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+        uses: TomHennen/wrangle/build/actions/shell@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -20,7 +20,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e0944de1f0748ef3210cb40db0a987dd5919e73d # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/preflight_guard@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
 
   check-change:
     needs: [guard]
@@ -38,6 +38,6 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@ba74caf4d236992224c23b072879410228a88d09 # chore/bump-pins-pre-v0.2.0 2026-06-12 (bootstrap)
+        uses: TomHennen/wrangle/actions/scan@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
         with:
           tools: ${{ inputs.tools }}


### PR DESCRIPTION
Routine pin → merge → bump cleanup (`make bump-action-pins`, `WRANGLE_PINS_BRANCH=main`), targeting `7ccdbc0` (the #381 squash merge). #381's bootstrap pin (`actions/scan@ba74caf`) was orphaned by the squash, so `check_pin_ancestry` is red on main until this lands — this is the recovery step from docs/e2e_testing.md.

After this merges, v0.2.0 is cuttable at/after the merge commit (pending the showcase check).

Verified: `check_pin_ancestry` green on the branch; containerized `./test.sh quick` green except the three pre-existing #378 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)