### PR TITLE
Add divergence guard for the govulncheck version literal

### DIFF
--- a/test/test_govulncheck_pin_consistency.bats
+++ b/test/test_govulncheck_pin_consistency.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+# Divergence guard for the govulncheck version, which lives in two places with
+# no shared source: test/Dockerfile's GOVULNCHECK_VERSION (what the unit suite
+# installs and exercises) and the govulncheck-version default in
+# build/actions/go/checks/action.yml (what adopters' builds run). The Dockerfile
+# comment asserts they match; this fails closed when they don't, so the version
+# the tests prove out can't drift from the one wrangle ships.
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    export REPO_ROOT
+}
+
+@test "govulncheck version agrees between test/Dockerfile and the go checks action default" {
+    cd "$REPO_ROOT"
+
+    local dockerfile_version action_version
+    dockerfile_version="$(grep -E '^ARG GOVULNCHECK_VERSION=' test/Dockerfile \
+        | head -1 | sed -E 's/.*=(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+    # The default: line belonging to the govulncheck-version input; awk scopes to
+    # that block so a sibling input's default (e.g. gofmt's) can't be picked up.
+    action_version="$(awk '/^  govulncheck-version:/{f=1} f && /default:/{print; exit}' \
+        build/actions/go/checks/action.yml \
+        | sed -E 's/.*"(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/')"
+
+    [ -n "$dockerfile_version" ]  # guard against the extraction silently matching nothing
+    [ -n "$action_version" ]
+
+    if [ "$dockerfile_version" != "$action_version" ]; then
+        printf 'govulncheck version drift: test/Dockerfile=%s, go checks action default=%s\n' \
+            "$dockerfile_version" "$action_version" >&2
+        return 1
+    fi
+}


### PR DESCRIPTION
## What

Adds `test/test_govulncheck_pin_consistency.bats`, a hard divergence-fail test that asserts the govulncheck version matches across the two places it lives with no shared source:

- `test/Dockerfile` → `ARG GOVULNCHECK_VERSION` (the version the unit suite installs and exercises)
- `build/actions/go/checks/action.yml` → the `govulncheck-version` input default (the version adopters' builds run)

The Dockerfile comment already *asserts* these match, but nothing enforced it — so a one-sided bump could pass tests against one version while shipping another. The guard fails closed on drift.

## Why

Closes #286 (the v0.3 Track B footgun guards). Mirrors the existing zizmor `requirements.txt ↔ action.yml` parity guard and the `test_thirdparty_pin_consistency.bats` cross-cutting pattern: same `test/` placement (auto-discovered by the `bats` Makefile target), same `setup()`/`REPO_ROOT` idiom, same fail-with-diagnostic style. The `default:` extraction is awk-scoped to the `govulncheck-version` block so a sibling input's default can't be mismatched.

## Note on the slsa-verifier half of #286

#286 also named the `slsa-verifier` installer pin "across several workflow files." That pin no longer exists anywhere in the repo — not in workflows, examples, or install scripts. The ampel migration (R9 in `docs/ampel_research.md`) retired wrangle's slsa-verifier-based install-time verification; ampel/bnd/cosign now come from `tools/go.mod`. With no duplicate literal left to guard, the govulncheck guard is the complete remaining work for #286, so this PR closes it.

## Testing

Validated the extraction and the negative (divergence) case directly; both files currently resolve to the same version, and a simulated one-sided bump trips the guard. The full containerized `bats`/`shellcheck` suite runs in CI.

https://claude.ai/code/session_01HbtDwskSbKspLq9BdgUeve