### PR TITLE
test: zizmor detection canary + dogfood adopter example/snippet pinning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,10 @@ integration:
 	@source lib/env.sh && ./test/setup_integration.sh && bats $(INTEGRATION_BATS)
 
 # Workflow security linting (matches tools/zizmor/action.yml's CI invocation).
-# --no-online-audits keeps the test container offline-friendly; the
-# online audits (e.g. unpinned-uses against the live registry) are
-# exercised by the same upstream action in CI.
+# --no-online-audits keeps the test container offline-friendly; the audits
+# that need network (e.g. known-vulnerable-actions against the GitHub
+# Advisories DB) are exercised by the same upstream action in CI. unpinned-uses
+# works offline, so this run does enforce SHA-pinning locally.
 zizmor:
 	@echo "=== zizmor ==="
 	@zizmor --no-online-audits .github/workflows actions/ tools/ build/

--- a/test/setup_integration.sh
+++ b/test/setup_integration.sh
@@ -44,6 +44,17 @@ if ! command -v ast-grep >/dev/null 2>&1; then
     ln -sf /tmp/wrangle-venvs/ast-grep/bin/ast-grep "$WRANGLE_BIN_DIR/ast-grep"
 fi
 
+# zizmor for the detection canary (tools/zizmor/test.bats) and the
+# example-workflow scan (test/test_examples_scan.bats). Same hash-pinned
+# requirements.txt the test container installs; entrypoint onto PATH via
+# WRANGLE_BIN_DIR. Without it those bats skip_or_fail (FATAL) under CI.
+if ! command -v zizmor >/dev/null 2>&1; then
+    python3 -m venv /tmp/wrangle-venvs/zizmor
+    /tmp/wrangle-venvs/zizmor/bin/pip install --quiet --no-cache-dir \
+        --require-hashes -r "$REPO_ROOT/tools/zizmor/requirements.txt"
+    ln -sf /tmp/wrangle-venvs/zizmor/bin/zizmor "$WRANGLE_BIN_DIR/zizmor"
+fi
+
 # wrangle-workflow-lint's lint.sh prefers this exact venv path (PyYAML is
 # a library — no entrypoint to put on PATH). Root (the test container)
 # writes /opt directly; the GitHub runner needs sudo.
@@ -70,3 +81,4 @@ printf 'setup_integration: installed tool versions:\n'
 osv-scanner --version | head -1
 ampel version | head -1
 cosign version 2>&1 | grep GitVersion
+zizmor --version | head -1

--- a/test/test_examples_scan.bats
+++ b/test/test_examples_scan.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+# Dogfoods the adopter-facing example workflows in gh_workflow_examples/.
+#
+# These are the files the docs tell adopters to copy into .github/workflows/,
+# yet nothing scans them: zizmor's directory walk only collects files already
+# under a .github/workflows/ path, and the pin-consistency guard only compares
+# SHAs among refs already pinned by SHA — a tag-pinned wrangle ref (the
+# regression that shipped unpinned examples) matches neither. This stages each
+# example the way an adopter would and runs the real scanner over it, so an
+# unpinned/tag-pinned reference fails CI here instead of on an adopter's first
+# run on the line wrangle told them to add.
+
+# skip_or_fail (fail-not-skip under CI) lives in a shared bats helper.
+load "lib/bats_helpers"
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    export REPO_ROOT
+    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/examples-scan-XXXXXX")"
+    export TMP_DIR
+}
+
+teardown() {
+    if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+@test "example workflows pass the same zizmor scan an adopter runs" {
+    command -v zizmor >/dev/null 2>&1 || skip_or_fail "zizmor not on PATH"
+
+    mkdir -p "$TMP_DIR/.github/workflows"
+    local staged=0 f
+    for f in "$REPO_ROOT"/gh_workflow_examples/*.yml; do
+        # Stage only real workflows. The directory also holds goreleaser
+        # configs and dependabot.yml, which have no top-level jobs: key;
+        # zizmor crashes when handed a goreleaser file as a workflow.
+        grep -qE '^jobs:' "$f" || continue
+        cp "$f" "$TMP_DIR/.github/workflows/"
+        staged=$((staged + 1))
+    done
+    # Guard against the glob/grep silently selecting nothing.
+    [ "$staged" -gt 0 ]
+
+    # zizmor exits 0 clean, 14 on findings; --no-online-audits still runs
+    # unpinned-uses (it works offline), which is the audit that catches a
+    # tag-pinned wrangle reference.
+    run zizmor --no-online-audits "$TMP_DIR"
+    if [ "$status" -ne 0 ]; then
+        printf '%s\n' "$output" >&2
+        return 1
+    fi
+}

--- a/test/test_pin_consistency.bats
+++ b/test/test_pin_consistency.bats
@@ -38,3 +38,26 @@ setup() {
         return 1
     fi
 }
+
+@test "no adopter-facing wrangle reference is tag- or branch-pinned" {
+    # Adopter-facing wrangle refs must pin a 40-hex SHA: a tag or branch ref
+    # (@vX.Y.Z, @main) trips an adopter's own zizmor unpinned-uses on first run.
+    # The example files are scanned by test_examples_scan.bats; README/FAQ
+    # snippets are markdown and aren't, so this catches the snippets too.
+    #
+    # Excluded: test/ fixtures (synthetic pins), the @__WRANGLE_SHA__ integration
+    # template token, @<...> doc placeholders, and the lone FAQ line that
+    # demonstrates the tag form behind an explicit `# zizmor: ignore` escape.
+    local bad
+    bad="$(grep -rniIE 'uses: [a-z]+/wrangle/[^@[:space:]]+@[^[:space:]]+' \
+            --exclude-dir=.git --exclude-dir=test "$REPO_ROOT" \
+        | grep -viE '# *zizmor: *ignore' \
+        | grep -viE '@[0-9a-f]{40}([[:space:]]|#|$)' \
+        | grep -viE '@<[^>]+>' \
+        | grep -viE '@__[A-Za-z_]+__' || true)"
+
+    if [ -n "$bad" ]; then
+        printf 'Tag/branch-pinned adopter-facing wrangle refs (must be @<40-hex SHA>):\n%s\n' "$bad" >&2
+        return 1
+    fi
+}

--- a/tools/zizmor/SPEC.md
+++ b/tools/zizmor/SPEC.md
@@ -20,3 +20,7 @@ Zizmor has two install paths and they are kept deliberately in sync:
 
 `tools/zizmor/action.yml`'s default `version` input and `tools/zizmor/requirements.txt`'s `zizmor==` pin must track each other; a structural test in `test.bats` enforces this. Bumping one without the other masks regressions between the local pre-push check and CI.
 
+## Detection canary
+
+`test.bats` runs the real binary against `fixtures/unpinned_uses.yml` — a deliberately tag-pinned action — and asserts the `unpinned-uses` audit still fires. The rest of the suite feeds synthetic SARIF, which proves the plumbing but never that zizmor still *detects* anything; the canary is the positive control that turns a false-negative regression (a zizmor version or config change that silently stops flagging a class) into a red test instead of a passing scan.
+

--- a/tools/zizmor/fixtures/unpinned_uses.yml
+++ b/tools/zizmor/fixtures/unpinned_uses.yml
@@ -1,0 +1,17 @@
+# Canary fixture for the unpinned-uses detection test in test.bats.
+#
+# The tag-pinned actions/checkout below is the deliberate flaw the canary
+# asserts zizmor still flags; persist-credentials:false keeps it the only
+# finding. zizmor only collects .github/workflows/* and action.yml, so this
+# file is never picked up by the repo's own scan — the test passes it to
+# zizmor explicitly.
+name: unpinned-uses canary
+on: push
+permissions: {}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false

--- a/tools/zizmor/test.bats
+++ b/tools/zizmor/test.bats
@@ -4,8 +4,12 @@
 #
 # Action-pattern tools wrap an upstream GitHub Action; there's no
 # install.sh or adapter.sh to unit-test. These cover action.yml
-# structure plus collect_sarif.sh's fail-closed disambiguation. Full
-# integration testing happens via dogfooding in CI.
+# structure, collect_sarif.sh's fail-closed disambiguation, and a
+# detection canary that runs the real binary against a known-bad
+# workflow. Full integration testing happens via dogfooding in CI.
+
+# skip_or_fail (fail-not-skip under CI) lives in a shared bats helper.
+load "../../test/lib/bats_helpers"
 
 setup() {
     ORIG_DIR="$(pwd)"
@@ -114,6 +118,28 @@ make_sarif() {
 
 @test "zizmor: collect_sarif.sh exists and is executable" {
     [ -x "$TOOL_DIR/collect_sarif.sh" ]
+}
+
+# --- detection canary: real zizmor still flags a known-bad workflow ---
+
+# A positive control for the scanner itself. Every other test here feeds
+# synthetic SARIF or checks action.yml structure — none proves zizmor still
+# *detects* anything, so a false-negative regression (a zizmor version that
+# stops flagging tag pins, or a config change that silences the audit) would
+# pass silently, exactly the gap that let unpinned wrangle examples ship.
+# This runs the real binary against a deliberately tag-pinned action and
+# asserts unpinned-uses fires. unpinned-uses works offline, so
+# --no-online-audits keeps it network-free; SARIF mode always exits 0 (the
+# findings live in the document), so the assertion is on SARIF content.
+@test "zizmor canary: unpinned-uses fires on a tag-pinned action" {
+    command -v zizmor >/dev/null 2>&1 || skip_or_fail "zizmor not on PATH"
+
+    # bash -c redirects zizmor's stderr away so $output is pure SARIF.
+    run bash -c "zizmor --no-online-audits --format sarif '$TOOL_DIR/fixtures/unpinned_uses.yml' 2>/dev/null"
+    # The ruleId is "zizmor/unpinned-uses"; match the audit name within it.
+    printf '%s' "$output" | jq -e \
+        '[.runs[].results[] | select(.ruleId | test("unpinned-uses"))] | length >= 1' \
+        >/dev/null
 }
 
 # --- collect_sarif.sh: fail-closed disambiguation ---


### PR DESCRIPTION
Closes the gap behind #389: our scan tests only ever asserted *true-negatives* (clean code → no findings), so a scanner going dark — or an unpinned example we ship — would pass silently. Three complementary positive controls.

## 1. Detection canary (`tools/zizmor/`)

The zizmor suite verified the *plumbing* (synthetic SARIF through `collect_sarif.sh`, `action.yml` structure) but never that zizmor still **detects** anything. A false-negative regression (a version or config change that silently stops flagging a class) would surface as a clean scan, indistinguishable from healthy code.

- `tools/zizmor/fixtures/unpinned_uses.yml` — a deliberately tag-pinned `actions/checkout@v4`, outside `.github/workflows/` and not named `action.yml`, so the repo's own `make zizmor` never collects it (verified).
- A `test.bats` case runs the **real** binary against it and asserts `unpinned-uses` fires (SARIF `ruleId` `zizmor/unpinned-uses`). Gated by `skip_or_fail`; `unpinned-uses` works offline so it's network-free, and SARIF mode exits 0 so the assertion is on SARIF content.

Generalizes to every future scan tool (e.g. poutine, #350): each gets a known-bad fixture + positive assertion.

## 2. Dogfood the example *files* (`test/test_examples_scan.bats`)

`gh_workflow_examples/` holds the workflows the docs tell adopters to copy into `.github/workflows/`, but **nothing scanned them**: zizmor's directory walk only collects files already under a `.github/workflows/` path, and `test_pin_consistency.bats` only compared SHAs among refs *already* pinned by SHA — a tag pin matched neither. The test stages each example the way an adopter would and runs the real zizmor over it, so a tag-pinned/unpinned reference fails CI here instead of on first adoption.

## 3. Tag-pin guard for *snippets* (`test/test_pin_consistency.bats`)

The example files are now scanned, but README/FAQ `uses:` snippets are markdown and aren't. A second pin-consistency test fails on any `uses: …/wrangle/…@<ref>` that isn't a 40-hex SHA, excepting test fixtures, the `@__WRANGLE_SHA__` template token, `@<…>` doc placeholders, and the lone FAQ line carrying the documented `# zizmor: ignore` escape.

## Drive-by

`make zizmor`'s Makefile comment wrongly called `unpinned-uses` an online audit only run in CI. It works **offline** — the local scan does enforce SHA-pinning. Corrected (now uses `known-vulnerable-actions` as the genuinely-online example).

## Verification

All affected bats suites pass. Each guard proven to have teeth — reverting a fixture to a tag pin flips the relevant test to `not ok` (zizmor canary, an example file, and a README snippet, respectively), and back to `ok` when restored. Fixture not collected by a full `make zizmor`; `wrangle-workflow-lint` and shellcheck clean.

## Deliberately *not* here

- **wrangle-test#10 (`showcase.yml` @main + suppressions).** SHA-pinning it would be cosmetic — the pinning concern is now covered mechanically by (2) and (3). Left as tracked debt.
- **End-to-end execution of the example files.** The integration test runs a hand-maintained template, not the literal examples, so they can drift. The clean fix is to generate that template from the examples; scoped as a follow-up, not bolted on here.

https://claude.ai/code/session_01TAYFnirhjvhr4KTzXbWN6A