### PR TITLE
docs: SHA-pin wrangle in examples/docs (zizmor-clean) + pinning FAQ + drift guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: tomhennen/wrangle/.github/workflows/check_source_change.yml@v0.2.0
+    uses: tomhennen/wrangle/.github/workflows/check_source_change.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
 ```
 
 Replace `DEFAULT_BRANCH` with the repository's default branch name.
@@ -109,11 +109,11 @@ PR CI tests the actual code in the PR branch, not `main`, because wrangle's own 
 3. If CI fails, investigate before re-pushing — it may reveal a real environment difference
 
 **What CI does not cover:**
-- Cross-repo consumption (`uses: tomhennen/wrangle/...@v0.2.0`) is only testable after tagging a release. If your change affects the reusable workflow interface, note this in the PR description.
+- Cross-repo consumption (`uses: tomhennen/wrangle/...@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0`) is only testable after tagging a release. If your change affects the reusable workflow interface, note this in the PR description.
 
 ## Do NOT
 
 - Do not add secrets beyond what the workflow documents — source scanning needs none; the container build needs only `gh_token` (see its example)
-- Do not use `@main` in production — always use a release tag (e.g., `@v0.2.0`)
+- Do not use `@main` in production — pin a released commit SHA (e.g., `@<sha> # v0.2.0`); a `@vX.Y.Z` tag is flagged by wrangle's own zizmor scan (`unpinned-uses`)
 - Do not add extra permissions beyond those listed for the workflow you adopt
 - Do not configure Dependabot auto-merge — adopt new versions only after a delay (see Quick Start)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: tomhennen/wrangle/.github/workflows/check_source_change.yml@v0.1.0
+    uses: tomhennen/wrangle/.github/workflows/check_source_change.yml@v0.2.0
 ```
 
 Replace `DEFAULT_BRANCH` with the repository's default branch name.
@@ -109,11 +109,11 @@ PR CI tests the actual code in the PR branch, not `main`, because wrangle's own 
 3. If CI fails, investigate before re-pushing — it may reveal a real environment difference
 
 **What CI does not cover:**
-- Cross-repo consumption (`uses: tomhennen/wrangle/...@v0.1.0`) is only testable after tagging a release. If your change affects the reusable workflow interface, note this in the PR description.
+- Cross-repo consumption (`uses: tomhennen/wrangle/...@v0.2.0`) is only testable after tagging a release. If your change affects the reusable workflow interface, note this in the PR description.
 
 ## Do NOT
 
 - Do not add secrets beyond what the workflow documents — source scanning needs none; the container build needs only `gh_token` (see its example)
-- Do not use `@main` in production — always use a release tag (e.g., `@v0.1.0`)
+- Do not use `@main` in production — always use a release tag (e.g., `@v0.2.0`)
 - Do not add extra permissions beyond those listed for the workflow you adopt
 - Do not configure Dependabot auto-merge — adopt new versions only after a delay (see Quick Start)

--- a/DEP_MGMT.md
+++ b/DEP_MGMT.md
@@ -90,7 +90,7 @@ whatever is already set.
 | Third-party GitHub Action | `@<40-hex sha> # vX` |
 | Wrangle self-ref in a reusable workflow | `@<sha> # main YYYY-MM-DD` |
 | Wrangle composite → sibling composite | relative path `./actions/…` |
-| Wrangle action in examples/docs | release tag `@vX.Y.Z` |
+| Wrangle action in examples/docs | commit SHA `@<sha> # vX.Y.Z` (zizmor `unpinned-uses` flags a tag) |
 | Go tool | `tool` directive + pinned `require` in `tools/go.mod` (+ `go.sum`) |
 | Python tool | `==version --hash=sha256:` in `requirements.txt` |
 | Binary with no package manager | version pinned in the install script |

--- a/README.md
+++ b/README.md
@@ -122,3 +122,8 @@ Go, Python, npm, and Container each run the full pipeline and produce an atteste
 | Container | [README](build/actions/container/README.md) | [build_and_publish_containers.yml](gh_workflow_examples/build_and_publish_containers.yml) |
 | Shell | — | [build_shell.yml](gh_workflow_examples/build_shell.yml) |
 | Source-only — no build, scan only | [README](actions/scan/README.md) | [check_source_change.yml](gh_workflow_examples/check_source_change.yml) |
+
+## FAQ
+
+Why the examples pin a release tag instead of a SHA, whether you have to, and
+how verification ties to your pin: see [docs/FAQ.md](docs/FAQ.md).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.0
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
     with:
       path: "."
 ```
@@ -125,5 +125,5 @@ Go, Python, npm, and Container each run the full pipeline and produce an atteste
 
 ## FAQ
 
-Why the examples pin a release tag instead of a SHA, whether you have to, and
-how verification ties to your pin: see [docs/FAQ.md](docs/FAQ.md).
+How to pin wrangle (by SHA, and why zizmor wants it that way), whether you can
+use a tag, and how verification ties to your pin: see [docs/FAQ.md](docs/FAQ.md).

--- a/actions/scan/README.md
+++ b/actions/scan/README.md
@@ -23,7 +23,7 @@ jobs:
       actions: read
       contents: read
       security-events: write   # SARIF upload to the Security tab
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.0
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
 ```
 
 Findings appear in the Security tab; the run's step summary shows an overview.
@@ -49,7 +49,7 @@ The May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical exam
 The `tools` input is a space-separated list. Default: `"osv zizmor scorecard:info dependency-review"`. Suffix with `:info` to make a tool's findings non-blocking.
 
 ```yaml
-uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.0
+uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
 with:
   tools: "osv zizmor"   # skip Scorecard and dependency-review
 ```

--- a/actions/scan/README.md
+++ b/actions/scan/README.md
@@ -23,7 +23,7 @@ jobs:
       actions: read
       contents: read
       security-events: write   # SARIF upload to the Security tab
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.1.0
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.0
 ```
 
 Findings appear in the Security tab; the run's step summary shows an overview.
@@ -49,7 +49,7 @@ The May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical exam
 The `tools` input is a space-separated list. Default: `"osv zizmor scorecard:info dependency-review"`. Suffix with `:info` to make a tool's findings non-blocking.
 
 ```yaml
-uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.1.0
+uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.0
 with:
   tools: "osv zizmor"   # skip Scorecard and dependency-review
 ```

--- a/actions/verify-vsa/README.md
+++ b/actions/verify-vsa/README.md
@@ -18,7 +18,7 @@ Drop it into your publish job between `download-artifact` and the publish step:
     name: ${{ needs.build.outputs.dist-artifact-name }}
     path: dist/
 
-- uses: TomHennen/wrangle/actions/verify-vsa@v0.2.0
+- uses: TomHennen/wrangle/actions/verify-vsa@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
   with:
     path: dist/
     resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/build/actions/go/README.md
+++ b/build/actions/go/README.md
@@ -17,7 +17,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.0
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
     with:
       path: "."
 ```

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -17,7 +17,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.2.0
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
     with:
       path: "."
       release-events: tag-only   # only tag pushes publish
@@ -58,7 +58,7 @@ Publishing happens in your workflow, so two things there are load-bearing — bo
 2. **Verify before you publish** — run wrangle's [`verify-vsa`](../../../actions/verify-vsa/README.md) action between `download-artifact` and `npm publish`, piping the build's `resource-uri` output, so the exact bytes leaving the runner are the bytes that passed wrangle's policy:
 
    ```yaml
-   - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.0
+   - uses: TomHennen/wrangle/actions/verify-vsa@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
      with:
        path: dist/
        resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -17,7 +17,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.0
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
     with:
       path: "."
       release-events: tag-only   # only tag pushes publish
@@ -58,7 +58,7 @@ Publishing happens in your workflow, so two things there are load-bearing — bo
 2. **Verify before you publish** — run wrangle's [`verify-vsa`](../../../actions/verify-vsa/README.md) action between `download-artifact` and the publish step, piping the build's `resource-uri` output, so the exact bytes leaving the runner are the bytes that passed wrangle's policy:
 
    ```yaml
-   - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.0
+   - uses: TomHennen/wrangle/actions/verify-vsa@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
      with:
        path: dist/
        resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/build/actions/shell/README.md
+++ b/build/actions/shell/README.md
@@ -13,7 +13,7 @@ jobs:
       contents: read
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.2.0
+    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
 ```
 
 PRs, pushes, and manual dispatches all run the same checks — there's no release step to gate.

--- a/build/actions/shell/README.md
+++ b/build/actions/shell/README.md
@@ -13,7 +13,7 @@ jobs:
       contents: read
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.1.0
+    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.2.0
 ```
 
 PRs, pushes, and manual dispatches all run the same checks — there's no release step to gate.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -26,7 +26,7 @@ SHA pins are opaque and go stale, but Dependabot handles both — it bumps the S
 and refreshes the `# vX.Y.Z` comment on wrangle's no-auto-merge cooldown (copy
 the [`dependabot.yml`](../gh_workflow_examples/dependabot.yml) starter).
 
-## Can I pin a `@vX.Y.Z` tag instead?
+### Can I pin a `@vX.Y.Z` tag instead?
 
 You can, but wrangle's bundled zizmor scan will flag it (`unpinned-uses`) because
 a tag can be moved. Since you only call wrangle once, the simplest fix is an
@@ -41,7 +41,7 @@ SHA. (Once wrangle publishes immutable release tags and zizmor treats them as
 pinned, tag pins will be clean with no ignore — tracked in
 [#387](https://github.com/TomHennen/wrangle/issues/387), not done yet.)
 
-## How does my pin affect verification?
+### How does my pin affect verification?
 
 Your verifier's expected identity must match **whatever you pinned** — wrangle's
 keyless VSA records the ref you invoked it at in the signing certificate. With a
@@ -53,7 +53,7 @@ SHA pin the identity is `…build_and_publish_<type>.yml@<sha>`:
   SHA (the [verification guide](verifying_artifacts.md) shows the form); a
   tag pin would instead match `@refs/tags/vX.Y.Z`.
 
-## Which SHA should I pin?
+### Which SHA should I pin?
 
 The commit the latest [release](https://github.com/TomHennen/wrangle/releases)
 tags, with that version in the comment. Dependabot and the examples under

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -4,55 +4,61 @@ Short answers to questions adopters ask. For mechanism and contracts, each
 answer links to the source of truth — start with [`SPEC.md`](SPEC.md) and the
 [verification guide](verifying_artifacts.md).
 
-## Why do the examples pin a release tag (`@vX.Y.Z`) instead of a commit SHA?
+## How should I pin wrangle's reusable workflows?
 
-The usual advice is to SHA-pin third-party actions, because tags are mutable.
-Wrangle's examples pin its *own* reusable workflows by **release tag** on
-purpose, for two reasons:
+By **commit SHA, with the version in a trailing comment** — exactly like any
+other third-party action:
 
-- **Your verifier's identity has to match what you pinned.** Wrangle signs each
-  VSA keylessly, and the Sigstore certificate records the ref you invoked
-  wrangle at. The copy-paste `cosign` verify command in the
-  [verification guide](verifying_artifacts.md) anchors the signer identity on
-  `@refs/tags/v…`, so a tag pin makes that command work unedited. (The
-  recommended `ampel` path accepts either — see the next question.)
-- **A tag version-locks the whole tested release.** A reusable workflow resolves
-  its internal action references at the ref you called it with, so `@v0.2.0`
-  runs exactly the internal toolchain that release shipped — see
-  [SPEC.md → Reusable Workflow Interface](SPEC.md#reusable-workflow-interface).
+```yaml
+uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@<sha> # v0.2.0
+```
 
-You don't trade away freshness: Dependabot bumps the tag for you (the
-[`dependabot.yml`](../gh_workflow_examples/dependabot.yml) starter wires it),
-on wrangle's no-auto-merge cooldown.
+Three reasons, and the examples are pinned this way:
 
-## Do I have to pin a tag for verification to work?
+- **It's wrangle's own rule.** To your repo, `TomHennen/wrangle` is a third-party
+  action, and wrangle's policy (and the wider GitHub Actions consensus) is that
+  third-party actions are SHA-pinned because tags are mutable.
+- **wrangle's own scan would otherwise flag you.** A wrangle build type runs
+  zizmor over your workflows, and zizmor's `unpinned-uses` flags a third-party
+  action that isn't SHA-pinned. Pin the SHA and your first run is clean; pin a
+  tag and you'll get a finding on the very line wrangle told you to add.
+- **You keep freshness.** Dependabot bumps the SHA and refreshes the `# vX.Y.Z`
+  comment on wrangle's no-auto-merge cooldown — copy the
+  [`dependabot.yml`](../gh_workflow_examples/dependabot.yml) starter.
 
-No. The recommended **`ampel verify`** path accepts a tag *or* a SHA — its
-policy matches the signer identity as `…@.+`. Only the **`cosign`** fallback
-command assumes a tag, and the [verification guide](verifying_artifacts.md)
-tells you how to adjust the identity regexp if you pinned a SHA.
+## Can I pin a `@vX.Y.Z` tag instead?
 
-The rule underneath both: **your verifier's expected identity must match
-whatever you actually pinned** — tag → `@refs/tags/vX.Y.Z`, SHA → `@<sha>`.
-Pinning a tag just means the documented commands work as written.
+You can, but wrangle's bundled zizmor scan will flag it (`unpinned-uses`) because
+a tag can be moved. The principled way to keep a tag is a **scoped** policy in
+your own `.github/zizmor.yml` — not a blanket disable:
 
-## Aren't mutable tags a supply-chain risk?
+```yaml
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "TomHennen/wrangle/*": ref-pin   # trust wrangle's release tags
+```
 
-A tag can be moved, so pinning one trusts wrangle's release process not to
-repoint it. Two things bound the blast radius:
+That exempts only wrangle's refs; your other actions still require a SHA. (Once
+wrangle publishes immutable release tags and zizmor treats them as pinned, tag
+pins will be clean by default — that work is tracked in
+[#387](https://github.com/TomHennen/wrangle/issues/387), not done yet.)
 
-- Every artifact you consume is checked against a **wrangle-signed VSA that
-  binds the signer identity and your source repo** — verification fails if the
-  bytes, the signer, or the origin repo don't match (see the
-  [verification guide](verifying_artifacts.md)).
-- **Dependabot** moves your pin forward only to published releases, after
-  wrangle's cooldown, with no auto-merge.
+## How does my pin affect verification?
 
-If you want the strongest pin, SHA-pin wrangle's workflow and adjust your verify
-identity as described above — verification still works.
+Your verifier's expected identity must match **whatever you pinned** — wrangle's
+keyless VSA records the ref you invoked it at in the signing certificate. With a
+SHA pin the identity is `…build_and_publish_<type>.yml@<sha>`:
 
-## Which version should I pin?
+- The recommended **`ampel verify`** path needs no change — its policy matches
+  the signer as `…@.+`.
+- The **`cosign`** fallback's `--certificate-identity-regexp` must match your
+  SHA (the [verification guide](verifying_artifacts.md) shows the form); a
+  tag pin would instead match `@refs/tags/vX.Y.Z`.
 
-The latest [release tag](https://github.com/TomHennen/wrangle/releases). The
-per-ecosystem READMEs under [`build/`](../build/) and the examples in
+## Which SHA should I pin?
+
+The commit the latest [release](https://github.com/TomHennen/wrangle/releases)
+tags, with that version in the comment. Dependabot and the examples under
 [`gh_workflow_examples/`](../gh_workflow_examples/) track the current release.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -13,36 +13,32 @@ other third-party action:
 uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@<sha> # v0.2.0
 ```
 
-Three reasons, and the examples are pinned this way:
+Two reasons:
 
-- **It's wrangle's own rule.** To your repo, `TomHennen/wrangle` is a third-party
-  action, and wrangle's policy (and the wider GitHub Actions consensus) is that
-  third-party actions are SHA-pinned because tags are mutable.
+- **A tag can be moved; a SHA can't** — the usual reason to pin any third-party
+  action by digest.
 - **wrangle's own scan would otherwise flag you.** A wrangle build type runs
   zizmor over your workflows, and zizmor's `unpinned-uses` flags a third-party
-  action that isn't SHA-pinned. Pin the SHA and your first run is clean; pin a
-  tag and you'll get a finding on the very line wrangle told you to add.
-- **You keep freshness.** Dependabot bumps the SHA and refreshes the `# vX.Y.Z`
-  comment on wrangle's no-auto-merge cooldown — copy the
-  [`dependabot.yml`](../gh_workflow_examples/dependabot.yml) starter.
+  action that isn't SHA-pinned. Pin a tag and your first run fails on the very
+  line wrangle told you to add; pin the SHA and it's clean.
+
+SHA pins are opaque and go stale, but Dependabot handles both — it bumps the SHA
+and refreshes the `# vX.Y.Z` comment on wrangle's no-auto-merge cooldown (copy
+the [`dependabot.yml`](../gh_workflow_examples/dependabot.yml) starter).
 
 ## Can I pin a `@vX.Y.Z` tag instead?
 
 You can, but wrangle's bundled zizmor scan will flag it (`unpinned-uses`) because
-a tag can be moved. The principled way to keep a tag is a **scoped** policy in
-your own `.github/zizmor.yml` — not a blanket disable:
+a tag can be moved. Since you only call wrangle once, the simplest fix is an
+inline ignore on that line:
 
 ```yaml
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        "TomHennen/wrangle/*": ref-pin   # trust wrangle's release tags
+uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.0 # zizmor: ignore[unpinned-uses]
 ```
 
-That exempts only wrangle's refs; your other actions still require a SHA. (Once
-wrangle publishes immutable release tags and zizmor treats them as pinned, tag
-pins will be clean by default — that work is tracked in
+It scopes the exception to the wrangle line; your other actions still need a
+SHA. (Once wrangle publishes immutable release tags and zizmor treats them as
+pinned, tag pins will be clean with no ignore — tracked in
 [#387](https://github.com/TomHennen/wrangle/issues/387), not done yet.)
 
 ## How does my pin affect verification?

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,58 @@
+# Wrangle FAQ
+
+Short answers to questions adopters ask. For mechanism and contracts, each
+answer links to the source of truth — start with [`SPEC.md`](SPEC.md) and the
+[verification guide](verifying_artifacts.md).
+
+## Why do the examples pin a release tag (`@vX.Y.Z`) instead of a commit SHA?
+
+The usual advice is to SHA-pin third-party actions, because tags are mutable.
+Wrangle's examples pin its *own* reusable workflows by **release tag** on
+purpose, for two reasons:
+
+- **Your verifier's identity has to match what you pinned.** Wrangle signs each
+  VSA keylessly, and the Sigstore certificate records the ref you invoked
+  wrangle at. The copy-paste `cosign` verify command in the
+  [verification guide](verifying_artifacts.md) anchors the signer identity on
+  `@refs/tags/v…`, so a tag pin makes that command work unedited. (The
+  recommended `ampel` path accepts either — see the next question.)
+- **A tag version-locks the whole tested release.** A reusable workflow resolves
+  its internal action references at the ref you called it with, so `@v0.2.0`
+  runs exactly the internal toolchain that release shipped — see
+  [SPEC.md → Reusable Workflow Interface](SPEC.md#reusable-workflow-interface).
+
+You don't trade away freshness: Dependabot bumps the tag for you (the
+[`dependabot.yml`](../gh_workflow_examples/dependabot.yml) starter wires it),
+on wrangle's no-auto-merge cooldown.
+
+## Do I have to pin a tag for verification to work?
+
+No. The recommended **`ampel verify`** path accepts a tag *or* a SHA — its
+policy matches the signer identity as `…@.+`. Only the **`cosign`** fallback
+command assumes a tag, and the [verification guide](verifying_artifacts.md)
+tells you how to adjust the identity regexp if you pinned a SHA.
+
+The rule underneath both: **your verifier's expected identity must match
+whatever you actually pinned** — tag → `@refs/tags/vX.Y.Z`, SHA → `@<sha>`.
+Pinning a tag just means the documented commands work as written.
+
+## Aren't mutable tags a supply-chain risk?
+
+A tag can be moved, so pinning one trusts wrangle's release process not to
+repoint it. Two things bound the blast radius:
+
+- Every artifact you consume is checked against a **wrangle-signed VSA that
+  binds the signer identity and your source repo** — verification fails if the
+  bytes, the signer, or the origin repo don't match (see the
+  [verification guide](verifying_artifacts.md)).
+- **Dependabot** moves your pin forward only to published releases, after
+  wrangle's cooldown, with no auto-merge.
+
+If you want the strongest pin, SHA-pin wrangle's workflow and adjust your verify
+identity as described above — verification still works.
+
+## Which version should I pin?
+
+The latest [release tag](https://github.com/TomHennen/wrangle/releases). The
+per-ecosystem READMEs under [`build/`](../build/) and the examples in
+[`gh_workflow_examples/`](../gh_workflow_examples/) track the current release.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -635,7 +635,7 @@ The scan action parses the `tools` input to dispatch adapter-pattern tools (thos
 
 The **step summary is the primary output**. It works on all repos — private, no Advanced Security, etc. SARIF upload to the Security tab is additive. The **metadata directory** (`$GITHUB_WORKSPACE/.wrangle/metadata/`) is a complete catalog of which tools ran and what they found, enabling future signed attestations.
 
-**Portability:** Shell script paths use `${{ github.action_path }}` for resolution relative to the composite action's own directory. Action-pattern tool steps use `./` paths (e.g., `uses: ./tools/zizmor`), which resolve to the same repo at the called ref — so when an adopter pins `@v0.1.0`, all internal actions resolve at that tag, and when wrangle's own CI runs on a PR branch, they resolve at the PR's code.
+**Portability:** Shell script paths use `${{ github.action_path }}` for resolution relative to the composite action's own directory. Action-pattern tool steps use `./` paths (e.g., `uses: ./tools/zizmor`), which resolve to the same repo at the called ref — so when an adopter pins `@v0.2.0`, all internal actions resolve at that tag, and when wrangle's own CI runs on a PR branch, they resolve at the PR's code.
 
 **Path constraint:** The composite action resolves the orchestrator via `${{ github.action_path }}/../../run.sh`, which means the scan action MUST remain at exactly `actions/scan/` (two directories below the repo root). This is a hard structural constraint — moving the action to a different depth breaks the relative path. If the directory layout changes, these paths must be updated in the same commit.
 
@@ -661,7 +661,7 @@ The scan action strips `:fail`/`:info` suffixes before passing tool names to the
 
 The reusable workflow (`.github/workflows/check_source_change.yml`) wraps the composite action for `workflow_call` consumers.
 
-**Internal path resolution:** All `uses:` steps inside the reusable workflow use `./` paths (e.g., `uses: ./actions/scan`). When a caller invokes the workflow at a specific ref (e.g., `@v0.1.0`), GitHub fetches the workflow at that ref, and all `./` references resolve to the same repo at that ref. This means adopters automatically get version-locked internal actions matching their pinned tag, and wrangle's own PR CI tests the PR branch's code (not main).
+**Internal path resolution:** All `uses:` steps inside the reusable workflow use `./` paths (e.g., `uses: ./actions/scan`). When a caller invokes the workflow at a specific ref (e.g., `@v0.2.0`), GitHub fetches the workflow at that ref, and all `./` references resolve to the same repo at that ref. This means adopters automatically get version-locked internal actions matching their pinned tag, and wrangle's own PR CI tests the PR branch's code (not main).
 
 ```yaml
 on:
@@ -691,7 +691,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.1.0
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.0
 ```
 
 This is the entire file an adopter needs. No secrets, no configuration, no dependencies to manage.
@@ -1040,7 +1040,7 @@ All `uses:` references in wrangle's own workflows and examples MUST be pinned:
 | Reference type | Pinning requirement |
 |---------------|---------------------|
 | Third-party actions | Full commit SHA |
-| Wrangle's own actions (in examples) | Release tag (e.g., `@v0.1.0`) |
+| Wrangle's own actions (in examples) | Release tag (e.g., `@v0.2.0`) |
 | Wrangle internal refs in reusable workflows | Relative path (`./`) — resolves to the workflow's own repo at the called ref |
 | Wrangle internal refs in composite actions | Relative path (`./`) — resolves to the same repo at the called ref |
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -635,7 +635,7 @@ The scan action parses the `tools` input to dispatch adapter-pattern tools (thos
 
 The **step summary is the primary output**. It works on all repos — private, no Advanced Security, etc. SARIF upload to the Security tab is additive. The **metadata directory** (`$GITHUB_WORKSPACE/.wrangle/metadata/`) is a complete catalog of which tools ran and what they found, enabling future signed attestations.
 
-**Portability:** Shell script paths use `${{ github.action_path }}` for resolution relative to the composite action's own directory. Action-pattern tool steps use `./` paths (e.g., `uses: ./tools/zizmor`), which resolve to the same repo at the called ref — so when an adopter pins `@v0.2.0`, all internal actions resolve at that tag, and when wrangle's own CI runs on a PR branch, they resolve at the PR's code.
+**Portability:** Shell script paths use `${{ github.action_path }}` for resolution relative to the composite action's own directory. Action-pattern tool steps use `./` paths (e.g., `uses: ./tools/zizmor`), which resolve to the same repo at the called ref — so when an adopter pins `@<sha>`, all internal actions resolve at that commit, and when wrangle's own CI runs on a PR branch, they resolve at the PR's code.
 
 **Path constraint:** The composite action resolves the orchestrator via `${{ github.action_path }}/../../run.sh`, which means the scan action MUST remain at exactly `actions/scan/` (two directories below the repo root). This is a hard structural constraint — moving the action to a different depth breaks the relative path. If the directory layout changes, these paths must be updated in the same commit.
 
@@ -661,7 +661,7 @@ The scan action strips `:fail`/`:info` suffixes before passing tool names to the
 
 The reusable workflow (`.github/workflows/check_source_change.yml`) wraps the composite action for `workflow_call` consumers.
 
-**Internal path resolution:** All `uses:` steps inside the reusable workflow use `./` paths (e.g., `uses: ./actions/scan`). When a caller invokes the workflow at a specific ref (e.g., `@v0.2.0`), GitHub fetches the workflow at that ref, and all `./` references resolve to the same repo at that ref. This means adopters automatically get version-locked internal actions matching their pinned tag, and wrangle's own PR CI tests the PR branch's code (not main).
+**Internal path resolution:** All `uses:` steps inside the reusable workflow use `./` paths (e.g., `uses: ./actions/scan`). When a caller invokes the workflow at a specific ref (e.g., `@<sha>`), GitHub fetches the workflow at that ref, and all `./` references resolve to the same repo at that ref. This means adopters automatically get version-locked internal actions matching their pinned ref, and wrangle's own PR CI tests the PR branch's code (not main).
 
 ```yaml
 on:
@@ -691,7 +691,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.0
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
 ```
 
 This is the entire file an adopter needs. No secrets, no configuration, no dependencies to manage.
@@ -1040,11 +1040,11 @@ All `uses:` references in wrangle's own workflows and examples MUST be pinned:
 | Reference type | Pinning requirement |
 |---------------|---------------------|
 | Third-party actions | Full commit SHA |
-| Wrangle's own actions (in examples) | Release tag (e.g., `@v0.2.0`) |
+| Wrangle's own actions (in examples) | Full commit SHA + `# vX.Y.Z` comment (a tag is flagged by zizmor `unpinned-uses`) |
 | Wrangle internal refs in reusable workflows | Relative path (`./`) — resolves to the workflow's own repo at the called ref |
 | Wrangle internal refs in composite actions | Relative path (`./`) — resolves to the same repo at the called ref |
 
-Adopters are advised to pin to a release tag. The `@main` ref MUST NOT appear in any `uses:` line in the repo, including examples and documentation.
+Adopters are advised to pin a released commit SHA (with the version in a `# vX.Y.Z` comment). The `@main` ref MUST NOT appear in any `uses:` line in the repo, including examples and documentation.
 
 ### Output Sanitization
 

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -73,7 +73,7 @@ For file artifacts (`cosign verify-blob-attestation`):
 ```bash
 cosign verify-blob-attestation --bundle <artifact>.intoto.jsonl --new-bundle-format \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github\.com/TomHennen/wrangle/\.github/workflows/build_and_publish_<type>\.yml@refs/tags/v' \
+  --certificate-identity-regexp '^https://github\.com/TomHennen/wrangle/\.github/workflows/build_and_publish_<type>\.yml@[0-9a-f]{40}$' \
   --certificate-github-workflow-repository <your-org>/<your-repo> \
   --type https://slsa.dev/verification_summary/v1 \
   <artifact>
@@ -84,10 +84,10 @@ jq -e '.predicate.resourceUri == "<resourceUri from the table above>"' <<<"$payl
 jq -e '.predicate.verifiedLevels | index("SLSA_BUILD_LEVEL_3")' <<<"$payload"
 ```
 
-Substitute `<type>` with `go`, `python`, or `npm`. The `@refs/tags/v` anchor
-assumes the adopter pinned wrangle at a release tag (the examples' default);
-adjust it if they pinned a SHA. `--type` must be the full URI — cosign
-rejects the `slsaverificationsummary` alias.
+Substitute `<type>` with `go`, `python`, or `npm`. The `@[0-9a-f]{40}` anchor
+assumes a SHA pin (the examples' default); use `@refs/tags/vX.Y.Z` instead if
+you pinned wrangle at a tag. `--type` must be the full URI — cosign rejects the
+`slsaverificationsummary` alias.
 
 For container images, a digest subject has no file blob, so the command is
 `cosign verify-attestation` (cosign v3) against the image. It prints the
@@ -97,7 +97,7 @@ verified envelope to stdout, so capture and decode that:
 cosign verify-attestation \
   --type https://slsa.dev/verification_summary/v1 \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github\.com/TomHennen/wrangle/\.github/workflows/build_and_publish_container\.yml@refs/tags/v' \
+  --certificate-identity-regexp '^https://github\.com/TomHennen/wrangle/\.github/workflows/build_and_publish_container\.yml@[0-9a-f]{40}$' \
   --certificate-github-workflow-repository <your-org>/<your-repo> \
   <imagename>@sha256:<digest> > vsa.json
 

--- a/gh_workflow_examples/build_and_publish_containers.yml
+++ b/gh_workflow_examples/build_and_publish_containers.yml
@@ -23,7 +23,7 @@ jobs:
       attestations: write  # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.2.0
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
     with:
       path: PATH/TO/FOLDER/WITH/Dockerfile
       imagename: ghcr.io/${{ github.repository }}/YOUR_IMAGE_NAME

--- a/gh_workflow_examples/build_and_publish_containers.yml
+++ b/gh_workflow_examples/build_and_publish_containers.yml
@@ -23,7 +23,7 @@ jobs:
       attestations: write  # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.1.0
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.2.0
     with:
       path: PATH/TO/FOLDER/WITH/Dockerfile
       imagename: ghcr.io/${{ github.repository }}/YOUR_IMAGE_NAME

--- a/gh_workflow_examples/build_go.yml
+++ b/gh_workflow_examples/build_go.yml
@@ -36,7 +36,7 @@ jobs:
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.0
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
     with:
       path: "."
       # release-events: tag-only         # default; uncomment + change to "non-pull-request" or "main-and-tags" for early failure detection on non-tag events

--- a/gh_workflow_examples/build_npm.yml
+++ b/gh_workflow_examples/build_npm.yml
@@ -50,7 +50,7 @@ jobs:
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.2.0
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
     with:
       path: "."
       release-events: tag-only          # only tag pushes publish (recommended default)
@@ -94,7 +94,7 @@ jobs:
 
       # Verify the downloaded tarball against wrangle's signed VSA — the
       # full policy verdict — before any bytes leave this runner.
-      - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.0
+      - uses: TomHennen/wrangle/actions/verify-vsa@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
         with:
           path: dist/
           resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/gh_workflow_examples/build_python.yml
+++ b/gh_workflow_examples/build_python.yml
@@ -47,7 +47,7 @@ jobs:
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.0
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
     with:
       path: "."
       release-events: tag-only          # only tag pushes publish (recommended default)
@@ -72,7 +72,7 @@ jobs:
 
       # Verify the downloaded dist against wrangle's signed VSA — the
       # full policy verdict — before any bytes leave this runner.
-      - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.0
+      - uses: TomHennen/wrangle/actions/verify-vsa@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
         with:
           path: dist/
           resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/gh_workflow_examples/build_shell.yml
+++ b/gh_workflow_examples/build_shell.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.1.0
+    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.2.0
     # with:
     #   scan-path: "."       # optional: subdirectory to scan (default: repo root)
     #   bats-path: ""        # optional: path to bats tests (default: auto-detect)

--- a/gh_workflow_examples/build_shell.yml
+++ b/gh_workflow_examples/build_shell.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.2.0
+    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0
     # with:
     #   scan-path: "."       # optional: subdirectory to scan (default: repo root)
     #   bats-path: ""        # optional: path to bats tests (default: auto-detect)

--- a/gh_workflow_examples/check_source_change.yml
+++ b/gh_workflow_examples/check_source_change.yml
@@ -14,4 +14,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.1.0
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.0

--- a/gh_workflow_examples/check_source_change.yml
+++ b/gh_workflow_examples/check_source_change.yml
@@ -14,4 +14,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.0
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@1448b250fb8d75841dfba3b2c8f5c23e85162b89 # v0.2.0

--- a/test/test_pin_consistency.bats
+++ b/test/test_pin_consistency.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+# Divergence guard for adopter-facing wrangle release-tag pins.
+#
+# Every example workflow and per-build-type README carries its own
+# `uses: TomHennen/wrangle/...@vX.Y.Z` pin, and nothing single-sources the
+# version. A release that bumps some pins but not all hands adopters a stale
+# wrangle on copy-paste, with no signal that anything is wrong. This fails
+# closed when the pins disagree.
+#
+# Scope is the release-tag pins only: SHA self-references (`@<40-hex>`) and the
+# `git+https://...@vX` policy locators (which may name any v* tag) are excluded
+# by anchoring on `uses: ` and a semver tag.
+
+setup() {
+    # Resolve the repo root from this file's location, not git — the test
+    # container mounts the repo read-only and runs as a different user than
+    # owns the checkout, so a git invocation here would trip git's
+    # dubious-ownership guard.
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    export REPO_ROOT
+    # Match `uses: <org>/wrangle/<path>@vX.Y.Z`. The org needs a
+    # case-insensitive scan (`grep -i`): GitHub treats owners that way and the
+    # docs mix `TomHennen` and `tomhennen`.
+    PIN_RE='uses: [a-z]+/wrangle/[^@[:space:]]+@v[0-9]+\.[0-9]+\.[0-9]+'
+    export PIN_RE
+}
+
+@test "adopter-facing wrangle tag pins all name the same version" {
+    local versions
+    versions="$(grep -rhoiIE "$PIN_RE" --exclude-dir=.git "$REPO_ROOT" \
+        | grep -oiE 'v[0-9]+\.[0-9]+\.[0-9]+$' | sort -u)"
+
+    # A non-empty result guards against the regex silently rotting to nothing.
+    [ -n "$versions" ]
+
+    local count
+    count="$(printf '%s\n' "$versions" | wc -l | tr -d ' ')"
+    if [ "$count" -ne 1 ]; then
+        printf 'Divergent wrangle release-tag pins (expected one version):\n%s\n' "$versions" >&2
+        grep -rniIE "$PIN_RE" --exclude-dir=.git "$REPO_ROOT" >&2
+        return 1
+    fi
+}

--- a/test/test_pin_consistency.bats
+++ b/test/test_pin_consistency.bats
@@ -1,43 +1,39 @@
 #!/usr/bin/env bats
 
-# Divergence guard for adopter-facing wrangle release-tag pins.
+# Divergence guard for adopter-facing wrangle release pins.
 #
 # Every example workflow and per-build-type README carries its own
-# `uses: TomHennen/wrangle/...@vX.Y.Z` pin, and nothing single-sources the
-# version. A release that bumps some pins but not all hands adopters a stale
-# wrangle on copy-paste, with no signal that anything is wrong. This fails
-# closed when the pins disagree.
+# `uses: TomHennen/wrangle/...@<sha> # vX.Y.Z` pin, and nothing single-sources
+# the SHA. A release that bumps some pins but not all hands adopters a stale
+# wrangle on copy-paste, with no signal. This fails closed when the pins
+# disagree on the commit.
 #
-# Scope is the release-tag pins only: SHA self-references (`@<40-hex>`) and the
-# `git+https://...@vX` policy locators (which may name any v* tag) are excluded
-# by anchoring on `uses: ` and a semver tag.
+# Scope is the adopter-facing release pins — anchored on `uses: ` + a 40-hex
+# SHA + a `# vX.Y.Z` version comment. Wrangle's internal self-references carry a
+# `# main YYYY-MM-DD` comment instead, so they're excluded; the
+# `git+https://...@vX` policy locators (no SHA, no `uses:`) are excluded too.
 
 setup() {
-    # Resolve the repo root from this file's location, not git — the test
-    # container mounts the repo read-only and runs as a different user than
-    # owns the checkout, so a git invocation here would trip git's
-    # dubious-ownership guard.
     REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
     export REPO_ROOT
-    # Match `uses: <org>/wrangle/<path>@vX.Y.Z`. The org needs a
-    # case-insensitive scan (`grep -i`): GitHub treats owners that way and the
-    # docs mix `TomHennen` and `tomhennen`.
-    PIN_RE='uses: [a-z]+/wrangle/[^@[:space:]]+@v[0-9]+\.[0-9]+\.[0-9]+'
+    # `uses: <org>/wrangle/<path>@<40-hex> # vX.Y.Z`. Org match is
+    # case-insensitive (docs mix `TomHennen` and `tomhennen`).
+    PIN_RE='uses: [a-z]+/wrangle/[^@[:space:]]+@[0-9a-f]{40} # v[0-9]+\.[0-9]+\.[0-9]+'
     export PIN_RE
 }
 
-@test "adopter-facing wrangle tag pins all name the same version" {
-    local versions
-    versions="$(grep -rhoiIE "$PIN_RE" --exclude-dir=.git "$REPO_ROOT" \
-        | grep -oiE 'v[0-9]+\.[0-9]+\.[0-9]+$' | sort -u)"
+@test "adopter-facing wrangle release pins all name the same commit" {
+    local shas
+    shas="$(grep -rhoiIE "$PIN_RE" --exclude-dir=.git "$REPO_ROOT" \
+        | grep -oiE '@[0-9a-f]{40}' | tr -d '@' | sort -u)"
 
-    # A non-empty result guards against the regex silently rotting to nothing.
-    [ -n "$versions" ]
+    # Non-empty guards against the regex silently rotting to nothing.
+    [ -n "$shas" ]
 
     local count
-    count="$(printf '%s\n' "$versions" | wc -l | tr -d ' ')"
+    count="$(printf '%s\n' "$shas" | wc -l | tr -d ' ')"
     if [ "$count" -ne 1 ]; then
-        printf 'Divergent wrangle release-tag pins (expected one version):\n%s\n' "$versions" >&2
+        printf 'Divergent wrangle release pins (expected one commit SHA):\n%s\n' "$shas" >&2
         grep -rniIE "$PIN_RE" --exclude-dir=.git "$REPO_ROOT" >&2
         return 1
     fi


### PR DESCRIPTION
## Why

Started as "bump stale `@v0.1.0` → `@v0.2.0` + FAQ + drift guard." Review surfaced a real contradiction (thread on `docs/FAQ.md`): tag-pinning wrangle's reusable workflows trips **zizmor's `unpinned-uses`** — and wrangle's *own* build types run that scan. To the adopter `TomHennen/wrangle` is a third-party action, which zizmor (and wrangle's own DEP_MGMT rule) require SHA-pinned. So the tag recommendation made an adopter's **first run fail on the line wrangle told them to add**.

Resolution (decided in discussion): **pin wrangle by commit SHA** like any third-party action. zizmor-clean out of the box, Dependabot-maintained, and the recommended `ampel verify` is unaffected (only the `cosign` fallback identity regexp becomes the SHA). The immutable-tag path that would make a `@vX.Y.Z` pin legitimately ignorable is blocked behind a publish-flow rework (see #387) and isn't honest yet.

## What

- **Flip every adopter-facing wrangle `uses:` pin to `@<sha> # v0.2.0`** — examples, build-type READMEs, README quickstart, the AGENTS snippet, the SPEC example. Policy locators (`git+https://…wrangle@v0.2.0#policies/…`) stay tags: zizmor doesn't see them and the policy contract version is independent.
- **Rewrite `docs/FAQ.md`** — recommend SHA-pinning and *why zizmor wants it*, the scoped `unpinned-uses: ref-pin` escape for adopters who insist on a tag (not a blanket disable), the immutable-tag future (#387), and the verification interaction (`cosign` regexp → SHA; `ampel` unchanged).
- **Flip the pinning-convention rows** in `DEP_MGMT.md` and `SPEC.md` (release tag → commit SHA), reword the `./`-resolution prose from "tag" to "ref", and the `cosign` identity regexp in `verifying_artifacts.md` to `@<40-hex>`.
- **Repurpose `test/test_pin_consistency.bats`** — assert the adopter-facing release pins (those carrying a `# vX.Y.Z` comment) all name one commit SHA; internal `# main` self-refs are excluded.

## Notes for review

- This reverses the deliberate "examples use tags" convention — flagging because it touches `DEP_MGMT.md`/`SPEC.md`. The driver is the zizmor self-contradiction; the trade-off (cosign fallback regexp, less human-readable pin) is documented in the FAQ.
- Guard logic validated by simulation (all pins resolve to the one v0.2.0 SHA → pass). Couldn't run the containerized lint/bats suite here (base-image pull blocked) — CI is the gate.
- Touches `README.md` in different regions than #394, so they shouldn't conflict.

https://claude.ai/code/session_01TAYFnirhjvhr4KTzXbWN6A