### PR TITLE
chore: bump wrangle self-ref pins to main after #384

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -97,7 +97,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/preflight_guard@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
 
   gate:
     needs: [guard]
@@ -108,7 +108,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/release_gate@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -130,7 +130,7 @@ jobs:
           persist-credentials: false
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/scan@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -153,7 +153,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      uses: TomHennen/wrangle/build/actions/container@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -250,7 +250,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/verify@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         with:
           subject: ${{ needs.build.outputs.digest }}
           policy: policies/wrangle-provenance-container-v1.hjson

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -149,7 +149,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/preflight_guard@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
 
   gate:
     needs: [guard]
@@ -159,7 +159,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/release_gate@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -182,7 +182,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/scan@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -207,7 +207,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/build/actions/go/checks@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/build/actions/go/release@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         id: release
         with:
           path: ${{ inputs.path }}
@@ -405,7 +405,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/verify@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-go-v1.hjson

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -124,7 +124,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/preflight_guard@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
 
   gate:
     needs: [guard]
@@ -135,7 +135,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/release_gate@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -158,7 +158,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/scan@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -188,7 +188,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/build/actions/npm@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         id: build
         with:
           path: ${{ inputs.path }}
@@ -322,7 +322,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/verify@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-npm-v1.hjson

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/preflight_guard@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -116,7 +116,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/release_gate@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -139,7 +139,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/scan@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -169,7 +169,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/build/actions/python@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         id: build
         with:
           path: ${{ inputs.path }}
@@ -313,7 +313,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/verify@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-python-v1.hjson

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/preflight_guard@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/scan@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+        uses: TomHennen/wrangle/build/actions/shell@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+      - uses: TomHennen/wrangle/actions/preflight_guard@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
 
   check-change:
     needs: [guard]
@@ -48,7 +48,7 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@7ccdbc03228ef20c7942406689423451499d690a # main 2026-06-12
+        uses: TomHennen/wrangle/actions/scan@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
         with:
           tools: ${{ inputs.tools }}
           go-cache: ${{ inputs.go-cache }}


### PR DESCRIPTION
claude: routine post-merge pin bump.

Rolls every reusable-workflow self-ref pin from `7ccdbc0` to `8160c96` (the #384 merge commit), per the bootstrap-pin lifecycle in `docs/e2e_testing.md`.

**Why it's needed:** until this lands, #384's caching is inert on wrangle's own dogfood — `local_build_shell.yml` passes `go-cache: enabled`, but `build_shell.yml`'s scan job still resolves `actions/scan@7ccdbc0`, which predates the `go-cache` input and has no cache steps. `check_pin_ancestry` stays green either way (the old pin is reachable), so this is a freshness/activation bump, not a red-main fix.

**Diff:** pin SHA + date-label lines only across all 6 reusable workflows; no logic change. `check_pin_ancestry.sh` passes locally (all pins reachable from HEAD).

After merge, the post-merge showcase exercises the real `actions/scan@8160c96` with caching on — that's where to confirm the scan-tool cache actually saves then restores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)