### PR TITLE
feat(verify): deliver the signed VSA to the GitHub attestation store

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -225,8 +225,9 @@ jobs:
     # requesting it here would be a startup-failing escalation; the bundle ships
     # as a workflow artifact and an OCI referrer, not a release asset.
     permissions:
-      id-token: write    # bnd keyless-signs the VSA via this workflow's OIDC identity
-      packages: write    # pull provenance and push the bundle referrer to ghcr
+      id-token: write       # bnd keyless-signs the VSA via this workflow's OIDC identity
+      attestations: write   # post the VSA to the GitHub attestation store
+      packages: write       # pull provenance and push the bundle referrer to ghcr
     steps:
       # Round-tripping the bundle through ghcr needs registry auth. Same pin as
       # the attest job's cosign-installer — bump in lockstep.

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -247,7 +247,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@af98635202c7f54e86413fe6b8d7a5cece6d3b41 # feat/bundle-single-intoto-181 2026-06-16 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@d051550ae788c89dd08b9d00a5127c5601b2f756 # feat/store-vsa-372 2026-06-16 (bootstrap PR HEAD; bump after merge)
         with:
           subjects: ${{ needs.build.outputs.digest }}
           policy: policies/wrangle-provenance-container-v1.hjson

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -247,7 +247,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@d051550ae788c89dd08b9d00a5127c5601b2f756 # feat/store-vsa-372 2026-06-16 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@0a91dfc4fbaae75585c1596f1f602fe8d7fc52e2 # feat/store-vsa-372 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           subjects: ${{ needs.build.outputs.digest }}
           policy: policies/wrangle-provenance-container-v1.hjson

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -420,7 +420,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@af98635202c7f54e86413fe6b8d7a5cece6d3b41 # feat/bundle-single-intoto-181 2026-06-16 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@d051550ae788c89dd08b9d00a5127c5601b2f756 # feat/store-vsa-372 2026-06-16 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.release.outputs.dist-files }}
           policy: policies/wrangle-provenance-go-v1.hjson

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -420,7 +420,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@d051550ae788c89dd08b9d00a5127c5601b2f756 # feat/store-vsa-372 2026-06-16 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@0a91dfc4fbaae75585c1596f1f602fe8d7fc52e2 # feat/store-vsa-372 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.release.outputs.dist-files }}
           policy: policies/wrangle-provenance-go-v1.hjson

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -401,8 +401,9 @@ jobs:
     needs: [guard, gate, release, attest]
     runs-on: ubuntu-latest
     permissions:
-      id-token: write    # bnd keyless-signs each VSA via this workflow's OIDC identity
-      contents: write    # attach the bundle to the release on tag pushes
+      id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
+      attestations: write   # post each VSA to the GitHub attestation store
+      contents: write       # attach the bundle to the release on tag pushes
     outputs:
       bundle-artifact-name: go-bundle-${{ needs.release.outputs.shortname }}
     steps:

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -319,8 +319,9 @@ jobs:
     needs: [guard, gate, build, attest]
     runs-on: ubuntu-latest
     permissions:
-      id-token: write    # bnd keyless-signs each VSA via this workflow's OIDC identity
-      contents: write    # attach the bundle to the release on tag pushes
+      id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
+      attestations: write   # post each VSA to the GitHub attestation store
+      contents: write       # attach the bundle to the release on tag pushes
     outputs:
       bundle-artifact-name: npm-bundle-${{ needs.build.outputs.shortname }}
     steps:

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -338,7 +338,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@d051550ae788c89dd08b9d00a5127c5601b2f756 # feat/store-vsa-372 2026-06-16 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@0a91dfc4fbaae75585c1596f1f602fe8d7fc52e2 # feat/store-vsa-372 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.build.outputs.dist-files }}
           policy: policies/wrangle-provenance-npm-v1.hjson

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -338,7 +338,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@af98635202c7f54e86413fe6b8d7a5cece6d3b41 # feat/bundle-single-intoto-181 2026-06-16 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@d051550ae788c89dd08b9d00a5127c5601b2f756 # feat/store-vsa-372 2026-06-16 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.build.outputs.dist-files }}
           policy: policies/wrangle-provenance-npm-v1.hjson

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -329,7 +329,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@af98635202c7f54e86413fe6b8d7a5cece6d3b41 # feat/bundle-single-intoto-181 2026-06-16 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@d051550ae788c89dd08b9d00a5127c5601b2f756 # feat/store-vsa-372 2026-06-16 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.build.outputs.dist-files }}
           policy: policies/wrangle-provenance-python-v1.hjson

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -329,7 +329,7 @@ jobs:
           path: provenance/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@d051550ae788c89dd08b9d00a5127c5601b2f756 # feat/store-vsa-372 2026-06-16 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@0a91dfc4fbaae75585c1596f1f602fe8d7fc52e2 # feat/store-vsa-372 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.build.outputs.dist-files }}
           policy: policies/wrangle-provenance-python-v1.hjson

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -310,8 +310,9 @@ jobs:
     needs: [guard, gate, build, attest]
     runs-on: ubuntu-latest
     permissions:
-      id-token: write    # bnd keyless-signs each VSA via this workflow's OIDC identity
-      contents: write    # attach the bundle to the release on tag pushes
+      id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
+      attestations: write   # post each VSA to the GitHub attestation store
+      contents: write       # attach the bundle to the release on tag pushes
     outputs:
       bundle-artifact-name: python-bundle-${{ needs.build.outputs.shortname }}
     steps:

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -5,16 +5,19 @@
 # forget. bnd signs each VSA keyless via the CALLING workflow's OIDC identity;
 # consumers verify with cosign --certificate-identity-regexp.
 #
-# Caller permissions: id-token: write (sign); contents: write only on the
-# tag/publish job (attach to release); packages: write only with oci-target.
+# Caller permissions: id-token: write (sign); attestations: write (post each VSA
+# to the GitHub attestation store); contents: write only on the tag/publish job
+# (attach to release); packages: write only with oci-target.
 name: Wrangle Verify
 description: >
   Verify a release's provenance against a wrangle PolicySet using ampel, sign
   one SLSA VSA per dist subject, and emit one per-artifact
   <artifact>.intoto.jsonl bundle per subject (provenance + that subject's VSA)
   into bundle-out — uploaded as one workflow artifact and attached to the GitHub
-  release on a tag push. With oci-target set (container build type) the bundle is
-  also pushed to the registry as an OCI referrer, which needs packages: write.
+  release on a tag push. Each signed VSA is also posted to the GitHub attestation
+  store for by-digest discovery (needs attestations: write). With oci-target set
+  (container build type) the VSA is also pushed to the registry as an OCI
+  referrer, which needs packages: write.
 
 inputs:
   subjects:
@@ -122,6 +125,10 @@ runs:
         BUNDLE_IN: ${{ inputs.bundle-in }}
         BUNDLE_OUT: ${{ inputs.bundle-out }}
         OCI_TARGET: ${{ inputs.oci-target }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        # bnd push github authenticates to the attestation store with this token;
+        # the attestations: write permission rides on it.
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         "$WRANGLE_ROOT/actions/verify/run_verify.sh" run
 

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -4,13 +4,16 @@
 #
 # Subcommands:
 #   run    emit -> sign -> append per subject in one process, so an unsigned VSA
-#          never lives on disk across a step boundary. With OCI_TARGET set, each
-#          signed VSA is also pushed by image digest as its own OCI referrer.
+#          never lives on disk across a step boundary. Each signed VSA is also
+#          posted to the GitHub attestation store (by-digest discovery); with
+#          OCI_TARGET set it is additionally pushed as its own OCI referrer.
 #   attach upload every bundle to the GitHub release for the current tag, if any.
 #
 # Arg-builder functions are pure so unit tests can assert the CLI shape offline.
 # Inputs arrive as env vars: SUBJECTS (newline-separated), POLICY, COLLECTOR,
-# FAIL, CONTEXT, BUNDLE_IN, BUNDLE_OUT, and optional ATTESTATION, OCI_TARGET.
+# FAIL, CONTEXT, BUNDLE_IN, BUNDLE_OUT, GITHUB_REPOSITORY (store push target),
+# GITHUB_TOKEN (bnd reads it to auth the store push), and optional ATTESTATION,
+# OCI_TARGET.
 
 set -euo pipefail
 set -f  # disable globbing — processes external input
@@ -79,6 +82,14 @@ wrangle_cosign_attach_args() {
     printf '%s\n' attach attestation \
         --attestation "$1" \
         "$2"
+}
+
+# Build the bnd arg vector that posts a signed VSA to the GitHub attestation
+# store. $1 is <owner>/<repo>; $2 the bnd-signed VSA file. The store is keyed
+# by subject digest, giving consumers by-digest discovery via ampel's github:
+# collector.
+wrangle_bnd_push_args() {
+    printf '%s\n' push github "$1" "$2"
 }
 
 # Split SUBJECTS into an array, dropping blank lines. Fail closed on an empty
@@ -171,6 +182,15 @@ wrangle_push_bundle() {
     wrangle_retry_once /dev/null cosign "${args[@]}"
 }
 
+# Post the signed VSA at $1 to the GitHub attestation store (all build types).
+# Provenance is already in the store from attest-build-provenance, so only the
+# VSA is pushed. Fails closed: a missing by-digest VSA is a real delivery gap.
+wrangle_push_store() {
+    local args
+    mapfile -t args < <(wrangle_bnd_push_args "$GITHUB_REPOSITORY" "$1")
+    wrangle_retry_once /dev/null bnd "${args[@]}"
+}
+
 # Verify every subject, sign its VSA, and write one bundle per subject into
 # BUNDLE_OUT — all in one process so an unsigned VSA never crosses a boundary.
 wrangle_run() {
@@ -208,10 +228,12 @@ wrangle_run() {
         cp "$seed" "$bundle"
         wrangle_verify_emit_vsa "$subject" "$tmp_vsa"
         wrangle_sign_vsa "$tmp_vsa"
-        # Flatten bnd's pretty statement to one JSON line: appended to the bundle
-        # and pushed alone as the referrer (cosign attach rejects multi-line).
+        # Flatten bnd's pretty statement to one JSON line: appended to the bundle,
+        # posted to the store, and pushed alone as the OCI referrer (cosign attach
+        # rejects multi-line).
         jq -c . "$tmp_vsa" > "$vsa_line"
         cat "$vsa_line" >> "$bundle"
+        wrangle_push_store "$vsa_line"
         wrangle_push_bundle "$vsa_line"
     done
     rm -f "$tmp_vsa" "$vsa_line" "$seed"

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -45,12 +45,30 @@ wrangle_retry_once() {
     "$@" > "$out"
 }
 
+# Emit the ampel subject flag for one subject, one arg per line. A digest-form
+# subject (algo:hex, e.g. a container) passes through; a file subject is hashed
+# to sha256 ourselves and passed as --subject-hash so the VSA subject carries a
+# single sha256 digest — ampel's file hasher emits sha256+sha512, but the GitHub
+# attestation store rejects a multi-digest subject.
+wrangle_subject_arg() {
+    local subject="$1" digest
+    if [[ "$subject" =~ ^[a-z0-9]+:[a-f0-9]+$ ]]; then
+        printf -- '--subject=%s\n' "$subject"
+        return 0
+    fi
+    # A missing/unreadable subject file must fail closed, not yield an empty hash.
+    digest="$(sha256sum "$subject")" || return 1
+    printf -- '--subject-hash=sha256:%s\n' "${digest%% *}"
+}
+
 # Build the ampel verify arg vector for one subject, one arg per line for
 # mapfile. $1 is the subject; $2 the unsigned-VSA output path.
 wrangle_ampel_verify_args() {
     local subject="$1" results_path="$2"
-    local args=(verify
-        --subject="$subject"
+    # Capture (not process-substitute) so a subject-hashing failure aborts.
+    local subject_arg
+    subject_arg="$(wrangle_subject_arg "$subject")"
+    local args=(verify "$subject_arg"
         --collector="$COLLECTOR"
         --policy="$(wrangle_resolve_policy "$POLICY")"
         --exit-code="$FAIL"
@@ -113,6 +131,12 @@ wrangle_verify_emit_vsa() {
     local subject="$1" results_path="$2"
     local args report rc=0
     mapfile -t args < <(wrangle_ampel_verify_args "$subject" "$results_path")
+    # Fail closed: an aborted arg builder (e.g. a subject file we couldn't hash)
+    # yields a short/empty vector, never a silently mis-verified subject.
+    if [[ "${args[0]:-}" != "verify" || "${args[1]:-}" != --subject* ]]; then
+        printf 'wrangle: could not build ampel args for %s\n' "$subject" >&2
+        return 2
+    fi
 
     # Capture the report to a file before sanitizing: ampel's --exit-code carries
     # the policy verdict, and piping straight into the truncating sanitizer could

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -73,6 +73,32 @@ teardown() {
     printf '%s\n' "${args[@]}" | grep -qx -- "--policy=/etc/wrangle/policy.hjson"
 }
 
+# --- subject arg (single-sha256 subject) ---
+
+@test "run_verify: subject_arg hashes a file subject to a single sha256 --subject-hash" {
+    # The store rejects a multi-digest subject; passing the file as a precomputed
+    # sha256 hash keeps the VSA subject single-digest (ampel's file hasher would
+    # otherwise add sha512).
+    printf 'CONTENT\n' > "$TEST_DIR/blob"
+    local want; want="$(sha256sum "$TEST_DIR/blob" | cut -d' ' -f1)"
+    run wrangle_subject_arg "$TEST_DIR/blob"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "--subject-hash=sha256:$want" ]]
+}
+
+@test "run_verify: subject_arg passes a digest subject through as --subject" {
+    # A container subject is already a digest; ampel synthesizes a single-digest
+    # descriptor from it, so it needs no re-hashing.
+    run wrangle_subject_arg "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "--subject=sha256:0000000000000000000000000000000000000000000000000000000000000000" ]]
+}
+
+@test "run_verify: subject_arg fails closed on an unreadable file subject" {
+    run wrangle_subject_arg "$TEST_DIR/does-not-exist.tgz"
+    [[ "$status" -ne 0 ]]
+}
+
 # --- ampel arg vector ---
 
 @test "run_verify: ampel args carry the core verify flags for the given subject" {
@@ -471,8 +497,10 @@ STUB
     cat > "$TEST_DIR/ampel" <<STUB
 #!/bin/bash
 # Emit a one-line JSON unsigned VSA naming the subject, where --results-path points.
+# File subjects are hashed by run_verify to --subject-hash; echo that back so the
+# test can prove the per-subject VSA reached the bundle and the store.
 subj=""
-for a in "\$@"; do case "\$a" in --subject=*) subj="\${a#--subject=}";; esac; done
+for a in "\$@"; do case "\$a" in --subject-hash=*) subj="\${a#--subject-hash=}";; --subject=*) subj="\${a#--subject=}";; esac; done
 for a in "\$@"; do case "\$a" in --results-path=*) printf '{"unsigned":"%s"}\n' "\$subj" > "\${a#--results-path=}";; esac; done
 printf 'report\n'
 STUB
@@ -490,25 +518,34 @@ STUB
     : > "$GITHUB_STEP_SUMMARY"
     : > "$TEST_DIR/pushed"
     printf '{"provenance":1}\n' > "$BUNDLE_IN"
-    export SUBJECTS=$'dist/a.tgz\ndist/b.whl'
+    # Real file subjects: run_verify sha256-hashes each into a single-digest
+    # --subject-hash, so the VSA's subject can't carry two digests (the store
+    # rejects that). Distinct bytes -> distinct digests the assertions key on.
+    mkdir -p "$TEST_DIR/dist"
+    printf 'AAA\n' > "$TEST_DIR/dist/a.tgz"
+    printf 'BBB\n' > "$TEST_DIR/dist/b.whl"
+    local ha hb
+    ha="sha256:$(sha256sum "$TEST_DIR/dist/a.tgz" | cut -d' ' -f1)"
+    hb="sha256:$(sha256sum "$TEST_DIR/dist/b.whl" | cut -d' ' -f1)"
+    export SUBJECTS="$TEST_DIR/dist/a.tgz"$'\n'"$TEST_DIR/dist/b.whl"
 
     run "$SCRIPT" run
     [[ "$status" -eq 0 ]]
     # One per-artifact bundle per subject, named <artifact-basename>.intoto.jsonl.
     local a="$BUNDLE_OUT/a.tgz.intoto.jsonl" b="$BUNDLE_OUT/b.whl.intoto.jsonl"
     [[ -f "$a" && -f "$b" ]]
-    # Each subject's signed VSA was posted to the store (one push per subject).
-    grep -q '"signed":{"unsigned":"dist/a.tgz"}' "$TEST_DIR/pushed"
-    grep -q '"signed":{"unsigned":"dist/b.whl"}' "$TEST_DIR/pushed"
+    # Each subject's signed VSA (keyed by its sha256) was posted to the store.
+    grep -q "\"signed\":{\"unsigned\":\"$ha\"}" "$TEST_DIR/pushed"
+    grep -q "\"signed\":{\"unsigned\":\"$hb\"}" "$TEST_DIR/pushed"
     # Each bundle is the seeded provenance line plus exactly that subject's VSA.
     [[ "$(wc -l < "$a")" -eq 2 ]]
     [[ "$(wc -l < "$b")" -eq 2 ]]
     run head -n1 "$a"; [[ "$output" == '{"provenance":1}' ]]
-    grep -q '"signed":{"unsigned":"dist/a.tgz"}' "$a"
-    grep -q '"signed":{"unsigned":"dist/b.whl"}' "$b"
+    grep -q "\"signed\":{\"unsigned\":\"$ha\"}" "$a"
+    grep -q "\"signed\":{\"unsigned\":\"$hb\"}" "$b"
     # A subject's bundle carries only its own VSA, not the other's.
-    ! grep -q '"unsigned":"dist/b.whl"' "$a"
-    ! grep -q '"unsigned":"dist/a.tgz"' "$b"
+    ! grep -q "$hb" "$a"
+    ! grep -q "$ha" "$b"
     # Every line is one JSON object (valid JSONL).
     run jq -e . "$a"; [[ "$status" -eq 0 ]]
     run jq -e . "$b"; [[ "$status" -eq 0 ]]

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -35,6 +35,7 @@ setup() {
     export BUNDLE_IN="$TEST_DIR/provenance.jsonl"
     # bundle-out is the directory the per-artifact bundles are written into.
     export BUNDLE_OUT="$TEST_DIR/bundles"
+    export GITHUB_REPOSITORY="o/r"
     export RUNNER_TEMP="$TEST_DIR"
     # The unsigned-VSA path the arg-vector tests reference.
     VSA="$TEST_DIR/vsa.intoto.jsonl"
@@ -181,6 +182,25 @@ teardown() {
     run "$COSIGN_BIN" download attestation --help
     [[ "$status" -eq 0 ]]
     [[ "$output" == *"download attestation"* ]]
+}
+
+# --- bnd push arg vector (GitHub attestation store) ---
+
+@test "run_verify: bnd push args target the store repo with the signed VSA file" {
+    local vsa="$TEST_DIR/vsa.jsonl"
+    mapfile -t args < <(wrangle_bnd_push_args "owner/repo" "$vsa")
+    [[ "${args[0]}" == "push" ]]
+    [[ "${args[1]}" == "github" ]]
+    # The org/repo is positional, then the bundle file.
+    [[ "${args[2]}" == "owner/repo" ]]
+    [[ "${args[3]}" == "$vsa" ]]
+}
+
+@test "run_verify: bnd push arg vector names a real bnd subcommand" {
+    if [[ ! -x "$BND_BIN" ]]; then skip_or_fail "real bnd not available"; fi
+    run "$BND_BIN" push github --help
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"GitHub attestation store"* ]]
 }
 
 # --- subject parsing ---
@@ -334,6 +354,45 @@ STUB
     [[ "$(wc -l < "$TEST_DIR/cosign-calls")" -eq 2 ]]
 }
 
+# --- push to GitHub attestation store ---
+
+@test "run_verify: push_store invokes bnd push github with the repo and VSA file" {
+    cat > "$TEST_DIR/bnd" <<STUB
+#!/bin/bash
+printf '%s\n' "\$@" > "$TEST_DIR/bnd-args"
+STUB
+    chmod +x "$TEST_DIR/bnd"
+    export PATH="$TEST_DIR:$PATH"
+    export GITHUB_REPOSITORY="owner/repo"
+    local vsa="$TEST_DIR/vsa.jsonl"
+    : > "$vsa"
+    run wrangle_push_store "$vsa"
+    [[ "$status" -eq 0 ]]
+    recorded="$(cat "$TEST_DIR/bnd-args")"
+    [[ "$recorded" == *"push"* ]]
+    [[ "$recorded" == *"github"* ]]
+    [[ "$recorded" == *"owner/repo"* ]]
+    [[ "$recorded" == *"$vsa"* ]]
+}
+
+@test "run_verify: push_store fails closed — a bnd failure fails the step" {
+    # The store is the by-digest delivery, so a push failure is a real delivery
+    # gap and must fail the job (after the one transient retry, so bnd runs twice).
+    cat > "$TEST_DIR/bnd" <<STUB
+#!/bin/bash
+printf 'x\n' >> "$TEST_DIR/bnd-calls"
+exit 7
+STUB
+    chmod +x "$TEST_DIR/bnd"
+    export PATH="$TEST_DIR:$PATH"
+    : > "$TEST_DIR/bnd-calls"
+    local vsa="$TEST_DIR/vsa.jsonl"
+    : > "$vsa"
+    run wrangle_push_store "$vsa"
+    [[ "$status" -ne 0 ]]
+    [[ "$(wc -l < "$TEST_DIR/bnd-calls")" -eq 2 ]]
+}
+
 # --- emit path plumbing (stubbed ampel) ---
 
 @test "run_verify: emit pipes ampel output through the HTML sanitizer" {
@@ -417,16 +476,19 @@ for a in "\$@"; do case "\$a" in --subject=*) subj="\${a#--subject=}";; esac; do
 for a in "\$@"; do case "\$a" in --results-path=*) printf '{"unsigned":"%s"}\n' "\$subj" > "\${a#--results-path=}";; esac; done
 printf 'report\n'
 STUB
-    # bnd "signs" by wrapping the unsigned statement (pretty-printed over two
-    # lines, so the jq -c flatten in run is load-bearing).
+    # bnd "signs" (statement) by wrapping the unsigned statement over two lines
+    # (so the jq -c flatten in run is load-bearing); "push" records the VSA it
+    # was handed so the test can prove the signed statement reached the store.
     cat > "$TEST_DIR/bnd" <<STUB
 #!/bin/bash
+if [[ "\$1" == "push" ]]; then cat "\$4" >> "$TEST_DIR/pushed"; exit 0; fi
 printf '{\n  "signed": '; cat "\$2"; printf '}\n'
 STUB
     chmod +x "$TEST_DIR/ampel" "$TEST_DIR/bnd"
     export PATH="$TEST_DIR:$PATH"
     export GITHUB_STEP_SUMMARY="$TEST_DIR/summary.md"
     : > "$GITHUB_STEP_SUMMARY"
+    : > "$TEST_DIR/pushed"
     printf '{"provenance":1}\n' > "$BUNDLE_IN"
     export SUBJECTS=$'dist/a.tgz\ndist/b.whl'
 
@@ -435,6 +497,9 @@ STUB
     # One per-artifact bundle per subject, named <artifact-basename>.intoto.jsonl.
     local a="$BUNDLE_OUT/a.tgz.intoto.jsonl" b="$BUNDLE_OUT/b.whl.intoto.jsonl"
     [[ -f "$a" && -f "$b" ]]
+    # Each subject's signed VSA was posted to the store (one push per subject).
+    grep -q '"signed":{"unsigned":"dist/a.tgz"}' "$TEST_DIR/pushed"
+    grep -q '"signed":{"unsigned":"dist/b.whl"}' "$TEST_DIR/pushed"
     # Each bundle is the seeded provenance line plus exactly that subject's VSA.
     [[ "$(wc -l < "$a")" -eq 2 ]]
     [[ "$(wc -l < "$b")" -eq 2 ]]
@@ -461,6 +526,7 @@ printf 'report\n'
 STUB
     cat > "$TEST_DIR/bnd" <<STUB
 #!/bin/bash
+[[ "\$1" == "push" ]] && exit 0
 cat "\$2"
 STUB
     # download returns a real provenance DSSE envelope so the seed filter keeps it.
@@ -510,6 +576,7 @@ printf 'report\n'
 STUB
     cat > "$TEST_DIR/bnd" <<STUB
 #!/bin/bash
+[[ "\$1" == "push" ]] && exit 0
 cat "\$2"
 STUB
     _dsse_line "https://slsa.dev/provenance/v1" > "$TEST_DIR/referrers.jsonl"

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -43,6 +43,8 @@ ampel verify --subject sha256:<digest> \
 
 That single command checks — fail-closed — the signature, wrangle's signer identity, that the build ran in *your* repo, and that policy passed at SLSA Build L3. No ampel? See the [artifact verification guide](../../../docs/verifying_artifacts.md) for an equivalent cosign recipe and the full trust model.
 
+The VSA is also posted to your repo's GitHub attestation store, so consumers can fetch it by the image digest via ampel's `--collector github:<your-org>/<your-repo>` — see the [by-digest path](../../../docs/verifying_artifacts.md#by-digest-from-the-github-attestation-store).
+
 The SBOM is also inspectable straight off the image: `docker buildx imagetools inspect --format '{{ json .SBOM.SPDX }}' <image>@<digest>`.
 
 ## Further reading

--- a/build/actions/go/README.md
+++ b/build/actions/go/README.md
@@ -80,6 +80,8 @@ ampel verify --subject <archive> \
 
 That single command checks — fail-closed — the signature, wrangle's signer identity, that the build ran in *your* repo, and that policy passed at SLSA Build L3. The module path is the `module` directive in your `go.mod`. No ampel? See the [artifact verification guide](../../../docs/verifying_artifacts.md) for an equivalent cosign recipe and the full trust model.
 
+The VSA is also posted to your repo's GitHub attestation store, so consumers can fetch it by digest with no download via ampel's `--collector github:<your-org>/<your-repo>` — see the [by-digest path](../../../docs/verifying_artifacts.md#by-digest-from-the-github-attestation-store).
+
 ## Further reading
 
 - [`SPEC.md`](./SPEC.md) — design rationale: tool choices, permissions architecture, cache isolation.

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -91,6 +91,8 @@ ampel verify --subject <tarball> \
 
 That single command checks — fail-closed — the signature, wrangle's signer identity, that the build ran in *your* repo, and that policy passed at SLSA Build L3. Scoped names go in the purl verbatim (`pkg:npm/@scope/pkg@1.2.3`). No ampel? See the [artifact verification guide](../../../docs/verifying_artifacts.md) for an equivalent cosign recipe, npm's registry-side check, and the full trust model.
 
+The VSA is also posted to your repo's GitHub attestation store, so consumers can fetch it by digest with no download via ampel's `--collector github:<your-org>/<your-repo>` — see the [by-digest path](../../../docs/verifying_artifacts.md#by-digest-from-the-github-attestation-store).
+
 ## Further reading
 
 - [`SPEC.md`](./SPEC.md) — design rationale: attestation model (L2 vs L3), tool choices.

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -87,6 +87,8 @@ ampel verify --subject <dist-file> \
 
 That single command checks — fail-closed — the signature, wrangle's signer identity, that the build ran in *your* repo, and that policy passed at SLSA Build L3. The `<name>` is [PEP 503-normalized](https://peps.python.org/pep-0503/#normalized-names). No ampel? See the [artifact verification guide](../../../docs/verifying_artifacts.md) for an equivalent cosign recipe, the PEP 740 path, and the full trust model.
 
+The VSA is also posted to your repo's GitHub attestation store, so consumers can fetch it by digest with no download via ampel's `--collector github:<your-org>/<your-repo>` — see the [by-digest path](../../../docs/verifying_artifacts.md#by-digest-from-the-github-attestation-store).
+
 ## Further reading
 
 - [`SPEC.md`](./SPEC.md) — this action's full specification: inputs, outputs, step sequence, security model.

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -16,7 +16,10 @@ Wrangle produces two attestations for every released artifact:
   own OCI referrer on the image digest (one VSA statement, which round-trips
   cleanly by digest), so `ampel`/`cosign` can fetch it without a download —
   provenance is a separate referrer. The combined `<artifact>.intoto.jsonl`
-  bundle (provenance + VSA) is also uploaded as a workflow artifact.
+  bundle (provenance + VSA) is also uploaded as a workflow artifact. For every
+  build type the VSA is *also* posted to your repo's GitHub attestation store,
+  so a consumer can fetch it by digest with no download — see [by-digest
+  fetch](#by-digest-from-the-github-attestation-store) below.
 
 A consumer's one-command check is the VSA: it carries the full verdict, so
 you trust one signature instead of re-running the policy engine.
@@ -67,6 +70,26 @@ The VSA rides as its own by-digest referrer, so the `oci:` collector finds it
 from just the image reference. The combined `<sha256-digest>.intoto.jsonl`
 bundle (provenance + VSA) is also available from the workflow-run artifacts if
 you'd rather verify from the file: `--collector jsonl:<sha256-digest>.intoto.jsonl`.
+
+### By-digest, from the GitHub attestation store
+
+The VSA also lands in your repo's GitHub attestation store, so ampel's
+`github:` collector fetches it by subject digest with no download — for every
+build type, including a container image by its OCI digest:
+
+```bash
+ampel verify --subject sha256:<digest> \
+  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
+  --collector github:<your-org>/<your-repo> \
+  --context expectedResourceUri:<resourceUri from the table above> \
+  --context sourceRepo:https://github.com/<your-org>/<your-repo>
+```
+
+The `gh attestation verify --predicate-type` filter does **not** accept the VSA
+predicate URI (`https://slsa.dev/verification_summary/v1`) — GitHub returns HTTP
+422 from its filter allowlist — so use ampel (recommended) or an unfiltered `gh
+attestation verify`. The filter only blocks the query; storing and unfiltered
+fetch work.
 
 Pin the policy locator to any wrangle `v*` release tag — it does **not**
 need to match the wrangle version the adopter builds with. The `-v1` in the


### PR DESCRIPTION
Additive store delivery for the signed VSA, stacked on #444.

Each signed VSA is now posted to the repo's GitHub attestation store via `bnd push github "$GITHUB_REPOSITORY" <vsa>`, giving consumers by-digest discovery through ampel's `github:` collector — for **all** build types, including the container image by its OCI digest (resolves #447's discovery gap). Every existing delivery is unchanged: release asset (npm/go/python), OCI VSA referrer (container), workflow artifact.

- **Producer:** new `wrangle_push_store` in `actions/verify/run_verify.sh`, fail-closed via `wrangle_retry_once`. Pushes the single signed VSA statement, not the combined bundle (provenance is already in the store from `attest-build-provenance`).
- **Permissions:** `attestations: write` on the verify job in all four `build_and_publish_*.yml`. Each workflow's `attest` job already grants it, so the caller's grant is no escalation.
- **Docs:** `docs/verifying_artifacts.md` + per-build-type READMEs gain a by-digest `github:` collector path, with the prose caveat that `gh attestation verify --predicate-type https://slsa.dev/verification_summary/v1` returns 422 (GitHub filter allowlist) — use ampel or an unfiltered `gh`.

**Store-write validation:** the spike confirmed reading the store and that `bnd push github` exists; whether GitHub *accepts storing* the VSA predicate is exercised by this PR's dispatch e2e (the POST carries no predicate-type filter, so it's expected to succeed). The consumer by-digest fetch (`ampel verify --collector github:`) runs in the companion repo template, which is external to this repo.

Bootstrap pins for `actions/verify` re-pointed to this PR's action commit.

Part of #420
Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)