### PR TITLE
feat(wrangle-lint): WL006 — flag missing github-actions Dependabot ecosystem

### DIFF
--- a/tools/wrangle-lint/SPEC.md
+++ b/tools/wrangle-lint/SPEC.md
@@ -24,6 +24,7 @@ wrangle-specific policy (see [Scope](#scope)).
 | WL003 | error | A `github-actions` entry globs `directory`/`directories` with `**` — it does not recurse into nested `action.yml` (and `/**` provokes duplicate PRs) |
 | WL004 | error | A composite `action.yml` directory in the repo is absent from the `github-actions` `directories` — its pins drift from the workflow copies |
 | WL005 | warning | An updates entry has no `cooldown.default-days >= 7` — bumps land before the community can surface a supply-chain attack (7 days is a recommended baseline) |
+| WL006 | error | Workflows under `.github/workflows` pin actions with `uses:`, but no `github-actions` ecosystem is configured — those action pins never get update PRs |
 
 ## Scope
 
@@ -48,8 +49,9 @@ tool-error cases a real scanner never produces on demand.
 
 ## Known limitations
 
-- Flagging a *missing* ecosystem the adopter needs (e.g. they build with
-  `build_and_publish_npm` but have no `npm` entry) is tracked in #409.
+- WL006 flags a missing `github-actions` ecosystem when workflows pin actions;
+  inferring *other* missing ecosystems from build workflows or manifests (e.g.
+  `build_and_publish_npm` but no `npm` entry) is still tracked in #409.
 - A *missing* `.github/dependabot.yml` has no line to anchor a comment to and is
   not inline-suppressible; the present-but-no-`updates` variant is (it's a real
   file), as is every other finding.

--- a/tools/wrangle-lint/main.go
+++ b/tools/wrangle-lint/main.go
@@ -15,6 +15,8 @@
 //	       github-actions directories — its pins drift from the workflow copies.
 //	WL005  an updates entry has no cooldown.default-days >= 7 — bumps land
 //	       before the community can surface a supply-chain attack.
+//	WL006  workflows pin actions with `uses:` but no github-actions ecosystem
+//	       is configured — those action pins never get update PRs.
 //
 // Findings are suppressible with an inline comment carrying a justification:
 //
@@ -64,6 +66,7 @@ var rules = map[string]ruleMeta{
 	"WL003": {"error", "7.0", "github-actions directory glob does not recurse into composites"},
 	"WL004": {"error", "7.0", "Composite action directory not covered by Dependabot"},
 	"WL005": {"warning", "4.0", "Dependabot cooldown missing or shorter than the adoption delay"},
+	"WL006": {"error", "7.0", "Workflows pin actions but no github-actions Dependabot ecosystem is configured"},
 }
 
 type finding struct {
@@ -136,6 +139,76 @@ func compositeDirs(srcDir string) (map[string]bool, error) {
 		return nil
 	})
 	return found, err
+}
+
+// externalActionRef matches a pinned reference to an external action or
+// reusable workflow (`owner/repo...@ref`) — the kind Dependabot's
+// github-actions ecosystem raises update PRs for. Local (`./...`) and
+// `docker://` refs are excluded: Dependabot does not bump them.
+var externalActionRef = regexp.MustCompile(`^[^./][^@]*/[^@]*@`)
+
+// usesExternalAction reports whether any `uses:` in the node tree pins an
+// external action or reusable workflow.
+func usesExternalAction(n *yaml.Node) bool {
+	n = resolve(n)
+	if n == nil {
+		return false
+	}
+	if n.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			v := resolve(n.Content[i+1])
+			if n.Content[i].Value == "uses" && v != nil && v.Kind == yaml.ScalarNode {
+				val := strings.TrimSpace(v.Value)
+				if !strings.HasPrefix(val, "docker://") && externalActionRef.MatchString(val) {
+					return true
+				}
+			}
+			if usesExternalAction(v) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, c := range n.Content {
+		if usesExternalAction(c) {
+			return true
+		}
+	}
+	return false
+}
+
+// workflowsPinActions reports whether any .github/workflows file pins an
+// external action or reusable workflow — the universal case for needing a
+// github-actions Dependabot ecosystem.
+func workflowsPinActions(srcDir string) (bool, error) {
+	dir := filepath.Join(srcDir, ".github", "workflows")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || (!strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".yaml")) {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return false, err
+		}
+		// A malformed workflow is the security scanners' concern, not this
+		// config audit's — skip it rather than failing the whole lint closed.
+		root, err := parseFirstDoc(content, name)
+		if err != nil || root == nil {
+			continue
+		}
+		if usesExternalAction(root) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 type dirRef struct {
@@ -231,6 +304,7 @@ func checkDependabot(ymlPath, uri, srcDir string) ([]finding, error) {
 		return nil, err
 	}
 
+	hasGitHubActions := false
 	for _, entry := range updates.Content {
 		entry = resolve(entry)
 		if entry.Kind != yaml.MappingNode {
@@ -250,6 +324,7 @@ func checkDependabot(ymlPath, uri, srcDir string) ([]finding, error) {
 		if eco != "github-actions" {
 			continue
 		}
+		hasGitHubActions = true
 
 		dirs := entryDirectories(entry)
 		hasGlob := false
@@ -288,6 +363,20 @@ func checkDependabot(ymlPath, uri, srcDir string) ([]finding, error) {
 				"Composite action '%s/action.yml' is not covered by the github-actions entry, so "+
 					"its pinned actions never get update PRs. Add \"%s\" to that entry's `directories`.",
 				c, c)})
+		}
+	}
+
+	if !hasGitHubActions {
+		pin, err := workflowsPinActions(srcDir)
+		if err != nil {
+			return nil, err
+		}
+		if pin {
+			findings = append(findings, finding{"WL006", uri, ymlPath, updates.Line,
+				"Workflows under .github/workflows pin actions with `uses:`, but the Dependabot " +
+					"config has no `github-actions` ecosystem entry, so those action pins never get " +
+					"update PRs. Add an `updates:` entry with `package-ecosystem: \"github-actions\"` " +
+					"(see gh_workflow_examples/dependabot.yml)."})
 		}
 	}
 	return findings, nil

--- a/tools/wrangle-lint/main.go
+++ b/tools/wrangle-lint/main.go
@@ -148,7 +148,9 @@ func compositeDirs(srcDir string) (map[string]bool, error) {
 var externalActionRef = regexp.MustCompile(`^[^./][^@]*/[^@]*@`)
 
 // usesExternalAction reports whether any `uses:` in the node tree pins an
-// external action or reusable workflow.
+// external action or reusable workflow. It matches a `uses` key at any depth
+// (step-level and reusable-workflow job-level), accepting the rare benign
+// false positive of a `with:` input literally named `uses`.
 func usesExternalAction(n *yaml.Node) bool {
 	n = resolve(n)
 	if n == nil {
@@ -372,6 +374,8 @@ func checkDependabot(ymlPath, uri, srcDir string) ([]finding, error) {
 			return nil, err
 		}
 		if pin {
+			// updates.Line is the first entry's line (a sequence node), which is
+			// the anchor a suppression comment must sit directly above.
 			findings = append(findings, finding{"WL006", uri, ymlPath, updates.Line,
 				"Workflows under .github/workflows pin actions with `uses:`, but the Dependabot " +
 					"config has no `github-actions` ecosystem entry, so those action pins never get " +

--- a/tools/wrangle-lint/main_test.go
+++ b/tools/wrangle-lint/main_test.go
@@ -229,7 +229,7 @@ updates:
     cooldown:
       default-days: 7
 `,
-				".github/workflows/release.yml": "on: push\njobs:\n  b:\n    uses: TomHennen/wrangle/.github/workflows/build_go.yml@abc123\n",
+				".github/workflows/release.yml": "on: push\njobs:\n  b:\n    uses: octo-org/ci/.github/workflows/build.yml@v1\n",
 			},
 			want: "WL006",
 		},

--- a/tools/wrangle-lint/main_test.go
+++ b/tools/wrangle-lint/main_test.go
@@ -172,6 +172,82 @@ updates:
 			files: map[string]string{".github/dependabot.yml": "---\n---\nversion: 2\nupdates:\n  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n"},
 			want:  "WL005",
 		},
+		{
+			name: "WL006 workflows pin actions but no github-actions ecosystem",
+			files: map[string]string{
+				".github/dependabot.yml": `version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    cooldown:
+      default-days: 7
+`,
+				".github/workflows/ci.yml": "on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n",
+			},
+			want: "WL006",
+		},
+		{
+			name: "WL006 not fired when github-actions ecosystem is present",
+			files: map[string]string{
+				".github/dependabot.yml":   cleanConfig,
+				".github/workflows/ci.yml": "on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n",
+			},
+			notWant: "WL006",
+		},
+		{
+			name: "WL006 not fired when no workflow pins an external action",
+			files: map[string]string{
+				".github/dependabot.yml": `version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    cooldown:
+      default-days: 7
+`,
+				".github/workflows/ci.yml": "on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/local\n",
+			},
+			notWant: "WL006",
+		},
+		{
+			name: "WL006 not fired with no workflows at all",
+			files: map[string]string{".github/dependabot.yml": `version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    cooldown:
+      default-days: 7
+`},
+			notWant: "WL006",
+		},
+		{
+			name: "WL006 detects reusable workflow pins",
+			files: map[string]string{
+				".github/dependabot.yml": `version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    cooldown:
+      default-days: 7
+`,
+				".github/workflows/release.yml": "on: push\njobs:\n  b:\n    uses: TomHennen/wrangle/.github/workflows/build_go.yml@abc123\n",
+			},
+			want: "WL006",
+		},
+		{
+			name: "WL006 suppressible with a justified ignore",
+			files: map[string]string{
+				".github/dependabot.yml": `version: 2
+updates:
+  # wrangle-lint: ignore WL006 -- action pins managed in a central repo
+  - package-ecosystem: "gomod"
+    directory: "/"
+    cooldown:
+      default-days: 7
+`,
+				".github/workflows/ci.yml": "on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n",
+			},
+			notWant: "WL006",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tools/wrangle-lint/main_test.go
+++ b/tools/wrangle-lint/main_test.go
@@ -234,6 +234,34 @@ updates:
 			want: "WL006",
 		},
 		{
+			name: "WL006 detects a .yaml-extension workflow",
+			files: map[string]string{
+				".github/dependabot.yml": `version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    cooldown:
+      default-days: 7
+`,
+				".github/workflows/ci.yaml": "on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n",
+			},
+			want: "WL006",
+		},
+		{
+			name: "WL006 not fired for a docker:// uses ref",
+			files: map[string]string{
+				".github/dependabot.yml": `version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    cooldown:
+      default-days: 7
+`,
+				".github/workflows/ci.yml": "on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: docker://alpine@sha256:abc\n",
+			},
+			notWant: "WL006",
+		},
+		{
 			name: "WL006 suppressible with a justified ignore",
 			files: map[string]string{
 				".github/dependabot.yml": `version: 2


### PR DESCRIPTION
Closes the **github-actions ecosystem-coverage** angle of #409 (the owner's "third, highest-priority signal" — github-actions itself).

## What

Adds **WL006**: when any `.github/workflows/*` file pins an external action or reusable workflow with `uses:`, but the Dependabot config has no `github-actions` ecosystem entry, those action pins — including the `uses: TomHennen/wrangle/...` self-reference — never get update PRs. WL006 flags that gap.

This is the *universal* signal from #409: every adopter has at least the calling workflow, and it's high-confidence with **no manifest heuristics**, so it fits the wrangle-lint SPEC's "every rule is a universal Dependabot best practice" scope.

## How

- Detection parses each workflow with the existing `yaml.v3` walker (no grep) and matches external `owner/repo…@ref` refs. Local `./…` and `docker://…` refs are excluded — Dependabot doesn't raise PRs for them.
- A malformed workflow is **skipped**, not failed-closed: workflow validity is the security scanners' concern, not this config audit's. (The audited `dependabot.yml` itself still fails closed on parse error, unchanged.)
- `error` / security-severity 7.0, consistent with WL003/WL004. Inline-suppressible like every other rule (`# wrangle-lint: ignore WL006 -- justification`), anchored to the `updates:` list.

## Scope decision (the rest of #409)

Deliberately **out of scope**, left tracked in #409:

- **Build-workflow inference** (`build_and_publish_npm` → `npm`, etc.) — relies on wrangle-specific knowledge, which would break the SPEC's universal-scope framing.
- **Manifest detection** (`go.mod`/`package.json` present, ecosystem absent) — universal but heuristic (vendored trees, monorepos, generated files), `:info`-only; weakest signal, most false-positive surface.

SPEC limitation note updated to say exactly this.

## Tests

- 6 new `TestRules` cases: fires; not-fired-when-present; local-`./`-only; no-workflows; reusable-workflow pins; justified-suppression.
- Full Go suite + `TestDogfood` (wrangle's own config has a `github-actions` entry, stays clean) green; `gofmt` clean.

## Dogfooding follow-up

`tomhennen/wrangle-test` ships a `gomod`-only `dependabot.yml` while running the wrangle workflows — exactly the gap WL006 catches. A companion change adds a `github-actions` entry there so its CI stays green once this lands. (Surfaced in the #409 comment.)

https://claude.ai/code/session_01CeEvgJzssFRkHnT1NwCKe1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeEvgJzssFRkHnT1NwCKe1)_