### PR TITLE
[OBSOLETE — folded into #469] feat(scan): expose the metadata directory as a composite output

### DIFF
--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -23,14 +23,27 @@ inputs:
     required: false
     default: ""
 
+outputs:
+  metadata-dir:
+    description: >
+      Filesystem path to the metadata directory holding each tool's
+      output.sarif and scan results — the same directory uploaded as the
+      wrangle-scan-results artifact.
+    value: ${{ steps.setup.outputs.metadata-dir }}
+
 runs:
   using: "composite"
   steps:
     - name: Set up wrangle
+      id: setup
       shell: bash
       env:
         WRANGLE_ROOT: ${{ github.action_path }}/../..
-      run: "$WRANGLE_ROOT/lib/setup.sh"
+      run: |
+        "$WRANGLE_ROOT/lib/setup.sh"
+        # shellcheck source=../../lib/env.sh
+        source "$WRANGLE_ROOT/lib/env.sh"
+        printf 'metadata-dir=%s\n' "$WRANGLE_METADATA_DIR" >> "$GITHUB_OUTPUT"
 
     # Stage the tool manifest's go.sum as a cache key under a non-lockfile
     # name: the osv adapter scans $GITHUB_WORKSPACE recursively, so a file


### PR DESCRIPTION
## What

The python/npm/container build composites each expose their metadata directory as a `metadata-dir` output. The scan composite only set `WRANGLE_METADATA_DIR` in the job env — so "every wrangle composite that writes a metadata directory exposes its location as an output" wasn't yet a uniform rule.

This adds the matching `metadata-dir` output to `actions/scan/action.yml`. The value is read from `lib/env.sh` (the single source of truth for where tools write), so it can't drift.

```yaml
outputs:
  metadata-dir:
    description: >
      Filesystem path to the metadata directory holding each tool's
      output.sarif and scan results — the same directory uploaded as the
      wrangle-scan-results artifact.
    value: ${{ steps.setup.outputs.metadata-dir }}
```

Useful for adopters who run `actions/scan` directly (the standalone-scan path) and want to consume the SARIF / scan results in a later step without knowing the internal `.wrangle/metadata` layout.

## Scope note

This came out of a "make the metadata location easy to find as an output" discussion. Two parts of that turned out not to need changes:
- **Workflow users are already covered** — the reusable workflows expose `metadata-artifact-name` / `dist-artifact-name` / `bundle-artifact-name` outputs, which are the right cross-job handles (the on-disk dir path isn't meaningful across jobs).
- **Go has no composite action** to add an output to — it's goreleaser-driven, with workflow jobs calling scripts directly.

So the one real inconsistency was the scan composite, which this fixes.

## Testing

No new unit test: this is composite-action output wiring (a `metadata-dir` value sourced from `env.sh`), the same shape the build composites use without a dedicated bats test; the underlying `env.sh` value is already covered. I validated the YAML parses and the output→`id: setup` wiring locally, but couldn't run the containerized `actionlint`/`shellcheck` suite (the Docker daemon won't start in my environment) — CI is the authoritative lint pass. The added `run:` block mirrors the existing env-sourcing pattern in the same file (shellcheck `source=` directive, quoted expansions, 4 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014V5a6SWEAVqApiQBqcnJht)_