### PR TITLE
Walk nested self-ref pins in bump_action_pins and check_pin_ancestry

### DIFF
--- a/test/test_bump_action_pins.bats
+++ b/test/test_bump_action_pins.bats
@@ -372,6 +372,32 @@ EOF
     ! grep -q '^set +f' "$REPO_ROOT/tools/bump_action_pins.sh"
 }
 
+@test "bump_action_pins: bumps nested self-ref pins in composites, not just workflows" {
+    # The footgun this guards: a nested pin in actions/ or build/ ageing while
+    # only .github/workflows/ got bumped. Recursion must reach both.
+    mkdir -p actions/scan build/actions/go/release
+    cat > .github/workflows/w.yml <<EOF
+jobs:
+  scan:
+    uses: TomHennen/wrangle/actions/scan@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    cat > actions/scan/action.yml <<EOF
+runs:
+  steps:
+    - uses: TomHennen/wrangle/tools/zizmor@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    cat > build/actions/go/release/action.yml <<EOF
+runs:
+  steps:
+    - uses: TomHennen/wrangle/build/actions/go@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    run "$SCRIPT" "$NEW_SHA"
+    [[ "$status" -eq 0 ]]
+    grep -q "actions/scan@${NEW_SHA}" .github/workflows/w.yml
+    grep -q "tools/zizmor@${NEW_SHA}" actions/scan/action.yml
+    grep -q "build/actions/go@${NEW_SHA}" build/actions/go/release/action.yml
+}
+
 @test "bump_action_pins: only mixed-SHA files are rewritten when some pins already match target" {
     # File with a mix of SHAs — must be rewritten so all pins reach target.
     cat > .github/workflows/mixed.yml <<EOF

--- a/test/test_check_pin_ancestry.bats
+++ b/test/test_check_pin_ancestry.bats
@@ -59,3 +59,30 @@ pin_workflow() {
     run bash -c "cd '$REPO' && '$SCRIPT'"
     [ "$status" -eq 0 ]
 }
+
+@test "check_pin_ancestry: FAILS on an orphaned nested pin in a composite (actions/)" {
+    # The pin lives in actions/, not .github/workflows/ — the gap that let the
+    # scan dispatch break. The walk must reach it.
+    commit "$REPO" A >/dev/null
+    git -C "$REPO" checkout -q -b feature
+    local b; b="$(commit "$REPO" B)"
+    git -C "$REPO" checkout -q -
+    commit "$REPO" C >/dev/null
+    mkdir -p "$REPO/actions/scan"
+    printf '      - uses: TomHennen/wrangle/tools/zizmor@%s # pin\n' "$b" \
+        > "$REPO/actions/scan/action.yml"
+    run bash -c "cd '$REPO' && '$SCRIPT'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *UNREACHABLE* ]]
+}
+
+@test "check_pin_ancestry: ignores placeholder shas in non-YAML files" {
+    # .bats fixtures and shell scripts carry placeholder self-ref shas; the
+    # YAML-only filter keeps them from being treated as real pins.
+    commit "$REPO" A >/dev/null
+    mkdir -p "$REPO/tools"
+    printf 'uses: TomHennen/wrangle/actions/scan@%s\n' \
+        "0000000000000000000000000000000000000000" > "$REPO/tools/example.bats"
+    run bash -c "cd '$REPO' && '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}

--- a/test/test_self_ref_pin_paths.bats
+++ b/test/test_self_ref_pin_paths.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+# tools/self_ref_pin_paths.sh is the single source of the directories that may
+# hold wrangle self-reference pins. Its whole point is that bump_action_pins.sh
+# (freshness) and check_pin_ancestry.sh (reachability) walk the *same* set — a
+# nested pin one tool bumps but the other never validates is exactly the #381
+# footgun. These tests fail closed if either consumer stops sourcing it or the
+# set diverges, since a hardcoded copy in either script would silently re-open
+# that gap.
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    LIB="$REPO_ROOT/tools/self_ref_pin_paths.sh"
+}
+
+@test "self_ref_pin_paths: emits the expected non-empty path set" {
+    # shellcheck source=../tools/self_ref_pin_paths.sh
+    source "$LIB"
+    mapfile -t paths < <(wrangle_self_ref_pin_paths)
+    [ "${#paths[@]}" -gt 0 ]
+    printf '%s\n' "${paths[@]}" | grep -qx '.github/workflows'
+    printf '%s\n' "${paths[@]}" | grep -qx 'actions'
+    printf '%s\n' "${paths[@]}" | grep -qx 'build'
+    printf '%s\n' "${paths[@]}" | grep -qx 'tools'
+}
+
+@test "self_ref_pin_paths: both pin tools source it rather than hardcoding paths" {
+    grep -q 'source .*self_ref_pin_paths.sh' "$REPO_ROOT/tools/bump_action_pins.sh"
+    grep -q 'source .*self_ref_pin_paths.sh' "$REPO_ROOT/tools/check_pin_ancestry.sh"
+}

--- a/tools/bump_action_pins.sh
+++ b/tools/bump_action_pins.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # tools/bump_action_pins.sh — Rewrite TomHennen/wrangle/...@<sha> action refs
-# in .github/workflows/ to a target SHA (default: current HEAD).
+# to a target SHA (default: current HEAD). Walks every tree that may carry such
+# pins (the shared tools/self_ref_pin_paths.sh set), so a nested pin inside a
+# composite is bumped alongside the workflow pins rather than aging on its own.
 #
 # Wrangle's reusable workflows pin to local composite actions via
 # fully-qualified SHA refs because GitHub resolves `uses: ./` relative
@@ -26,7 +28,6 @@
 #
 # Env overrides (escape hatch for forks / testing):
 #   WRANGLE_PINS_REPO   — repo prefix to match (default: TomHennen/wrangle)
-#   WRANGLE_PINS_DIR    — directory to walk (default: .github/workflows)
 #   WRANGLE_PINS_BRANCH — branch label to write into the comment.
 #                         Default detection (in order):
 #                           1. If target_sha is reachable from `main` (i.e.,
@@ -55,7 +56,10 @@ if [[ -z "$REPO_ROOT" ]]; then
 fi
 
 PINS_REPO="${WRANGLE_PINS_REPO:-TomHennen/wrangle}"
-PINS_DIR="${WRANGLE_PINS_DIR:-.github/workflows}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=self_ref_pin_paths.sh
+source "$SCRIPT_DIR/self_ref_pin_paths.sh"
 
 if [[ $# -gt 1 ]]; then
     printf 'Usage: %s [<sha>]\n' "$0" >&2
@@ -124,17 +128,27 @@ new_suffix="@${target_sha} # ${escaped_branch} ${escaped_date}"
 match='\(^[[:space:]]*-\{0,1\}[[:space:]]*uses:[[:space:]]*'"$escaped_repo"'/[^@[:space:]]*\)@[0-9a-f]\{40\}\([[:space:]]*#.*\)\{0,1\}'
 replace='\1'"$new_suffix"
 
-# Expand the workflow-file glob inside a subshell so the `set +f` toggle
-# is unconditionally scoped — even if collection fails, the parent stays
-# noglob. Files then iterate in the parent with `set -f` still on.
+# Resolve the pin-path set against this clone, skipping trees it lacks.
+mapfile -t pin_paths < <(wrangle_self_ref_pin_paths)
+search_dirs=()
+for rel in "${pin_paths[@]}"; do
+    [[ -d "$REPO_ROOT/$rel" ]] && search_dirs+=("$REPO_ROOT/$rel")
+done
+
+# Expand the YAML glob inside a subshell so the `set +f` toggle is
+# unconditionally scoped — even if collection fails, the parent stays noglob.
+# `globstar` recurses so nested composite action.yml files are found, not only
+# the flat workflows dir. Files then iterate in the parent with `set -f` on.
 files=()
 while IFS= read -r f; do
     files+=("$f")
 done < <(
     set +f
-    shopt -s nullglob
-    for g in "$REPO_ROOT/$PINS_DIR"/*.yml "$REPO_ROOT/$PINS_DIR"/*.yaml; do
-        [[ -f "$g" ]] && printf '%s\n' "$g"
+    shopt -s nullglob globstar
+    for base in "${search_dirs[@]}"; do
+        for g in "$base"/**/*.yml "$base"/**/*.yaml; do
+            [[ -f "$g" ]] && printf '%s\n' "$g"
+        done
     done
 )
 

--- a/tools/check_pin_ancestry.sh
+++ b/tools/check_pin_ancestry.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 set -f
 
 # tools/check_pin_ancestry.sh — fail if any wrangle self-reference action pin
-# under .github/workflows is not reachable from HEAD.
+# is not reachable from HEAD. Walks every tree that may carry such pins (the
+# shared tools/self_ref_pin_paths.sh set), not just .github/workflows, so a
+# nested pin in a composite is held to the same reachability invariant.
 #
 # Why this exists: a "bootstrap pin" (see test/integration/SPEC.md §Known
 # limitations) points a nested `TomHennen/wrangle/...@<sha>` self-reference at a
@@ -25,27 +27,38 @@ set -f
 
 REPO_PREFIX="${WRANGLE_PINS_REPO:-TomHennen/wrangle}"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=self_ref_pin_paths.sh
+source "$SCRIPT_DIR/self_ref_pin_paths.sh"
+
 repo_root="$(git rev-parse --show-toplevel)" || {
     printf 'check_pin_ancestry: not inside a git work tree\n' >&2
     exit 2
 }
-workflows_dir="${WRANGLE_WORKFLOWS_DIR:-$repo_root/.github/workflows}"
 
-if [[ ! -d "$workflows_dir" ]]; then
-    printf 'check_pin_ancestry: no workflows dir at %s\n' "$workflows_dir" >&2
+mapfile -t pin_paths < <(wrangle_self_ref_pin_paths)
+search_dirs=()
+for rel in "${pin_paths[@]}"; do
+    [[ -d "$repo_root/$rel" ]] && search_dirs+=("$repo_root/$rel")
+done
+if [[ ${#search_dirs[@]} -eq 0 ]]; then
+    printf 'check_pin_ancestry: none of the pin paths exist under %s\n' "$repo_root" >&2
     exit 2
 fi
 
 # Collect the unique 40-hex shas pinned on a TomHennen/wrangle/...@<sha> ref.
+# Restricted to YAML so action/workflow files are searched but shell scripts,
+# SPEC.md, and .bats fixtures (which carry placeholder shas) can't false-match.
 # The prefix's '.' is escaped so an org/repo name can't act as a regex wildcard.
 escaped_prefix="$(printf '%s' "$REPO_PREFIX" | sed 's/\./\\./g')"
 mapfile -t shas < <(
-    grep -rhoE "${escaped_prefix}/[^@[:space:]]+@[0-9a-f]{40}" "$workflows_dir" 2>/dev/null \
+    grep -rhoE --include='*.yml' --include='*.yaml' \
+        "${escaped_prefix}/[^@[:space:]]+@[0-9a-f]{40}" "${search_dirs[@]}" 2>/dev/null \
         | grep -oE '[0-9a-f]{40}$' | sort -u
 )
 
 if [[ ${#shas[@]} -eq 0 ]]; then
-    printf 'check_pin_ancestry: no %s pins found under %s\n' "$REPO_PREFIX" "$workflows_dir"
+    printf 'check_pin_ancestry: no %s pins found in the pin paths\n' "$REPO_PREFIX"
     exit 0
 fi
 

--- a/tools/self_ref_pin_paths.sh
+++ b/tools/self_ref_pin_paths.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# tools/self_ref_pin_paths.sh — single source of the repo-relative directories
+# that may hold wrangle self-reference action pins
+# (uses: TomHennen/wrangle/...@<sha>).
+#
+# Both bump_action_pins.sh (freshness) and check_pin_ancestry.sh (reachability)
+# walk this exact set, so a nested pin inside a composite — like actions/scan's
+# tools/{zizmor,scorecard,dependency-review} refs — can't age or orphan unseen
+# the way one would if the two tools disagreed on where to look.
+#
+# Usage: source this file, then collect the paths into an array.
+#   source "$SCRIPT_DIR/self_ref_pin_paths.sh"
+#   mapfile -t dirs < <(wrangle_self_ref_pin_paths)
+# Callers resolve each entry against the git toplevel and skip any that are
+# absent, so trees a given clone lacks are simply not searched.
+wrangle_self_ref_pin_paths() {
+    printf '%s\n' \
+        .github/workflows \
+        actions \
+        build \
+        tools
+}


### PR DESCRIPTION
## What

Both pin tools walked only `.github/workflows/`, so the nested `TomHennen/wrangle/...@<sha>` self-references that live inside composites — today, `actions/scan/action.yml`'s `tools/{zizmor,scorecard,dependency-review}` pins — were:

- never bumped by `bump_action_pins.sh` (they silently aged), and
- never validated by `check_pin_ancestry.sh` (one could point at an orphaned SHA with no red CI).

This is the gap that broke the scan dispatch in #381 (a workflow-pin bump moved `actions/scan` to a SHA whose nested zizmor pin still resolved a pre-fix tree).

## How

- **New `tools/self_ref_pin_paths.sh`** — single source of the directory set (`.github/workflows`, `actions`, `build`, `tools`), exposed as a sourced function (matching the `lib/sanitize.sh` sourced-helper pattern). Both tools consume it, so they can't disagree on where pins live (DEP_MGMT §Drift).
- **`bump_action_pins.sh`** — recurses with `globstar` across the set so nested `action.yml` files are bumped alongside workflow pins; keeps the `set +f`-in-a-subshell exception-safety pattern.
- **`check_pin_ancestry.sh`** — walks the set via `grep -r`.
- Both restrict matching to `*.yml`/`*.yaml`, so shell scripts, `SPEC.md`, and `.bats` fixtures carrying placeholder shas can't false-match. The single-dir override env vars (`WRANGLE_PINS_DIR`, `WRANGLE_WORKFLOWS_DIR`) are removed — they had no consumers and the path set is now the source of truth.

## Tests

- `test_self_ref_pin_paths.bats` (new) — asserts the set is non-empty and that **both** tools source the shared lib rather than hardcoding paths (fails closed if either drifts).
- `test_bump_action_pins.bats` — new case: nested pins in `actions/` and `build/` get bumped, not just workflows.
- `test_check_pin_ancestry.bats` — new cases: an orphaned nested pin in `actions/` fails; placeholder shas in non-YAML files are ignored.

Verified manually: `check_pin_ancestry.sh` now sees the `actions/scan` pins (2 unique shas) and passes; `bump_action_pins.sh` recursively bumps pins under `.github/workflows`, `actions/`, and `build/` in a scratch repo while leaving third-party pins alone. shellcheck/bats run in CI.

## Note for the reviewer — placement

I put the shared lib in `tools/` (adjacent to its only two consumers, both dev-tooling scripts at `tools/` root) rather than `lib/`. CLAUDE.md describes `lib/` as helpers shared across actions/tools, but its examples (`env.sh`, `sanitize.sh`, `download_verify.sh`) are adopter-facing *runtime* helpers; this is dev-only. Happy to move it to `lib/` if you'd prefer the literal reading.

Closes #382.

https://claude.ai/code/session_01HbtDwskSbKspLq9BdgUeve

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbtDwskSbKspLq9BdgUeve)_