### PR TITLE
docs(examples): clarify caller permissions are a ceiling, not per-job grants

### DIFF
--- a/gh_workflow_examples/build_and_publish_containers.yml
+++ b/gh_workflow_examples/build_and_publish_containers.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   build-and-publish:
+    # Maximum the caller grants; wrangle's internal jobs each drop to the subset they actually need.
     permissions:
       contents: read       # checkout
       id-token: write      # OIDC for keyless Cosign signing

--- a/gh_workflow_examples/build_go.yml
+++ b/gh_workflow_examples/build_go.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   build:
+    # Maximum the caller grants; wrangle's internal jobs each drop to the subset they actually need.
     permissions:
       contents: write   # goreleaser creates the Release + wrangle's verify job attaches the VSA
       id-token: write   # OIDC for Sigstore signing

--- a/gh_workflow_examples/build_npm.yml
+++ b/gh_workflow_examples/build_npm.yml
@@ -44,6 +44,7 @@ on:
 
 jobs:
   build:
+    # Maximum the caller grants; wrangle's internal jobs each drop to the subset they actually need.
     permissions:
       contents: write   # wrangle's verify job attaches the VSA to the release on tags; GitHub validates at startup even on non-tag runs
       id-token: write   # OIDC for Sigstore signing

--- a/gh_workflow_examples/build_python.yml
+++ b/gh_workflow_examples/build_python.yml
@@ -41,6 +41,7 @@ on:
 
 jobs:
   build:
+    # Maximum the caller grants; wrangle's internal jobs each drop to the subset they actually need.
     permissions:
       contents: write   # wrangle's verify job attaches the VSA to the release on tags; GitHub validates at startup even on non-tag runs
       id-token: write   # OIDC for Sigstore signing


### PR DESCRIPTION
## What

Adds a one-line comment above the `permissions:` block in each example caller workflow (`build_python.yml`, `build_npm.yml`, `build_go.yml`, `build_and_publish_containers.yml`):

```yaml
# Maximum the caller grants; wrangle's internal jobs each drop to the subset they actually need.
permissions:
  contents: write   # ...
```

## Why

The caller's build job lists the union of permissions the reusable workflow may need across its internal jobs (notably `contents: write`). At a glance that reads as over-broad for a tool that preaches least privilege — a reader can mistake the ceiling the caller grants for what any single job actually holds. The comment names the relationship so the optic doesn't invite a "why does the security tool want write on every build?" reaction. No behavior change; comment-only.

## Testing

`make workflowstyle` passes. zizmor isn't installed in the authoring sandbox, but the change is comment-only and cannot alter zizmor findings — CI runs the full suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_0149J7Ty5JHCv7zbUCfBnpii)_