### PR TITLE
fix(deps): reconcile drifted third-party pins in composites + add drift guard

### DIFF
--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -161,7 +161,7 @@ runs:
 
     - name: Upload scan results artifact
       if: always()
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       continue-on-error: true
       with:
         name: wrangle-scan-results

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -107,7 +107,7 @@ runs:
         "$WRANGLE_ROOT/actions/verify/run_verify.sh" run
 
     - name: Upload VSA artifact
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}.intoto.jsonl
         path: ${{ inputs.artifact-name }}.intoto.jsonl

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -82,7 +82,7 @@ runs:
         set -euo pipefail
         "${{ github.action_path }}/validate_inputs.sh" "$INPUT_PATH" "$INPUT_REGISTRY" "$INPUT_IMAGENAME" "$INPUT_CACHE"
 
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
 

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -107,7 +107,7 @@ runs:
           type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
     - name: Log in to the Container registry
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ${{ inputs.registry }}
         username: ${{ github.actor }}
@@ -240,7 +240,7 @@ runs:
           "$WRANGLE_ROOT/lib/format_sarif_summary.sh" "./metadata" >> "$GITHUB_STEP_SUMMARY"
         fi
 
-    - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         # Convention shared with other build types: <type>-metadata-<shortname>,

--- a/build/actions/go/release/action.yml
+++ b/build/actions/go/release/action.yml
@@ -201,7 +201,7 @@ runs:
         "${{ github.action_path }}/compute_hashes.sh" "$INPUT_PATH/dist/checksums.txt"
 
     - name: Install Cosign (for syft signature verification)
-      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
     - name: Install syft
       shell: bash

--- a/build/actions/npm/action.yml
+++ b/build/actions/npm/action.yml
@@ -170,7 +170,7 @@ runs:
         printf 'hashes=%s\n' "$HASHES" >> "$GITHUB_OUTPUT"
 
     - name: Install Cosign (for syft signature verification)
-      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
     - name: Install syft
       shell: bash

--- a/build/actions/python/action.yml
+++ b/build/actions/python/action.yml
@@ -174,7 +174,7 @@ runs:
         printf 'hashes=%s\n' "$HASHES" >> "$GITHUB_OUTPUT"
 
     - name: Install Cosign (for syft signature verification)
-      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
     - name: Install syft
       shell: bash

--- a/test/test_thirdparty_pin_consistency.bats
+++ b/test/test_thirdparty_pin_consistency.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+# Divergence guard for third-party action pins inside wrangle's own workflows
+# and composites. Dependabot updates each occurrence independently, and a
+# composite whose directory it doesn't track is left on a stale SHA while the
+# workflow copy moves on — which is how a fixed-CVE action lingers. This fails
+# closed when the same action is pinned to more than one SHA across wrangle's
+# internals.
+#
+# Scope is wrangle's *internal* refs: .github/workflows plus the composites
+# under actions/, build/, tools/. gh_workflow_examples/ is excluded — those are
+# adopter samples whose pins (e.g. their own publish-job setup-node) are
+# intentionally independent of wrangle's internals. Self-references
+# (TomHennen/wrangle/...) use a different pin scheme and are guarded elsewhere.
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    export REPO_ROOT
+}
+
+@test "third-party action pins are uniform across wrangle's workflows and composites" {
+    cd "$REPO_ROOT"
+
+    # Unique action@sha pairs across the internal trees, minus self-refs.
+    local pairs
+    pairs="$(grep -rhoiE 'uses: [a-z0-9_.-]+/[a-z0-9_.-]+@[0-9a-f]{40}' \
+        --include='*.yml' --include='*.yaml' \
+        .github/workflows actions build tools \
+        | sed -E 's/^[Uu]ses: //' \
+        | grep -viE '^TomHennen/wrangle' \
+        | sort -u)"
+
+    [ -n "$pairs" ]  # guard against the regex silently matching nothing
+
+    # An action whose name (the part before @) appears more than once in the
+    # de-duplicated pair list is pinned to two different SHAs → drift.
+    local dupes
+    dupes="$(printf '%s\n' "$pairs" | awk -F@ '{print $1}' | sort | uniq -d)"
+
+    if [ -n "$dupes" ]; then
+        printf 'Third-party actions pinned to >1 SHA across wrangle internals:\n' >&2
+        printf '%s\n' "$dupes" | while IFS= read -r action; do
+            printf '%s\n' "$pairs" | grep -iF "$action@" >&2
+        done
+        return 1
+    fi
+}


### PR DESCRIPTION
## Why

Dependabot updates third-party pins in the reusable workflows but not in the composite `action.yml` files (root cause + config fix: #390). Four actions had drifted — the workflow copy current, the composite copy stale:

| Action | Composite was | Now |
|---|---|---|
| `actions/checkout` | v6.0.2 (`build/actions/container`) | **v6.0.3** |
| `sigstore/cosign-installer` | v4.1.1 (`go/release`, `python`, `npm`) | **v4.1.2** |
| `actions/upload-artifact` | v7.0.0 (`actions/scan`, `actions/verify`, `build/actions/container`) | **v7.0.1** |
| `docker/login-action` | v3.7.0 (`build/actions/container`) | **v4.2.0** |

All target versions were already adopted on `main` (cooldown served); this brings the composites in line. The last two (`upload-artifact`, `login-action`) were surfaced by the guard below after the first pass only caught checkout/cosign.

## What

- The four pin reconciliations above (SHA bumps only, no behavior change).
- **`test/test_thirdparty_pin_consistency.bats`** — a hermetic divergence guard asserting every third-party action resolves to a single SHA across wrangle's own workflows + composites. `gh_workflow_examples/` is excluded (adopter samples with intentionally independent pins, e.g. their own publish-job `setup-node`); self-refs are guarded separately. It fails closed on the next composite Dependabot misses, backstopping the #390 config fix.

## Pairs with

- **#390** — enumerates the composite dirs in `dependabot.yml` so Dependabot stops missing them in the first place (separate PR). This PR is the cleanup + the mechanical backstop.

## Testing

Guard logic validated by simulation (passes with all four reconciled; flagged each drift before its fix). The bats run happens in the unit suite in CI — I can't run the containerized suite here (base-image pull blocked).

https://claude.ai/code/session_01TAYFnirhjvhr4KTzXbWN6A