### PR TITLE
docs: instruct PRs to close the issues they fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ Adapters do NOT receive secrets (env stripped by the orchestrator). If a tool ne
 - Branch from `main`, descriptive branch names.
 - All PRs must pass CI (`make test` via GitHub Actions); shellcheck cleanly; actionlint cleanly.
 - **No merge without an `LGTM` from the repository owner.** A PR may be merged only after the owner has commented `LGTM` on it; given that approval, it may be merged once CI is green. Green CI alone is never authorization to merge.
+- If a PR fully fixes a tracked issue, close it from the PR description with a GitHub closing keyword (`Fixes #NNN`) so the issue isn't left open after merge; if you're unsure whether the PR fully resolves the issue, ask the owner rather than guessing.
 - Update the README and `gh_workflow_examples/` if the adoption interface changes.
 - For personal-environment preferences that shouldn't be checked in (your local test command, your shell, your editor's quirks), use `CLAUDE.local.md` — it's git-ignored.
 


### PR DESCRIPTION
## What

Adds a bullet to the **Contributing process** section of `CLAUDE.md`: when a PR fully fixes a tracked issue, close it from the PR description with a GitHub closing keyword (`Fixes #NNN`), and ask the owner when unsure whether the PR fully resolves the issue.

## Why

We've shipped several PRs that addressed tracked issues, but the issues stayed open after merge because nothing in the description linked them for auto-close. Using GitHub's native closing keywords means the issue closes on merge, so the tracker stays accurate without manual cleanup. The "ask if unsure" clause keeps partial fixes from silently closing issues they don't fully resolve.

Note: this PR is itself a process/docs change, not a fix for a tracked issue, so it has no `Fixes #NNN` of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)