### PR TITLE
docs(readme): frame wrangle as a proof of concept; fix overclaimed guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ uses one of wrangle's reusable workflows.  With that single job developers get:
 * Automatic execution of unit tests
 * Automatic builds with safe defaults
 * [SBOMs](https://spdx.dev)
-* [SLSA Build Level 3 provenance](docs/slsa-conformance.md) — per build type, mapped to evidence
+* [SLSA Build Level 3 provenance](docs/REQUIREMENTS_MAPPING.md) — per build type, mapped to evidence
 * Build provenance verified against SLSA policy (fail-closed) with [Ampel](https://github.com/carabiner-dev/ampel)
 * A [SLSA VSA](https://slsa.dev/verification_summary/v1) letting downstream users easily verify the artifacts you distribute.
 * and more
@@ -35,7 +35,7 @@ and let developers focus on the features they want to ship.
 Wrangle's goal is to **prove it's possible** to hand a developer one workflow call and give
 back a hardened, fail-closed, *verifiable* supply chain — SLSA Build L3 provenance and a signed
 VSA included — without asking them to understand or assemble any of it. The list above is the
-bet; [`docs/slsa-conformance.md`](docs/slsa-conformance.md) is the receipts (which build types
+bet; [`docs/REQUIREMENTS_MAPPING.md`](docs/REQUIREMENTS_MAPPING.md) is the receipts (which build types
 meet which level, with evidence); the warning at the top is the honest status — it works and
 wrangle dogfoods it, but it hasn't had an independent security review.
 
@@ -123,7 +123,7 @@ Wrangle is a supply-chain security tool, so its defaults lean toward safety:
   the build *before* anything is published. For build types that publish inline (Go, container), a
   failed attestation or policy check fails the run after the push rather than rolling it back — so
   the guarantee consumers rely on is that a bad artifact carries no PASSED VSA, not that it never
-  appeared. The [conformance map](docs/slsa-conformance.md) has the per-build-type timing.
+  appeared. The [conformance map](docs/REQUIREMENTS_MAPPING.md) has the per-build-type timing.
 - **Dangerous triggers: blocked where it can, flagged everywhere else.** Wrangle refuses to run its
   own workflows under `pull_request_target` (and `workflow_run` chained from it), and its source
   scan runs Zizmor across *all* your workflows to flag that pattern wherever else it appears — it

--- a/README.md
+++ b/README.md
@@ -22,13 +22,33 @@ uses one of wrangle's reusable workflows.  With that single job developers get:
 * Automatic execution of unit tests
 * Automatic builds with safe defaults
 * [SBOMs](https://spdx.dev)
-* [SLSA Build Level 3 provenance](https://slsa.dev/spec/v1.2/levels)
+* [SLSA Build Level 3 provenance](docs/slsa-conformance.md) — per build type, mapped to evidence
 * Build provenance verified against SLSA policy (fail-closed) with [Ampel](https://github.com/carabiner-dev/ampel)
 * A [SLSA VSA](https://slsa.dev/verification_summary/v1) letting downstream users easily verify the artifacts you distribute.
 * and more
 
 The promise is that if developers use wrangle, wrangle will take care of drudgery, safely,
 and let developers focus on the features they want to ship.
+
+## What wrangle is proving
+
+Wrangle's goal is to **prove it's possible** to hand a developer one workflow call and give
+back a hardened, fail-closed, *verifiable* supply chain — SLSA Build L3 provenance and a signed
+VSA included — without asking them to understand or assemble any of it. The list above is the
+bet; [`docs/slsa-conformance.md`](docs/slsa-conformance.md) is the receipts (which build types
+meet which level, with evidence); the warning at the top is the honest status — it works and
+wrangle dogfoods it, but it hasn't had an independent security review.
+
+Two things fall out of building it this way:
+
+- **You stop having to know what you're supposed to do.** Wrangle makes the choices — which
+  tools, which gates, safe defaults — and ships them as one versioned unit. As the landscape
+  moves and wrangle adds protections, you pick them up by bumping a pin; you don't have to
+  discover that you needed them.
+- **It shrinks what an automated agent can get wrong.** When an AI agent wires your release, a
+  dozen hand-assembled security steps are a dozen things to misconfigure. One fail-closed call
+  is far less surface — and the result is *independently verifiable* (the VSA), no matter how
+  the agent behaved.
 
 ## Quick Start
 
@@ -99,8 +119,15 @@ ecosystems run the whole pipeline.
 
 Wrangle is a supply-chain security tool, so its defaults lean toward safety:
 
-- **Fail-closed on security guarantees.** If a security problem is found (e.g. vulnerability found,
-  attestation generation failure) releases will be blocked by default.
+- **Fail-closed on security guarantees.** A load-bearing source-scan finding (OSV, Zizmor) blocks
+  the build *before* anything is published. For build types that publish inline (Go, container), a
+  failed attestation or policy check fails the run after the push rather than rolling it back — so
+  the guarantee consumers rely on is that a bad artifact carries no PASSED VSA, not that it never
+  appeared. The [conformance map](docs/slsa-conformance.md) has the per-build-type timing.
+- **Dangerous triggers: blocked where it can, flagged everywhere else.** Wrangle refuses to run its
+  own workflows under `pull_request_target` (and `workflow_run` chained from it), and its source
+  scan runs Zizmor across *all* your workflows to flag that pattern wherever else it appears — it
+  can surface a risky trigger in a workflow it doesn't control, even though only you can remove it.
 - **Keyless signing.** Attestations are signed with [Sigstore](https://www.sigstore.dev/) using
   Wrangle's identity combined with your repo's identity.
 - **Verifiable provenance.** The provenance ties each artifact back to the exact workflow that

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wrangle
 
 > [!WARNING]
-> Wrangle is **experimental**. Interfaces, policies, and security guarantees are still settling, and the code hasn't had independent security review — don't rely on it to protect anything important yet. Kick the tires, file issues, but keep your existing protections in place.
+> Wrangle is an **experimental proof of concept** — it aims to show that one workflow call can give you a verifiable SLSA Build L3 supply chain ([what it proves, per build type](docs/REQUIREMENTS_MAPPING.md)). It hasn't had independent security review; don't rely on it to protect anything important yet. Kick the tires, file issues, but keep your existing protections in place.
 
 Developers want to ship features.  They'd like to do it securely but it's hard.  We ask too much of them:
 
@@ -29,26 +29,6 @@ uses one of wrangle's reusable workflows.  With that single job developers get:
 
 The promise is that if developers use wrangle, wrangle will take care of drudgery, safely,
 and let developers focus on the features they want to ship.
-
-## What wrangle is proving
-
-Wrangle's goal is to **prove it's possible** to hand a developer one workflow call and give
-back a hardened, fail-closed, *verifiable* supply chain — SLSA Build L3 provenance and a signed
-VSA included — without asking them to understand or assemble any of it. The list above is the
-bet; [`docs/REQUIREMENTS_MAPPING.md`](docs/REQUIREMENTS_MAPPING.md) is the receipts (which build types
-meet which level, with evidence); the warning at the top is the honest status — it works and
-wrangle dogfoods it, but it hasn't had an independent security review.
-
-Two things fall out of building it this way:
-
-- **You stop having to know what you're supposed to do.** Wrangle makes the choices — which
-  tools, which gates, safe defaults — and ships them as one versioned unit. As the landscape
-  moves and wrangle adds protections, you pick them up by bumping a pin; you don't have to
-  discover that you needed them.
-- **It shrinks what an automated agent can get wrong.** When an AI agent wires your release, a
-  dozen hand-assembled security steps are a dozen things to misconfigure. One fail-closed call
-  is far less surface — and the result is *independently verifiable* (the VSA), no matter how
-  the agent behaved.
 
 ## Quick Start
 
@@ -119,15 +99,8 @@ ecosystems run the whole pipeline.
 
 Wrangle is a supply-chain security tool, so its defaults lean toward safety:
 
-- **Fail-closed on security guarantees.** A load-bearing source-scan finding (OSV, Zizmor) blocks
-  the build *before* anything is published. For build types that publish inline (Go, container), a
-  failed attestation or policy check fails the run after the push rather than rolling it back — so
-  the guarantee consumers rely on is that a bad artifact carries no PASSED VSA, not that it never
-  appeared. The [conformance map](docs/REQUIREMENTS_MAPPING.md) has the per-build-type timing.
-- **Dangerous triggers: blocked where it can, flagged everywhere else.** Wrangle refuses to run its
-  own workflows under `pull_request_target` (and `workflow_run` chained from it), and its source
-  scan runs Zizmor across *all* your workflows to flag that pattern wherever else it appears — it
-  can surface a risky trigger in a workflow it doesn't control, even though only you can remove it.
+- **Fail-closed on security guarantees.** A load-bearing scan finding blocks the build before
+  publish; a failed attestation or policy check means no PASSED VSA is emitted for the artifact.
 - **Keyless signing.** Attestations are signed with [Sigstore](https://www.sigstore.dev/) using
   Wrangle's identity combined with your repo's identity.
 - **Verifiable provenance.** The provenance ties each artifact back to the exact workflow that

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wrangle
 
 > [!WARNING]
-> Wrangle is an **experimental proof of concept** — it aims to show that one workflow call can give you a verifiable SLSA Build L3 supply chain ([what it proves, per build type](docs/REQUIREMENTS_MAPPING.md)). It hasn't had independent security review; don't rely on it to protect anything important yet. Kick the tires, file issues, but keep your existing protections in place.
+> Wrangle is an **experimental proof of concept**. Interfaces, policies, and security guarantees are still settling, and the code hasn't had independent security review — don't rely on it to protect anything important yet. Kick the tires, file issues, but keep your existing protections in place.
 
 Developers want to ship features.  They'd like to do it securely but it's hard.  We ask too much of them:
 


### PR DESCRIPTION
## Why

Two threads from the evaluation: (1) the README's confident feature bullets clashed with the "experimental, don't rely on this" banner — an evaluator grades you against the bar your prose implies, not the one you're claiming; (2) three specific claims ran ahead of the code.

Per our discussion, the fix keeps the strong language but **frames it as the thesis wrangle is proving** ("wrangle's goal is to prove it's possible to…"), and corrects the inaccurate guarantees.

## What

- **New "What wrangle is proving" section** — states the PoC thesis, links the conformance map as the evidence, keeps the experimental status honest. Folds in two value props the README never made explicit:
  - **Removes the burden of knowing what to do** — choices pre-made, shipped as one versioned unit, you pick up new protections by bumping a pin (the answer to "why not wire the tools myself").
  - **Shrinks what an automated agent can get wrong** — one fail-closed call vs. a dozen hand-wired steps, and the result is independently verifiable regardless of how the agent behaved.
- **Fixed "fail-closed → releases will be blocked"** — accurate now: scan findings block before publish, but Go/container publish inline and verification follows, so the guarantee is "a bad artifact carries no PASSED VSA," not "never shipped." Links the conformance map for per-type timing.
- **Reframed `pull_request_target` as detect-vs-block** — wrangle blocks its *own* flow and flags the pattern repo-wide via Zizmor, but can't remove a trigger in a workflow it doesn't own (fair credit + honest limit).
- **SLSA L3 bullet** now points at `docs/slsa-conformance.md` instead of the generic levels page.

## Review note

The **voice/framing is the main thing to eyeball** — I took your "wrangle's goal is to prove it's possible to…" steer and kept the strong claims under it. Adjust tone freely. (Depends on the conformance map in #392 for its links; touches different README regions than the FAQ PR #389, so they shouldn't conflict.)

https://claude.ai/code/session_01TAYFnirhjvhr4KTzXbWN6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAYFnirhjvhr4KTzXbWN6A)_