### PR TITLE
[OBSOLETE — redone as SARIF on #469] feat(osv): OSV scan attestation (produce + trusted-sign)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -253,6 +253,16 @@ jobs:
           name: ${{ needs.build.outputs.metadata-artifact-name }}
           path: metadata/
 
+      # The inert scan-results metadata (OSV results.json + manifest) from the
+      # untrusted scan job; wrangle-attest wraps + signs it here in the trusted
+      # context. continue-on-error so a scan-tools-less build (no artifact) still
+      # verifies — run_verify skips a scan-metadata-dir that does not exist.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: wrangle-scan-results
+          path: scan-metadata/
+
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify@d48f3f4afee459fc272fdbbd67dc29c90da11d79 # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
@@ -261,6 +271,7 @@ jobs:
           collector: oci:${{ needs.build.outputs.imagename }}@${{ needs.build.outputs.digest }}
           bundle-out: bundles
           metadata-dir: metadata
+          scan-metadata-dir: scan-metadata
           artifact-name: container-bundle-${{ needs.build.outputs.shortname }}
           # resourceUri is the OCI image ref a container consumer fetches and
           # pins when verifying the VSA; the subject digest is the cryptographic bind.

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -264,7 +264,7 @@ jobs:
           path: scan-metadata/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@d48f3f4afee459fc272fdbbd67dc29c90da11d79 # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@4035b0e3e9aa96972d8d759d321eba6f7871ddc2 # feat/osv-attestation 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           subjects: ${{ needs.build.outputs.digest }}
           policy: policies/wrangle-provenance-container-v1.hjson

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -437,7 +437,7 @@ jobs:
           path: scan-metadata/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@d48f3f4afee459fc272fdbbd67dc29c90da11d79 # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@4035b0e3e9aa96972d8d759d321eba6f7871ddc2 # feat/osv-attestation 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.release.outputs.dist-files }}
           policy: policies/wrangle-provenance-go-v1.hjson

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -426,6 +426,16 @@ jobs:
           name: ${{ needs.release.outputs.metadata-artifact-name }}
           path: metadata/
 
+      # The inert scan-results metadata (OSV results.json + manifest) from the
+      # untrusted scan job; wrangle-attest wraps + signs it here in the trusted
+      # context. continue-on-error so a scan-tools-less build (no artifact) still
+      # verifies — run_verify skips a scan-metadata-dir that does not exist.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: wrangle-scan-results
+          path: scan-metadata/
+
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify@d48f3f4afee459fc272fdbbd67dc29c90da11d79 # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
@@ -435,6 +445,7 @@ jobs:
           bundle-in: provenance/provenance.jsonl
           bundle-out: bundles
           metadata-dir: metadata
+          scan-metadata-dir: scan-metadata
           artifact-name: go-bundle-${{ needs.release.outputs.shortname }}
           # resourceUri is the golang module purl consumers pin when verifying;
           # each subject digest is the cryptographic bind.

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -344,6 +344,16 @@ jobs:
           name: ${{ needs.build.outputs.metadata-artifact-name }}
           path: metadata/
 
+      # The inert scan-results metadata (OSV results.json + manifest) from the
+      # untrusted scan job; wrangle-attest wraps + signs it here in the trusted
+      # context. continue-on-error so a scan-tools-less build (no artifact) still
+      # verifies — run_verify skips a scan-metadata-dir that does not exist.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: wrangle-scan-results
+          path: scan-metadata/
+
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify@d48f3f4afee459fc272fdbbd67dc29c90da11d79 # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
@@ -353,6 +363,7 @@ jobs:
           bundle-in: provenance/provenance.jsonl
           bundle-out: bundles
           metadata-dir: metadata
+          scan-metadata-dir: scan-metadata
           artifact-name: npm-bundle-${{ needs.build.outputs.shortname }}
           # resourceUri is the npm purl consumers pin when verifying the VSAs;
           # each subject digest is the cryptographic bind.

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -355,7 +355,7 @@ jobs:
           path: scan-metadata/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@d48f3f4afee459fc272fdbbd67dc29c90da11d79 # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@4035b0e3e9aa96972d8d759d321eba6f7871ddc2 # feat/osv-attestation 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.build.outputs.dist-files }}
           policy: policies/wrangle-provenance-npm-v1.hjson

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -335,6 +335,16 @@ jobs:
           name: ${{ needs.build.outputs.metadata-artifact-name }}
           path: metadata/
 
+      # The inert scan-results metadata (OSV results.json + manifest) from the
+      # untrusted scan job; wrangle-attest wraps + signs it here in the trusted
+      # context. continue-on-error so a scan-tools-less build (no artifact) still
+      # verifies — run_verify skips a scan-metadata-dir that does not exist.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: wrangle-scan-results
+          path: scan-metadata/
+
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify@d48f3f4afee459fc272fdbbd67dc29c90da11d79 # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
@@ -344,6 +354,7 @@ jobs:
           bundle-in: provenance/provenance.jsonl
           bundle-out: bundles
           metadata-dir: metadata
+          scan-metadata-dir: scan-metadata
           artifact-name: python-bundle-${{ needs.build.outputs.shortname }}
           # resourceUri names the package the VSAs cover (pkg:pypi, PEP
           # 503-normalized); the consumer/gate check pins it. Each subject

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -346,7 +346,7 @@ jobs:
           path: scan-metadata/
 
       # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify@d48f3f4afee459fc272fdbbd67dc29c90da11d79 # feat/wrangle-attest-sbom 2026-06-18 (bootstrap PR HEAD; bump after merge)
+      - uses: TomHennen/wrangle/actions/verify@4035b0e3e9aa96972d8d759d321eba6f7871ddc2 # feat/osv-attestation 2026-06-18 (bootstrap PR HEAD; bump after merge)
         with:
           dist-files: ${{ needs.build.outputs.dist-files }}
           policy: policies/wrangle-provenance-python-v1.hjson

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -86,6 +86,15 @@ inputs:
       the attestation store. Leave empty to emit VSA-only bundles.
     required: false
     default: ""
+  scan-metadata-dir:
+    description: >
+      Directory holding the inert scan-results metadata (the scan job's
+      wrangle-scan-results artifact: OSV results.json + manifest.json). The
+      results are produced in the untrusted scan job; wrangle-attest wraps and
+      signs them here in the trusted context, appending one signed scan statement
+      per subject. Leave empty for builds that ran no scan.
+    required: false
+    default: ""
   oci-target:
     description: >
       When set, fetch the provenance from and push the bundle to this OCI image
@@ -134,6 +143,7 @@ runs:
         BUNDLE_OUT: ${{ inputs.bundle-out }}
         OCI_TARGET: ${{ inputs.oci-target }}
         METADATA_ROOT: ${{ inputs.metadata-dir }}
+        SCAN_METADATA_ROOT: ${{ inputs.scan-metadata-dir }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         # bnd push github authenticates to the attestation store with this token;
         # the attestations: write permission rides on it.

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -13,8 +13,9 @@
 # Inputs arrive as env vars: SUBJECTS (newline-separated), POLICY, COLLECTOR,
 # FAIL, CONTEXT, BUNDLE_IN, BUNDLE_OUT, GITHUB_REPOSITORY (store push target),
 # GITHUB_TOKEN (bnd reads it to auth the store push), and optional ATTESTATION,
-# OCI_TARGET, METADATA_ROOT (the build metadata dir wrangle-attest walks for the
-# SBOM manifest, appended as a signed statement per subject).
+# OCI_TARGET, METADATA_ROOT (the build metadata dir — SBOM manifest) and
+# SCAN_METADATA_ROOT (the inert scan-results dir — OSV manifest), both walked by
+# wrangle-attest and appended as signed statements per subject.
 
 set -euo pipefail
 set -f  # disable globbing — processes external input
@@ -226,30 +227,42 @@ wrangle_push_bundle() {
     wrangle_retry_once /dev/null cosign "${args[@]}"
 }
 
-# Build the wrangle-attest arg vector that turns the build metadata into unsigned
-# in-toto statements, one per line for mapfile. $1 is the single sha256 subject;
-# $2 the JSONL output path. METADATA_ROOT holds the build's manifest.json files
-# (sbom.spdx.json + its manifest); --commit is woven into the scan/v1 envelope
-# only, ignored by the SBOM passthrough.
-wrangle_attest_args() {
-    printf '%s\n' \
-        --metadata-root="$METADATA_ROOT" \
-        --subject="$1" \
-        --out="$2"
+# Collect the metadata roots wrangle-attest walks, one per line. METADATA_ROOT
+# is the build's metadata (sbom.spdx.json + manifest); SCAN_METADATA_ROOT is the
+# inert scan-results metadata (osv results.json + manifest) produced in the
+# untrusted scan job — wrapping + signing it here keeps the statement minted in
+# the trusted context. A root is included only when it names an existing dir.
+wrangle_metadata_roots() {
+    [[ -n "${METADATA_ROOT:-}" && -d "${METADATA_ROOT:-}" ]] && printf '%s\n' "$METADATA_ROOT"
+    [[ -n "${SCAN_METADATA_ROOT:-}" && -d "${SCAN_METADATA_ROOT:-}" ]] && printf '%s\n' "$SCAN_METADATA_ROOT"
 }
 
-# For one subject, build the SBOM (and any other build-metadata) statement(s),
-# sign each, append each to the bundle, and post each to the store. No-op when
-# METADATA_ROOT is unset/empty (a build that produced no metadata). $1 is the
-# subject, $2 the bundle file. wrangle-attest fails closed on a malformed
-# manifest, so an absent statement is a real gap, not a silent skip.
+# Build the wrangle-attest arg vector that turns the metadata roots into unsigned
+# in-toto statements, one per line for mapfile. $1 is the single sha256 subject;
+# $2 the JSONL output path; the remaining args are the metadata roots. --commit
+# is woven into the scan/v1 envelope only, ignored by the OSV/SBOM passthrough.
+wrangle_attest_args() {
+    local subj_sha="$1" out="$2"; shift 2
+    local root
+    for root in "$@"; do
+        printf -- '--metadata-root=%s\n' "$root"
+    done
+    printf '%s\n' --subject="$subj_sha" --out="$out"
+}
+
+# For one subject, build the metadata statement(s) (SBOM, OSV, …), sign each,
+# append each to the bundle, and post each to the store. No-op when no metadata
+# root exists (a build that produced none). $1 is the subject, $2 the bundle
+# file. wrangle-attest fails closed on a malformed manifest, so an absent
+# statement is a real gap, not a silent skip.
 wrangle_emit_metadata_statements() {
-    [[ -z "${METADATA_ROOT:-}" || ! -d "${METADATA_ROOT:-}" ]] && return 0
-    local subject="$1" bundle="$2" subj_sha
+    local subject="$1" bundle="$2" subj_sha roots
+    mapfile -t roots < <(wrangle_metadata_roots)
+    [[ "${#roots[@]}" -eq 0 ]] && return 0
     subj_sha="$(wrangle_subject_sha256 "$subject")" || return 1
     local stmts args
     stmts="$(mktemp "${RUNNER_TEMP:-/tmp}/attest.XXXXXX")"
-    mapfile -t args < <(wrangle_attest_args "$subj_sha" "$stmts")
+    mapfile -t args < <(wrangle_attest_args "$subj_sha" "$stmts" "${roots[@]}")
     # A malformed/missing manifest aborts here — never ship a bundle silently
     # missing its SBOM statement.
     wrangle-attest "${args[@]}" || { rm -f "$stmts"; return 1; }

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -126,12 +126,32 @@ teardown() {
 
 # --- wrangle-attest arg vector ---
 
-@test "run_verify: attest args carry the metadata-root, subject, and out" {
-    export METADATA_ROOT="$TEST_DIR/meta"
-    mapfile -t args < <(wrangle_attest_args "sha256:abc" "$TEST_DIR/out.jsonl")
+@test "run_verify: attest args carry each metadata-root, subject, and out" {
+    mapfile -t args < <(wrangle_attest_args "sha256:abc" "$TEST_DIR/out.jsonl" \
+        "$TEST_DIR/meta" "$TEST_DIR/scan-meta")
     printf '%s\n' "${args[@]}" | grep -qx -- "--metadata-root=$TEST_DIR/meta"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--metadata-root=$TEST_DIR/scan-meta"
     printf '%s\n' "${args[@]}" | grep -qx -- "--subject=sha256:abc"
     printf '%s\n' "${args[@]}" | grep -qx -- "--out=$TEST_DIR/out.jsonl"
+}
+
+@test "run_verify: metadata roots include only existing build + scan dirs" {
+    mkdir -p "$TEST_DIR/build-meta" "$TEST_DIR/scan-meta"
+    export METADATA_ROOT="$TEST_DIR/build-meta"
+    export SCAN_METADATA_ROOT="$TEST_DIR/scan-meta"
+    mapfile -t roots < <(wrangle_metadata_roots)
+    [ "${#roots[@]}" -eq 2 ]
+    printf '%s\n' "${roots[@]}" | grep -qx -- "$TEST_DIR/build-meta"
+    printf '%s\n' "${roots[@]}" | grep -qx -- "$TEST_DIR/scan-meta"
+}
+
+@test "run_verify: a metadata root naming a missing dir is dropped" {
+    mkdir -p "$TEST_DIR/scan-meta"
+    export METADATA_ROOT="$TEST_DIR/absent-build"
+    export SCAN_METADATA_ROOT="$TEST_DIR/scan-meta"
+    mapfile -t roots < <(wrangle_metadata_roots)
+    [ "${#roots[@]}" -eq 1 ]
+    [ "${roots[0]}" = "$TEST_DIR/scan-meta" ]
 }
 
 # --- ampel arg vector ---
@@ -681,7 +701,7 @@ exit 1
 STUB
     chmod +x "$TEST_DIR/bnd"
     export PATH="$TEST_DIR:$PATH"
-    unset METADATA_ROOT
+    unset METADATA_ROOT SCAN_METADATA_ROOT
     local bundle="$TEST_DIR/bundle.jsonl"
     printf '{"provenance":1}\n' > "$bundle"
     run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
@@ -725,6 +745,38 @@ STUB
     [[ "$(tail -1 "$bundle" | jq -r '.signed.predicateType')" == "https://spdx.dev/Document" ]]
     # The signed statement reached the store, bound to the single sha256 subject.
     [[ "$(jq -r '.signed.subject[0].digest.sha256' "$TEST_DIR/pushed")" == "$(printf '0%.0s' {1..64})" ]]
+}
+
+@test "run_verify: emit_metadata wraps the OSV scan-results from SCAN_METADATA_ROOT" {
+    # The inert OSV results.json + manifest in SCAN_METADATA_ROOT becomes a signed
+    # osv-schema statement bound to the same single sha256 subject — the shape the
+    # no-exploitable-vulns tenet reads (data.results[]...vulnerabilities[].id).
+    if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
+    mkdir -p "$TEST_DIR/scan-meta/osv"
+    printf '{"results":[{"packages":[{"vulnerabilities":[{"id":"CVE-2021-3121"}]}]}]}\n' \
+        > "$TEST_DIR/scan-meta/osv/results.json"
+    printf '{"predicate-type":"https://ossf.github.io/osv-schema/results","result-file":"results.json"}\n' \
+        > "$TEST_DIR/scan-meta/osv/manifest.json"
+    cat > "$TEST_DIR/bnd" <<STUB
+#!/bin/bash
+if [[ "\$1" == "push" ]]; then exit 0; fi
+printf '{\n  "signed": '; cat "\$2"; printf '}\n'
+STUB
+    chmod +x "$TEST_DIR/bnd"
+    local attest_dir; attest_dir="$(dirname "$ATTEST_BIN")"
+    export PATH="$TEST_DIR:$attest_dir:$PATH"
+    unset METADATA_ROOT
+    export SCAN_METADATA_ROOT="$TEST_DIR/scan-meta"
+    export GITHUB_REPOSITORY="o/r"
+    export OCI_TARGET=""
+    local bundle="$TEST_DIR/bundle.jsonl"
+    printf '{"provenance":1}\n' > "$bundle"
+    run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
+    [[ "$status" -eq 0 ]]
+    [[ "$(wc -l < "$bundle")" -eq 2 ]]
+    [[ "$(tail -1 "$bundle" | jq -r '.signed.predicateType')" == "https://ossf.github.io/osv-schema/results" ]]
+    # The tenet's CEL path resolves on the wrapped predicate.
+    [[ "$(tail -1 "$bundle" | jq -r '.signed.predicate.results[0].packages[0].vulnerabilities[0].id')" == "CVE-2021-3121" ]]
 }
 
 @test "run_verify: emit_metadata fails closed on a malformed manifest" {

--- a/tools/osv/adapter.sh
+++ b/tools/osv/adapter.sh
@@ -9,6 +9,12 @@ set -f  # disable globbing — adapter processes external input paths
 # Exit: 0 = no findings, 1 = findings found, 2 = tool error
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRANGLE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Unversioned osv-schema predicate: the attestation engine passes the OSV JSON
+# results through as the predicate verbatim, and the upstream no-exploitable-vulns
+# tenet (+ its internal:vex transformer) reads data.results[]...vulnerabilities[].id.
+OSV_PREDICATE_TYPE="https://ossf.github.io/osv-schema/results"
 
 if [[ $# -ne 2 ]]; then
     printf 'Usage: adapter.sh <src_dir> <output_dir>\n' >&2
@@ -30,6 +36,7 @@ fi
 
 SARIF_FILE="${OUTPUT_DIR}/output.sarif"
 MD_FILE="${OUTPUT_DIR}/output.md"
+RESULTS_FILE="${OUTPUT_DIR}/results.json"
 
 # Run OSV-Scanner for SARIF output
 osv_exit=0
@@ -62,6 +69,29 @@ if ! jq empty "$SARIF_FILE" 2>/dev/null; then
     printf 'wrangle/osv: produced invalid JSON in SARIF output\n' >&2
     exit 2
 fi
+
+# Emit the OSV JSON results too: this is the shape the attestation engine binds
+# as the osv-schema predicate, and the no-exploitable-vulns tenet reads from it.
+# A second scan invocation (osv-scanner has no SARIF->JSON conversion); its exit
+# code mirrors the SARIF run (0 clean / 1 findings / 128 no-sources) so we accept
+# those and reject anything else as a tool error.
+json_exit=0
+osv-scanner scan --format json --output "$RESULTS_FILE" -r "$SRC_DIR" || json_exit=$?
+if [[ "$json_exit" -eq 128 ]]; then
+    # No package sources: match the SARIF path with an empty results object.
+    jq -n '{"results": []}' > "$RESULTS_FILE"
+elif [[ "$json_exit" -ge 2 ]] && [[ "$json_exit" -ne 1 ]]; then
+    printf 'wrangle/osv: osv-scanner --format json exited with unexpected code %d\n' "$json_exit" >&2
+    exit 2
+fi
+if ! jq empty "$RESULTS_FILE" 2>/dev/null; then
+    printf 'wrangle/osv: produced invalid JSON in results output\n' >&2
+    exit 2
+fi
+
+# Declare the results file to the attestation engine via the standard manifest.
+"$WRANGLE_ROOT/lib/write_attest_manifest.sh" \
+    "$OUTPUT_DIR" "$OSV_PREDICATE_TYPE" "results.json"
 
 # Generate markdown summary from the SARIF we just produced. Using a local
 # render_md.sh (rather than a second osv-scanner invocation with

--- a/tools/osv/test.bats
+++ b/tools/osv/test.bats
@@ -71,6 +71,8 @@ case "${OSV_MOCK_MODE:-clean}" in
   "runs": [{"tool": {"driver": {"name": "osv-scanner", "version": "2.3.5"}}, "results": []}]
 }
 SARIF
+        elif [[ "$format" == "json" ]]; then
+            printf '{"results": []}\n' > "$output_file"
         fi
         exit 0
         ;;
@@ -83,12 +85,18 @@ SARIF
   "runs": [{"tool": {"driver": {"name": "osv-scanner", "version": "2.3.5", "rules": [{"id": "GHSA-1234-5678-abcd", "shortDescription": {"text": "Test vulnerability"}}]}}, "results": [{"ruleId": "GHSA-1234-5678-abcd", "level": "error", "message": {"text": "Package 'foo@1.0.0' is vulnerable to 'GHSA-1234-5678-abcd'."}, "locations": [{"physicalLocation": {"artifactLocation": {"uri": "package-lock.json"}, "region": {"startLine": 1}}}]}]}]
 }
 SARIF
+        elif [[ "$format" == "json" ]]; then
+            cat > "$output_file" << 'JSON'
+{"results": [{"source": {"path": "package-lock.json"}, "packages": [{"package": {"name": "foo", "version": "1.0.0"}, "vulnerabilities": [{"id": "GHSA-1234-5678-abcd"}]}]}]}
+JSON
         fi
         exit 1
         ;;
     real-findings)
         if [[ "$format" == "sarif" ]]; then
             cp "$OSV_REAL_SARIF" "$output_file"
+        elif [[ "$format" == "json" ]]; then
+            printf '{"results": [{"packages": [{"vulnerabilities": [{"id": "CVE-2021-3121"}]}]}]}\n' > "$output_file"
         fi
         exit 1
         ;;
@@ -100,6 +108,18 @@ SARIF
         ;;
     bad-json)
         if [[ "$format" == "sarif" ]]; then
+            printf 'not valid json{{{\n' > "$output_file"
+        elif [[ "$format" == "json" ]]; then
+            printf '{"results": []}\n' > "$output_file"
+        fi
+        exit 0
+        ;;
+    bad-json-results)
+        if [[ "$format" == "sarif" ]]; then
+            cat > "$output_file" << 'SARIF'
+{"version": "2.1.0", "runs": [{"tool": {"driver": {"name": "osv-scanner"}}, "results": []}]}
+SARIF
+        elif [[ "$format" == "json" ]]; then
             printf 'not valid json{{{\n' > "$output_file"
         fi
         exit 0
@@ -355,6 +375,41 @@ SARIF
     [ "$status" -eq 0 ]
     [ -s "$TMP_DIR/output/output.md" ]
     grep -qi "no known vulnerabilities" "$TMP_DIR/output/output.md"
+}
+
+# --- adapter.sh: OSV JSON results + attestation manifest ------------------
+
+@test "osv adapter: emits OSV JSON results + manifest (clean)" {
+    export OSV_MOCK_MODE="clean"
+    run "$ADAPTER" "$TMP_DIR/src" "$TMP_DIR/output"
+    [ "$status" -eq 0 ]
+    [ -f "$TMP_DIR/output/results.json" ]
+    jq -e '.results' "$TMP_DIR/output/results.json"
+    [ -f "$TMP_DIR/output/manifest.json" ]
+    [ "$(jq -r '."predicate-type"' "$TMP_DIR/output/manifest.json")" = "https://ossf.github.io/osv-schema/results" ]
+    [ "$(jq -r '."result-file"' "$TMP_DIR/output/manifest.json")" = "results.json" ]
+}
+
+@test "osv adapter: JSON results carry vulnerability ids the tenet reads (findings)" {
+    export OSV_MOCK_MODE="findings"
+    run "$ADAPTER" "$TMP_DIR/src" "$TMP_DIR/output"
+    [ "$status" -eq 1 ]
+    # The no-exploitable-vulns tenet's CEL reads data.results[].packages[].vulnerabilities[].id.
+    [ "$(jq -r '.results[0].packages[0].vulnerabilities[0].id' "$TMP_DIR/output/results.json")" = "GHSA-1234-5678-abcd" ]
+}
+
+@test "osv adapter: no package sources still writes empty JSON results + manifest" {
+    export OSV_MOCK_MODE="no-sources"
+    run "$ADAPTER" "$TMP_DIR/src" "$TMP_DIR/output"
+    [ "$status" -eq 0 ]
+    [ "$(jq '.results | length' "$TMP_DIR/output/results.json")" -eq 0 ]
+    [ -f "$TMP_DIR/output/manifest.json" ]
+}
+
+@test "osv adapter: invalid JSON results produces exit 2" {
+    export OSV_MOCK_MODE="bad-json-results"
+    run "$ADAPTER" "$TMP_DIR/src" "$TMP_DIR/output"
+    [ "$status" -eq 2 ]
 }
 
 # Regression test for #197: SARIF and the markdown summary must agree.


### PR DESCRIPTION
Part of #420 — Phase 1, PR 2 (stacks on #465 / \`feat/wrangle-attest-sbom\`).

Adds the **OSV scan attestation** to the attestation engine pipeline: the OSV adapter now emits OSV JSON results + a manifest, and the trusted \`verify\` job wraps, signs, bundles, and stores the resulting osv-schema statement.

## Producer (\`tools/osv/adapter.sh\`)
- Emits \`results.json\` via \`osv-scanner scan --format json\` alongside the existing SARIF (a second invocation — osv-scanner has no SARIF→JSON conversion). Exit-code handling mirrors the SARIF path (0 clean / 1 findings / 128 no-sources → empty \`{"results":[]}\`); anything else is a tool error.
- Writes \`manifest.json\` = \`{"predicate-type":"https://ossf.github.io/osv-schema/results","result-file":"results.json"}\` via the existing \`lib/write_attest_manifest.sh\` (the **unversioned** osv-schema type, which keeps the upstream \`no-exploitable-vulns-osv\` tenet + its \`internal:vex\` transformer working).
- Existing SARIF / findings-gate / markdown behavior unchanged.

## Verify wiring (trust boundary)
- OSV results are produced in the **untrusted** \`scan\` job (adopter code present) and uploaded as the inert \`wrangle-scan-results\` artifact (already existed).
- The **trusted** \`verify\` job now downloads that artifact and feeds it to \`wrangle-attest\` as a **second \`--metadata-root\`** (alongside PR1's build-metadata root), so the OSV statement is wrapped + signed in the trusted context — never trusting a signature minted where adopter code ran.
- New \`scan-metadata-dir\` input (→ \`SCAN_METADATA_ROOT\`); \`run_verify.sh\` collects existing roots and skips a missing dir. The scan-results download is \`continue-on-error\` so a scan-tools-less build still verifies. Wired into all four \`build_and_publish_*.yml\` verify jobs.
- The engine itself is unchanged (it already handles OSV passthrough).

## Subject binding
Bound to the artifact's **single \`sha256\`** (same as SBOM/VSA) — store-safe (the GitHub attestation store rejects multi-digest → 422), gh-verifiable, and tenet-compatible. **The source-commit / dual-subject binding is deferred** (it's captured via the SLSA provenance's commit→artifact materials); deferring keeps the statement store-round-trippable today.

## Tenet satisfiability (verified, not assumed)
The upstream tenet (\`carabiner-dev/policies@85078db…#openvex/no-exploitable-vulns-osv.json\`) accepts the unversioned \`https://ossf.github.io/osv-schema/results\` predicate type and reads \`predicates[0].data.results[].packages[].vulnerabilities[].id\`. A bats test drives the real \`wrangle-attest\` and asserts the produced statement resolves on exactly that path. **Wiring the tenet into the verify policy is #328 (out of scope here.)**

## e2e
The dispatch e2e runs the build_and_publish workflows on a push in the companion repo; the verify job fails closed if the OSV statement can't be built/signed/pushed, so produce→sign→deliver→store-round-trip is exercised by the existing job (single-sha256 → passes like SBOM). No companion-repo change needed.

## Tests
- \`tools/osv/test.bats\`: JSON results + manifest emission, vuln-id shape, no-sources empty results, invalid-JSON-results → exit 2.
- \`actions/verify/test_run_verify.bats\`: metadata-roots collection (build + scan, missing-dir drop), multi-root arg vector, and OSV scan-results passthrough through the real engine (predicate + CEL path).
- \`./test.sh quick\`-equivalent layers green locally (bats, shellcheck, actionlint, go test/vet); \`check_pin_ancestry\` passes. Full + e2e via CI.

The 4 \`actions/verify\` bootstrap pins are re-pointed to this PR's HEAD (final commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)