### PR TITLE
Pin cosign-installer's cosign-release to the cosign in tools/go.mod

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -253,6 +253,9 @@ jobs:
       # needs registry auth. Same pin as the verify job's cosign-installer — bump
       # in lockstep.
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Must match the cosign built from tools/go.mod — the version the suite tests.
+          cosign-release: v3.0.6
 
       # Use the job's own GITHUB_TOKEN (packages: write above), like the build
       # job — not the passed gh_token, which zizmor's secrets-outside-env flags

--- a/build/actions/go/release/action.yml
+++ b/build/actions/go/release/action.yml
@@ -202,6 +202,9 @@ runs:
 
     - name: Install Cosign (for syft signature verification)
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      with:
+        # Must match the cosign built from tools/go.mod — the version the suite tests.
+        cosign-release: v3.0.6
 
     - name: Install syft
       shell: bash

--- a/build/actions/npm/action.yml
+++ b/build/actions/npm/action.yml
@@ -171,6 +171,9 @@ runs:
 
     - name: Install Cosign (for syft signature verification)
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      with:
+        # Must match the cosign built from tools/go.mod — the version the suite tests.
+        cosign-release: v3.0.6
 
     - name: Install syft
       shell: bash

--- a/build/actions/python/action.yml
+++ b/build/actions/python/action.yml
@@ -175,6 +175,9 @@ runs:
 
     - name: Install Cosign (for syft signature verification)
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      with:
+        # Must match the cosign built from tools/go.mod — the version the suite tests.
+        cosign-release: v3.0.6
 
     - name: Install syft
       shell: bash

--- a/test/test_cosign_version_consistency.bats
+++ b/test/test_cosign_version_consistency.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+# Divergence guard for the cosign version. wrangle's unit/integration suites
+# exercise the cosign built from tools/go.mod, while the publish workflows
+# install cosign via sigstore/cosign-installer. If the installer's cosign and
+# go.mod's cosign drift, a flag/output change can pass the suite against one
+# version and break a real release on another. This pins every cosign-installer
+# step's cosign-release to go.mod's version and fails closed when they diverge.
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    export REPO_ROOT
+}
+
+@test "every cosign-installer step pins cosign-release to the cosign in tools/go.mod" {
+    cd "$REPO_ROOT"
+
+    local gomod_ver
+    gomod_ver="$(grep -E 'github.com/sigstore/cosign/v[0-9]+ v[0-9]' tools/go.mod \
+        | head -1 | sed -E 's#.* (v[0-9]+\.[0-9]+\.[0-9]+).*#\1#')"
+    [ -n "$gomod_ver" ]  # guard against the extraction silently matching nothing
+
+    # Count cosign-installer steps vs. cosign-release pins matching go.mod across
+    # wrangle's own trees (gh_workflow_examples are adopter samples, excluded).
+    # Equal-and-nonzero means every installer is pinned to the tested version;
+    # a new installer without the pin, or a mismatched/stale pin, drops a match.
+    local installers matches
+    installers="$(grep -rhE --include='*.yml' --include='*.yaml' --exclude-dir=fixtures \
+        'uses:[[:space:]]*sigstore/cosign-installer@' .github/workflows build actions | wc -l | tr -d ' ')"
+    matches="$(grep -rhE --include='*.yml' --include='*.yaml' --exclude-dir=fixtures \
+        "cosign-release:[[:space:]]*${gomod_ver}\$" .github/workflows build actions | wc -l | tr -d ' ')"
+
+    [ "$installers" -gt 0 ]
+    if [ "$installers" -ne "$matches" ]; then
+        printf 'cosign drift: %s cosign-installer step(s), %s pinned to go.mod cosign %s\n' \
+            "$installers" "$matches" "$gomod_ver" >&2
+        return 1
+    fi
+}


### PR DESCRIPTION
## What

wrangle's unit/integration suites exercise the cosign built from `tools/go.mod` (v3.0.6, Dependabot-bumped). The four publish steps installed cosign via `sigstore/cosign-installer@v4.1.2` with **no `cosign-release:` input**, so production ran the installer's *default* cosign — which can drift from the tested version, letting a cosign flag/output change pass the suite but break a real release.

This pins `cosign-release: v3.0.6` on all four installer steps and adds a divergence-fail bats test.

## Files

- `.github/workflows/build_and_publish_container.yml`, `build/actions/{go/release,python,npm}/action.yml` — add `cosign-release: v3.0.6`.
- `test/test_cosign_version_consistency.bats` — extracts the cosign version from `tools/go.mod` and asserts every `cosign-installer` step in wrangle's own trees pins `cosign-release` to it (counts installer steps vs. matching pins; equal-and-nonzero). A new installer without the pin, or a stale pin after a go.mod bump, fails closed. Mirrors the zizmor/govulncheck guard pattern; `gh_workflow_examples/` and `fixtures/` are excluded.

## Upstream check (per CLAUDE.md "read upstream docs")

Confirmed against `sigstore/cosign-installer@v4.1.2`'s `action.yml`: the input is **`cosign-release`**, format `vX.Y.Z` (rejects `< v2.0.0`). Notably its default is *already* `v3.0.6` — identical to go.mod today — so this doesn't change which cosign runs now; it makes the choice **explicit and guarded** so a future go.mod bump *or* an installer bump (which moves the implicit default) can't silently desync the tested and shipped cosign.

## Testing

Verified locally: go.mod extraction yields `v3.0.6`; 4 installer steps ↔ 4 matching pins (aligned); a simulated stale version drops matches → guard fails. All four edited YAML files parse. shellcheck/bats run in CI.

## Note

The v0.3 Track B roadmap boxes in `docs/SPEC.md` for #286, #382, and (with this) #349 are all complete but still show `- [ ]` — this repo doesn't flip them in feature PRs, so I left them. Happy to send a one-line doc PR checking all three off if you want.

No merge until you `LGTM`.

Closes #349.

https://claude.ai/code/session_01HbtDwskSbKspLq9BdgUeve

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbtDwskSbKspLq9BdgUeve)_