### PR TITLE
chore(release): bump adopter example pins to @v0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
 ```

--- a/actions/scan/README.md
+++ b/actions/scan/README.md
@@ -23,7 +23,7 @@ jobs:
       actions: read
       contents: read
       security-events: write   # SARIF upload to the Security tab
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
 ```
 
 Findings appear in the Security tab; the run's step summary shows an overview.
@@ -49,7 +49,7 @@ The May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical exam
 The `tools` input is a space-separated list. Default: `"osv zizmor scorecard:info dependency-review wrangle-lint"`. Suffix with `:info` to make a tool's findings non-blocking.
 
 ```yaml
-uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
 with:
   tools: "osv zizmor"   # skip Scorecard and dependency-review
 ```

--- a/actions/verify-vsa/README.md
+++ b/actions/verify-vsa/README.md
@@ -19,7 +19,7 @@ Drop it into your publish job between `download-artifact` and the publish step:
     path: dist/
 
 # Pin by release tag; a SHA-pinned build's VSA fails this gate (see below).
-- uses: TomHennen/wrangle/actions/verify-vsa@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+- uses: TomHennen/wrangle/actions/verify-vsa@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
   with:
     path: dist/
     resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -35,7 +35,7 @@ Consumers verify the image with one command — ampel fetches the VSA straight f
 
 ```bash
 ampel verify --subject sha256:<digest> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
   --collector oci:<imagename>@sha256:<digest> \
   --context expectedResourceUri:<imagename>@sha256:<digest> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/build/actions/go/README.md
+++ b/build/actions/go/README.md
@@ -17,7 +17,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
 ```
@@ -72,7 +72,7 @@ Downstream users verify a release archive with one command. Download the archive
 
 ```bash
 ampel verify --subject <archive> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
   --attestation <archive>.intoto.jsonl \
   --context expectedResourceUri:pkg:golang/<module-path>@<version> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -17,7 +17,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       release-events: tag-only   # only tag pushes publish
@@ -58,7 +58,7 @@ Publishing happens in your workflow, so two things there are load-bearing — bo
 2. **Verify before you publish** — run wrangle's [`verify-vsa`](../../../actions/verify-vsa/README.md) action between `download-artifact` and `npm publish`, piping the build's `resource-uri` output, so the exact bytes leaving the runner are the bytes that passed wrangle's policy:
 
    ```yaml
-   - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+   - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
      with:
        path: dist/
        resource-uri: ${{ needs.build.outputs.resource-uri }}
@@ -83,7 +83,7 @@ Downstream users verify the released tarball with one command. Download the tarb
 
 ```bash
 ampel verify --subject <tarball> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
   --attestation <tarball>.intoto.jsonl \
   --context expectedResourceUri:pkg:npm/<name>@<version> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -17,7 +17,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       release-events: tag-only   # only tag pushes publish
@@ -58,7 +58,7 @@ Publishing happens in your workflow, so two things there are load-bearing — bo
 2. **Verify before you publish** — run wrangle's [`verify-vsa`](../../../actions/verify-vsa/README.md) action between `download-artifact` and the publish step, piping the build's `resource-uri` output, so the exact bytes leaving the runner are the bytes that passed wrangle's policy:
 
    ```yaml
-   - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+   - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
      with:
        path: dist/
        resource-uri: ${{ needs.build.outputs.resource-uri }}
@@ -79,7 +79,7 @@ Downstream users verify a dist file with one command. Download the wheel (or sdi
 
 ```bash
 ampel verify --subject <dist-file> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
   --attestation <dist-file>.intoto.jsonl \
   --context expectedResourceUri:pkg:pypi/<name>@<version> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/build/actions/shell/README.md
+++ b/build/actions/shell/README.md
@@ -13,7 +13,7 @@ jobs:
       contents: read
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
 ```
 
 PRs, pushes, and manual dispatches all run the same checks — there's no release step to gate.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -10,7 +10,7 @@ Pin by release **tag** (`@vX.Y.Z`), with an inline zizmor exception on that one
 line:
 
 ```yaml
-uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
 ```
 
 wrangle's release tags are

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -690,7 +690,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
 ```
 
 This is the entire file an adopter needs. No secrets, no configuration, no dependencies to manage.

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -41,7 +41,7 @@ from the release, then:
 
 ```bash
 ampel verify --subject <artifact> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
   --attestation <artifact>.intoto.jsonl \
   --context expectedResourceUri:<resourceUri from the table above> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>
@@ -52,7 +52,7 @@ download step:
 
 ```bash
 ampel verify --subject sha256:<digest> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
   --collector oci:<imagename>@sha256:<digest> \
   --context expectedResourceUri:<imagename>@sha256:<digest> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/gh_workflow_examples/build_and_publish_containers.yml
+++ b/gh_workflow_examples/build_and_publish_containers.yml
@@ -23,7 +23,7 @@ jobs:
       attestations: write  # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: PATH/TO/FOLDER/WITH/Dockerfile
       imagename: ghcr.io/${{ github.repository }}/YOUR_IMAGE_NAME

--- a/gh_workflow_examples/build_go.yml
+++ b/gh_workflow_examples/build_go.yml
@@ -36,7 +36,7 @@ jobs:
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       # release-events: tag-only         # default; uncomment + change to "non-pull-request" or "main-and-tags" for early failure detection on non-tag events

--- a/gh_workflow_examples/build_npm.yml
+++ b/gh_workflow_examples/build_npm.yml
@@ -50,7 +50,7 @@ jobs:
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       release-events: tag-only          # only tag pushes publish (recommended default)
@@ -94,7 +94,7 @@ jobs:
 
       # Verify the downloaded tarball against wrangle's signed VSA — the
       # full policy verdict — before any bytes leave this runner.
-      - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+      - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
         with:
           path: dist/
           resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/gh_workflow_examples/build_python.yml
+++ b/gh_workflow_examples/build_python.yml
@@ -47,7 +47,7 @@ jobs:
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       release-events: tag-only          # only tag pushes publish (recommended default)
@@ -72,7 +72,7 @@ jobs:
 
       # Verify the downloaded dist against wrangle's signed VSA — the
       # full policy verdict — before any bytes leave this runner.
-      - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+      - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
         with:
           path: dist/
           resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/gh_workflow_examples/build_shell.yml
+++ b/gh_workflow_examples/build_shell.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
     # with:
     #   scan-path: "."       # optional: subdirectory to scan (default: repo root)
     #   bats-path: ""        # optional: path to bats tests (default: auto-detect)

--- a/gh_workflow_examples/check_source_change.yml
+++ b/gh_workflow_examples/check_source_change.yml
@@ -14,4 +14,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable


### PR DESCRIPTION
claude: Step 1 of cutting **v0.2.2** (RELEASING.md §2). Bumps every adopter-facing wrangle pin (`uses:` + ampel `--policy`) from `@v0.2.1` → `@v0.2.2` across examples/READMEs/FAQ/SPEC/verifying_artifacts. `./test.sh` green (drift + pin-consistency guards pass). After this merges, the release is cut at the merge commit; the `@v0.2.2` tag resolves to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)