### PR TITLE
test(verify-vsa): assert the subject-digest bind rejects tampered bytes

### DIFF
--- a/test/consumer/verify_consumer_vsa.bats
+++ b/test/consumer/verify_consumer_vsa.bats
@@ -206,6 +206,23 @@ require_sigstore() {
     [[ "$status" -ne 0 ]]
 }
 
+# The keystone bind: the VSA must cover THESE bytes. Every other Path-B case
+# varies a context or the signer identity; this one holds the real VSA, repo,
+# and resourceUri valid and varies only the *subject bytes*. A pass here would
+# mean "a signed VSA for the real package verifies a different blob" — i.e. the
+# publish gate would green-light substituted bytes that never passed policy.
+@test "consumer B: ampel verify FAILS on tampered subject bytes (valid VSA, wrong content)" {
+    [[ -x "$AMPEL_BIN" ]] || skip_or_fail "real ampel not available"
+    require_sigstore
+    cp "$BLOB" "$TMP/tampered.tgz"
+    printf 'tamper' >> "$TMP/tampered.tgz"   # one extra byte -> different sha256
+    run "$AMPEL_BIN" verify --subject "$TMP/tampered.tgz" \
+        --policy "$POLICY" --attestation "$VSA" \
+        --context "expectedResourceUri:$RESOURCE_URI" \
+        --context "sourceRepo:https://github.com/$SIGNER_REPO"
+    [[ "$status" -ne 0 ]]
+}
+
 # --- adopter-side publish gate (actions/verify-vsa) ---
 # The gate script evaluates the consumer PolicySet with ampel; running it
 # against the same real fixture proves the script's ampel invocation and
@@ -233,6 +250,24 @@ require_sigstore() {
     cp "$VSA" "$TMP/vsas/npm-package.tgz.intoto.jsonl"
     PATH="$(dirname "$AMPEL_BIN"):$PATH" \
         ARTIFACT_PATH="$TMP/dist" RESOURCE_URI="$RESOURCE_URI" REPO="attacker/repo" VSA_DIR="$TMP/vsas" \
+        run "$REPO_ROOT/actions/verify-vsa/verify_vsa.sh"
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"ampel rejected"* ]]
+}
+
+# The exact runner-side substitution this gate exists to stop: a tampered blob
+# sitting under the same basename as a legitimately-signed VSA. Repo,
+# resourceUri, and signer identity all still match the real VSA — only the
+# bytes differ — so this is rejected iff the subject-digest bind holds.
+@test "verify-vsa: gate script rejects a tampered blob under a matching VSA basename" {
+    [[ -x "$AMPEL_BIN" ]] || skip_or_fail "real ampel not available"
+    require_sigstore
+    mkdir -p "$TMP/dist" "$TMP/vsas"
+    cp "$BLOB" "$TMP/dist/npm-package.tgz"
+    printf 'tamper' >> "$TMP/dist/npm-package.tgz"   # substitute the published bytes
+    cp "$VSA" "$TMP/vsas/npm-package.tgz.intoto.jsonl"
+    PATH="$(dirname "$AMPEL_BIN"):$PATH" \
+        ARTIFACT_PATH="$TMP/dist" RESOURCE_URI="$RESOURCE_URI" REPO="$SIGNER_REPO" VSA_DIR="$TMP/vsas" \
         run "$REPO_ROOT/actions/verify-vsa/verify_vsa.sh"
     [[ "$status" -eq 1 ]]
     [[ "$output" == *"ampel rejected"* ]]


### PR DESCRIPTION
## Why

`test/consumer/verify_consumer_vsa.bats` has a fail-closed regression case for every VSA property — wrong `resourceUri`, wrong origin repo, missing `sourceRepo`, wrong signer identity — *except* the keystone one: that the VSA covers **these bytes**. The "these exact bytes are what passed policy" guarantee (README/`verifying_artifacts.md`, and the whole reason `actions/verify-vsa` exists) was asserted in docs and delegated entirely to ampel's internal `--subject`/`--attestation` matching, with no test. If that upstream behavior ever loosened, the publish gate would silently approve substituted bytes and nothing here would catch it.

## What

Two cases against the **real signed fixtures**, each holding repo / resourceUri / signer identity valid and varying **only the subject bytes** (one appended byte → different SHA-256):

1. `ampel verify --subject <tampered> --attestation <valid VSA>` must exit non-zero.
2. The `actions/verify-vsa` **gate script** must reject a tampered blob placed under the same basename as a legitimately-signed VSA — the exact runner-side substitution (swap the bytes between `download-artifact` and publish, keep the legit VSA) the gate is designed to stop.

No production code changes; this is a backstop. Expected result: both fail-closed (and surface the existing `ampel rejected` path in the gate case).

## Testing

These join the existing consumer cases in the **`integration (real binaries)`** job (real cosign + ampel + Sigstore), gated by `skip_or_fail`. I could not run them in the authoring environment (no ampel binary, and the test container's base image can't be pulled under the network policy) — they'll execute in the integration CI job. They mirror the established fixtures/patterns in the same file.

Context: came out of the supply-chain self-evaluation; this is the "test your keystone" item.

https://claude.ai/code/session_01TAYFnirhjvhr4KTzXbWN6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAYFnirhjvhr4KTzXbWN6A)_