### PR TITLE
Reorganize README: move Ecosystems section before How Wrangle Works

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ but we can make it easier.  Copy
 Once in place it will create a PR whenever a dependency (including Wrangle!) needs to
 be updated.
 
+## Ecosystems
+
+Go, Python, npm, and Container each run the full pipeline and produce an attested, verifiable artifact; Shell and source-only run the checks only. Pick the row matching your project:
+
+| Ecosystem | README | Example |
+|-----------|--------|---------|
+| Go — uses your `.goreleaser.yml` | [README](build/actions/go/README.md) | [build_go.yml](gh_workflow_examples/build_go.yml) with example goreleaser configs in [pure-Go](gh_workflow_examples/build_go.goreleaser.yml) or [cgo cross-compile](gh_workflow_examples/build_go_cgo.goreleaser.yml) |
+| Python — uv or pip, auto-detected | [README](build/actions/python/README.md) | [build_python.yml](gh_workflow_examples/build_python.yml) |
+| npm — npm or pnpm, auto-detected | [README](build/actions/npm/README.md) | [build_npm.yml](gh_workflow_examples/build_npm.yml) |
+| Container | [README](build/actions/container/README.md) | [build_and_publish_containers.yml](gh_workflow_examples/build_and_publish_containers.yml) |
+| Shell | — | [build_shell.yml](gh_workflow_examples/build_shell.yml) |
+| Source-only — no build, scan only | [README](actions/scan/README.md) | [check_source_change.yml](gh_workflow_examples/check_source_change.yml) |
+
 ## How Wrangle Works
 
 Behind that one workflow call, wrangle runs your code through a pipeline of well-known security
@@ -109,19 +122,6 @@ Wrangle is a supply-chain security tool, so its defaults lean toward safety:
   `permissions:` block, so the scan and test jobs run read-only while only the publish, sign,
   and attest jobs hold write or token scopes (`contents: write`, `packages: write`,
   `id-token: write`, `attestations: write`) — and only for the length of that one job.
-
-## Ecosystems
-
-Go, Python, npm, and Container each run the full pipeline and produce an attested, verifiable artifact; Shell and source-only run the checks only. Pick the row matching your project:
-
-| Ecosystem | README | Example |
-|-----------|--------|---------|
-| Go — uses your `.goreleaser.yml` | [README](build/actions/go/README.md) | [build_go.yml](gh_workflow_examples/build_go.yml) with example goreleaser configs in [pure-Go](gh_workflow_examples/build_go.goreleaser.yml) or [cgo cross-compile](gh_workflow_examples/build_go_cgo.goreleaser.yml) |
-| Python — uv or pip, auto-detected | [README](build/actions/python/README.md) | [build_python.yml](gh_workflow_examples/build_python.yml) |
-| npm — npm or pnpm, auto-detected | [README](build/actions/npm/README.md) | [build_npm.yml](gh_workflow_examples/build_npm.yml) |
-| Container | [README](build/actions/container/README.md) | [build_and_publish_containers.yml](gh_workflow_examples/build_and_publish_containers.yml) |
-| Shell | — | [build_shell.yml](gh_workflow_examples/build_shell.yml) |
-| Source-only — no build, scan only | [README](actions/scan/README.md) | [check_source_change.yml](gh_workflow_examples/check_source_change.yml) |
 
 ## FAQ
 


### PR DESCRIPTION
## What does this PR do?

Reorders the README.md to move the "Ecosystems" section earlier in the document, placing it immediately after the Dependabot setup instructions and before the "How Wrangle Works" section. This improves the document flow by presenting ecosystem-specific guidance (Go, Python, npm, Container, Shell, Source-only) to readers sooner, before diving into the internal mechanics of the pipeline.

The content itself is unchanged — only the section position is moved.

## Checklist

- [x] Spec updated if contracts changed (N/A — documentation only)
- [x] `make test` passes locally (N/A — documentation only)
- [x] CI passes on this PR
- [x] No new `continue-on-error` without justification in a comment (N/A)
- [x] No `@main` refs in `uses:` lines (N/A)
- [x] Tool `SPEC.md` exists/updated for any tool changes (N/A)

https://claude.ai/code/session_01NhLT5kzhEj91sXy7168egh