### PR TITLE
[OBSOLETE — rebased onto #469 as #474] feat(wrangle-attest): SBOM attestation engine + verify wiring

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -254,7 +254,7 @@ jobs:
           path: metadata/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@0d8a5f66d6ec87f6680124665f8f09a71c53666a # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@d48f3f4afee459fc272fdbbd67dc29c90da11d79 # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           subjects: ${{ needs.build.outputs.digest }}
           policy: policies/wrangle-provenance-container-v1.hjson

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -254,7 +254,7 @@ jobs:
           path: metadata/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@0a91dfc4fbaae75585c1596f1f602fe8d7fc52e2 # feat/store-vsa-372 2026-06-18 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@0d8a5f66d6ec87f6680124665f8f09a71c53666a # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           subjects: ${{ needs.build.outputs.digest }}
           policy: policies/wrangle-provenance-container-v1.hjson

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -246,6 +246,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The build metadata (sbom.spdx.json + its attest manifest); wrangle-attest
+      # turns it into a signed SBOM statement bound to the image digest.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.build.outputs.metadata-artifact-name }}
+          path: metadata/
+
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify@0a91dfc4fbaae75585c1596f1f602fe8d7fc52e2 # feat/store-vsa-372 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
@@ -253,6 +260,7 @@ jobs:
           policy: policies/wrangle-provenance-container-v1.hjson
           collector: oci:${{ needs.build.outputs.imagename }}@${{ needs.build.outputs.digest }}
           bundle-out: bundles
+          metadata-dir: metadata
           artifact-name: container-bundle-${{ needs.build.outputs.shortname }}
           # resourceUri is the OCI image ref a container consumer fetches and
           # pins when verifying the VSA; the subject digest is the cryptographic bind.

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -419,6 +419,13 @@ jobs:
           name: go-provenance-bundle-${{ needs.release.outputs.shortname }}
           path: provenance/
 
+      # The build metadata (sbom.spdx.json + its attest manifest); wrangle-attest
+      # turns it into one signed SBOM statement per subject.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.release.outputs.metadata-artifact-name }}
+          path: metadata/
+
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify@0a91dfc4fbaae75585c1596f1f602fe8d7fc52e2 # feat/store-vsa-372 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
@@ -427,6 +434,7 @@ jobs:
           collector: jsonl:provenance/provenance.jsonl
           bundle-in: provenance/provenance.jsonl
           bundle-out: bundles
+          metadata-dir: metadata
           artifact-name: go-bundle-${{ needs.release.outputs.shortname }}
           # resourceUri is the golang module purl consumers pin when verifying;
           # each subject digest is the cryptographic bind.

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -427,7 +427,7 @@ jobs:
           path: metadata/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@0a91dfc4fbaae75585c1596f1f602fe8d7fc52e2 # feat/store-vsa-372 2026-06-18 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@0d8a5f66d6ec87f6680124665f8f09a71c53666a # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.release.outputs.dist-files }}
           policy: policies/wrangle-provenance-go-v1.hjson

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -427,7 +427,7 @@ jobs:
           path: metadata/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@0d8a5f66d6ec87f6680124665f8f09a71c53666a # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@d48f3f4afee459fc272fdbbd67dc29c90da11d79 # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.release.outputs.dist-files }}
           policy: policies/wrangle-provenance-go-v1.hjson

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -345,7 +345,7 @@ jobs:
           path: metadata/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@0d8a5f66d6ec87f6680124665f8f09a71c53666a # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@d48f3f4afee459fc272fdbbd67dc29c90da11d79 # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.build.outputs.dist-files }}
           policy: policies/wrangle-provenance-npm-v1.hjson

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -345,7 +345,7 @@ jobs:
           path: metadata/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@0a91dfc4fbaae75585c1596f1f602fe8d7fc52e2 # feat/store-vsa-372 2026-06-18 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@0d8a5f66d6ec87f6680124665f8f09a71c53666a # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.build.outputs.dist-files }}
           policy: policies/wrangle-provenance-npm-v1.hjson

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -337,6 +337,13 @@ jobs:
           name: npm-provenance-bundle-${{ needs.build.outputs.shortname }}
           path: provenance/
 
+      # The build metadata (sbom.spdx.json + its attest manifest); wrangle-attest
+      # turns it into one signed SBOM statement per subject.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.build.outputs.metadata-artifact-name }}
+          path: metadata/
+
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify@0a91dfc4fbaae75585c1596f1f602fe8d7fc52e2 # feat/store-vsa-372 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
@@ -345,6 +352,7 @@ jobs:
           collector: jsonl:provenance/provenance.jsonl
           bundle-in: provenance/provenance.jsonl
           bundle-out: bundles
+          metadata-dir: metadata
           artifact-name: npm-bundle-${{ needs.build.outputs.shortname }}
           # resourceUri is the npm purl consumers pin when verifying the VSAs;
           # each subject digest is the cryptographic bind.

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -328,6 +328,13 @@ jobs:
           name: python-provenance-bundle-${{ needs.build.outputs.shortname }}
           path: provenance/
 
+      # The build metadata (sbom.spdx.json + its attest manifest); wrangle-attest
+      # turns it into one signed SBOM statement per subject.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.build.outputs.metadata-artifact-name }}
+          path: metadata/
+
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify@0a91dfc4fbaae75585c1596f1f602fe8d7fc52e2 # feat/store-vsa-372 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
@@ -336,6 +343,7 @@ jobs:
           collector: jsonl:provenance/provenance.jsonl
           bundle-in: provenance/provenance.jsonl
           bundle-out: bundles
+          metadata-dir: metadata
           artifact-name: python-bundle-${{ needs.build.outputs.shortname }}
           # resourceUri names the package the VSAs cover (pkg:pypi, PEP
           # 503-normalized); the consumer/gate check pins it. Each subject

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -336,7 +336,7 @@ jobs:
           path: metadata/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@0a91dfc4fbaae75585c1596f1f602fe8d7fc52e2 # feat/store-vsa-372 2026-06-18 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@0d8a5f66d6ec87f6680124665f8f09a71c53666a # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.build.outputs.dist-files }}
           policy: policies/wrangle-provenance-python-v1.hjson

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -336,7 +336,7 @@ jobs:
           path: metadata/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@0d8a5f66d6ec87f6680124665f8f09a71c53666a # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@d48f3f4afee459fc272fdbbd67dc29c90da11d79 # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.build.outputs.dist-files }}
           policy: policies/wrangle-provenance-python-v1.hjson

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,11 @@ workflowstyle:
 	@echo "=== wrangle-workflow-lint ==="
 	@./tools/wrangle-workflow-lint/lint.sh
 
-# Run first-party Go unit tests (the wrangle-lint rule engine).
+# Run first-party Go unit tests (the wrangle-lint rule engine and the
+# wrangle-attest attestation engine).
 gotest:
 	@echo "=== go test ==="
-	@go -C tools test ./wrangle-lint/...
+	@go -C tools test ./wrangle-lint/... ./wrangle-attest/...
 
 # Lint all shell scripts (.sh and .bats) via the same script CI's dogfooded
 # shell build runs, so the local and CI shellcheck surfaces can't drift (#368).

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -78,6 +78,14 @@ inputs:
     description: 'When "true" (default) and the run is a tag push, attach the bundle to the release.'
     required: false
     default: "true"
+  metadata-dir:
+    description: >
+      Directory holding the build's metadata (the build job's metadata artifact:
+      sbom.spdx.json + its manifest.json). wrangle-attest walks it to build one
+      signed SBOM statement per subject, appended to each bundle and posted to
+      the attestation store. Leave empty to emit VSA-only bundles.
+    required: false
+    default: ""
   oci-target:
     description: >
       When set, fetch the provenance from and push the bundle to this OCI image
@@ -125,6 +133,7 @@ runs:
         BUNDLE_IN: ${{ inputs.bundle-in }}
         BUNDLE_OUT: ${{ inputs.bundle-out }}
         OCI_TARGET: ${{ inputs.oci-target }}
+        METADATA_ROOT: ${{ inputs.metadata-dir }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         # bnd push github authenticates to the attestation store with this token;
         # the attestations: write permission rides on it.

--- a/actions/verify/install_tools.sh
+++ b/actions/verify/install_tools.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 set -f
 
-# Build the verify tools into WRANGLE_BIN_DIR: ampel (verify) and bnd (sign)
-# always; cosign (push the VSA as an OCI referrer) only when OCI_TARGET names a
-# container image digest — npm/go/python verify never pushes, so it never needs
-# cosign. Installing the rest of the tool manifest here would compile the scan
-# toolchain (osv-scanner et al.) that verify never runs.
+# Build the verify tools into WRANGLE_BIN_DIR: ampel (verify), bnd (sign), and
+# wrangle-attest (build the unsigned scan/build statements) always; cosign (push
+# the VSA as an OCI referrer) only when OCI_TARGET names a container image digest
+# — npm/go/python verify never pushes, so it never needs cosign. Installing the
+# rest of the tool manifest here would compile the scan toolchain (osv-scanner
+# et al.) that verify never runs.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../lib/env.sh
@@ -15,6 +16,7 @@ source "${SCRIPT_DIR}/../../lib/env.sh"
 pkgs=(
     github.com/carabiner-dev/ampel/cmd/ampel
     github.com/carabiner-dev/bnd
+    github.com/TomHennen/wrangle/tools/wrangle-attest
 )
 if [[ -n "${OCI_TARGET:-}" ]]; then
     pkgs+=(github.com/sigstore/cosign/v3/cmd/cosign)

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -13,7 +13,8 @@
 # Inputs arrive as env vars: SUBJECTS (newline-separated), POLICY, COLLECTOR,
 # FAIL, CONTEXT, BUNDLE_IN, BUNDLE_OUT, GITHUB_REPOSITORY (store push target),
 # GITHUB_TOKEN (bnd reads it to auth the store push), and optional ATTESTATION,
-# OCI_TARGET.
+# OCI_TARGET, METADATA_ROOT (the build metadata dir wrangle-attest walks for the
+# SBOM manifest, appended as a signed statement per subject).
 
 set -euo pipefail
 set -f  # disable globbing — processes external input
@@ -59,6 +60,25 @@ wrangle_subject_arg() {
     # A missing/unreadable subject file must fail closed, not yield an empty hash.
     digest="$(sha256sum "$subject")" || return 1
     printf -- '--subject-hash=sha256:%s\n' "${digest%% *}"
+}
+
+# Resolve a subject to the single sha256:<hex> the attestation engine binds to.
+# A sha256 digest subject (container) passes through; any other digest algorithm
+# is rejected (the store accepts only sha256); a file subject is hashed. The SBOM
+# statement thus shares the VSA's single-sha256 subject, so a policy resolving by
+# artifact digest finds both.
+wrangle_subject_sha256() {
+    local subject="$1" digest
+    if [[ "$subject" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+        printf '%s\n' "$subject"
+        return 0
+    fi
+    if [[ "$subject" =~ ^[a-z0-9]+:[a-f0-9]+$ ]]; then
+        printf 'wrangle: subject %s is not sha256 — the attestation store accepts only sha256\n' "$subject" >&2
+        return 1
+    fi
+    digest="$(sha256sum "$subject")" || return 1
+    printf 'sha256:%s\n' "${digest%% *}"
 }
 
 # Build the ampel verify arg vector for one subject, one arg per line for
@@ -206,6 +226,50 @@ wrangle_push_bundle() {
     wrangle_retry_once /dev/null cosign "${args[@]}"
 }
 
+# Build the wrangle-attest arg vector that turns the build metadata into unsigned
+# in-toto statements, one per line for mapfile. $1 is the single sha256 subject;
+# $2 the JSONL output path. METADATA_ROOT holds the build's manifest.json files
+# (sbom.spdx.json + its manifest); --commit is woven into the scan/v1 envelope
+# only, ignored by the SBOM passthrough.
+wrangle_attest_args() {
+    printf '%s\n' \
+        --metadata-root="$METADATA_ROOT" \
+        --subject="$1" \
+        --out="$2"
+}
+
+# For one subject, build the SBOM (and any other build-metadata) statement(s),
+# sign each, append each to the bundle, and post each to the store. No-op when
+# METADATA_ROOT is unset/empty (a build that produced no metadata). $1 is the
+# subject, $2 the bundle file. wrangle-attest fails closed on a malformed
+# manifest, so an absent statement is a real gap, not a silent skip.
+wrangle_emit_metadata_statements() {
+    [[ -z "${METADATA_ROOT:-}" || ! -d "${METADATA_ROOT:-}" ]] && return 0
+    local subject="$1" bundle="$2" subj_sha
+    subj_sha="$(wrangle_subject_sha256 "$subject")"
+    local stmts args
+    stmts="$(mktemp "${RUNNER_TEMP:-/tmp}/attest.XXXXXX")"
+    mapfile -t args < <(wrangle_attest_args "$subj_sha" "$stmts")
+    wrangle-attest "${args[@]}"
+    # Sign and deliver each unsigned statement line in the same trusted process
+    # as the VSA, so an unsigned statement never crosses a step boundary. Flatten
+    # bnd's pretty statement to one line: appended to the bundle, posted to the
+    # store, and pushed alone as the OCI referrer (cosign attach rejects multi-line).
+    local signed line_file
+    signed="$(mktemp "${RUNNER_TEMP:-/tmp}/attestsigned.XXXXXX")"
+    line_file="$(mktemp "${RUNNER_TEMP:-/tmp}/attestline.XXXXXX")"
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        printf '%s\n' "$line" > "$signed.unsigned"
+        wrangle_retry_once "$signed" bnd statement "$signed.unsigned"
+        jq -c . "$signed" > "$line_file"
+        cat "$line_file" >> "$bundle"
+        wrangle_push_store "$line_file"
+        wrangle_push_bundle "$line_file"
+    done < "$stmts"
+    rm -f "$stmts" "$signed" "$signed.unsigned" "$line_file"
+}
+
 # Post the signed VSA at $1 to the GitHub attestation store (all build types).
 # Provenance is already in the store from attest-build-provenance, so only the
 # VSA is pushed. Fails closed: a missing by-digest VSA is a real delivery gap.
@@ -259,6 +323,9 @@ wrangle_run() {
         cat "$vsa_line" >> "$bundle"
         wrangle_push_store "$vsa_line"
         wrangle_push_bundle "$vsa_line"
+        # Append the build-metadata statements (SBOM, …) bound to this same
+        # single-sha256 subject, signed and delivered alongside the VSA.
+        wrangle_emit_metadata_statements "$subject" "$bundle"
     done
     rm -f "$tmp_vsa" "$vsa_line" "$seed"
 }

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -246,11 +246,13 @@ wrangle_attest_args() {
 wrangle_emit_metadata_statements() {
     [[ -z "${METADATA_ROOT:-}" || ! -d "${METADATA_ROOT:-}" ]] && return 0
     local subject="$1" bundle="$2" subj_sha
-    subj_sha="$(wrangle_subject_sha256 "$subject")"
+    subj_sha="$(wrangle_subject_sha256 "$subject")" || return 1
     local stmts args
     stmts="$(mktemp "${RUNNER_TEMP:-/tmp}/attest.XXXXXX")"
     mapfile -t args < <(wrangle_attest_args "$subj_sha" "$stmts")
-    wrangle-attest "${args[@]}"
+    # A malformed/missing manifest aborts here — never ship a bundle silently
+    # missing its SBOM statement.
+    wrangle-attest "${args[@]}" || { rm -f "$stmts"; return 1; }
     # Sign and deliver each unsigned statement line in the same trusted process
     # as the VSA, so an unsigned statement never crosses a step boundary. Flatten
     # bnd's pretty statement to one line: appended to the bundle, posted to the

--- a/actions/verify/test_install_tools.bats
+++ b/actions/verify/test_install_tools.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
-# Behavioral test for install_tools.sh: ampel + bnd are always built; cosign is
-# built only when OCI_TARGET is set (the container build pushes the VSA
-# referrer). A fake `go` records the packages it was asked to install.
+# Behavioral test for install_tools.sh: ampel + bnd + wrangle-attest are always
+# built; cosign is built only when OCI_TARGET is set (the container build pushes
+# the VSA referrer). A fake `go` records the packages it was asked to install.
 
 setup() {
     DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
@@ -39,11 +39,12 @@ teardown() {
     rm -rf "$TEST_DIR"
 }
 
-@test "install_tools.sh: without OCI_TARGET builds ampel+bnd, not cosign" {
+@test "install_tools.sh: without OCI_TARGET builds ampel+bnd+wrangle-attest, not cosign" {
     PATH="$FAKE_BIN:$PATH" run "$DIR/install_tools.sh"
     [ "$status" -eq 0 ]
     grep -Fq 'github.com/carabiner-dev/ampel/cmd/ampel' "$GO_RECORD"
     grep -Fq 'github.com/carabiner-dev/bnd' "$GO_RECORD"
+    grep -Fq 'github.com/TomHennen/wrangle/tools/wrangle-attest' "$GO_RECORD"
     ! grep -Fq 'cosign' "$GO_RECORD"
 }
 
@@ -52,5 +53,6 @@ teardown() {
     [ "$status" -eq 0 ]
     grep -Fq 'github.com/carabiner-dev/ampel/cmd/ampel' "$GO_RECORD"
     grep -Fq 'github.com/carabiner-dev/bnd' "$GO_RECORD"
+    grep -Fq 'github.com/TomHennen/wrangle/tools/wrangle-attest' "$GO_RECORD"
     grep -Fq 'github.com/sigstore/cosign/v3/cmd/cosign' "$GO_RECORD"
 }

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -706,7 +706,8 @@ if [[ "\$1" == "push" ]]; then cat "\$4" >> "$TEST_DIR/pushed"; exit 0; fi
 printf '{\n  "signed": '; cat "\$2"; printf '}\n'
 STUB
     chmod +x "$TEST_DIR/bnd"
-    export PATH="$(dirname "$ATTEST_BIN"):$TEST_DIR:$PATH"
+    local attest_dir; attest_dir="$(dirname "$ATTEST_BIN")"
+    export PATH="$attest_dir:$TEST_DIR:$PATH"
     export METADATA_ROOT="$TEST_DIR/meta"
     export GITHUB_REPOSITORY="o/r"
     export OCI_TARGET=""
@@ -729,7 +730,8 @@ STUB
     if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
     mkdir -p "$TEST_DIR/meta"
     printf '{"predicate-type":"https://spdx.dev/Document"}\n' > "$TEST_DIR/meta/manifest.json"
-    export PATH="$(dirname "$ATTEST_BIN"):$PATH"
+    local attest_dir; attest_dir="$(dirname "$ATTEST_BIN")"
+    export PATH="$attest_dir:$PATH"
     export METADATA_ROOT="$TEST_DIR/meta"
     local bundle="$TEST_DIR/bundle.jsonl"; : > "$bundle"
     run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -24,6 +24,7 @@ setup() {
     AMPEL_BIN="$(command -v ampel || echo "${WRANGLE_BIN_DIR:-/nonexistent}/ampel")"
     BND_BIN="$(command -v bnd || echo "${WRANGLE_BIN_DIR:-/nonexistent}/bnd")"
     COSIGN_BIN="$(command -v cosign || echo "${WRANGLE_BIN_DIR:-/nonexistent}/cosign")"
+    ATTEST_BIN="$(command -v wrangle-attest || echo "${WRANGLE_BIN_DIR:-/nonexistent}/wrangle-attest")"
 
     export SUBJECTS=$'dist/app-1.2.3.tgz'
     export POLICY="policies/release.json"
@@ -97,6 +98,40 @@ teardown() {
 @test "run_verify: subject_arg fails closed on an unreadable file subject" {
     run wrangle_subject_arg "$TEST_DIR/does-not-exist.tgz"
     [[ "$status" -ne 0 ]]
+}
+
+# --- subject sha256 (the bare digest wrangle-attest binds the SBOM to) ---
+
+@test "run_verify: subject_sha256 passes a sha256 digest subject through" {
+    run wrangle_subject_sha256 "sha256:$(printf '0%.0s' {1..64})"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "sha256:$(printf '0%.0s' {1..64})" ]]
+}
+
+@test "run_verify: subject_sha256 hashes a file subject to its sha256" {
+    printf 'CONTENT\n' > "$TEST_DIR/blob"
+    local want; want="$(sha256sum "$TEST_DIR/blob" | cut -d' ' -f1)"
+    run wrangle_subject_sha256 "$TEST_DIR/blob"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "sha256:$want" ]]
+}
+
+@test "run_verify: subject_sha256 rejects a non-sha256 digest the store can't take" {
+    # The attestation store keys by sha256; a sha512 digest subject must fail
+    # closed, not silently produce an unstorable statement.
+    run wrangle_subject_sha256 "sha512:$(printf 'a%.0s' {1..128})"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"not sha256"* ]]
+}
+
+# --- wrangle-attest arg vector ---
+
+@test "run_verify: attest args carry the metadata-root, subject, and out" {
+    export METADATA_ROOT="$TEST_DIR/meta"
+    mapfile -t args < <(wrangle_attest_args "sha256:abc" "$TEST_DIR/out.jsonl")
+    printf '%s\n' "${args[@]}" | grep -qx -- "--metadata-root=$TEST_DIR/meta"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--subject=sha256:abc"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--out=$TEST_DIR/out.jsonl"
 }
 
 # --- ampel arg vector ---
@@ -632,6 +667,72 @@ STUB
     export OCI_TARGET="ghcr.io/o/r/img@sha256:0000000000000000000000000000000000000000000000000000000000000000"
 
     run "$SCRIPT" run
+    [[ "$status" -ne 0 ]]
+}
+
+# --- build-metadata (SBOM) statement emission ---
+
+@test "run_verify: emit_metadata is a no-op when METADATA_ROOT is unset" {
+    # npm/go/python/container without a metadata dir: nothing is appended and no
+    # signer is invoked. A bnd stub that fails proves the path returns 0 untouched.
+    cat > "$TEST_DIR/bnd" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+    chmod +x "$TEST_DIR/bnd"
+    export PATH="$TEST_DIR:$PATH"
+    unset METADATA_ROOT
+    local bundle="$TEST_DIR/bundle.jsonl"
+    printf '{"provenance":1}\n' > "$bundle"
+    run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
+    [[ "$status" -eq 0 ]]
+    [[ "$(wc -l < "$bundle")" -eq 1 ]]
+}
+
+@test "run_verify: emit_metadata builds, signs, appends, and pushes the SBOM statement" {
+    # End-to-end with the real wrangle-attest (offline) and a stub bnd/cosign:
+    # an SBOM manifest + sbom.spdx.json in METADATA_ROOT becomes a signed SPDX
+    # statement appended to the bundle and posted to the store.
+    if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
+    mkdir -p "$TEST_DIR/meta"
+    printf '{"spdxVersion":"SPDX-2.3","name":"x"}\n' > "$TEST_DIR/meta/sbom.spdx.json"
+    printf '{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}\n' \
+        > "$TEST_DIR/meta/manifest.json"
+    # bnd statement wraps the unsigned line so the jq -c flatten is load-bearing;
+    # bnd push records the file it was handed so the store delivery is provable.
+    cat > "$TEST_DIR/bnd" <<STUB
+#!/bin/bash
+if [[ "\$1" == "push" ]]; then cat "\$4" >> "$TEST_DIR/pushed"; exit 0; fi
+printf '{\n  "signed": '; cat "\$2"; printf '}\n'
+STUB
+    chmod +x "$TEST_DIR/bnd"
+    export PATH="$(dirname "$ATTEST_BIN"):$TEST_DIR:$PATH"
+    export METADATA_ROOT="$TEST_DIR/meta"
+    export GITHUB_REPOSITORY="o/r"
+    export OCI_TARGET=""
+    : > "$TEST_DIR/pushed"
+    local bundle="$TEST_DIR/bundle.jsonl"
+    printf '{"provenance":1}\n' > "$bundle"
+    run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
+    [[ "$status" -eq 0 ]]
+    # The SBOM statement was appended to the bundle (provenance line + SBOM line).
+    # The stub bnd wraps the signed statement under .signed.
+    [[ "$(wc -l < "$bundle")" -eq 2 ]]
+    [[ "$(tail -1 "$bundle" | jq -r '.signed.predicateType')" == "https://spdx.dev/Document" ]]
+    # The signed statement reached the store, bound to the single sha256 subject.
+    [[ "$(jq -r '.signed.subject[0].digest.sha256' "$TEST_DIR/pushed")" == "$(printf '0%.0s' {1..64})" ]]
+}
+
+@test "run_verify: emit_metadata fails closed on a malformed manifest" {
+    # wrangle-attest fails closed on a bad manifest; the verify step must surface
+    # that rather than silently shipping a bundle with no SBOM statement.
+    if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
+    mkdir -p "$TEST_DIR/meta"
+    printf '{"predicate-type":"https://spdx.dev/Document"}\n' > "$TEST_DIR/meta/manifest.json"
+    export PATH="$(dirname "$ATTEST_BIN"):$PATH"
+    export METADATA_ROOT="$TEST_DIR/meta"
+    local bundle="$TEST_DIR/bundle.jsonl"; : > "$bundle"
+    run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
     [[ "$status" -ne 0 ]]
 }
 

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -706,8 +706,10 @@ if [[ "\$1" == "push" ]]; then cat "\$4" >> "$TEST_DIR/pushed"; exit 0; fi
 printf '{\n  "signed": '; cat "\$2"; printf '}\n'
 STUB
     chmod +x "$TEST_DIR/bnd"
+    # TEST_DIR first so the stub bnd wins; the real bnd is co-located with
+    # wrangle-attest in WRANGLE_BIN_DIR and would otherwise shadow the stub.
     local attest_dir; attest_dir="$(dirname "$ATTEST_BIN")"
-    export PATH="$attest_dir:$TEST_DIR:$PATH"
+    export PATH="$TEST_DIR:$attest_dir:$PATH"
     export METADATA_ROOT="$TEST_DIR/meta"
     export GITHUB_REPOSITORY="o/r"
     export OCI_TARGET=""
@@ -716,9 +718,10 @@ STUB
     printf '{"provenance":1}\n' > "$bundle"
     run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
     [[ "$status" -eq 0 ]]
-    # The SBOM statement was appended to the bundle (provenance line + SBOM line).
-    # The stub bnd wraps the signed statement under .signed.
+    # The seeded provenance line plus exactly one appended SPDX statement; the
+    # stub bnd wraps the signed statement under .signed.
     [[ "$(wc -l < "$bundle")" -eq 2 ]]
+    [[ "$(grep -c '"https://spdx.dev/Document"' "$bundle")" -eq 1 ]]
     [[ "$(tail -1 "$bundle" | jq -r '.signed.predicateType')" == "https://spdx.dev/Document" ]]
     # The signed statement reached the store, bound to the single sha256 subject.
     [[ "$(jq -r '.signed.subject[0].digest.sha256' "$TEST_DIR/pushed")" == "$(printf '0%.0s' {1..64})" ]]

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -223,11 +223,8 @@ runs:
         METADATA_DIR: ${{ steps.meta_dir.outputs.metadata-dir }}
       run: |
         set -euo pipefail
-        SBOM_PATH="${METADATA_DIR}/sbom.spdx.json"
-        # Reference by digest, not tag — the :latest tag only exists on
-        # main-branch builds, so bare image name fails on other branches.
-        docker buildx imagetools inspect "${IMAGE}@${DIGEST}" --format "{{ json .SBOM.SPDX }}" > "$SBOM_PATH"
-        printf 'sbom=%s\n' "$SBOM_PATH" >> "$GITHUB_OUTPUT"
+        "${{ github.action_path }}/extract_sbom.sh" \
+            "${IMAGE}@${DIGEST}" "${METADATA_DIR}" "$GITHUB_OUTPUT"
 
     - name: Generate summary
       if: always()

--- a/build/actions/container/extract_sbom.sh
+++ b/build/actions/container/extract_sbom.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — handles image refs and paths
+# Extract the SPDX SBOM from a built image and write the wrangle-attest manifest
+# next to it so the verify-stage engine produces an SBOM attestation.
+#
+# Usage: extract_sbom.sh <image-ref> <metadata-dir> <github-output>
+#   <image-ref>     image referenced by digest (tag-only refs miss non-main builds)
+#   <metadata-dir>  dir the SBOM + manifest.json are written to
+#   <github-output> $GITHUB_OUTPUT to record the sbom path on
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRANGLE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+main() {
+    if [[ "$#" -ne 3 ]]; then
+        printf 'Usage: %s <image-ref> <metadata-dir> <github-output>\n' "${0##*/}" >&2
+        return 2
+    fi
+    local image_ref="$1" metadata_dir="$2" github_output="$3"
+    local sbom_path="${metadata_dir}/sbom.spdx.json"
+
+    docker buildx imagetools inspect "$image_ref" --format "{{ json .SBOM.SPDX }}" > "$sbom_path"
+    "$WRANGLE_ROOT/lib/write_attest_manifest.sh" \
+        "$metadata_dir" "https://spdx.dev/Document" "sbom.spdx.json"
+    printf 'sbom=%s\n' "$sbom_path" >> "$github_output"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -272,6 +272,33 @@ teardown() {
     [[ "$status" -eq 0 ]]
 }
 
+@test "container: extract_sbom.sh writes the SBOM, the attest manifest, and the output" {
+    # Fake docker so the test needs no real image; it echoes the SBOM JSON.
+    fakebin="$(mktemp -d)"
+    cat > "$fakebin/docker" << 'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' '{"spdxVersion":"SPDX-2.3","name":"img"}'
+FAKE
+    chmod +x "$fakebin/docker"
+    meta="$(mktemp -d)"
+    out="$(mktemp)"
+    PATH="$fakebin:$PATH" run "$ACTION_DIR/extract_sbom.sh" "img@sha256:abc" "$meta" "$out"
+    [[ "$status" -eq 0 ]]
+    run jq -e '.spdxVersion' "$meta/sbom.spdx.json"
+    [[ "$status" -eq 0 ]]
+    run jq -r '."predicate-type"' "$meta/manifest.json"
+    [[ "$output" == "https://spdx.dev/Document" ]]
+    run jq -r '."result-file"' "$meta/manifest.json"
+    [[ "$output" == "sbom.spdx.json" ]]
+    grep -Fq "sbom=$meta/sbom.spdx.json" "$out"
+    rm -rf "$fakebin" "$meta" "$out"
+}
+
+@test "container: extract_sbom.sh usage error on wrong arg count" {
+    run "$ACTION_DIR/extract_sbom.sh" "img@sha256:abc"
+    [[ "$status" -eq 2 ]]
+}
+
 @test "container: action.yml exposes metadata-dir output" {
     run grep -E '^[[:space:]]+metadata-dir:' "$ACTION_DIR/action.yml"
     [[ "$status" -eq 0 ]]

--- a/build/actions/go/release/action.yml
+++ b/build/actions/go/release/action.yml
@@ -219,11 +219,14 @@ runs:
       env:
         INPUT_PATH: ${{ inputs.path }}
         METADATA_DIR: ${{ steps.metadata.outputs.metadata-dir }}
+        WRANGLE_ROOT: ${{ github.action_path }}/../../../..
       run: |
         set -euo pipefail
         mkdir -p "$METADATA_DIR"
-        "${{ github.action_path }}/../../../../tools/syft/generate_sbom.sh" \
+        "$WRANGLE_ROOT/tools/syft/generate_sbom.sh" \
             "$INPUT_PATH" "$METADATA_DIR/sbom.spdx.json"
+        "$WRANGLE_ROOT/lib/write_attest_manifest.sh" \
+            "$METADATA_DIR" "https://spdx.dev/Document" "sbom.spdx.json"
 
     - name: Generate summary
       if: always()

--- a/build/actions/npm/action.yml
+++ b/build/actions/npm/action.yml
@@ -188,6 +188,7 @@ runs:
       env:
         INPUT_PATH: ${{ inputs.path }}
         METADATA_DIR: ${{ steps.metadata.outputs.metadata-dir }}
+        WRANGLE_ROOT: ${{ github.action_path }}/../../..
       # syft over the project source. Same tool wrangle's python build
       # type uses; OWASP-known-conformant for SPDX. (Earlier SPEC drafts
       # picked the npm-CLI's in-tree SBOM command, but its conformance
@@ -202,6 +203,8 @@ runs:
         SBOM_PATH="${METADATA_DIR}/sbom.spdx.json"
         BIN_DIR="${WRANGLE_BIN_DIR:-${RUNNER_TEMP:-.}/.wrangle/bin}"
         "$BIN_DIR/syft" dir:"$INPUT_PATH" -o spdx-json > "$SBOM_PATH"
+        "$WRANGLE_ROOT/lib/write_attest_manifest.sh" \
+            "$METADATA_DIR" "https://spdx.dev/Document" "sbom.spdx.json"
         printf 'SBOM written to %s\n' "$SBOM_PATH"
 
     - name: Generate summary

--- a/build/actions/python/action.yml
+++ b/build/actions/python/action.yml
@@ -192,11 +192,14 @@ runs:
       env:
         INPUT_PATH: ${{ inputs.path }}
         METADATA_DIR: ${{ steps.metadata.outputs.metadata-dir }}
+        WRANGLE_ROOT: ${{ github.action_path }}/../../..
       run: |
         set -euo pipefail
         SBOM_PATH="${METADATA_DIR}/sbom.spdx.json"
         BIN_DIR="${WRANGLE_BIN_DIR:-${RUNNER_TEMP:-.}/.wrangle/bin}"
         "$BIN_DIR/syft" dir:"$INPUT_PATH" -o spdx-json > "$SBOM_PATH"
+        "$WRANGLE_ROOT/lib/write_attest_manifest.sh" \
+            "$METADATA_DIR" "https://spdx.dev/Document" "sbom.spdx.json"
         printf 'SBOM written to %s\n' "$SBOM_PATH"
 
     - name: Generate summary

--- a/lib/write_attest_manifest.sh
+++ b/lib/write_attest_manifest.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — handles path arguments
+# lib/write_attest_manifest.sh — write the manifest.json a producer leaves for
+# the wrangle-attest engine to discover, next to its native result file.
+#
+# The manifest is the tool↔engine contract: predicate-type implies the result
+# format, result-file is relative to the manifest's own dir. Tools never set
+# subjects — the engine owns those.
+#
+# Usage: write_attest_manifest.sh <metadata_dir> <predicate-type> <result-file>
+#   <metadata_dir>   dir holding the result file; the manifest is written here
+#   <predicate-type> the in-toto predicate type URI
+#   <result-file>    result filename, relative to <metadata_dir>
+#
+# tool/result fields (only the wrangle scan/v1 predicate needs them) are added
+# by the scan adapters, not this helper — SBOM/OSV/scorecard are passthrough.
+
+main() {
+    if [[ "$#" -ne 3 ]]; then
+        printf 'Usage: %s <metadata_dir> <predicate-type> <result-file>\n' "${0##*/}" >&2
+        return 2
+    fi
+    local metadata_dir="$1" predicate_type="$2" result_file="$3"
+    mkdir -p "$metadata_dir"
+    # jq -n builds the JSON so a result-file or URI with a quote/backslash is
+    # escaped, never breaking the manifest the engine parses strictly.
+    jq -n \
+        --arg pt "$predicate_type" \
+        --arg rf "$result_file" \
+        '{"predicate-type": $pt, "result-file": $rf}' \
+        > "$metadata_dir/manifest.json"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/test/test_write_attest_manifest.bats
+++ b/test/test_write_attest_manifest.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+# Tests for lib/write_attest_manifest.sh — the producer-side helper that writes
+# the manifest.json the wrangle-attest engine discovers.
+
+setup() {
+    SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../lib" && pwd)/write_attest_manifest.sh"
+    TEST_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "write_attest_manifest: writes the pinned schema for an SBOM" {
+    run "$SCRIPT" "$TEST_DIR/meta" "https://spdx.dev/Document" "sbom.spdx.json"
+    [[ "$status" -eq 0 ]]
+    run jq -r '."predicate-type"' "$TEST_DIR/meta/manifest.json"
+    [[ "$output" == "https://spdx.dev/Document" ]]
+    run jq -r '."result-file"' "$TEST_DIR/meta/manifest.json"
+    [[ "$output" == "sbom.spdx.json" ]]
+    # Passthrough manifests carry no tool/result fields.
+    run jq -e 'has("tool") or has("result")' "$TEST_DIR/meta/manifest.json"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "write_attest_manifest: creates the metadata dir if absent" {
+    run "$SCRIPT" "$TEST_DIR/nested/dir" "https://spdx.dev/Document" "sbom.spdx.json"
+    [[ "$status" -eq 0 ]]
+    [[ -f "$TEST_DIR/nested/dir/manifest.json" ]]
+}
+
+@test "write_attest_manifest: jq-escapes a value with quotes (no broken JSON)" {
+    # A pathological result-file name must not break the manifest the engine
+    # parses strictly; jq -n escapes it.
+    run "$SCRIPT" "$TEST_DIR/meta" 'https://spdx.dev/Document' 'we"ird.json'
+    [[ "$status" -eq 0 ]]
+    run jq -r '."result-file"' "$TEST_DIR/meta/manifest.json"
+    [[ "$output" == 'we"ird.json' ]]
+}
+
+@test "write_attest_manifest: usage error on wrong arg count" {
+    run "$SCRIPT" "$TEST_DIR/meta" "https://spdx.dev/Document"
+    [[ "$status" -eq 2 ]]
+    [[ "$output" == *"Usage:"* ]]
+}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,6 +3,7 @@ module github.com/TomHennen/wrangle/tools
 go 1.26.4
 
 tool (
+	github.com/TomHennen/wrangle/tools/wrangle-attest
 	github.com/TomHennen/wrangle/tools/wrangle-lint
 	github.com/carabiner-dev/ampel/cmd/ampel
 	github.com/carabiner-dev/bnd
@@ -12,7 +13,9 @@ tool (
 )
 
 require (
+	github.com/in-toto/attestation v1.2.0
 	github.com/owenrumney/go-sarif/v3 v3.3.0
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -272,7 +275,6 @@ require (
 	github.com/hjson/hjson-go/v4 v4.6.0 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20251118225945-96ee0021ea0f // indirect
 	github.com/icholy/digest v1.1.0 // indirect
-	github.com/in-toto/attestation v1.2.0 // indirect
 	github.com/in-toto/in-toto-golang v0.11.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
@@ -469,7 +471,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260608224507-4308a22a1bab // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260608224507-4308a22a1bab // indirect
 	google.golang.org/grpc v1.81.1 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.2 // indirect

--- a/tools/wrangle-attest/SPEC.md
+++ b/tools/wrangle-attest/SPEC.md
@@ -1,0 +1,76 @@
+# wrangle-attest — shared attestation engine
+
+`wrangle-attest` turns the inert result files scan/build tools leave behind into
+**unsigned** in-toto v1 Statements, ready for `bnd` to sign in the trusted
+post-build context (`actions/verify`). It is the single producer-side engine:
+adding the Nth attestation type is a new manifest + (for a novel predicate
+shape) a new case here, never new signing code.
+
+## Tools declare, the engine decides
+
+A producer writes a `manifest.json` next to its native result file. The manifest
+is the only tool↔engine contract:
+
+```jsonc
+{
+  "predicate-type": "<URI>",           // required; implies the result-file format
+  "result-file":    "<relative-path>", // required; relative to the manifest's own dir
+  "tool":   { "name": "<str>", "version": "<str>" },  // .../wrangle/attestation/scan/v1 only
+  "result": "clean" | "findings"                       // .../wrangle/attestation/scan/v1 only
+}
+```
+
+There is **no `format`** field (the predicate-type implies it) and tools **never
+set subjects** — the engine owns the subject. A malformed manifest, an unknown
+predicate-type, a missing/absolute/`..` result-file, or an unknown field fails
+the whole run closed; scan output is untrusted input.
+
+## Predicate-type → handling
+
+| predicate-type | result-file | handling |
+|---|---|---|
+| `https://spdx.dev/Document` | `sbom.spdx.json` | passthrough (SPDX is the predicate) |
+| `https://ossf.github.io/osv-schema/results` | OSV JSON | passthrough |
+| `https://scorecard.dev/result/v0.1` | scorecard JSON | passthrough |
+| `https://github.com/TomHennen/wrangle/attestation/scan/v1` | `output.sarif` | thin envelope `{tool, scannedCommit, result, sarif}` |
+
+Passthrough embeds the result file verbatim as the predicate (it must be a JSON
+object). The thin envelope hoists `tool`/`result`/`scannedCommit` to the top
+level so policy filters on `predicate.tool.name` / `predicate.result` without
+parsing nested SARIF. v1 ships SBOM; the OSV/scorecard/SARIF cases are wired so
+later producer PRs are manifest-only.
+
+## Engine-owned subject
+
+Every statement is bound to the **single sha256 artifact subject** passed via
+`--subject`. The GitHub attestation store (`bnd push github`) keys by subject
+digest and rejects a multi-digest subject, so a single sha256 is the only shape
+that round-trips through the store — and it is the same digest `run_verify.sh`
+binds the VSA to, so a policy resolving by artifact digest finds both. Binding
+the scanned git commit as a second subject is deferred to the source-scan PRs.
+
+## CLI
+
+```
+wrangle-attest --metadata-root <dir>... --subject sha256:<hex> \
+    [--commit <hex-sha>] --out <file>
+```
+
+Walks each `--metadata-root` for `manifest.json`, builds one unsigned Statement
+per manifest bound to `--subject`, and writes them all to `--out` as JSONL.
+`--commit` is woven into the `scan/v1` envelope only; passthrough predicates
+ignore it. All statements are built into a buffer before `--out` is touched, so a
+failure on the Nth manifest never leaves a partially-written file. Exit 0 on
+success; non-zero (fail closed) on any error.
+
+Signing is **not** here: `run_verify.sh` bnd-signs each emitted statement in the
+same trusted process as the VSA, so the engine has no Sigstore code and is fully
+offline-unit-testable.
+
+## Testing
+
+`go test ./wrangle-attest/` — table-driven manifest parse/validate (fail-closed
+cases), subject parsing (single sha256, fail-closed on multi/short/wrong-algo),
+and golden Statements (`testdata/`) for the SBOM passthrough and the SARIF
+thin-envelope shapes. Regenerate goldens with `go test ./wrangle-attest/
+-update`. The `actions/verify` bats cover the `run_verify.sh` glue.

--- a/tools/wrangle-attest/main.go
+++ b/tools/wrangle-attest/main.go
@@ -1,0 +1,45 @@
+// Command wrangle-attest is the shared attestation engine: it turns the inert
+// result files that scan/build tools leave behind into UNSIGNED in-toto v1
+// Statements, ready for `bnd` to sign in the trusted post-build context
+// (actions/verify). It is the single producer-side engine: adding the Nth
+// attestation type is a new manifest + (for a novel predicate shape) a new case
+// here, never new signing code.
+//
+// Tools declare, the engine decides. Each producer writes a manifest.json next
+// to its native result (sbom.spdx.json, results.json, output.sarif, …):
+//
+//	{
+//	  "predicate-type": "<URI>",           // required; implies the result format
+//	  "result-file":    "<relative-path>", // required; relative to the manifest dir
+//	  "tool":   {"name": "<str>", "version": "<str>"}, // .../scan/v1 only
+//	  "result": "clean" | "findings"                    // .../scan/v1 only
+//	}
+//
+// The engine walks --metadata-root for manifest.json files and builds one
+// Statement per manifest:
+//   - passthrough predicates (SPDX, OSV, scorecard) embed the result file
+//     verbatim as the predicate;
+//   - the wrangle scan predicate (.../wrangle/attestation/scan/v1) wraps SARIF
+//     in a thin envelope {tool, scannedCommit, result, sarif} so policy can
+//     filter on predicate.tool.name / predicate.result without parsing SARIF.
+//
+// The engine OWNS the subject: every statement is bound to the SINGLE sha256
+// subject passed via --subject (the same artifact digest the run's VSA binds
+// to). The GitHub attestation store rejects a multi-digest subject, so a single
+// sha256 is the only shape that round-trips through `bnd push github`. Binding
+// the scanned commit as a second subject is deferred to the source-scan PRs.
+//
+// All output is UNSIGNED. Signing stays in actions/verify/run_verify.sh, which
+// bnd-signs each emitted statement in the same trusted process as the VSA — so
+// this engine has no Sigstore code and is fully offline-unit-testable.
+//
+// Fail closed: a malformed/missing manifest, an unknown predicate-type, a
+// missing result file, or a malformed subject aborts with a non-zero exit
+// BEFORE any output is written, so a partial/corrupt bundle is never produced.
+package main
+
+import "os"
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stderr))
+}

--- a/tools/wrangle-attest/manifest.go
+++ b/tools/wrangle-attest/manifest.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Predicate types the engine knows how to build. A manifest naming any other
+// type fails closed — an unrecognized type would otherwise pass an unvalidated
+// blob through as a signed attestation.
+const (
+	predicateSPDX      = "https://spdx.dev/Document"
+	predicateOSV       = "https://ossf.github.io/osv-schema/results"
+	predicateScorecard = "https://scorecard.dev/result/v0.1"
+	predicateScanV1    = "https://github.com/TomHennen/wrangle/attestation/scan/v1"
+)
+
+// manifest is the tool↔engine contract written next to each native result.
+// `result-file` is resolved relative to the manifest's own directory so a
+// producer cannot escape its metadata dir or reach an absolute path.
+type manifest struct {
+	PredicateType string `json:"predicate-type"`
+	ResultFile    string `json:"result-file"`
+	Tool          *struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	} `json:"tool"`
+	Result string `json:"result"`
+
+	// dir is the manifest's own directory; set on discovery, not from JSON.
+	dir string
+}
+
+// validate enforces the pinned manifest schema, treating the manifest as
+// untrusted scan output. tool/result are required ONLY for the scan/v1 thin
+// envelope and ignored for passthrough predicates.
+func (m *manifest) validate() error {
+	if m.PredicateType == "" {
+		return errors.New("missing predicate-type")
+	}
+	if m.ResultFile == "" {
+		return errors.New("missing result-file")
+	}
+	// A result-file is a name within the manifest's dir, never an escape.
+	if filepath.IsAbs(m.ResultFile) || containsDotDot(m.ResultFile) {
+		return fmt.Errorf("result-file %q must be a path within the manifest directory", m.ResultFile)
+	}
+	switch m.PredicateType {
+	case predicateSPDX, predicateOSV, predicateScorecard:
+		// Passthrough: the result file IS the predicate; no extra fields.
+	case predicateScanV1:
+		if m.Tool == nil || m.Tool.Name == "" {
+			return fmt.Errorf("%s requires tool.name", predicateScanV1)
+		}
+		if m.Result != "clean" && m.Result != "findings" {
+			return fmt.Errorf("%s requires result clean|findings, got %q", predicateScanV1, m.Result)
+		}
+	default:
+		return fmt.Errorf("unknown predicate-type %q", m.PredicateType)
+	}
+	return nil
+}
+
+func containsDotDot(p string) bool {
+	for _, seg := range strings.Split(filepath.ToSlash(p), "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+// resultPath is the absolute path to the manifest's native result file.
+func (m *manifest) resultPath() string {
+	return filepath.Join(m.dir, m.ResultFile)
+}
+
+// discoverManifests walks each root for manifest.json files, parses and
+// validates each, and returns them sorted by path for deterministic output.
+// Any malformed manifest fails the whole run (fail closed). A root with no
+// manifests is not an error — a build may legitimately produce none.
+func discoverManifests(roots []string) ([]manifest, error) {
+	var found []manifest
+	for _, root := range roots {
+		info, err := os.Stat(root)
+		if err != nil {
+			return nil, fmt.Errorf("metadata-root %q: %w", root, err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("metadata-root %q is not a directory", root)
+		}
+		err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || d.Name() != "manifest.json" {
+				return nil
+			}
+			m, err := parseManifest(path)
+			if err != nil {
+				return fmt.Errorf("%s: %w", path, err)
+			}
+			found = append(found, m)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	sort.Slice(found, func(i, j int) bool { return found[i].dir < found[j].dir })
+	return found, nil
+}
+
+func parseManifest(path string) (manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return manifest{}, err
+	}
+	var m manifest
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&m); err != nil {
+		return manifest{}, fmt.Errorf("invalid manifest JSON: %w", err)
+	}
+	m.dir = filepath.Dir(path)
+	if err := m.validate(); err != nil {
+		return manifest{}, err
+	}
+	return m, nil
+}

--- a/tools/wrangle-attest/manifest_test.go
+++ b/tools/wrangle-attest/manifest_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, name)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseManifestFailClosed(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		wantErr bool
+	}{
+		{
+			name:    "valid spdx passthrough",
+			content: `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`,
+		},
+		{
+			name:    "valid scan/v1 with tool and result",
+			content: `{"predicate-type":"https://github.com/TomHennen/wrangle/attestation/scan/v1","result-file":"output.sarif","tool":{"name":"zizmor","version":"1.0"},"result":"findings"}`,
+		},
+		{
+			name:    "missing predicate-type",
+			content: `{"result-file":"sbom.spdx.json"}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing result-file",
+			content: `{"predicate-type":"https://spdx.dev/Document"}`,
+			wantErr: true,
+		},
+		{
+			name:    "unknown predicate-type",
+			content: `{"predicate-type":"https://evil.example/x","result-file":"r.json"}`,
+			wantErr: true,
+		},
+		{
+			name:    "scan/v1 missing tool",
+			content: `{"predicate-type":"https://github.com/TomHennen/wrangle/attestation/scan/v1","result-file":"output.sarif","result":"clean"}`,
+			wantErr: true,
+		},
+		{
+			name:    "scan/v1 invalid result value",
+			content: `{"predicate-type":"https://github.com/TomHennen/wrangle/attestation/scan/v1","result-file":"output.sarif","tool":{"name":"z"},"result":"maybe"}`,
+			wantErr: true,
+		},
+		{
+			name:    "result-file path traversal",
+			content: `{"predicate-type":"https://spdx.dev/Document","result-file":"../../etc/passwd"}`,
+			wantErr: true,
+		},
+		{
+			name:    "result-file nested traversal",
+			content: `{"predicate-type":"https://spdx.dev/Document","result-file":"sub/../../etc/passwd"}`,
+			wantErr: true,
+		},
+		{
+			name:    "result-file absolute path",
+			content: `{"predicate-type":"https://spdx.dev/Document","result-file":"/etc/passwd"}`,
+			wantErr: true,
+		},
+		{
+			name:    "unknown manifest field",
+			content: `{"predicate-type":"https://spdx.dev/Document","result-file":"r.json","format":"spdx"}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed json",
+			content: `{not json`,
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "manifest.json", tc.content)
+			_, err := parseManifest(filepath.Join(dir, "manifest.json"))
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDiscoverManifestsSortedAndFailClosed(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "go/b/manifest.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, root, "go/a/manifest.json", `{"predicate-type":"https://ossf.github.io/osv-schema/results","result-file":"results.json"}`)
+	got, err := discoverManifests([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 manifests, got %d", len(got))
+	}
+	// Deterministic order: a before b.
+	if filepath.Base(got[0].dir) != "a" || filepath.Base(got[1].dir) != "b" {
+		t.Fatalf("manifests not sorted by dir: %s, %s", got[0].dir, got[1].dir)
+	}
+
+	// A second malformed manifest fails the whole walk.
+	writeFile(t, root, "go/c/manifest.json", `{"bad`)
+	if _, err := discoverManifests([]string{root}); err == nil {
+		t.Fatal("expected discovery to fail closed on a malformed manifest")
+	}
+}
+
+func TestDiscoverManifestsMissingRoot(t *testing.T) {
+	if _, err := discoverManifests([]string{filepath.Join(t.TempDir(), "nope")}); err == nil {
+		t.Fatal("expected error for missing metadata-root")
+	}
+}

--- a/tools/wrangle-attest/run.go
+++ b/tools/wrangle-attest/run.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+// metadataRoots collects repeated --metadata-root flags.
+type metadataRoots []string
+
+func (r *metadataRoots) String() string { return fmt.Sprint([]string(*r)) }
+func (r *metadataRoots) Set(v string) error {
+	*r = append(*r, v)
+	return nil
+}
+
+// run is the testable entry point. It discovers manifests, binds each to the
+// single artifact subject, builds one unsigned Statement per manifest, and
+// writes them all to --out as JSONL. The file is written whole (buffer first)
+// so a mid-run failure never leaves a half-written line. run_verify.sh signs
+// each emitted line in the trusted post-build context.
+func run(args []string, stderr io.Writer) int {
+	fs := flag.NewFlagSet("wrangle-attest", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	var roots metadataRoots
+	fs.Var(&roots, "metadata-root", "directory to walk for manifest.json (repeatable)")
+	subject := fs.String("subject", "", "artifact subject digest sha256:<hex> every statement binds to")
+	commit := fs.String("commit", "", "scanned git commit, woven into the scan/v1 envelope only")
+	out := fs.String("out", "", "file the UNSIGNED in-toto JSONL statements are written to")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if err := validateFlags(roots, *subject, *out); err != nil {
+		fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
+		return 2
+	}
+
+	subj, err := newSubject(*subject)
+	if err != nil {
+		fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
+		return 2
+	}
+
+	manifests, err := discoverManifests(roots)
+	if err != nil {
+		fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
+		return 2
+	}
+
+	// Build every statement into a buffer first; only touch --out once all
+	// succeed, so an error on the Nth manifest can't corrupt the output.
+	var buf bytes.Buffer
+	for _, m := range manifests {
+		stmt, err := buildStatement(m, subj, *commit)
+		if err != nil {
+			fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
+			return 2
+		}
+		line, err := marshalStatement(stmt)
+		if err != nil {
+			fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
+			return 2
+		}
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+
+	if err := os.WriteFile(*out, buf.Bytes(), 0o644); err != nil {
+		fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
+		return 2
+	}
+	fmt.Fprintf(stderr, "wrangle-attest: wrote %d statement(s) to %s\n", len(manifests), *out)
+	return 0
+}
+
+func validateFlags(roots []string, subject, out string) error {
+	if len(roots) == 0 {
+		return fmt.Errorf("at least one --metadata-root is required")
+	}
+	if subject == "" {
+		return fmt.Errorf("--subject is required")
+	}
+	if out == "" {
+		return fmt.Errorf("--out is required")
+	}
+	return nil
+}

--- a/tools/wrangle-attest/run_test.go
+++ b/tools/wrangle-attest/run_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var update = flag.Bool("update", false, "regenerate golden files")
+
+func TestRunWritesSBOMStatement(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "meta/go/foo/manifest.json",
+		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, dir, "meta/go/foo/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3","name":"x"}`)
+	out := filepath.Join(dir, "sbom.intoto.jsonl")
+
+	var stderr bytes.Buffer
+	rc := run([]string{
+		"--metadata-root", filepath.Join(dir, "meta"),
+		"--subject", testArtifactDigest,
+		"--out", out,
+	}, &stderr)
+	if rc != 0 {
+		t.Fatalf("run rc=%d stderr=%s", rc, stderr.String())
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 statement line, got %d:\n%s", len(lines), data)
+	}
+
+	var stmt struct {
+		Type          string `json:"_type"`
+		PredicateType string `json:"predicateType"`
+		Subject       []struct {
+			Digest map[string]string `json:"digest"`
+		} `json:"subject"`
+	}
+	if err := json.Unmarshal([]byte(lines[0]), &stmt); err != nil {
+		t.Fatalf("statement is not valid JSON: %v", err)
+	}
+	if stmt.PredicateType != "https://spdx.dev/Document" {
+		t.Fatalf("wrong predicateType: %q", stmt.PredicateType)
+	}
+	// Single sha256 subject — the store rejects multi-digest.
+	if len(stmt.Subject) != 1 || len(stmt.Subject[0].Digest) != 1 ||
+		stmt.Subject[0].Digest["sha256"] != "011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95" {
+		t.Fatalf("expected single sha256 subject, got %+v", stmt.Subject)
+	}
+}
+
+func TestRunFlagValidation(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "meta/foo/manifest.json",
+		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, dir, "meta/foo/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3"}`)
+	meta := filepath.Join(dir, "meta")
+	out := filepath.Join(dir, "b.jsonl")
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"no metadata-root", []string{"--subject", testArtifactDigest, "--out", out}},
+		{"no subject", []string{"--metadata-root", meta, "--out", out}},
+		{"no out", []string{"--metadata-root", meta, "--subject", testArtifactDigest}},
+		{"bad subject", []string{"--metadata-root", meta, "--subject", "notadigest", "--out", out}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			if rc := run(tc.args, &stderr); rc == 0 {
+				t.Fatalf("expected non-zero exit, got 0")
+			}
+		})
+	}
+}
+
+// A failure on any manifest must not leave a partially-written --out file.
+func TestRunFailClosedNoOutput(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "meta/ok/manifest.json",
+		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, dir, "meta/ok/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3"}`)
+	// Second manifest names a result file that does not exist -> build fails.
+	writeFile(t, dir, "meta/broken/manifest.json",
+		`{"predicate-type":"https://spdx.dev/Document","result-file":"missing.json"}`)
+	out := filepath.Join(dir, "out.jsonl")
+
+	var stderr bytes.Buffer
+	rc := run([]string{
+		"--metadata-root", filepath.Join(dir, "meta"),
+		"--subject", testArtifactDigest,
+		"--out", out,
+	}, &stderr)
+	if rc == 0 {
+		t.Fatal("expected fail-closed exit")
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatalf("expected no output file on a failed run, stat err=%v", err)
+	}
+}

--- a/tools/wrangle-attest/statement.go
+++ b/tools/wrangle-attest/statement.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	intoto "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// buildStatement turns one manifest into an unsigned in-toto v1 Statement bound
+// to the single artifact subject. The predicate is either the result file
+// verbatim (passthrough) or a thin SARIF envelope, per predicate-type. commit
+// is woven into the scan/v1 envelope only; passthrough predicates ignore it.
+func buildStatement(m manifest, subject *intoto.ResourceDescriptor, commit string) (*intoto.Statement, error) {
+	pred, err := buildPredicate(m, commit)
+	if err != nil {
+		return nil, err
+	}
+	stmt := &intoto.Statement{
+		Type:          intoto.StatementTypeUri,
+		Subject:       []*intoto.ResourceDescriptor{subject},
+		PredicateType: m.PredicateType,
+		Predicate:     pred,
+	}
+	if err := stmt.Validate(); err != nil {
+		return nil, fmt.Errorf("statement for %s: %w", m.PredicateType, err)
+	}
+	return stmt, nil
+}
+
+// buildPredicate reads the manifest's result file and shapes it for the
+// statement. Passthrough types embed the JSON object as-is; the scan/v1 type
+// wraps SARIF in {tool, scannedCommit, result, sarif}.
+func buildPredicate(m manifest, commit string) (*structpb.Struct, error) {
+	raw, err := os.ReadFile(m.resultPath())
+	if err != nil {
+		return nil, fmt.Errorf("result-file: %w", err)
+	}
+	switch m.PredicateType {
+	case predicateSPDX, predicateOSV, predicateScorecard:
+		return jsonObjectToStruct(raw)
+	case predicateScanV1:
+		var sarif json.RawMessage
+		if err := json.Unmarshal(raw, &sarif); err != nil {
+			return nil, fmt.Errorf("result-file is not valid JSON: %w", err)
+		}
+		envelope := map[string]any{
+			"tool":          map[string]any{"name": m.Tool.Name, "version": m.Tool.Version},
+			"scannedCommit": commit,
+			"result":        m.Result,
+			"sarif":         sarif,
+		}
+		enc, err := json.Marshal(envelope)
+		if err != nil {
+			return nil, err
+		}
+		return jsonObjectToStruct(enc)
+	default:
+		// validate() already rejects unknown types; defensive belt-and-braces.
+		return nil, fmt.Errorf("unknown predicate-type %q", m.PredicateType)
+	}
+}
+
+// jsonObjectToStruct decodes a JSON object into a structpb.Struct. A predicate
+// MUST be a JSON object (in-toto requires it); a top-level array/scalar fails
+// closed rather than producing a malformed statement.
+func jsonObjectToStruct(raw []byte) (*structpb.Struct, error) {
+	s := &structpb.Struct{}
+	if err := protojson.Unmarshal(raw, s); err != nil {
+		return nil, fmt.Errorf("predicate must be a JSON object: %w", err)
+	}
+	return s, nil
+}
+
+// marshalStatement renders a Statement as a single compact JSONL line. protojson
+// emits the in-toto-canonical field names (`_type`, `predicateType`); compacting
+// through encoding/json strips protojson's non-deterministic whitespace so the
+// output is one object per line.
+func marshalStatement(stmt *intoto.Statement) ([]byte, error) {
+	js, err := protojson.Marshal(stmt)
+	if err != nil {
+		return nil, err
+	}
+	var canonical any
+	if err := json.Unmarshal(js, &canonical); err != nil {
+		return nil, err
+	}
+	return json.Marshal(canonical)
+}

--- a/tools/wrangle-attest/statement_test.go
+++ b/tools/wrangle-attest/statement_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// goldenStatement asserts that building a statement from a manifest + the fixed
+// subject produces exactly the golden JSON. Golden files pin the on-the-wire
+// shape both consumers (policy CEL) and the later SARIF-producer PRs depend on;
+// regenerate with -update when the contract intentionally changes.
+func TestBuildStatementGolden(t *testing.T) {
+	cases := []struct {
+		name       string
+		manifest   string
+		resultName string
+		result     string
+		golden     string
+	}{
+		{
+			name:       "sbom passthrough",
+			manifest:   `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`,
+			resultName: "sbom.spdx.json",
+			result:     `{"spdxVersion":"SPDX-2.3","name":"test","SPDXID":"SPDXRef-DOCUMENT","packages":[{"name":"pkg","SPDXID":"SPDXRef-pkg"}]}`,
+			golden:     "testdata/sbom.statement.json",
+		},
+		{
+			name:       "scan/v1 sarif envelope",
+			manifest:   `{"predicate-type":"https://github.com/TomHennen/wrangle/attestation/scan/v1","result-file":"output.sarif","tool":{"name":"zizmor","version":"1.13.0"},"result":"findings"}`,
+			resultName: "output.sarif",
+			result:     `{"version":"2.1.0","$schema":"https://json.schemastore.org/sarif-2.1.0.json","runs":[{"tool":{"driver":{"name":"zizmor"}},"results":[]}]}`,
+			golden:     "testdata/scan.statement.json",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "manifest.json", tc.manifest)
+			writeFile(t, dir, tc.resultName, tc.result)
+			m, err := parseManifest(filepath.Join(dir, "manifest.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			subj, err := newSubject(testArtifactDigest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stmt, err := buildStatement(m, subj, "5741a1afbdffa5eb9ab95dd212ce8c310631e355")
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := marshalStatement(stmt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertGolden(t, tc.golden, got)
+		})
+	}
+}
+
+func TestBuildStatementFailClosed(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "manifest.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	m, err := parseManifest(filepath.Join(dir, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	subj, _ := newSubject(testArtifactDigest)
+
+	// Missing result file.
+	if _, err := buildStatement(m, subj, ""); err == nil {
+		t.Fatal("expected error for missing result file")
+	}
+
+	// A predicate that is a JSON array, not an object, must fail.
+	writeFile(t, dir, "sbom.spdx.json", `[1,2,3]`)
+	if _, err := buildStatement(m, subj, ""); err == nil {
+		t.Fatal("expected error for non-object predicate")
+	}
+}
+
+// assertGolden compares got to the golden file, normalizing both through a
+// generic JSON round-trip so formatting differences don't cause spurious fails.
+// Run `go test -update` to (re)write golden files.
+func assertGolden(t *testing.T, path string, got []byte) {
+	t.Helper()
+	if *update {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		pretty := mustIndent(t, got)
+		if err := os.WriteFile(path, pretty, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s: %v (run go test -update)", path, err)
+	}
+	if !jsonEqual(t, got, want) {
+		t.Fatalf("statement mismatch for %s:\ngot:  %s\nwant: %s", path, mustIndent(t, got), want)
+	}
+}
+
+func jsonEqual(t *testing.T, a, b []byte) bool {
+	t.Helper()
+	var av, bv any
+	if err := json.Unmarshal(a, &av); err != nil {
+		t.Fatalf("unmarshal got: %v", err)
+	}
+	if err := json.Unmarshal(b, &bv); err != nil {
+		t.Fatalf("unmarshal want: %v", err)
+	}
+	ab, _ := json.Marshal(av)
+	bb, _ := json.Marshal(bv)
+	return string(ab) == string(bb)
+}
+
+func mustIndent(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatal(err)
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(out, '\n')
+}

--- a/tools/wrangle-attest/subjects.go
+++ b/tools/wrangle-attest/subjects.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	intoto "github.com/in-toto/attestation/go/v1"
+)
+
+// The artifact subject is a single sha256 digest. The GitHub attestation store
+// (bnd push github) keys by subject digest and rejects a multi-digest subject,
+// so sha256 is the only algorithm the engine binds to. run_verify.sh already
+// computes this same digest for the VSA subject, so the SBOM and the VSA share
+// one subject and a policy resolving by artifact digest finds both.
+var sha256DigestRe = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// newSubject parses the single --subject digest (sha256:<hex>) into the
+// in-toto descriptor every statement is bound to. A malformed digest fails
+// closed rather than producing an unbound or wrongly-bound attestation.
+func newSubject(subject string) (*intoto.ResourceDescriptor, error) {
+	if !sha256DigestRe.MatchString(subject) {
+		return nil, fmt.Errorf("subject %q must be sha256:<64-hex>", subject)
+	}
+	hex := strings.TrimPrefix(subject, "sha256:")
+	return &intoto.ResourceDescriptor{
+		Digest: map[string]string{"sha256": hex},
+	}, nil
+}

--- a/tools/wrangle-attest/subjects_test.go
+++ b/tools/wrangle-attest/subjects_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+const testArtifactDigest = "sha256:011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95"
+
+func TestNewSubject(t *testing.T) {
+	d, err := newSubject(testArtifactDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := d.Digest["sha256"]; got != "011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95" {
+		t.Fatalf("subject digest wrong: %q", got)
+	}
+	// Exactly one algorithm — the store rejects multi-digest subjects.
+	if len(d.Digest) != 1 {
+		t.Fatalf("expected a single-digest subject, got %d entries", len(d.Digest))
+	}
+}
+
+func TestNewSubjectFailClosed(t *testing.T) {
+	cases := []string{
+		"",
+		"sha256:",
+		"011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95", // no algo prefix
+		"sha512:011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95",
+		"sha256:nothex",
+		"sha256:011b95c8", // too short
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			if _, err := newSubject(c); err == nil {
+				t.Fatalf("expected error for subject %q", c)
+			}
+		})
+	}
+}

--- a/tools/wrangle-attest/testdata/sbom.statement.json
+++ b/tools/wrangle-attest/testdata/sbom.statement.json
@@ -1,0 +1,22 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "predicate": {
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "test",
+    "packages": [
+      {
+        "SPDXID": "SPDXRef-pkg",
+        "name": "pkg"
+      }
+    ],
+    "spdxVersion": "SPDX-2.3"
+  },
+  "predicateType": "https://spdx.dev/Document",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95"
+      }
+    }
+  ]
+}

--- a/tools/wrangle-attest/testdata/scan.statement.json
+++ b/tools/wrangle-attest/testdata/scan.statement.json
@@ -1,0 +1,33 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "predicate": {
+    "result": "findings",
+    "sarif": {
+      "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+      "runs": [
+        {
+          "results": [],
+          "tool": {
+            "driver": {
+              "name": "zizmor"
+            }
+          }
+        }
+      ],
+      "version": "2.1.0"
+    },
+    "scannedCommit": "5741a1afbdffa5eb9ab95dd212ce8c310631e355",
+    "tool": {
+      "name": "zizmor",
+      "version": "1.13.0"
+    }
+  },
+  "predicateType": "https://github.com/TomHennen/wrangle/attestation/scan/v1",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Part of #420. PR1 of the scan/build-attestation epic; stacks on #453 (store-vsa).

## What this does

**Engine** (`tools/wrangle-attest/`, already on the branch): turns the inert result files build/scan tools leave behind into UNSIGNED in-toto v1 Statements. Tools drop a `manifest.json` (`predicate-type` + `result-file`) next to their native result; the engine walks `--metadata-root`, builds one Statement per manifest bound to the single `--subject` sha256, and writes JSONL. SBOM (SPDX) is the v1 producer; OSV/scorecard/SARIF cases are wired for later manifest-only PRs. No signing here — fully offline-unit-testable.

**Producer side**: each build type, after writing `sbom.spdx.json`, drops a `manifest.json` (`https://spdx.dev/Document` → `sbom.spdx.json`) via `lib/write_attest_manifest.sh`. Container SBOM extraction moved into `extract_sbom.sh`.

**Verify wiring**: the verify job downloads the build metadata artifact and passes it as `metadata-dir`. Per subject, `run_verify.sh` runs `wrangle-attest` to build the SBOM Statement bound to that subject's **single sha256** (the same digest the VSA binds to — the store rejects multi-digest, so no dual-subject/multi-digest for SBOM), bnd-signs it, appends it to the per-artifact bundle (#444), and pushes it to the attestation store (#453's path) + the OCI referrer for container. Fails closed on a malformed/absent manifest.

The SBOM Statement's predicate is `https://spdx.dev/Document` bound to the artifact sha256 — exactly what the `sbom-exists` tenet in `policies/wrangle-default-v1.hjson` matches and resolves by.

## Validation

`./test.sh quick` green; shellcheck + actionlint clean; engine `go test` green; `check_pin_ancestry.sh` passes. The 4 `actions/verify` bootstrap pins are re-pointed to this PR's HEAD so the integration test exercises the new verify action.

**The full `test` + `dispatch` (e2e) CI is the real validation** — the dispatch must confirm the SBOM attestation is produced, signed, and delivered (bundle + store), and that `sbom-exists` is satisfiable against it. Not yet confirmed end-to-end on a real runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)