### PR TITLE
Make wrangle-lint default-on and dogfooded (post-#406 bootstrap bump)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,7 +21,7 @@ Wrangle's own workflows all have filenames that start with `local_`.
 
 **Embedded source scan.** Each of these workflows runs a `scan` job (the `actions/scan` composite) before building, so adopters get scanning *and* build/publish from one workflow — no separate `check_source_change.yml` needed.
 
-- **`scan-tools` input** — space-separated tools, default `"osv zizmor scorecard:info dependency-review"`. Suffix a tool with `:info` to make it non-blocking. Empty string disables scanning entirely.
+- **`scan-tools` input** — space-separated tools, default `"osv zizmor scorecard:info dependency-review wrangle-lint"`. Suffix a tool with `:info` to make it non-blocking. Empty string disables scanning entirely.
 - **Publish gating.** A load-bearing (`:fail`) finding blocks publishing. The point where it blocks differs by build type:
   - **container** — blocks the `build` job on *every* event; the docker push happens mid-composite and is not release-gated, so this is the documented exception.
   - **go** — blocks the `release` job on release events; PR snapshot builds still run.

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -62,7 +62,7 @@ on:
           build (and therefore the push). Empty string disables scanning.
         required: false
         type: string
-        default: "osv zizmor scorecard:info dependency-review"
+        default: "osv zizmor scorecard:info dependency-review wrangle-lint"
       go-cache:
         description: >
           Set to "enabled" to cache the Go module + build caches the
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/preflight_guard@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
 
   gate:
     needs: [guard]
@@ -120,7 +120,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/release_gate@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -142,7 +142,7 @@ jobs:
           persist-credentials: false
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/scan@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -168,7 +168,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      uses: TomHennen/wrangle/build/actions/container@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -265,7 +265,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/verify@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         with:
           subject: ${{ needs.build.outputs.digest }}
           policy: policies/wrangle-provenance-container-v1.hjson

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -112,7 +112,7 @@ on:
           release. Empty string disables scanning.
         required: false
         type: string
-        default: "osv zizmor scorecard:info dependency-review"
+        default: "osv zizmor scorecard:info dependency-review wrangle-lint"
       go-cache:
         description: >
           Set to "enabled" to cache the Go module + build caches the
@@ -161,7 +161,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/preflight_guard@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
 
   gate:
     needs: [guard]
@@ -171,7 +171,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/release_gate@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -194,7 +194,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/scan@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -222,7 +222,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/build/actions/go/checks@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -284,7 +284,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/build/actions/go/release@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         id: release
         with:
           path: ${{ inputs.path }}
@@ -420,7 +420,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/verify@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-go-v1.hjson

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -82,7 +82,7 @@ on:
           blocking the caller's publish. Empty string disables scanning.
         required: false
         type: string
-        default: "osv zizmor scorecard:info dependency-review"
+        default: "osv zizmor scorecard:info dependency-review wrangle-lint"
       go-cache:
         description: >
           Set to "enabled" to cache the Go module + build caches the
@@ -136,7 +136,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/preflight_guard@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
 
   gate:
     needs: [guard]
@@ -147,7 +147,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/release_gate@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -170,7 +170,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/scan@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/build/actions/npm@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         id: build
         with:
           path: ${{ inputs.path }}
@@ -337,7 +337,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/verify@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-npm-v1.hjson

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -62,7 +62,7 @@ on:
           blocking the caller's publish. Empty string disables scanning.
         required: false
         type: string
-        default: "osv zizmor scorecard:info dependency-review"
+        default: "osv zizmor scorecard:info dependency-review wrangle-lint"
       go-cache:
         description: >
           Set to "enabled" to cache the Go module + build caches the
@@ -113,7 +113,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/preflight_guard@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -128,7 +128,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/release_gate@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -151,7 +151,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/scan@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -184,7 +184,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/build/actions/python@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         id: build
         with:
           path: ${{ inputs.path }}
@@ -328,7 +328,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/verify@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         with:
           subject: dist/${{ matrix.artifact }}
           policy: policies/wrangle-provenance-python-v1.hjson

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -33,7 +33,7 @@ on:
           Empty string disables scanning.
         required: false
         type: string
-        default: "osv zizmor scorecard:info dependency-review"
+        default: "osv zizmor scorecard:info dependency-review wrangle-lint"
       go-cache:
         description: >
           Set to "enabled" to cache the Go module + build caches the
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/preflight_guard@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/scan@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+        uses: TomHennen/wrangle/build/actions/shell@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -7,7 +7,7 @@ on:
         description: "Space-separated list of tools to run (suffix :info for informational)"
         required: false
         type: string
-        default: "osv zizmor scorecard:info dependency-review"
+        default: "osv zizmor scorecard:info dependency-review wrangle-lint"
       go-cache:
         description: >
           Set to "enabled" to cache the Go module + build caches the
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+      - uses: TomHennen/wrangle/actions/preflight_guard@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
 
   check-change:
     needs: [guard]
@@ -48,7 +48,7 @@ jobs:
       # action-pattern tools (zizmor, scorecard) via uses: internally.
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@8160c96f7134fffa7751210e21a05c4652b336dd # main 2026-06-13
+        uses: TomHennen/wrangle/actions/scan@344eedec99a5d7ed85d6d1f7d347d32a00253548 # main 2026-06-13
         with:
           tools: ${{ inputs.tools }}
           go-cache: ${{ inputs.go-cache }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ and `build/actions/<type>/README.md`.
 Two notes for every build workflow:
 
 - **`scan-tools` input** — space-separated source-scan tools, default
-  `"osv zizmor scorecard:info dependency-review"`. Suffix a tool with
+  `"osv zizmor scorecard:info dependency-review wrangle-lint"`. Suffix a tool with
   `:info` to make it non-blocking; empty string disables scanning. A
   load-bearing (`:fail`) finding blocks publishing.
 - **Caller permissions** — REQUIRED to grant `actions: read` and

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -217,7 +217,7 @@ Asymmetry: container vs. python. The container reusable workflow's docker push h
 
 ### Source-scan gating
 
-Contract introduced in [#334](https://github.com/TomHennen/wrangle/issues/334). Every `build_and_publish_*.yml` runs the embedded `scan` job (`actions/scan`) before building, controlled by a `scan-tools` input (default `"osv zizmor scorecard:info dependency-review"`; `:info`-suffixed tools are non-blocking; empty string disables the scan). A load-bearing (`:fail`) scan finding blocks publishing — but, like `release-events`, *where* it blocks tracks each build type's publish path, because that path is what must be prevented:
+Contract introduced in [#334](https://github.com/TomHennen/wrangle/issues/334). Every `build_and_publish_*.yml` runs the embedded `scan` job (`actions/scan`) before building, controlled by a `scan-tools` input (default `"osv zizmor scorecard:info dependency-review wrangle-lint"`; `:info`-suffixed tools are non-blocking; empty string disables the scan). A load-bearing (`:fail`) scan finding blocks publishing — but, like `release-events`, *where* it blocks tracks each build type's publish path, because that path is what must be prevented:
 
 - **container** — the `build` job `needs: [scan]`, so a finding blocks the build (and therefore the mid-composite push) on **every** event, not only release events. This is the documented exception, mirroring the `release-events` container asymmetry above: the push is mid-composite and not release-gated, so the scan gate cannot defer to release time either.
 - **go** — the scan gates the `release` job on release events; PR snapshot builds still run, consistent with the `release-events` model.


### PR DESCRIPTION
## What

Completes the bootstrap rollout of `wrangle-lint` now that #406 is on `main`.

#406 added `wrangle-lint` to the `actions/scan` *action's* own default, but the reusable workflows pin `actions/scan@<main-SHA>` and pass their own `scan-tools` default — so `wrangle-lint` wasn't actually running anywhere (or being dogfooded). This PR closes that loop:

- **Bump** every `actions/scan` (and sibling) self-ref pin to the merged main SHA `344eede`, which contains the wrangle-lint scan action.
- **Default-on:** add `wrangle-lint` to the six reusable workflows' `scan-tools` defaults and the three docs that state the default (`.github/workflows/README.md`, `AGENTS.md`, `docs/SPEC.md`).

## Why `:fail` is safe to default

Verified both repos that the integration run scans pass `wrangle-lint` clean, so defaulting at `:fail` won't break CI:

- **wrangle itself** — `.github/dependabot.yml` passes WL001–005 (the dogfood test asserts this).
- **companion `wrangle-test`** — its `dependabot.yml` is a single `gomod` entry with `cooldown.default-days: 7` and no github-actions entry, so wrangle-lint finds nothing (WL003/WL004 only apply within a github-actions entry; WL005 is satisfied).

This is the first run that exercises `wrangle-lint` end-to-end (build/scan jobs + the companion integration dispatch).

Follow-up to #406.

https://claude.ai/code/session_019U6fAobfgNxtwfNCy99BSM

---
_Generated by [Claude Code](https://claude.ai/code/session_019U6fAobfgNxtwfNCy99BSM)_