### PR TITLE
fix(dependabot): enumerate composite action.yml dirs for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,27 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    # Glob finds all action.yml files: .github/workflows/, actions/scan/,
-    # build/actions/container/, tools/scorecard/, tools/zizmor/, etc.
-    # New composite actions are picked up automatically.
+    # github-actions only auto-discovers workflow files and composite action.yml
+    # at directories listed explicitly — a "/**" glob does not recurse into
+    # nested action.yml, so composites were silently never bumped. "/" covers
+    # .github/workflows; every other directory holding an action.yml is listed.
+    # A new composite needs an entry here (a divergence test backstops a miss).
     directories:
-      - "/**"
+      - "/"
+      - "/actions/preflight_guard"
+      - "/actions/release_gate"
+      - "/actions/scan"
+      - "/actions/verify"
+      - "/actions/verify-vsa"
+      - "/build/actions/container"
+      - "/build/actions/go/checks"
+      - "/build/actions/go/release"
+      - "/build/actions/npm"
+      - "/build/actions/python"
+      - "/build/actions/shell"
+      - "/tools/dependency-review"
+      - "/tools/scorecard"
+      - "/tools/zizmor"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5

--- a/gh_workflow_examples/dependabot.yml
+++ b/gh_workflow_examples/dependabot.yml
@@ -9,8 +9,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directories:
-      - "/**"
+    # "/" covers .github/workflows, where your `uses: TomHennen/wrangle/...` pin
+    # lives. If you add your OWN composite actions in subdirectories, add a
+    # directory entry per action — github-actions globs don't recurse into
+    # nested action.yml files.
+    directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Why

Closes the root cause of #390. Dependabot's `github-actions` ecosystem doesn't make a `directories: ["/**"]` glob recurse into nested composite `action.yml` ([dependabot-core#6949](https://github.com/dependabot/dependabot-core/issues/6949), [#5970](https://github.com/dependabot/dependabot-core/issues/5970); globstar also double-scans, [#10884](https://github.com/dependabot/dependabot-core/issues/10884)). So every composite was silently never bumped, and four third-party pins drifted from their workflow copies (checkout, cosign-installer, upload-artifact, docker/login-action — reconciled in #391).

## What

Replace the `/**` glob with explicit `directories:` entries — `/` (covers `.github/workflows`) plus each of the 14 directories that hold an `action.yml` (`actions/*`, `build/actions/**` incl. the go sub-actions, the three `tools/*` action wrappers). Correct the misleading "glob finds everything" comment.

This is the **upstream** fix (Dependabot stops creating the drift); #391 is the cleanup + a divergence guard that fails CI if a future composite is added without an entry here.

## Notes / follow-ups

- We keep the public layout (your call — no adopters yet, but relocating composites under `.github/` would churn the public `uses:` paths and the `actions/scan` depth contract for no real Dependabot win, since composite `action.yml` still needs explicit entries either way).
- `open-pull-requests-limit: 5` across 15 directories could throttle a wide bump (some dirs lag until earlier PRs merge). If that bites, Dependabot `groups` would batch a single action's bump across dirs — a possible follow-up, not done here.
- I can't validate Dependabot's discovery from here; confirm via Insights → Dependency graph once merged that the composite manifests are listed.

https://claude.ai/code/session_01TAYFnirhjvhr4KTzXbWN6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAYFnirhjvhr4KTzXbWN6A)_