### PR TITLE
claude: v0.3.0 roadmap + release-train model; drop spec-change issue-first rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,6 @@ Adapters do NOT receive secrets (env stripped by the orchestrator). If a tool ne
 
 - Branch from `main`, descriptive branch names.
 - All PRs must pass CI (`make test` via GitHub Actions); shellcheck cleanly; actionlint cleanly.
-- Spec changes (`docs/SPEC.md`) require discussion — open an issue first.
 - Update the README and `gh_workflow_examples/` if the adoption interface changes.
 - For personal-environment preferences that shouldn't be checked in (your local test command, your shell, your editor's quirks), use `CLAUDE.local.md` — it's git-ignored.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -111,6 +111,26 @@ wrangle attaches nothing to its own Releases, so this needs no
 draft-then-publish ordering here — unlike the build-type publish flows,
 which do (the VSA is attached post-publish).
 
+### Release train and milestone scope
+
+Releases are cut **continuously off `main`** as point releases (`0.2.x`)
+whenever there's something worth shipping. A milestone (e.g. `v0.3.0`)
+names the *eventual* minor tag and is the body of work that defines it —
+membership means "part of the `0.3` story," **independent of which point
+release first ships a given piece.** A merged milestone issue ships in the
+next `0.2.x`; it stays in the milestone until the milestone's whole scope
+is done; the minor tag (`0.3.0`) is cut only then. Pre-1.0, a `0.2.x` may
+therefore carry feature work, not just fixes — acceptable below 1.0.
+
+**Ordering constraint for dependency chains (loud).** When a feature is a
+chain — producer → delivery → a gate that *requires* the producer's
+output — ship the additive mechanism early but **flip the user-visible
+gate last.** Shipping a change that makes a policy require an attestation
+in a `0.2.x` *before* the producer emits it on every build type
+hard-fails adopters' release gates mid-train. Keep new outputs additive
+until the loop closes, and hold consumer-facing docs until the feature is
+validated end-to-end (don't document untested consumer commands).
+
 Wrangle does not currently ship a release-helper workflow; tagging is
 a release-management concern that belongs to the maintainer's chosen
 versioning policy (semver here). If that changes, this section is the

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -122,7 +122,7 @@ next `0.2.x`; it stays in the milestone until the milestone's whole scope
 is done; the minor tag (`0.3.0`) is cut only then. Pre-1.0, a `0.2.x` may
 therefore carry feature work, not just fixes — acceptable below 1.0.
 
-**Ordering constraint for dependency chains (loud).** When a feature is a
+**Ordering constraint for dependency chains.** When a feature is a
 chain — producer → delivery → a gate that *requires* the producer's
 output — ship the additive mechanism early but **flip the user-visible
 gate last.** Shipping a change that makes a policy require an attestation

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1182,6 +1182,72 @@ and a config layer doesn't reduce the irreducible per-adopter inputs
 - Test integration as a profile-level concept — each build type already runs tests inside its own action
 - npm/pnpm/yarn workspaces ([#208](https://github.com/TomHennen/wrangle/issues/208)) — own track
 
+### v0.3.0 — Make the VSA mean something
+
+Theme: prove the full scan→attest→policy→consumer loop end-to-end. Today the
+VSA attests **build provenance only**. The release PolicySets already require
+SBOM and OSV tenets ([`policies/wrangle-default-v1.hjson`](../policies/wrangle-default-v1.hjson)),
+but nothing produces and signs the attestations those tenets consume — so they
+cannot pass on a real release. v0.3 builds that producer side, so the VSA comes
+to mean "scanned, has an SBOM, clean," and a consumer can verify it from the
+GitHub attestation store.
+
+This is a proof-of-concept release: the goal is to demonstrate the loop is
+possible, not to harden it. Success criterion — one build type goes green
+through a policy that *requires* SBOM + OSV attestations, and a consumer
+verifies that artifact from the attestation store. Reliability, ergonomics,
+and the adopter-facing workflow-policy work are explicitly deferred to v0.4
+(below).
+
+**Track A — the VSA loop:**
+
+- [ ] Emit a signed attestation for each scan-type action (SBOM, OSV, workflow
+      scan, scorecard), signed from wrangle's registered identity. Producer side
+      of the tenets the PolicySets already require. Tracking: [#420](https://github.com/TomHennen/wrangle/issues/420)
+- [ ] Deliver those attestations (and the VSA) to GitHub's attestation store —
+      the one-command consumer path. Tracking: [#372](https://github.com/TomHennen/wrangle/issues/372)
+- [ ] Close the consumer half: make `wrangle-default-v1` / `wrangle-strict-v1`
+      satisfiable against the new attestations rather than retiring them.
+      Tracking: [#328](https://github.com/TomHennen/wrangle/issues/328)
+- [ ] Bundle the per-build attestations into a single in-toto JSONL so delivery
+      is one file. Tracking: [#181](https://github.com/TomHennen/wrangle/issues/181)
+- [ ] Resolve the intermittent verify failure where one tenet fails to match a
+      recognized signer identity while siblings pass — rides with #420 because
+      adding tenets and signed attestations stresses exactly this surface.
+      Tracking: [#354](https://github.com/TomHennen/wrangle/issues/354)
+
+**Track B — close the footguns wrangle's own development keeps hitting.**
+Wrangle is a scanning framework; dogfooding its own discipline against the
+footguns that bite its development is on-theme. The adopter-facing config-drift
+footguns are already closed (`wrangle-lint` WL004 + the third-party pin
+divergence guard); what remains is the wrangle-internal set neither covers:
+
+- [ ] `bump_action_pins` / `check_pin_ancestry` walk only `.github/workflows/`,
+      so nested self-reference pins in `actions/`/`build/`/`tools/` age with no
+      freshness or reachability check — the gap that broke the scan dispatch in
+      #381. Single-source the path set across both scripts. Tracking: [#382](https://github.com/TomHennen/wrangle/issues/382)
+- [ ] Divergence-fail guard for the duplicated `govulncheck` version literal
+      (`test/Dockerfile` ↔ `build/actions/go/checks` default), mirroring the
+      zizmor parity guard. Tracking: [#286](https://github.com/TomHennen/wrangle/issues/286)
+- [ ] Single-source the cosign *binary* version (`tools/go.mod` vs the
+      cosign-installer default) so integration-tested and shipped cosign can't
+      drift. Tracking: [#349](https://github.com/TomHennen/wrangle/issues/349)
+
+**Deferred to v0.4+** (sound work, out of the PoC's path):
+
+- Adopter-facing workflow policy via poutine + a wrangle Rego rule pack —
+      transitive pin analysis (`unpinnable_action`), the per-job minimal
+      `permissions:` invariant ([#338](https://github.com/TomHennen/wrangle/issues/338),
+      folded in), and least-privilege rules (sensitive write scopes only on an
+      allowlisted publish/attest job pattern). Its own theme, dogfooded on
+      wrangle and shipped to adopters. Tracking: [#350](https://github.com/TomHennen/wrangle/issues/350)
+- Verify/sign reliability — `bnd` signing retry on transient Sigstore errors ([#369](https://github.com/TomHennen/wrangle/issues/369)).
+- Consumer ergonomics — `release:` collector for npm/go ([#314](https://github.com/TomHennen/wrangle/issues/314)), wrangle as `verifier.id` ([#317](https://github.com/TomHennen/wrangle/issues/317)).
+- Additional scan tools — actionlint ([#344](https://github.com/TomHennen/wrangle/issues/344)); shared SARIF-adapter helper ([#408](https://github.com/TomHennen/wrangle/issues/408), [#279](https://github.com/TomHennen/wrangle/issues/279)).
+- Go build knobs — validation-only sub-shape ([#239](https://github.com/TomHennen/wrangle/issues/239)), PR-build cost knob ([#245](https://github.com/TomHennen/wrangle/issues/245)).
+- `tools.lock` manifest ([#264](https://github.com/TomHennen/wrangle/issues/264)) — still marginal at current tool count.
+- Dependency-graph submission ([#385](https://github.com/TomHennen/wrangle/issues/385)) — a Dependabot graph snapshot, not a signed predicate; distinct from #420.
+
 ### v1.0.0 — OpenSSF ready
 
 - [ ] OpenSSF contribution proposal


### PR DESCRIPTION
claude: Adds a **v0.3.0** section to `docs/SPEC.md §Roadmap` and drops the "spec changes require an issue first" line from `CLAUDE.md`.

## v0.3.0 — Make the VSA mean something

A proof-of-concept release organized around one demonstrable claim: the VSA should mean *"scanned, has an SBOM, clean,"* not just *"build provenance."* Today the release PolicySets already require SBOM/OSV tenets, but nothing produces and signs the attestations those tenets consume.

**Track A — the VSA loop:** #420 (emit signed scan attestations — the missing producer side) → #372 (deliver to the GitHub attestation store) → #328 (make the PolicySets satisfiable) → #181 (bundle) → #354 (rides along — #420 stresses the multi-tenet signer-match surface).

**Track B — internal footguns:** the cheap wrangle-own guards not covered by `wrangle-lint`/the third-party drift guard — #382 (self-ref nested pin freshness), #286 (govulncheck parity guard), #349 (single-source the cosign binary version).

**Deferred to v0.4:** the adopter-facing poutine + wrangle Rego workflow-policy pack (#350, with #338's per-job permissions invariant folded in, plus least-privilege allowlist rules) — promoted to its own theme; reliability (#369), consumer ergonomics (#314/#317), and the long tail.

### Notes for review

- This reflects a scoping discussion, not just the prior GitHub milestone — the v0.3.0 milestone is now stale against it (issues to add/remove are noted in the discussion; not touched here).
- `#387` (immutable tags) already shipped via #418, so it's not in scope.
- The dropped CLAUDE.md line is a deliberate process change (roadmap edits like this one shouldn't need a prior issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)