### PR TITLE
test(verify-vsa): pin WRANGLE_BIN_DIR so the ampel shim isn't shadowed

### DIFF
--- a/actions/verify-vsa/test.bats
+++ b/actions/verify-vsa/test.bats
@@ -30,6 +30,10 @@ printf '%s\n' "\$*" >> "$AMPEL_LOG"
 exit "\${AMPEL_SHIM_EXIT:-0}"
 EOF
     chmod +x "$TMP/bin/ampel"
+    # env.sh (sourced by verify_vsa.sh) prepends WRANGLE_BIN_DIR ahead of the
+    # shim, so pin it at the shim dir — otherwise a real ampel left in the
+    # default ./.wrangle/bin by a prior integration run shadows the shim.
+    export WRANGLE_BIN_DIR="$TMP/bin"
     PATH="$TMP/bin:$PATH"
 }
 


### PR DESCRIPTION
## What

`actions/verify-vsa/test.bats` `setup()` now exports `WRANGLE_BIN_DIR="$TMP/bin"` (the shim dir), in addition to prepending it to `PATH`.

## Why

The behavioral tests install an `ampel` shim at the front of `PATH`, but `verify_vsa.sh` sources `lib/env.sh`, which re-prepends `WRANGLE_BIN_DIR` (default `./.wrangle/bin`) *ahead* of the shim. `ampel` is resolved by PATH lookup (no absolute path), so on a dev machine where a prior `./test.sh integration` left a real `ampel` in `./.wrangle/bin` — which `test.sh` bind-mounts into the container — the real binary shadows the shim and chokes on the placeholder VSA fixture. CI never sees it because `.wrangle/` is git-ignored, so a CI checkout has no real binary to shadow with.

Only the `verify-vsa` suite had this hole: the two `actions/verify/` suites that drive `env.sh`-sourcing scripts already pin `WRANGLE_BIN_DIR` at their shim dirs, and no other shim-using bats run a script that sources `env.sh`. The existing `"fails when ampel is not on PATH"` test already overrode `WRANGLE_BIN_DIR` per-test for exactly this reason — this generalizes that to the whole suite.

## Verification

Reproduced the precondition by planting a failing "real" `ampel` in `./.wrangle/bin`, then ran the suite with `WRANGLE_BIN_DIR`/`RUNNER_TEMP` unset:

- **Pre-fix:** tests 11, 12, 14, 15 fail (`status` ≠ 0 / shim never invoked). The issue named 11/14/15; the `WRANGLE_VSA_NON_STRICT` case (12), added after the issue was filed, has the same root cause.
- **Post-fix:** all 21 pass.

Also confirmed the mechanism directly against the real `lib/env.sh`: with `WRANGLE_BIN_DIR` unset the planted binary wins; pinned at the shim dir, the shim wins.

Docker wasn't available in the authoring environment, so the full containerized `./test.sh` couldn't run here — verified with a standalone bats-core 1.13.0. Change is test-only (one `export` in `setup()`).

Fixes #378.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMfME38C2Le29i2yyPnfTu)_