### PR TITLE
[OBSOLETE — superseded by #469] docs: add a "where each output is stored" map for adopters

### DIFF
--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -22,14 +22,16 @@ Copy [`build_and_publish_containers.yml`](../../../gh_workflow_examples/build_an
 
 ## Where's my stuff?
 
-After a build:
+Every run uploads its full output set as workflow artifacts on the run summary — the metadata (SBOM, scan results, build info) and the provenance + VSA `sha256-<digest>.intoto.jsonl` bundle — kept ~90 days, downloadable when you're signed in. Their names are [workflow outputs](../../../.github/workflows/build_and_publish_container.yml).
+
+The copies that ship somewhere durable:
 
 - **Image** — pushed to `ghcr.io`.
-- **Provenance + VSA** — OCI referrers on the image digest (containers cut no GitHub release), and together in a per-artifact `sha256-<digest>.intoto.jsonl` bundle kept as a workflow artifact.
-- **SBOM** — an OCI attestation on the image, and a workflow artifact.
+- **SBOM** — an OCI attestation on the image.
+- **Provenance + VSA** — OCI referrers on the image digest (containers cut no GitHub release).
 - **Scan findings** — the Security tab.
 
-The [cross-ecosystem map](../../../docs/verifying_artifacts.md#where-each-output-is-stored) lays all four build types out side by side.
+For the cross-ecosystem view, see [where each output is stored](../../../docs/verifying_artifacts.md#where-each-output-is-stored).
 
 ## Good to know
 

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -20,6 +20,17 @@ Copy [`build_and_publish_containers.yml`](../../../gh_workflow_examples/build_an
 - **SLSA Build L3 provenance** for the image digest ([the requirements it meets](../../../docs/REQUIREMENTS_MAPPING.md)).
 - **A signed VSA** pushed to the registry as its own OCI referrer on the image digest — so consumers can verify the image with one command — and also delivered in the per-artifact `.intoto.jsonl` bundle (provenance + VSA) as a workflow artifact. The provenance is a separate referrer (from `attest-build-provenance`).
 
+## Where's my stuff?
+
+After a build:
+
+- **Image** — pushed to `ghcr.io`.
+- **Provenance + VSA** — OCI referrers on the image digest (containers cut no GitHub release), and together in a per-artifact `sha256-<digest>.intoto.jsonl` bundle kept as a workflow artifact.
+- **SBOM** — an OCI attestation on the image, and a workflow artifact.
+- **Scan findings** — the Security tab.
+
+The [cross-ecosystem map](../../../docs/verifying_artifacts.md#where-each-output-is-stored) lays all four build types out side by side.
+
 ## Good to know
 
 - **`release-events`** (default: `non-pull-request`) gates provenance generation and verification — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating". The docker push itself happens earlier and is gated by your workflow's own `on:` triggers.

--- a/build/actions/go/README.md
+++ b/build/actions/go/README.md
@@ -48,14 +48,15 @@ Push a `v`-prefixed semver tag (e.g. `v1.2.3`) and wrangle runs the full pipelin
 
 ## Where's my stuff?
 
-After a release run:
+Every run uploads its full output set as workflow artifacts on the run summary — the metadata (SBOM, scan results, build info), the archives, and the provenance + VSA bundle — kept ~90 days, downloadable when you're signed in. Their names are [workflow outputs](../../../.github/workflows/build_and_publish_go.yml).
+
+The copies that ship somewhere durable:
 
 - **Binaries + `checksums.txt`** — the GitHub release goreleaser cut.
-- **Provenance + VSA** — together in a per-artifact `<archive>.intoto.jsonl` bundle, attached to that release and kept as a workflow artifact.
-- **SBOM** — a workflow artifact.
+- **Provenance + VSA** (`<archive>.intoto.jsonl`) — attached to that release.
 - **Scan findings** — the Security tab.
 
-The [cross-ecosystem map](../../../docs/verifying_artifacts.md#where-each-output-is-stored) lays all four build types out side by side.
+For the cross-ecosystem view, see [where each output is stored](../../../docs/verifying_artifacts.md#where-each-output-is-stored).
 
 ## Good to know
 

--- a/build/actions/go/README.md
+++ b/build/actions/go/README.md
@@ -46,6 +46,17 @@ Push a `v`-prefixed semver tag (e.g. `v1.2.3`) and wrangle runs the full pipelin
 - **SLSA Build L3 provenance** tying each artifact to the workflow that built it ([the requirements it meets](../../../docs/REQUIREMENTS_MAPPING.md)).
 - **A signed VSA** attached to the release, so downstream users can verify your artifacts with one command.
 
+## Where's my stuff?
+
+After a release run:
+
+- **Binaries + `checksums.txt`** — the GitHub release goreleaser cut.
+- **Provenance + VSA** — together in a per-artifact `<archive>.intoto.jsonl` bundle, attached to that release and kept as a workflow artifact.
+- **SBOM** — a workflow artifact.
+- **Scan findings** — the Security tab.
+
+The [cross-ecosystem map](../../../docs/verifying_artifacts.md#where-each-output-is-stored) lays all four build types out side by side.
+
 ## Good to know
 
 - **Tags must be `v`-prefixed semver** (`v1.2.3`) — goreleaser derives the version from the nearest `v*` tag. No `v*` tags yet? Use the [example config](../../../gh_workflow_examples/build_go.goreleaser.yml)'s snapshot template, which doesn't depend on tag history.

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -45,14 +45,15 @@ These steps set up [npm Trusted Publishing](https://docs.npmjs.com/trusted-publi
 
 ## Where's my stuff?
 
-After a release run:
+Every run uploads its full output set as workflow artifacts on the run summary — the metadata (SBOM, scan results, build info), the tarball, and the provenance + VSA bundle — kept ~90 days, downloadable when you're signed in. Their names are [workflow outputs](../../../.github/workflows/build_and_publish_npm.yml).
 
-- **Tarball** — published to npmjs.org; also kept as a workflow artifact.
-- **Provenance + VSA** — together in a per-artifact `<tarball>.intoto.jsonl` bundle, attached to your GitHub release when you cut one and always kept as a workflow artifact. The npm registry also carries an L2 provenance attestation.
-- **SBOM** — a workflow artifact.
+The copies that ship somewhere durable:
+
+- **Tarball** — npmjs.org, with an L2 provenance attestation.
+- **Provenance + VSA** (`<tarball>.intoto.jsonl`) — attached to your GitHub release, when you cut one.
 - **Scan findings** — the Security tab.
 
-The [cross-ecosystem map](../../../docs/verifying_artifacts.md#where-each-output-is-stored) lays all four build types out side by side.
+For the cross-ecosystem view, see [where each output is stored](../../../docs/verifying_artifacts.md#where-each-output-is-stored).
 
 ## Your publish job
 

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -43,6 +43,17 @@ These steps set up [npm Trusted Publishing](https://docs.npmjs.com/trusted-publi
 - **SLSA Build L3 provenance** ([the requirements it meets](../../../docs/REQUIREMENTS_MAPPING.md)), in addition to the L2 attestation `npm publish --provenance` writes to the registry.
 - **A signed VSA** attached to the release on tag pushes, so downstream users can verify the tarball with one command.
 
+## Where's my stuff?
+
+After a release run:
+
+- **Tarball** — published to npmjs.org; also kept as a workflow artifact.
+- **Provenance + VSA** — together in a per-artifact `<tarball>.intoto.jsonl` bundle, attached to your GitHub release when you cut one and always kept as a workflow artifact. The npm registry also carries an L2 provenance attestation.
+- **SBOM** — a workflow artifact.
+- **Scan findings** — the Security tab.
+
+The [cross-ecosystem map](../../../docs/verifying_artifacts.md#where-each-output-is-stored) lays all four build types out side by side.
+
 ## Your publish job
 
 Publishing happens in your workflow, so two things there are load-bearing — both already wired in the example:

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -45,14 +45,15 @@ These steps set up [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publi
 
 ## Where's my stuff?
 
-After a release run:
+Every run uploads its full output set as workflow artifacts on the run summary — the metadata (SBOM, scan results, build info), the wheel + sdist, and the provenance + VSA bundle — kept ~90 days, downloadable when you're signed in. Their names are [workflow outputs](../../../.github/workflows/build_and_publish_python.yml).
 
-- **Wheel + sdist** — published to PyPI; also kept as workflow artifacts.
-- **Provenance + VSA** — together in a per-artifact `<dist-file>.intoto.jsonl` bundle, attached to your GitHub release when you cut one and always kept as a workflow artifact. PyPI also carries a PEP 740 attestation.
-- **SBOM** — a workflow artifact.
+The copies that ship somewhere durable:
+
+- **Wheel + sdist** — PyPI, with a PEP 740 attestation.
+- **Provenance + VSA** (`<dist-file>.intoto.jsonl`) — attached to your GitHub release, when you cut one.
 - **Scan findings** — the Security tab.
 
-The [cross-ecosystem map](../../../docs/verifying_artifacts.md#where-each-output-is-stored) lays all four build types out side by side.
+For the cross-ecosystem view, see [where each output is stored](../../../docs/verifying_artifacts.md#where-each-output-is-stored).
 
 ## Your publish job
 

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -43,6 +43,17 @@ These steps set up [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publi
 - **SLSA Build L3 provenance** ([the requirements it meets](../../../docs/REQUIREMENTS_MAPPING.md)), plus PEP 740 attestations on PyPI from the publish step.
 - **A signed VSA** attached to the release on tag pushes, so downstream users can verify your dist files with one command.
 
+## Where's my stuff?
+
+After a release run:
+
+- **Wheel + sdist** — published to PyPI; also kept as workflow artifacts.
+- **Provenance + VSA** — together in a per-artifact `<dist-file>.intoto.jsonl` bundle, attached to your GitHub release when you cut one and always kept as a workflow artifact. PyPI also carries a PEP 740 attestation.
+- **SBOM** — a workflow artifact.
+- **Scan findings** — the Security tab.
+
+The [cross-ecosystem map](../../../docs/verifying_artifacts.md#where-each-output-is-stored) lays all four build types out side by side.
+
 ## Your publish job
 
 Publishing happens in your workflow, so two things there are load-bearing — both already wired in the example:

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -21,6 +21,21 @@ Wrangle produces two attestations for every released artifact:
 A consumer's one-command check is the VSA: it carries the full verdict, so
 you trust one signature instead of re-running the policy engine.
 
+## Where each output is stored
+
+Every build produces the same outputs; this is where each one lands.
+
+| Output | Go | Python | npm | Container |
+|---|---|---|---|---|
+| Built artifact | GitHub release | PyPI | npmjs.org | image in `ghcr.io` |
+| SBOM (SPDX) | workflow artifact | workflow artifact | workflow artifact | OCI attestation on the image, and a workflow artifact |
+| Provenance + VSA (`<artifact>.intoto.jsonl` bundle) | GitHub release + workflow artifact | GitHub release (when one exists) + workflow artifact | GitHub release (when one exists) + workflow artifact | OCI referrers on the image digest + workflow artifact |
+| Scan findings (SARIF) | Security tab | Security tab | Security tab | Security tab |
+
+Provenance and VSA travel together in one per-artifact JSONL [in-toto bundle](https://github.com/in-toto/attestation/blob/main/spec/v1/bundle.md); the provenance also lands in [GitHub's attestation store](https://docs.github.com/actions/security-guides/using-artifact-attestations). Python and npm carry an extra ecosystem-native attestation beside it — PEP 740 on PyPI, an L2 provenance attestation on the npm registry.
+
+wrangle attaches the bundle to a GitHub release but never creates one: a Python or npm project that publishes only to PyPI/npm and cuts no release keeps just the workflow-artifact copy (retained ~90 days). Go always has a goreleaser-created release, and container bundles are fetched by digest from the registry. Workflow-artifact names and the on-disk `metadata/<type>/<shortname>/` layout are documented in each reusable workflow's outputs and [`SPEC.md`](SPEC.md).
+
 ## What to plug in, per ecosystem
 
 | Build type | VSA location | `resourceUri` to expect | Signing workflow |

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -23,18 +23,18 @@ you trust one signature instead of re-running the policy engine.
 
 ## Where each output is stored
 
-Every build produces the same outputs; this is where each one lands.
+Every run uploads its full output set as workflow artifacts on the run summary — the metadata (SBOM, scan results, build info), the built artifact, and the provenance + VSA bundle — kept ~90 days, downloadable when you're signed in to GitHub. That's the complete set; the table below shows the durable copies each build type publishes on top of it.
 
 | Output | Go | Python | npm | Container |
 |---|---|---|---|---|
 | Built artifact | GitHub release | PyPI | npmjs.org | image in `ghcr.io` |
-| SBOM (SPDX) | workflow artifact | workflow artifact | workflow artifact | OCI attestation on the image, and a workflow artifact |
-| Provenance + VSA (`<artifact>.intoto.jsonl` bundle) | GitHub release + workflow artifact | GitHub release (when one exists) + workflow artifact | GitHub release (when one exists) + workflow artifact | OCI referrers on the image digest + workflow artifact |
+| SBOM (SPDX) | run artifact only | run artifact only | run artifact only | OCI attestation on the image |
+| Provenance + VSA (`<artifact>.intoto.jsonl` bundle) | GitHub release | GitHub release (when one exists) | GitHub release (when one exists) | OCI referrers on the image digest |
 | Scan findings (SARIF) | Security tab | Security tab | Security tab | Security tab |
 
 Provenance and VSA travel together in one per-artifact JSONL [in-toto bundle](https://github.com/in-toto/attestation/blob/main/spec/v1/bundle.md); the provenance also lands in [GitHub's attestation store](https://docs.github.com/actions/security-guides/using-artifact-attestations). Python and npm carry an extra ecosystem-native attestation beside it — PEP 740 on PyPI, an L2 provenance attestation on the npm registry.
 
-wrangle attaches the bundle to a GitHub release but never creates one: a Python or npm project that publishes only to PyPI/npm and cuts no release keeps just the workflow-artifact copy (retained ~90 days). Go always has a goreleaser-created release, and container bundles are fetched by digest from the registry. Workflow-artifact names and the on-disk `metadata/<type>/<shortname>/` layout are documented in each reusable workflow's outputs and [`SPEC.md`](SPEC.md).
+wrangle attaches the bundle to a GitHub release but never creates one: a Python or npm project that publishes only to PyPI/npm and cuts no release has only the ~90-day run-artifact copy. Go always has a goreleaser-created release, and container bundles are fetched by digest from the registry. The `metadata/<type>/<shortname>/` on-disk layout and the run-artifact names are documented in [`SPEC.md`](SPEC.md) and each reusable workflow's outputs.
 
 ## What to plug in, per ecosystem
 


### PR DESCRIPTION
## What

Adopters could answer *"where does my VSA go?"* from `verifying_artifacts.md`, but had no single answer for the SBOM, the provenance+VSA bundle, and scan findings — that info was spread across the four build READMEs, the reusable-workflow YAML, and `SPEC.md`.

- **`docs/verifying_artifacts.md`** — new **"Where each output is stored"** section: a cross-ecosystem table mapping every output (built artifact, SBOM, provenance+VSA bundle, scan findings) to its home per build type, plus the workflow-artifact retention and durable-home notes.
- **Build READMEs (go / python / npm / container)** — a new per-type **"Where's my stuff?"** section: a post-run location lookup for that ecosystem, linking the cross-ecosystem table. ("What you get" stays the feature pitch; this is the at-a-glance "where did it land".)

Rebased onto current `main` and aligned to **#444**'s single per-artifact bundle: provenance + VSA now travel together in one `<artifact>.intoto.jsonl` (`sha256-<digest>.intoto.jsonl` for containers).

## Verified against a real release

Checked `tomhennen/wrangle-test` release `v20260616-b6d313b` (the first post-#444 release):
- Every artifact has a sibling `<artifact>.intoto.jsonl` bundle — Go, Python wheel+sdist, npm tgz, and the container as `sha256-<digest>.intoto.jsonl`.
- Downloaded the Go and container bundles: each is exactly two lines — `slsa.dev/provenance/v1` + `slsa.dev/verification_summary/v1`, confirming the "provenance + VSA together" row.

## The "durable home" note

`actions/verify/action.yml` attaches the bundle to a release *if one exists — wrangle does not create releases*. Neither example workflow cuts one, so a Python/npm project publishing only to PyPI/npm keeps the bundle solely as the ~90-day workflow artifact. The table states this so the asymmetry with Go (goreleaser-created release) and container (registry referrer) is visible. Current behavior, not a planned change — the durable-home fix is tracked separately (#372).

## Testing

Docs-only; no workflow/shell/Go content that `make test` validates, and the suite has no markdown/link checks. Confirmed the `test_vsa_identity_anchor.bats` drift guard still holds — its cosign identity anchor is untouched and the additions introduce no `yml@` token.

Implements the documentation deliverable of #457 (left open: the VSA-naming decision it also raised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
