### PR TITLE
feat(scan): opt-in go-cache on build_and_publish_* scan jobs, cold on release

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -63,6 +63,18 @@ on:
         required: false
         type: string
         default: "osv zizmor scorecard:info dependency-review"
+      go-cache:
+        description: >
+          Set to "enabled" to cache the Go module + build caches the
+          source-scan tools build from source (osv-scanner et al. —
+          #343) on PR / non-release runs. Release builds always run
+          cache-free regardless: the scan gates an attested release, so
+          its tools build cold and a poisoned cache cannot forge a
+          passing scan (docs/SLSA_L3_AUDIT.md). Default off — the cache
+          is ~1.5–3 GB against this repo's Actions cache quota.
+        required: false
+        type: string
+        default: ""
     secrets:
       gh_token:
         description: "GitHub token with write access"
@@ -117,7 +129,7 @@ jobs:
   # is not release-gated, so a load-bearing (:fail) finding must block
   # `build` itself on every event — hence `build` needs `scan`.
   scan:
-    needs: [guard]
+    needs: [guard, gate]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -134,6 +146,9 @@ jobs:
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
+          # Cold on release: the scan gates an attested build, so a
+          # poisoned tool cache must not be able to forge a passing scan.
+          go-cache: ${{ needs.gate.outputs.should-release == 'true' && '' || inputs.go-cache }}
 
   build:
     # needs `gate` so the build can read should-release and disable the

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -113,6 +113,18 @@ on:
         required: false
         type: string
         default: "osv zizmor scorecard:info dependency-review"
+      go-cache:
+        description: >
+          Set to "enabled" to cache the Go module + build caches the
+          source-scan tools build from source (osv-scanner et al. —
+          #343) on PR / non-release runs. Release builds always run
+          cache-free regardless: the scan gates an attested release, so
+          its tools build cold and a poisoned cache cannot forge a
+          passing scan (docs/SLSA_L3_AUDIT.md). Default off — the cache
+          is ~1.5–3 GB against this repo's Actions cache quota.
+        required: false
+        type: string
+        default: ""
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -168,7 +180,7 @@ jobs:
   # blocks the release on release events (see release.if) — decoupled
   # scan/build runs can't gate publish.
   scan:
-    needs: [guard]
+    needs: [guard, gate]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -186,6 +198,9 @@ jobs:
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
+          # Cold on release: the scan gates an attested build, so a
+          # poisoned tool cache must not be able to forge a passing scan.
+          go-cache: ${{ needs.gate.outputs.should-release == 'true' && '' || inputs.go-cache }}
 
   # Quality gates with `contents: read` only. `go test` executes
   # arbitrary adopter test code; the minimum-permissions posture

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -83,6 +83,18 @@ on:
         required: false
         type: string
         default: "osv zizmor scorecard:info dependency-review"
+      go-cache:
+        description: >
+          Set to "enabled" to cache the Go module + build caches the
+          source-scan tools build from source (osv-scanner et al. —
+          #343) on PR / non-release runs. Release builds always run
+          cache-free regardless: the scan gates an attested release, so
+          its tools build cold and a poisoned cache cannot forge a
+          passing scan (docs/SLSA_L3_AUDIT.md). Default off — the cache
+          is ~1.5–3 GB against this repo's Actions cache quota.
+        required: false
+        type: string
+        default: ""
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -144,7 +156,7 @@ jobs:
   # the run so the caller's publish (gated on this workflow via needs:)
   # is blocked — decoupled scan/build runs can't gate publish.
   scan:
-    needs: [guard]
+    needs: [guard, gate]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -162,6 +174,9 @@ jobs:
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
+          # Cold on release: the scan gates an attested build, so a
+          # poisoned tool cache must not be able to forge a passing scan.
+          go-cache: ${{ needs.gate.outputs.should-release == 'true' && '' || inputs.go-cache }}
 
   build:
     needs: [guard]

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -63,6 +63,18 @@ on:
         required: false
         type: string
         default: "osv zizmor scorecard:info dependency-review"
+      go-cache:
+        description: >
+          Set to "enabled" to cache the Go module + build caches the
+          source-scan tools build from source (osv-scanner et al. —
+          #343) on PR / non-release runs. Release builds always run
+          cache-free regardless: the scan gates an attested release, so
+          its tools build cold and a poisoned cache cannot forge a
+          passing scan (docs/SLSA_L3_AUDIT.md). Default off — the cache
+          is ~1.5–3 GB against this repo's Actions cache quota.
+        required: false
+        type: string
+        default: ""
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -125,7 +137,7 @@ jobs:
   # the run so the caller's publish (gated on this workflow via needs:)
   # is blocked — decoupled scan/build runs can't gate publish.
   scan:
-    needs: [guard]
+    needs: [guard, gate]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -143,6 +155,9 @@ jobs:
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
+          # Cold on release: the scan gates an attested build, so a
+          # poisoned tool cache must not be able to forge a passing scan.
+          go-cache: ${{ needs.gate.outputs.should-release == 'true' && '' || inputs.go-cache }}
 
   build:
     # needs `gate` so the build can read should-release and disable the

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -132,6 +132,20 @@ teardown() {
     [[ "$status" -eq 0 ]]
 }
 
+@test "container: scan job needs gate so go-cache can read should-release" {
+    local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
+    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$wf\" | grep -E 'needs:.*gate'"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: scan job forces go-cache off on release" {
+    # The scan gates the attested build; its Go tool cache must build cold on
+    # release so a poisoned cache cannot forge a passing scan.
+    local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
+    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$wf\" | grep -E \"go-cache:.*should-release == 'true' && ''\""
+    [[ "$status" -eq 0 ]]
+}
+
 @test "container: build job needs scan (load-bearing finding blocks the mid-composite push)" {
     local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
     run bash -c "sed -n '/^  build:/,/^  [a-z]/p' \"$wf\" | grep -E 'needs:.*scan'"

--- a/build/actions/go/test.bats
+++ b/build/actions/go/test.bats
@@ -651,6 +651,18 @@ func main() {}
     grep -qE "if:.*inputs\\.scan-tools != ''" <<<"$section"
 }
 
+@test "go: scan job needs gate so go-cache can read should-release" {
+    section="$(awk '/^  [a-z][a-z_-]*:$/ { in_section = ($0 == "  scan:") } in_section' "$WORKFLOW")"
+    grep -qE 'needs:.*gate' <<<"$section"
+}
+
+@test "go: scan job forces go-cache off on release" {
+    # The scan gates the attested release; its Go tool cache must build cold
+    # on release so a poisoned cache cannot forge a passing scan.
+    section="$(awk '/^  [a-z][a-z_-]*:$/ { in_section = ($0 == "  scan:") } in_section' "$WORKFLOW")"
+    grep -qE "go-cache:.*should-release == 'true' && ''" <<<"$section"
+}
+
 @test "go: workflow release job needs scan (load-bearing finding blocks publish)" {
     section="$(awk '/^  [a-z][a-z_-]*:$/ { in_section = ($0 == "  release:") } in_section' "$WORKFLOW")"
     grep -qE '^    needs: \[.*scan.*\]' <<<"$section"

--- a/build/actions/npm/test.bats
+++ b/build/actions/npm/test.bats
@@ -731,6 +731,18 @@ write_pkg_json() {
     [[ "$status" -eq 0 ]]
 }
 
+@test "npm: scan job needs gate so go-cache can read should-release" {
+    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E 'needs:.*gate'"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "npm: scan job forces go-cache off on release" {
+    # The scan gates the attested release; its Go tool cache must build cold
+    # on release so a poisoned cache cannot forge a passing scan.
+    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E \"go-cache:.*should-release == 'true' && ''\""
+    [[ "$status" -eq 0 ]]
+}
+
 @test "npm: workflow has gate job calling release_gate" {
     run grep -E '^  gate:' "$WORKFLOW"
     [[ "$status" -eq 0 ]]

--- a/build/actions/python/test.bats
+++ b/build/actions/python/test.bats
@@ -422,6 +422,18 @@ write_pyproject() {
     [[ "$status" -eq 0 ]]
 }
 
+@test "python: scan job needs gate so go-cache can read should-release" {
+    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E 'needs:.*gate'"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "python: scan job forces go-cache off on release" {
+    # The scan gates the attested release; its Go tool cache must build cold
+    # on release so a poisoned cache cannot forge a passing scan.
+    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E \"go-cache:.*should-release == 'true' && ''\""
+    [[ "$status" -eq 0 ]]
+}
+
 @test "python: workflow has gate job calling release_gate" {
     run grep -E '^  gate:' "$WORKFLOW"
     [[ "$status" -eq 0 ]]

--- a/docs/SLSA_L3_AUDIT.md
+++ b/docs/SLSA_L3_AUDIT.md
@@ -110,6 +110,19 @@ adopter consuming wrangle through one of wrangle's **reusable workflows**:
 > The per-builder generator analysis below is retained as the historical record
 > of the pre-#316 architecture; it is not the current implementation.
 
+> **Update — 2026-06-13 ([#396](https://github.com/TomHennen/wrangle/issues/396)).**
+> The source-scan job in all four `build_and_publish_*` workflows gained an
+> opt-in `go-cache` input (default off) that caches the Go module + build
+> caches `actions/scan`'s `go install` populates for osv-scanner et al. On
+> these attested workflows the cache is **force-disabled on release**
+> (`needs.gate.outputs.should-release == 'true'`), exactly like the artifact
+> caches Findings 1–2 gate: the scan gates the attested release and the Go
+> build cache trusts compiled output on a hit, so a release-blocking scanner
+> must build cold — otherwise a poisoned cache could forge a passing scan.
+> Only PR / non-release runs cache (no provenance; per-PR cache scope).
+> **The Build Track levels above are unchanged** — nothing cached reaches a
+> release build.
+
 Two caveats narrow every Build L3 row above:
 
 - **Direct composite consumption is not a supported L3 path.** Calling the


### PR DESCRIPTION
claude: implements #396.

## What
Adds an opt-in `go-cache` input (default off) to all four `build_and_publish_*` reusable workflows, wired to the **scan** job. PR / non-release runs cache the Go module + build caches `actions/scan`'s `go install` populates for osv-scanner et al.; release runs build cold.

`scan: needs: [guard, gate]` (was `[guard]`) so it can read `should-release`:
```yaml
go-cache: ${{ needs.gate.outputs.should-release == 'true' && '' || inputs.go-cache }}
```

## Why cold on release — corrects #396's stated rationale
The issue argued ungated was safe ("scan produces no provenance") and leaned on "different cache keys = isolated." Both are wrong on review:

- **The keys argument doesn't hold.** `setup-go` restores by **restore-key prefix** (`setup-go-{os}-{arch}-go-{version}-…`), so the scan-tool cache and an adopter's Go-module build cache can cross-pollinate on PR builds despite different `go.sum`.
- **These scan jobs gate the attested release** (`release`/`attest` need `scan`). The Go **build cache trusts compiled output on a hit**, so a poisoned cache could produce an osv-scanner that reports a false pass and lets a vulnerable release through. The release-blocking scanner must build cold.

So this gates the scan cache off on release exactly like the artifact caches already do (`should-release`), and matches the scan action's own input doc ("gate off on release for scan jobs that gate an attested build"). Nothing cached reaches a release build → Build Track levels unchanged. Recorded as a dated note in `docs/SLSA_L3_AUDIT.md`.

## Tests
- 2 structural tests per workflow (8 total): scan needs gate; scan forces go-cache off on release. Mirror the existing "disables the uv cache for release builds" pattern.
- All four `build/actions/*/test.bats` green (npm 88, python 71, container 60, go 126); workflow-lint clean. (actionlint/zizmor run in CI.)

## Deferred
Companion-repo dogfood opt-in (setting `go-cache: enabled` in wrangle-test's showcase to exercise the cache-on path) is a separate change — this PR defaults off, so its integration run validates the default path doesn't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)