### PR TITLE
docs(SPEC): register wrangle-lint in the Supported Tools table

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -706,6 +706,7 @@ This is the entire file an adopter needs. No secrets, no configuration, no depen
 | [Zizmor](https://github.com/zizmorcore/zizmor) | Action (wraps `zizmorcore/zizmor-action`) | Security-focused linting of GitHub Actions workflows |
 | [OSSF Scorecard](https://scorecard.dev/) | Action (wraps `ossf/scorecard-action`) | Assesses repo security health across 18+ categories |
 | [Dependency Review](https://github.com/actions/dependency-review-action) | Action (wraps `actions/dependency-review-action`) | PR-time gate: blocks PRs that introduce known-vulnerable dependencies. Runs on `pull_request` events only |
+| wrangle-lint | Adapter (first-party Go) | Audits the adopter's `.github/dependabot.yml` for config footguns that silently defeat dependency hygiene (see `tools/wrangle-lint/SPEC.md`) |
 
 ### Two Tool Patterns
 


### PR DESCRIPTION
Registers `wrangle-lint` in `docs/SPEC.md`'s **Supported Tools** table — the one place it was still missing after #406 (the tool) and #412 (default-on). One row; full details remain in `tools/wrangle-lint/SPEC.md`.

Follow-up to #406 / #412.

https://claude.ai/code/session_019U6fAobfgNxtwfNCy99BSM

---
_Generated by [Claude Code](https://claude.ai/code/session_019U6fAobfgNxtwfNCy99BSM)_