### PR TITLE
feat(wrangle-attest): SBOM attestation engine + verify wiring (rebased onto #469)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -120,7 +120,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -153,7 +153,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -184,7 +184,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/build/actions/container@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -284,7 +284,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: container
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -120,7 +120,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -153,7 +153,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -184,7 +184,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@fa08d98b55fef0d5ad28cf026d56d08c137e0eb2 # feat/469-unify-metadata-artifact 2026-06-19
+      uses: TomHennen/wrangle/build/actions/container@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -284,7 +284,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: container
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -120,7 +120,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -153,7 +153,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -184,7 +184,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/build/actions/container@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -284,7 +284,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: container
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -120,7 +120,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -153,7 +153,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -184,7 +184,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/build/actions/container@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -284,7 +284,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: container
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -171,7 +171,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -195,7 +195,7 @@ jobs:
 
       # Shared name derivation so the scan and release jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -203,7 +203,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -236,7 +236,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/checks@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -303,7 +303,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/release@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: release
         with:
           path: ${{ inputs.path }}
@@ -327,7 +327,7 @@ jobs:
           printf 'module=%s\n' "$(go -C "$INPUT_PATH" list -m | head -n1)" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         with:
           build-type: go
@@ -450,7 +450,7 @@ jobs:
       attestation-bundle-name: ${{ needs.release.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: go
           shortname: ${{ needs.release.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -171,7 +171,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -195,7 +195,7 @@ jobs:
 
       # Shared name derivation so the scan and release jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -203,7 +203,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -236,7 +236,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/checks@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -303,7 +303,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/release@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: release
         with:
           path: ${{ inputs.path }}
@@ -327,7 +327,7 @@ jobs:
           printf 'module=%s\n' "$(go -C "$INPUT_PATH" list -m | head -n1)" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         with:
           build-type: go
@@ -450,7 +450,7 @@ jobs:
       attestation-bundle-name: ${{ needs.release.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: go
           shortname: ${{ needs.release.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -171,7 +171,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -195,7 +195,7 @@ jobs:
 
       # Shared name derivation so the scan and release jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -203,7 +203,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -236,7 +236,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/checks@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -303,7 +303,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/release@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: release
         with:
           path: ${{ inputs.path }}
@@ -327,7 +327,7 @@ jobs:
           printf 'module=%s\n' "$(go -C "$INPUT_PATH" list -m | head -n1)" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         with:
           build-type: go
@@ -450,7 +450,7 @@ jobs:
       attestation-bundle-name: ${{ needs.release.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: go
           shortname: ${{ needs.release.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -171,7 +171,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -195,7 +195,7 @@ jobs:
 
       # Shared name derivation so the scan and release jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -203,7 +203,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -236,7 +236,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/checks@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -303,7 +303,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/release@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: release
         with:
           path: ${{ inputs.path }}
@@ -327,7 +327,7 @@ jobs:
           printf 'module=%s\n' "$(go -C "$INPUT_PATH" list -m | head -n1)" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         with:
           build-type: go
@@ -450,7 +450,7 @@ jobs:
       attestation-bundle-name: ${{ needs.release.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: go
           shortname: ${{ needs.release.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -139,7 +139,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -150,7 +150,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -174,7 +174,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -182,7 +182,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -222,7 +222,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/npm@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -231,7 +231,7 @@ jobs:
           ignore-scripts: ${{ inputs.ignore-scripts }}
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         with:
           build-type: npm
@@ -348,7 +348,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: npm
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -139,7 +139,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -150,7 +150,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -174,7 +174,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -182,7 +182,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -222,7 +222,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/npm@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -231,7 +231,7 @@ jobs:
           ignore-scripts: ${{ inputs.ignore-scripts }}
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         with:
           build-type: npm
@@ -348,7 +348,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: npm
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -139,7 +139,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -150,7 +150,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -174,7 +174,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -182,7 +182,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -222,7 +222,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/npm@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -231,7 +231,7 @@ jobs:
           ignore-scripts: ${{ inputs.ignore-scripts }}
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         with:
           build-type: npm
@@ -348,7 +348,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: npm
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -139,7 +139,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -150,7 +150,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -174,7 +174,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -182,7 +182,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -222,7 +222,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/npm@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -231,7 +231,7 @@ jobs:
           ignore-scripts: ${{ inputs.ignore-scripts }}
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         with:
           build-type: npm
@@ -348,7 +348,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: npm
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -116,7 +116,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -131,7 +131,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -155,7 +155,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/python@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -232,7 +232,7 @@ jobs:
           printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         with:
           build-type: python
@@ -341,7 +341,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: python
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -116,7 +116,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -131,7 +131,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -155,7 +155,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/python@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -232,7 +232,7 @@ jobs:
           printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         with:
           build-type: python
@@ -341,7 +341,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: python
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -116,7 +116,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -131,7 +131,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -155,7 +155,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/python@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -232,7 +232,7 @@ jobs:
           printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         with:
           build-type: python
@@ -341,7 +341,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: python
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -116,7 +116,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -131,7 +131,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -155,7 +155,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/python@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -232,7 +232,7 @@ jobs:
           printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         id: names
         with:
           build-type: python
@@ -341,7 +341,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           build-type: python
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+        uses: TomHennen/wrangle/build/actions/shell@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+        uses: TomHennen/wrangle/build/actions/shell@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+        uses: TomHennen/wrangle/build/actions/shell@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+        uses: TomHennen/wrangle/build/actions/shell@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   check-change:
     needs: [guard]
@@ -51,7 +51,7 @@ jobs:
       # (root path), so the shortname is empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+        uses: TomHennen/wrangle/actions/scan@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           tools: ${{ inputs.tools }}
           artifact-name: scan

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   check-change:
     needs: [guard]
@@ -51,7 +51,7 @@ jobs:
       # (root path), so the shortname is empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+        uses: TomHennen/wrangle/actions/scan@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           tools: ${{ inputs.tools }}
           artifact-name: scan

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   check-change:
     needs: [guard]
@@ -51,7 +51,7 @@ jobs:
       # (root path), so the shortname is empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+        uses: TomHennen/wrangle/actions/scan@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           tools: ${{ inputs.tools }}
           artifact-name: scan

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
   check-change:
     needs: [guard]
@@ -51,7 +51,7 @@ jobs:
       # (root path), so the shortname is empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+        uses: TomHennen/wrangle/actions/scan@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
         with:
           tools: ${{ inputs.tools }}
           artifact-name: scan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,29 @@ jobs:
       - name: Run tests
         run: ./test.sh
 
+  # Real keyless signing through the engine: the unit suite is hermetic
+  # (local-key) and the dispatch e2e proves the full bnd-push + ampel round-trip,
+  # so this job covers the one path neither does — that wrangle-attest --sign
+  # produces a valid Fulcio/Rekor-backed Sigstore bundle with ambient GitHub
+  # OIDC. Tag-gated so it never runs in the hermetic unit suite.
+  keyless-attest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # mint the ambient OIDC token the keyless signer exchanges at Fulcio
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: tools/go.mod
+          cache-dependency-path: tools/go.sum
+
+      - name: Keyless sign integration test
+        run: ./test/keyless_attest.sh
+
   # End-to-end exercise of the verify-vsa composite action itself (the
   # script's logic is bats-covered; this covers the composite wiring: the
   # Go-built ampel install, the bundle artifact download by pattern, and the

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,11 @@ workflowstyle:
 	@echo "=== wrangle-workflow-lint ==="
 	@./tools/wrangle-workflow-lint/lint.sh
 
-# Run first-party Go unit tests (the wrangle-lint rule engine).
+# Run first-party Go unit tests (the wrangle-lint rule engine and the
+# wrangle-attest attestation engine).
 gotest:
 	@echo "=== go test ==="
-	@go -C tools test ./wrangle-lint/...
+	@go -C tools test ./wrangle-lint/... ./wrangle-attest/...
 
 # Lint all shell scripts (.sh and .bats) via the same script CI's dogfooded
 # shell build runs, so the local and CI shellcheck surfaces can't drift (#368).

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -99,7 +99,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      uses: TomHennen/wrangle/tools/zizmor@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      uses: TomHennen/wrangle/tools/scorecard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@041a3fcc56df40113f1b0f6f319c707a6283c5ff # main 2026-06-19
+      uses: TomHennen/wrangle/tools/dependency-review@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -99,7 +99,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/tools/zizmor@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/tools/scorecard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/tools/dependency-review@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -99,7 +99,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/tools/zizmor@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/tools/scorecard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/tools/dependency-review@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -99,7 +99,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/tools/zizmor@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/tools/scorecard@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/tools/dependency-review@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
 
     - name: Generate step summary
       if: always()

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -78,6 +78,14 @@ inputs:
     description: 'When "true" (default) and the run is a tag push, attach the bundle to the release.'
     required: false
     default: "true"
+  metadata-dir:
+    description: >
+      Directory holding the build's metadata (the build job's metadata artifact:
+      sbom.spdx.json + its manifest.json). wrangle-attest walks it to build one
+      signed SBOM statement per subject, appended to each bundle and posted to
+      the attestation store. Leave empty to emit VSA-only bundles.
+    required: false
+    default: ""
   oci-target:
     description: >
       When set, fetch the provenance from and push the bundle to this OCI image
@@ -125,6 +133,7 @@ runs:
         BUNDLE_IN: ${{ inputs.bundle-in }}
         BUNDLE_OUT: ${{ inputs.bundle-out }}
         OCI_TARGET: ${{ inputs.oci-target }}
+        METADATA_ROOT: ${{ inputs.metadata-dir }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         # bnd push github authenticates to the attestation store with this token;
         # the attestations: write permission rides on it.

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -81,8 +81,9 @@ inputs:
   metadata-dir:
     description: >
       Directory holding the build's metadata (the build job's metadata artifact:
-      sbom.spdx.json + its manifest.json). wrangle-attest walks it to build one
-      signed SBOM statement per subject, appended to each bundle and posted to
+      sbom.spdx.json + its top-level manifest.json). wrangle-attest reads that
+      manifest to build one signed SBOM statement per subject, appended to each
+      bundle and posted to
       the attestation store. Leave empty to emit VSA-only bundles.
     required: false
     default: ""

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -81,7 +81,7 @@ inputs:
   metadata-dir:
     description: >
       Directory holding the build's metadata (the build job's metadata artifact:
-      sbom.spdx.json + its top-level manifest.json). wrangle-attest reads that
+      sbom.spdx.json + its top-level wrangle_attestation_metadata.json). wrangle-attest reads that
       manifest to build one signed SBOM statement per subject, appended to each
       bundle and posted to
       the attestation store. Leave empty to emit VSA-only bundles.

--- a/actions/verify/install_tools.sh
+++ b/actions/verify/install_tools.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 set -f
 
-# Build the verify tools into WRANGLE_BIN_DIR: ampel (verify) and bnd (sign)
-# always; cosign (push the VSA as an OCI referrer) only when OCI_TARGET names a
-# container image digest — npm/go/python verify never pushes, so it never needs
-# cosign. Installing the rest of the tool manifest here would compile the scan
-# toolchain (osv-scanner et al.) that verify never runs.
+# Build the verify tools into WRANGLE_BIN_DIR: ampel (verify), bnd (sign), and
+# wrangle-attest (build the unsigned scan/build statements) always; cosign (push
+# the VSA as an OCI referrer) only when OCI_TARGET names a container image digest
+# — npm/go/python verify never pushes, so it never needs cosign. Installing the
+# rest of the tool manifest here would compile the scan toolchain (osv-scanner
+# et al.) that verify never runs.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../lib/env.sh
@@ -15,6 +16,7 @@ source "${SCRIPT_DIR}/../../lib/env.sh"
 pkgs=(
     github.com/carabiner-dev/ampel/cmd/ampel
     github.com/carabiner-dev/bnd
+    github.com/TomHennen/wrangle/tools/wrangle-attest
 )
 if [[ -n "${OCI_TARGET:-}" ]]; then
     pkgs+=(github.com/sigstore/cosign/v3/cmd/cosign)

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -13,7 +13,8 @@
 # Inputs arrive as env vars: SUBJECTS (newline-separated), POLICY, COLLECTOR,
 # FAIL, CONTEXT, BUNDLE_IN, BUNDLE_OUT, GITHUB_REPOSITORY (store push target),
 # GITHUB_TOKEN (bnd reads it to auth the store push), and optional ATTESTATION,
-# OCI_TARGET.
+# OCI_TARGET, METADATA_ROOT (the build metadata dir wrangle-attest walks for the
+# SBOM manifest, appended as a signed statement per subject).
 
 set -euo pipefail
 set -f  # disable globbing — processes external input
@@ -59,6 +60,25 @@ wrangle_subject_arg() {
     # A missing/unreadable subject file must fail closed, not yield an empty hash.
     digest="$(sha256sum "$subject")" || return 1
     printf -- '--subject-hash=sha256:%s\n' "${digest%% *}"
+}
+
+# Resolve a subject to the single sha256:<hex> the attestation engine binds to.
+# A sha256 digest subject (container) passes through; any other digest algorithm
+# is rejected (the store accepts only sha256); a file subject is hashed. The SBOM
+# statement thus shares the VSA's single-sha256 subject, so a policy resolving by
+# artifact digest finds both.
+wrangle_subject_sha256() {
+    local subject="$1" digest
+    if [[ "$subject" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+        printf '%s\n' "$subject"
+        return 0
+    fi
+    if [[ "$subject" =~ ^[a-z0-9]+:[a-f0-9]+$ ]]; then
+        printf 'wrangle: subject %s is not sha256 — the attestation store accepts only sha256\n' "$subject" >&2
+        return 1
+    fi
+    digest="$(sha256sum "$subject")" || return 1
+    printf 'sha256:%s\n' "${digest%% *}"
 }
 
 # Build the ampel verify arg vector for one subject, one arg per line for
@@ -206,6 +226,50 @@ wrangle_push_bundle() {
     wrangle_retry_once /dev/null cosign "${args[@]}"
 }
 
+# Build the wrangle-attest arg vector that turns the build metadata into unsigned
+# in-toto statements, one per line for mapfile. $1 is the single sha256 subject;
+# $2 the JSONL output path. METADATA_ROOT holds the build's manifest.json files
+# (sbom.spdx.json + its manifest); --commit is woven into the scan/v1 envelope
+# only, ignored by the SBOM passthrough.
+wrangle_attest_args() {
+    printf '%s\n' \
+        --metadata-root="$METADATA_ROOT" \
+        --subject="$1" \
+        --out="$2"
+}
+
+# For one subject, build the SBOM (and any other build-metadata) statement(s),
+# sign each, append each to the bundle, and post each to the store. No-op when
+# METADATA_ROOT is unset/empty (a build that produced no metadata). $1 is the
+# subject, $2 the bundle file. wrangle-attest fails closed on a malformed
+# manifest, so an absent statement is a real gap, not a silent skip.
+wrangle_emit_metadata_statements() {
+    [[ -z "${METADATA_ROOT:-}" || ! -d "${METADATA_ROOT:-}" ]] && return 0
+    local subject="$1" bundle="$2" subj_sha
+    subj_sha="$(wrangle_subject_sha256 "$subject")"
+    local stmts args
+    stmts="$(mktemp "${RUNNER_TEMP:-/tmp}/attest.XXXXXX")"
+    mapfile -t args < <(wrangle_attest_args "$subj_sha" "$stmts")
+    wrangle-attest "${args[@]}"
+    # Sign and deliver each unsigned statement line in the same trusted process
+    # as the VSA, so an unsigned statement never crosses a step boundary. Flatten
+    # bnd's pretty statement to one line: appended to the bundle, posted to the
+    # store, and pushed alone as the OCI referrer (cosign attach rejects multi-line).
+    local signed line_file
+    signed="$(mktemp "${RUNNER_TEMP:-/tmp}/attestsigned.XXXXXX")"
+    line_file="$(mktemp "${RUNNER_TEMP:-/tmp}/attestline.XXXXXX")"
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        printf '%s\n' "$line" > "$signed.unsigned"
+        wrangle_retry_once "$signed" bnd statement "$signed.unsigned"
+        jq -c . "$signed" > "$line_file"
+        cat "$line_file" >> "$bundle"
+        wrangle_push_store "$line_file"
+        wrangle_push_bundle "$line_file"
+    done < "$stmts"
+    rm -f "$stmts" "$signed" "$signed.unsigned" "$line_file"
+}
+
 # Post the signed VSA at $1 to the GitHub attestation store (all build types).
 # Provenance is already in the store from attest-build-provenance, so only the
 # VSA is pushed. Fails closed: a missing by-digest VSA is a real delivery gap.
@@ -259,6 +323,9 @@ wrangle_run() {
         cat "$vsa_line" >> "$bundle"
         wrangle_push_store "$vsa_line"
         wrangle_push_bundle "$vsa_line"
+        # Append the build-metadata statements (SBOM, …) bound to this same
+        # single-sha256 subject, signed and delivered alongside the VSA.
+        wrangle_emit_metadata_statements "$subject" "$bundle"
     done
     rm -f "$tmp_vsa" "$vsa_line" "$seed"
 }

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -62,25 +62,6 @@ wrangle_subject_arg() {
     printf -- '--subject-hash=sha256:%s\n' "${digest%% *}"
 }
 
-# Resolve a subject to the single sha256:<hex> the attestation engine binds to.
-# A sha256 digest subject (container) passes through; any other digest algorithm
-# is rejected (the store accepts only sha256); a file subject is hashed. The SBOM
-# statement thus shares the VSA's single-sha256 subject, so a policy resolving by
-# artifact digest finds both.
-wrangle_subject_sha256() {
-    local subject="$1" digest
-    if [[ "$subject" =~ ^sha256:[a-f0-9]{64}$ ]]; then
-        printf '%s\n' "$subject"
-        return 0
-    fi
-    if [[ "$subject" =~ ^[a-z0-9]+:[a-f0-9]+$ ]]; then
-        printf 'wrangle: subject %s is not sha256 — the attestation store accepts only sha256\n' "$subject" >&2
-        return 1
-    fi
-    digest="$(sha256sum "$subject")" || return 1
-    printf 'sha256:%s\n' "${digest%% *}"
-}
-
 # Build the ampel verify arg vector for one subject, one arg per line for
 # mapfile. $1 is the subject; $2 the unsigned-VSA output path.
 wrangle_ampel_verify_args() {
@@ -228,14 +209,15 @@ wrangle_push_bundle() {
 
 # Build the wrangle-attest arg vector that turns the build metadata into signed
 # in-toto statements (one signed Sigstore-bundle JSONL line per statement), one
-# arg per line for mapfile. $1 is the single sha256 subject; $2 the JSONL output
-# path. METADATA_ROOT holds the build's wrangle_attestation_metadata.json files
-# (sbom.spdx.json + its manifest); --commit is woven into the scan/v1 envelope
-# only, ignored by the SBOM passthrough.
+# arg per line for mapfile. $1 is the pre-formed subject arg (--subject=<digest>
+# or --artifact=<file>); $2 the JSONL output path. METADATA_ROOT holds the
+# build's wrangle_attestation_metadata.json files (sbom.spdx.json + its
+# manifest); --commit is woven into the scan/v1 envelope only, ignored by the
+# SBOM passthrough.
 wrangle_attest_args() {
     printf '%s\n' \
         --metadata-root="$METADATA_ROOT" \
-        --subject="$1" \
+        "$1" \
         --sign \
         --out="$2"
 }
@@ -243,17 +225,23 @@ wrangle_attest_args() {
 # For one subject, build and sign the SBOM (and any other build-metadata)
 # statement(s) via the engine, then append each signed line to the bundle and
 # post each to the store. No-op when METADATA_ROOT is unset/empty (a build that
-# produced no metadata). $1 is the subject, $2 the bundle file. The engine signs
-# in the same trusted process as the VSA and fails closed on a malformed
-# manifest or signing failure (no partial bundle), so an absent statement is a
-# real gap, not a silent skip.
+# produced no metadata). $1 is the subject, $2 the bundle file. A digest subject
+# (container) passes through as --subject; a file subject is handed to the
+# engine via --artifact, which self-digests it to the same sha256 the VSA binds
+# to. The engine signs in the same trusted process as the VSA and fails closed
+# on a malformed manifest, an unreadable artifact, or a signing failure (no
+# partial bundle), so an absent statement is a real gap, not a silent skip.
 wrangle_emit_metadata_statements() {
     [[ -z "${METADATA_ROOT:-}" || ! -d "${METADATA_ROOT:-}" ]] && return 0
-    local subject="$1" bundle="$2" subj_sha
-    subj_sha="$(wrangle_subject_sha256 "$subject")" || return 1
+    local subject="$1" bundle="$2" subject_arg
+    if [[ "$subject" =~ ^[a-z0-9]+:[a-f0-9]+$ ]]; then
+        subject_arg="--subject=$subject"
+    else
+        subject_arg="--artifact=$subject"
+    fi
     local stmts args
     stmts="$(mktemp "${RUNNER_TEMP:-/tmp}/attest.XXXXXX")"
-    mapfile -t args < <(wrangle_attest_args "$subj_sha" "$stmts")
+    mapfile -t args < <(wrangle_attest_args "$subject_arg" "$stmts")
     wrangle_retry_once /dev/null wrangle-attest "${args[@]}" || { rm -f "$stmts"; return 1; }
     # Each line is one signed Sigstore bundle (compact JSONL): appended to the
     # bundle, posted to the store, and pushed alone as the OCI referrer (cosign

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -246,11 +246,13 @@ wrangle_attest_args() {
 wrangle_emit_metadata_statements() {
     [[ -z "${METADATA_ROOT:-}" || ! -d "${METADATA_ROOT:-}" ]] && return 0
     local subject="$1" bundle="$2" subj_sha
-    subj_sha="$(wrangle_subject_sha256 "$subject")"
+    subj_sha="$(wrangle_subject_sha256 "$subject")" || return 1
     local stmts args
     stmts="$(mktemp "${RUNNER_TEMP:-/tmp}/attest.XXXXXX")"
     mapfile -t args < <(wrangle_attest_args "$subj_sha" "$stmts")
-    wrangle-attest "${args[@]}"
+    # A malformed/missing manifest aborts here — never ship a bundle silently
+    # missing its SBOM statement.
+    wrangle-attest "${args[@]}" || { rm -f "$stmts"; return 1; }
     # Sign and deliver each unsigned statement line in the same trusted process
     # as the VSA, so an unsigned statement never crosses a step boundary. Flatten
     # bnd's pretty statement to one line: appended to the bundle, posted to the

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -14,7 +14,7 @@
 # FAIL, CONTEXT, BUNDLE_IN, BUNDLE_OUT, GITHUB_REPOSITORY (store push target),
 # GITHUB_TOKEN (bnd reads it to auth the store push), and optional ATTESTATION,
 # OCI_TARGET, METADATA_ROOT (the build metadata dir holding the top-level SBOM
-# manifest wrangle-attest reads, appended as a signed statement per subject).
+# manifest wrangle-attest reads, signed by the engine and appended per subject).
 
 set -euo pipefail
 set -f  # disable globbing — processes external input
@@ -226,23 +226,27 @@ wrangle_push_bundle() {
     wrangle_retry_once /dev/null cosign "${args[@]}"
 }
 
-# Build the wrangle-attest arg vector that turns the build metadata into unsigned
-# in-toto statements, one per line for mapfile. $1 is the single sha256 subject;
-# $2 the JSONL output path. METADATA_ROOT holds the build's wrangle_attestation_metadata.json files
+# Build the wrangle-attest arg vector that turns the build metadata into signed
+# in-toto statements (one signed Sigstore-bundle JSONL line per statement), one
+# arg per line for mapfile. $1 is the single sha256 subject; $2 the JSONL output
+# path. METADATA_ROOT holds the build's wrangle_attestation_metadata.json files
 # (sbom.spdx.json + its manifest); --commit is woven into the scan/v1 envelope
 # only, ignored by the SBOM passthrough.
 wrangle_attest_args() {
     printf '%s\n' \
         --metadata-root="$METADATA_ROOT" \
         --subject="$1" \
+        --sign \
         --out="$2"
 }
 
-# For one subject, build the SBOM (and any other build-metadata) statement(s),
-# sign each, append each to the bundle, and post each to the store. No-op when
-# METADATA_ROOT is unset/empty (a build that produced no metadata). $1 is the
-# subject, $2 the bundle file. wrangle-attest fails closed on a malformed
-# manifest, so an absent statement is a real gap, not a silent skip.
+# For one subject, build and sign the SBOM (and any other build-metadata)
+# statement(s) via the engine, then append each signed line to the bundle and
+# post each to the store. No-op when METADATA_ROOT is unset/empty (a build that
+# produced no metadata). $1 is the subject, $2 the bundle file. The engine signs
+# in the same trusted process as the VSA and fails closed on a malformed
+# manifest or signing failure (no partial bundle), so an absent statement is a
+# real gap, not a silent skip.
 wrangle_emit_metadata_statements() {
     [[ -z "${METADATA_ROOT:-}" || ! -d "${METADATA_ROOT:-}" ]] && return 0
     local subject="$1" bundle="$2" subj_sha
@@ -250,26 +254,20 @@ wrangle_emit_metadata_statements() {
     local stmts args
     stmts="$(mktemp "${RUNNER_TEMP:-/tmp}/attest.XXXXXX")"
     mapfile -t args < <(wrangle_attest_args "$subj_sha" "$stmts")
-    # A malformed/missing manifest aborts here — never ship a bundle silently
-    # missing its SBOM statement.
-    wrangle-attest "${args[@]}" || { rm -f "$stmts"; return 1; }
-    # Sign and deliver each unsigned statement line in the same trusted process
-    # as the VSA, so an unsigned statement never crosses a step boundary. Flatten
-    # bnd's pretty statement to one line: appended to the bundle, posted to the
-    # store, and pushed alone as the OCI referrer (cosign attach rejects multi-line).
-    local signed line_file
-    signed="$(mktemp "${RUNNER_TEMP:-/tmp}/attestsigned.XXXXXX")"
+    wrangle_retry_once /dev/null wrangle-attest "${args[@]}" || { rm -f "$stmts"; return 1; }
+    # Each line is one signed Sigstore bundle (compact JSONL): appended to the
+    # bundle, posted to the store, and pushed alone as the OCI referrer (cosign
+    # attach rejects multi-line).
+    local line_file
     line_file="$(mktemp "${RUNNER_TEMP:-/tmp}/attestline.XXXXXX")"
     while IFS= read -r line; do
         [[ -z "$line" ]] && continue
-        printf '%s\n' "$line" > "$signed.unsigned"
-        wrangle_retry_once "$signed" bnd statement "$signed.unsigned"
-        jq -c . "$signed" > "$line_file"
+        printf '%s\n' "$line" > "$line_file"
         cat "$line_file" >> "$bundle"
         wrangle_push_store "$line_file"
         wrangle_push_bundle "$line_file"
     done < "$stmts"
-    rm -f "$stmts" "$signed" "$signed.unsigned" "$line_file"
+    rm -f "$stmts" "$line_file"
 }
 
 # Post the signed VSA at $1 to the GitHub attestation store (all build types).

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -13,8 +13,8 @@
 # Inputs arrive as env vars: SUBJECTS (newline-separated), POLICY, COLLECTOR,
 # FAIL, CONTEXT, BUNDLE_IN, BUNDLE_OUT, GITHUB_REPOSITORY (store push target),
 # GITHUB_TOKEN (bnd reads it to auth the store push), and optional ATTESTATION,
-# OCI_TARGET, METADATA_ROOT (the build metadata dir wrangle-attest walks for the
-# SBOM manifest, appended as a signed statement per subject).
+# OCI_TARGET, METADATA_ROOT (the build metadata dir holding the top-level SBOM
+# manifest wrangle-attest reads, appended as a signed statement per subject).
 
 set -euo pipefail
 set -f  # disable globbing — processes external input

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -228,7 +228,7 @@ wrangle_push_bundle() {
 
 # Build the wrangle-attest arg vector that turns the build metadata into unsigned
 # in-toto statements, one per line for mapfile. $1 is the single sha256 subject;
-# $2 the JSONL output path. METADATA_ROOT holds the build's manifest.json files
+# $2 the JSONL output path. METADATA_ROOT holds the build's wrangle_attestation_metadata.json files
 # (sbom.spdx.json + its manifest); --commit is woven into the scan/v1 envelope
 # only, ignored by the SBOM passthrough.
 wrangle_attest_args() {

--- a/actions/verify/test_install_tools.bats
+++ b/actions/verify/test_install_tools.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
-# Behavioral test for install_tools.sh: ampel + bnd are always built; cosign is
-# built only when OCI_TARGET is set (the container build pushes the VSA
-# referrer). A fake `go` records the packages it was asked to install.
+# Behavioral test for install_tools.sh: ampel + bnd + wrangle-attest are always
+# built; cosign is built only when OCI_TARGET is set (the container build pushes
+# the VSA referrer). A fake `go` records the packages it was asked to install.
 
 setup() {
     DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
@@ -39,11 +39,12 @@ teardown() {
     rm -rf "$TEST_DIR"
 }
 
-@test "install_tools.sh: without OCI_TARGET builds ampel+bnd, not cosign" {
+@test "install_tools.sh: without OCI_TARGET builds ampel+bnd+wrangle-attest, not cosign" {
     PATH="$FAKE_BIN:$PATH" run "$DIR/install_tools.sh"
     [ "$status" -eq 0 ]
     grep -Fq 'github.com/carabiner-dev/ampel/cmd/ampel' "$GO_RECORD"
     grep -Fq 'github.com/carabiner-dev/bnd' "$GO_RECORD"
+    grep -Fq 'github.com/TomHennen/wrangle/tools/wrangle-attest' "$GO_RECORD"
     ! grep -Fq 'cosign' "$GO_RECORD"
 }
 
@@ -52,5 +53,6 @@ teardown() {
     [ "$status" -eq 0 ]
     grep -Fq 'github.com/carabiner-dev/ampel/cmd/ampel' "$GO_RECORD"
     grep -Fq 'github.com/carabiner-dev/bnd' "$GO_RECORD"
+    grep -Fq 'github.com/TomHennen/wrangle/tools/wrangle-attest' "$GO_RECORD"
     grep -Fq 'github.com/sigstore/cosign/v3/cmd/cosign' "$GO_RECORD"
 }

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -706,7 +706,8 @@ if [[ "\$1" == "push" ]]; then cat "\$4" >> "$TEST_DIR/pushed"; exit 0; fi
 printf '{\n  "signed": '; cat "\$2"; printf '}\n'
 STUB
     chmod +x "$TEST_DIR/bnd"
-    export PATH="$(dirname "$ATTEST_BIN"):$TEST_DIR:$PATH"
+    local attest_dir; attest_dir="$(dirname "$ATTEST_BIN")"
+    export PATH="$attest_dir:$TEST_DIR:$PATH"
     export METADATA_ROOT="$TEST_DIR/meta"
     export GITHUB_REPOSITORY="o/r"
     export OCI_TARGET=""
@@ -729,7 +730,8 @@ STUB
     if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
     mkdir -p "$TEST_DIR/meta"
     printf '{"predicate-type":"https://spdx.dev/Document"}\n' > "$TEST_DIR/meta/manifest.json"
-    export PATH="$(dirname "$ATTEST_BIN"):$PATH"
+    local attest_dir; attest_dir="$(dirname "$ATTEST_BIN")"
+    export PATH="$attest_dir:$PATH"
     export METADATA_ROOT="$TEST_DIR/meta"
     local bundle="$TEST_DIR/bundle.jsonl"; : > "$bundle"
     run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -126,12 +126,24 @@ teardown() {
 
 # --- wrangle-attest arg vector ---
 
-@test "run_verify: attest args carry the metadata-root, subject, and out" {
+@test "run_verify: attest args carry the metadata-root, subject, sign, and out" {
     export METADATA_ROOT="$TEST_DIR/meta"
     mapfile -t args < <(wrangle_attest_args "sha256:abc" "$TEST_DIR/out.jsonl")
     printf '%s\n' "${args[@]}" | grep -qx -- "--metadata-root=$TEST_DIR/meta"
     printf '%s\n' "${args[@]}" | grep -qx -- "--subject=sha256:abc"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--sign"
     printf '%s\n' "${args[@]}" | grep -qx -- "--out=$TEST_DIR/out.jsonl"
+}
+
+@test "run_verify: attest arg vector is accepted by the real wrangle-attest parser" {
+    # The real engine rejects an unknown flag; a run that gets past flag parsing
+    # (failing later on the bogus subject/root) proves every flag name matches.
+    if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
+    export METADATA_ROOT="$TEST_DIR/meta"
+    mapfile -t args < <(wrangle_attest_args "sha256:abc" "$TEST_DIR/out.jsonl")
+    run "$ATTEST_BIN" "${args[@]}"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" != *"flag provided but not defined"* ]]
 }
 
 # --- ampel arg vector ---
@@ -673,13 +685,14 @@ STUB
 # --- build-metadata (SBOM) statement emission ---
 
 @test "run_verify: emit_metadata is a no-op when METADATA_ROOT is unset" {
-    # npm/go/python/container without a metadata dir: nothing is appended and no
-    # signer is invoked. A bnd stub that fails proves the path returns 0 untouched.
-    cat > "$TEST_DIR/bnd" <<'STUB'
+    # npm/go/python/container without a metadata dir: nothing is appended and the
+    # engine isn't invoked. A wrangle-attest stub that fails proves the path
+    # returns 0 untouched.
+    cat > "$TEST_DIR/wrangle-attest" <<'STUB'
 #!/bin/bash
 exit 1
 STUB
-    chmod +x "$TEST_DIR/bnd"
+    chmod +x "$TEST_DIR/wrangle-attest"
     export PATH="$TEST_DIR:$PATH"
     unset METADATA_ROOT
     local bundle="$TEST_DIR/bundle.jsonl"
@@ -689,53 +702,51 @@ STUB
     [[ "$(wc -l < "$bundle")" -eq 1 ]]
 }
 
-@test "run_verify: emit_metadata builds, signs, appends, and pushes the SBOM statement" {
-    # End-to-end with the real wrangle-attest (offline) and a stub bnd/cosign:
-    # an SBOM manifest + sbom.spdx.json in METADATA_ROOT becomes a signed SPDX
-    # statement appended to the bundle and posted to the store.
-    if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
-    mkdir -p "$TEST_DIR/meta"
-    printf '{"spdxVersion":"SPDX-2.3","name":"x"}\n' > "$TEST_DIR/meta/sbom.spdx.json"
-    printf '{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}\n' \
-        > "$TEST_DIR/meta/wrangle_attestation_metadata.json"
-    # bnd statement wraps the unsigned line so the jq -c flatten is load-bearing;
-    # bnd push records the file it was handed so the store delivery is provable.
+@test "run_verify: emit_metadata appends and pushes the engine's signed statement" {
+    # The engine signs keyless (network/OIDC), so a stub wrangle-attest emits a
+    # deterministic compact signed line — this exercises the shell glue (append +
+    # store + referrer), not the engine (Go-unit-tested; dispatch-e2e for keyless).
+    cat > "$TEST_DIR/wrangle-attest" <<STUB
+#!/bin/bash
+subj=""
+for a in "\$@"; do case "\$a" in --subject=*) subj="\${a#--subject=}";; --out=*) out="\${a#--out=}";; esac; done
+printf '{"signedStatement":{"predicateType":"https://spdx.dev/Document","subject":[{"digest":{"sha256":"%s"}}]}}\n' "\${subj#sha256:}" > "\$out"
+STUB
+    # push records the file it was handed so store delivery is provable.
     cat > "$TEST_DIR/bnd" <<STUB
 #!/bin/bash
-if [[ "\$1" == "push" ]]; then cat "\$4" >> "$TEST_DIR/pushed"; exit 0; fi
-printf '{\n  "signed": '; cat "\$2"; printf '}\n'
+[[ "\$1" == "push" ]] && { cat "\$4" >> "$TEST_DIR/pushed"; exit 0; }
+exit 0
 STUB
-    chmod +x "$TEST_DIR/bnd"
-    # TEST_DIR first so the stub bnd wins; the real bnd is co-located with
-    # wrangle-attest in WRANGLE_BIN_DIR and would otherwise shadow the stub.
-    local attest_dir; attest_dir="$(dirname "$ATTEST_BIN")"
-    export PATH="$TEST_DIR:$attest_dir:$PATH"
-    export METADATA_ROOT="$TEST_DIR/meta"
+    chmod +x "$TEST_DIR/wrangle-attest" "$TEST_DIR/bnd"
+    export PATH="$TEST_DIR:$PATH"
+    export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
     export GITHUB_REPOSITORY="o/r"
     export OCI_TARGET=""
     : > "$TEST_DIR/pushed"
     local bundle="$TEST_DIR/bundle.jsonl"
     printf '{"provenance":1}\n' > "$bundle"
-    run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
+    local sha; sha="$(printf '0%.0s' {1..64})"
+    run wrangle_emit_metadata_statements "sha256:$sha" "$bundle"
     [[ "$status" -eq 0 ]]
-    # The seeded provenance line plus exactly one appended SPDX statement; the
-    # stub bnd wraps the signed statement under .signed.
+    # Seeded provenance line plus exactly one appended signed statement.
     [[ "$(wc -l < "$bundle")" -eq 2 ]]
-    [[ "$(grep -c '"https://spdx.dev/Document"' "$bundle")" -eq 1 ]]
-    [[ "$(tail -1 "$bundle" | jq -r '.signed.predicateType')" == "https://spdx.dev/Document" ]]
+    [[ "$(tail -1 "$bundle" | jq -r '.signedStatement.predicateType')" == "https://spdx.dev/Document" ]]
     # The signed statement reached the store, bound to the single sha256 subject.
-    [[ "$(jq -r '.signed.subject[0].digest.sha256' "$TEST_DIR/pushed")" == "$(printf '0%.0s' {1..64})" ]]
+    [[ "$(jq -r '.signedStatement.subject[0].digest.sha256' "$TEST_DIR/pushed")" == "$sha" ]]
 }
 
-@test "run_verify: emit_metadata fails closed on a malformed manifest" {
-    # wrangle-attest fails closed on a bad manifest; the verify step must surface
-    # that rather than silently shipping a bundle with no SBOM statement.
-    if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
-    mkdir -p "$TEST_DIR/meta"
-    printf '{"predicate-type":"https://spdx.dev/Document"}\n' > "$TEST_DIR/meta/wrangle_attestation_metadata.json"
-    local attest_dir; attest_dir="$(dirname "$ATTEST_BIN")"
-    export PATH="$attest_dir:$PATH"
-    export METADATA_ROOT="$TEST_DIR/meta"
+@test "run_verify: emit_metadata fails closed when the engine fails" {
+    # The engine fails closed on a malformed manifest or a signing failure; the
+    # verify step must surface that rather than shipping an SBOM-less bundle.
+    cat > "$TEST_DIR/wrangle-attest" <<'STUB'
+#!/bin/bash
+exit 2
+STUB
+    chmod +x "$TEST_DIR/wrangle-attest"
+    export PATH="$TEST_DIR:$PATH"
+    export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
+    export WRANGLE_RETRY_DELAY=0
     local bundle="$TEST_DIR/bundle.jsonl"; : > "$bundle"
     run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
     [[ "$status" -ne 0 ]]

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -744,6 +744,24 @@ STUB
     ! grep -q -- "--subject=" "$TEST_DIR/attest-args"
 }
 
+@test "run_verify: the real engine emits the in-toto statement in unsigned mode" {
+    # Happy path against the real binary, hermetically: unsigned mode needs no
+    # OIDC/network, so it proves end-to-end manifest -> in-toto statement without
+    # a stub. (The shell glue always signs; this drives the engine directly.)
+    if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
+    local meta="$TEST_DIR/meta"; mkdir -p "$meta"
+    printf '{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}\n' \
+        > "$meta/wrangle_attestation_metadata.json"
+    printf '{"spdxVersion":"SPDX-2.3","name":"x"}\n' > "$meta/sbom.spdx.json"
+    local out="$TEST_DIR/out.intoto.jsonl"
+    local sha; sha="$(printf '0%.0s' {1..64})"
+    run "$ATTEST_BIN" --metadata-root="$meta" --subject="sha256:$sha" --out="$out"
+    [[ "$status" -eq 0 ]]
+    [[ "$(wc -l < "$out")" -eq 1 ]]
+    [[ "$(jq -r '.predicateType' "$out")" == "https://spdx.dev/Document" ]]
+    [[ "$(jq -r '.subject[0].digest.sha256' "$out")" == "$sha" ]]
+}
+
 @test "run_verify: emit_metadata fails closed when the real engine sees a malformed manifest" {
     # The real engine fails closed at discoverManifests — before newSigner — so a
     # malformed top-level manifest aborts hermetically (no OIDC/network). Drive

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -100,39 +100,21 @@ teardown() {
     [[ "$status" -ne 0 ]]
 }
 
-# --- subject sha256 (the bare digest wrangle-attest binds the SBOM to) ---
-
-@test "run_verify: subject_sha256 passes a sha256 digest subject through" {
-    run wrangle_subject_sha256 "sha256:$(printf '0%.0s' {1..64})"
-    [[ "$status" -eq 0 ]]
-    [[ "$output" == "sha256:$(printf '0%.0s' {1..64})" ]]
-}
-
-@test "run_verify: subject_sha256 hashes a file subject to its sha256" {
-    printf 'CONTENT\n' > "$TEST_DIR/blob"
-    local want; want="$(sha256sum "$TEST_DIR/blob" | cut -d' ' -f1)"
-    run wrangle_subject_sha256 "$TEST_DIR/blob"
-    [[ "$status" -eq 0 ]]
-    [[ "$output" == "sha256:$want" ]]
-}
-
-@test "run_verify: subject_sha256 rejects a non-sha256 digest the store can't take" {
-    # The attestation store keys by sha256; a sha512 digest subject must fail
-    # closed, not silently produce an unstorable statement.
-    run wrangle_subject_sha256 "sha512:$(printf 'a%.0s' {1..128})"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"not sha256"* ]]
-}
-
 # --- wrangle-attest arg vector ---
 
-@test "run_verify: attest args carry the metadata-root, subject, sign, and out" {
+@test "run_verify: attest args carry the metadata-root, subject arg, sign, and out" {
     export METADATA_ROOT="$TEST_DIR/meta"
-    mapfile -t args < <(wrangle_attest_args "sha256:abc" "$TEST_DIR/out.jsonl")
+    mapfile -t args < <(wrangle_attest_args "--subject=sha256:abc" "$TEST_DIR/out.jsonl")
     printf '%s\n' "${args[@]}" | grep -qx -- "--metadata-root=$TEST_DIR/meta"
     printf '%s\n' "${args[@]}" | grep -qx -- "--subject=sha256:abc"
     printf '%s\n' "${args[@]}" | grep -qx -- "--sign"
     printf '%s\n' "${args[@]}" | grep -qx -- "--out=$TEST_DIR/out.jsonl"
+}
+
+@test "run_verify: attest args pass an --artifact subject arg through verbatim" {
+    export METADATA_ROOT="$TEST_DIR/meta"
+    mapfile -t args < <(wrangle_attest_args "--artifact=$TEST_DIR/dist/a.tgz" "$TEST_DIR/out.jsonl")
+    printf '%s\n' "${args[@]}" | grep -qx -- "--artifact=$TEST_DIR/dist/a.tgz"
 }
 
 @test "run_verify: attest arg vector is accepted by the real wrangle-attest parser" {
@@ -140,7 +122,7 @@ teardown() {
     # (failing later on the bogus subject/root) proves every flag name matches.
     if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
     export METADATA_ROOT="$TEST_DIR/meta"
-    mapfile -t args < <(wrangle_attest_args "sha256:abc" "$TEST_DIR/out.jsonl")
+    mapfile -t args < <(wrangle_attest_args "--subject=sha256:abc" "$TEST_DIR/out.jsonl")
     run "$ATTEST_BIN" "${args[@]}"
     [[ "$status" -ne 0 ]]
     [[ "$output" != *"flag provided but not defined"* ]]
@@ -736,20 +718,48 @@ STUB
     [[ "$(jq -r '.signedStatement.subject[0].digest.sha256' "$TEST_DIR/pushed")" == "$sha" ]]
 }
 
-@test "run_verify: emit_metadata fails closed when the engine fails" {
-    # The engine fails closed on a malformed manifest or a signing failure; the
-    # verify step must surface that rather than shipping an SBOM-less bundle.
-    cat > "$TEST_DIR/wrangle-attest" <<'STUB'
+@test "run_verify: emit_metadata hands a file subject to the engine via --artifact" {
+    # go/npm/python subjects are dist files: the engine self-digests them via
+    # --artifact, so the shell passes the path, never a precomputed digest.
+    cat > "$TEST_DIR/wrangle-attest" <<STUB
 #!/bin/bash
-exit 2
+for a in "\$@"; do case "\$a" in --out=*) out="\${a#--out=}";; esac; done
+printf '%s\n' "\$@" > "$TEST_DIR/attest-args"
+printf '{"signedStatement":1}\n' > "\$out"
 STUB
     chmod +x "$TEST_DIR/wrangle-attest"
     export PATH="$TEST_DIR:$PATH"
     export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
+    export OCI_TARGET=""
+    cat > "$TEST_DIR/bnd" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+    chmod +x "$TEST_DIR/bnd"
+    mkdir -p "$TEST_DIR/dist"; printf 'AAA\n' > "$TEST_DIR/dist/a.tgz"
+    local bundle="$TEST_DIR/bundle.jsonl"; printf '{"provenance":1}\n' > "$bundle"
+    run wrangle_emit_metadata_statements "$TEST_DIR/dist/a.tgz" "$bundle"
+    [[ "$status" -eq 0 ]]
+    grep -qx -- "--artifact=$TEST_DIR/dist/a.tgz" "$TEST_DIR/attest-args"
+    ! grep -q -- "--subject=" "$TEST_DIR/attest-args"
+}
+
+@test "run_verify: emit_metadata fails closed when the real engine sees a malformed manifest" {
+    # The real engine fails closed at discoverManifests — before newSigner — so a
+    # malformed top-level manifest aborts hermetically (no OIDC/network). Drive
+    # the real binary to prove genuine engine fail-closed, not a stubbed exit.
+    if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
+    local dir="$TEST_DIR/wrangle-attest-bin"; mkdir -p "$dir"
+    ln -sf "$ATTEST_BIN" "$dir/wrangle-attest"
+    export PATH="$dir:$PATH"
+    export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
     export WRANGLE_RETRY_DELAY=0
-    local bundle="$TEST_DIR/bundle.jsonl"; : > "$bundle"
+    printf 'not json\n' > "$METADATA_ROOT/wrangle_attestation_metadata.json"
+    local bundle="$TEST_DIR/bundle.jsonl"; printf '{"provenance":1}\n' > "$bundle"
     run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
     [[ "$status" -ne 0 ]]
+    # Nothing appended: the seeded provenance line is untouched.
+    [[ "$(wc -l < "$bundle")" -eq 1 ]]
 }
 
 # --- attach to release (wrangle_attach_release) ---

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -24,6 +24,7 @@ setup() {
     AMPEL_BIN="$(command -v ampel || echo "${WRANGLE_BIN_DIR:-/nonexistent}/ampel")"
     BND_BIN="$(command -v bnd || echo "${WRANGLE_BIN_DIR:-/nonexistent}/bnd")"
     COSIGN_BIN="$(command -v cosign || echo "${WRANGLE_BIN_DIR:-/nonexistent}/cosign")"
+    ATTEST_BIN="$(command -v wrangle-attest || echo "${WRANGLE_BIN_DIR:-/nonexistent}/wrangle-attest")"
 
     export SUBJECTS=$'dist/app-1.2.3.tgz'
     export POLICY="policies/release.json"
@@ -97,6 +98,40 @@ teardown() {
 @test "run_verify: subject_arg fails closed on an unreadable file subject" {
     run wrangle_subject_arg "$TEST_DIR/does-not-exist.tgz"
     [[ "$status" -ne 0 ]]
+}
+
+# --- subject sha256 (the bare digest wrangle-attest binds the SBOM to) ---
+
+@test "run_verify: subject_sha256 passes a sha256 digest subject through" {
+    run wrangle_subject_sha256 "sha256:$(printf '0%.0s' {1..64})"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "sha256:$(printf '0%.0s' {1..64})" ]]
+}
+
+@test "run_verify: subject_sha256 hashes a file subject to its sha256" {
+    printf 'CONTENT\n' > "$TEST_DIR/blob"
+    local want; want="$(sha256sum "$TEST_DIR/blob" | cut -d' ' -f1)"
+    run wrangle_subject_sha256 "$TEST_DIR/blob"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "sha256:$want" ]]
+}
+
+@test "run_verify: subject_sha256 rejects a non-sha256 digest the store can't take" {
+    # The attestation store keys by sha256; a sha512 digest subject must fail
+    # closed, not silently produce an unstorable statement.
+    run wrangle_subject_sha256 "sha512:$(printf 'a%.0s' {1..128})"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"not sha256"* ]]
+}
+
+# --- wrangle-attest arg vector ---
+
+@test "run_verify: attest args carry the metadata-root, subject, and out" {
+    export METADATA_ROOT="$TEST_DIR/meta"
+    mapfile -t args < <(wrangle_attest_args "sha256:abc" "$TEST_DIR/out.jsonl")
+    printf '%s\n' "${args[@]}" | grep -qx -- "--metadata-root=$TEST_DIR/meta"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--subject=sha256:abc"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--out=$TEST_DIR/out.jsonl"
 }
 
 # --- ampel arg vector ---
@@ -632,6 +667,72 @@ STUB
     export OCI_TARGET="ghcr.io/o/r/img@sha256:0000000000000000000000000000000000000000000000000000000000000000"
 
     run "$SCRIPT" run
+    [[ "$status" -ne 0 ]]
+}
+
+# --- build-metadata (SBOM) statement emission ---
+
+@test "run_verify: emit_metadata is a no-op when METADATA_ROOT is unset" {
+    # npm/go/python/container without a metadata dir: nothing is appended and no
+    # signer is invoked. A bnd stub that fails proves the path returns 0 untouched.
+    cat > "$TEST_DIR/bnd" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+    chmod +x "$TEST_DIR/bnd"
+    export PATH="$TEST_DIR:$PATH"
+    unset METADATA_ROOT
+    local bundle="$TEST_DIR/bundle.jsonl"
+    printf '{"provenance":1}\n' > "$bundle"
+    run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
+    [[ "$status" -eq 0 ]]
+    [[ "$(wc -l < "$bundle")" -eq 1 ]]
+}
+
+@test "run_verify: emit_metadata builds, signs, appends, and pushes the SBOM statement" {
+    # End-to-end with the real wrangle-attest (offline) and a stub bnd/cosign:
+    # an SBOM manifest + sbom.spdx.json in METADATA_ROOT becomes a signed SPDX
+    # statement appended to the bundle and posted to the store.
+    if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
+    mkdir -p "$TEST_DIR/meta"
+    printf '{"spdxVersion":"SPDX-2.3","name":"x"}\n' > "$TEST_DIR/meta/sbom.spdx.json"
+    printf '{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}\n' \
+        > "$TEST_DIR/meta/manifest.json"
+    # bnd statement wraps the unsigned line so the jq -c flatten is load-bearing;
+    # bnd push records the file it was handed so the store delivery is provable.
+    cat > "$TEST_DIR/bnd" <<STUB
+#!/bin/bash
+if [[ "\$1" == "push" ]]; then cat "\$4" >> "$TEST_DIR/pushed"; exit 0; fi
+printf '{\n  "signed": '; cat "\$2"; printf '}\n'
+STUB
+    chmod +x "$TEST_DIR/bnd"
+    export PATH="$(dirname "$ATTEST_BIN"):$TEST_DIR:$PATH"
+    export METADATA_ROOT="$TEST_DIR/meta"
+    export GITHUB_REPOSITORY="o/r"
+    export OCI_TARGET=""
+    : > "$TEST_DIR/pushed"
+    local bundle="$TEST_DIR/bundle.jsonl"
+    printf '{"provenance":1}\n' > "$bundle"
+    run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
+    [[ "$status" -eq 0 ]]
+    # The SBOM statement was appended to the bundle (provenance line + SBOM line).
+    # The stub bnd wraps the signed statement under .signed.
+    [[ "$(wc -l < "$bundle")" -eq 2 ]]
+    [[ "$(tail -1 "$bundle" | jq -r '.signed.predicateType')" == "https://spdx.dev/Document" ]]
+    # The signed statement reached the store, bound to the single sha256 subject.
+    [[ "$(jq -r '.signed.subject[0].digest.sha256' "$TEST_DIR/pushed")" == "$(printf '0%.0s' {1..64})" ]]
+}
+
+@test "run_verify: emit_metadata fails closed on a malformed manifest" {
+    # wrangle-attest fails closed on a bad manifest; the verify step must surface
+    # that rather than silently shipping a bundle with no SBOM statement.
+    if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
+    mkdir -p "$TEST_DIR/meta"
+    printf '{"predicate-type":"https://spdx.dev/Document"}\n' > "$TEST_DIR/meta/manifest.json"
+    export PATH="$(dirname "$ATTEST_BIN"):$PATH"
+    export METADATA_ROOT="$TEST_DIR/meta"
+    local bundle="$TEST_DIR/bundle.jsonl"; : > "$bundle"
+    run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
     [[ "$status" -ne 0 ]]
 }
 

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -697,7 +697,7 @@ STUB
     mkdir -p "$TEST_DIR/meta"
     printf '{"spdxVersion":"SPDX-2.3","name":"x"}\n' > "$TEST_DIR/meta/sbom.spdx.json"
     printf '{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}\n' \
-        > "$TEST_DIR/meta/manifest.json"
+        > "$TEST_DIR/meta/wrangle_attestation_metadata.json"
     # bnd statement wraps the unsigned line so the jq -c flatten is load-bearing;
     # bnd push records the file it was handed so the store delivery is provable.
     cat > "$TEST_DIR/bnd" <<STUB
@@ -732,7 +732,7 @@ STUB
     # that rather than silently shipping a bundle with no SBOM statement.
     if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
     mkdir -p "$TEST_DIR/meta"
-    printf '{"predicate-type":"https://spdx.dev/Document"}\n' > "$TEST_DIR/meta/manifest.json"
+    printf '{"predicate-type":"https://spdx.dev/Document"}\n' > "$TEST_DIR/meta/wrangle_attestation_metadata.json"
     local attest_dir; attest_dir="$(dirname "$ATTEST_BIN")"
     export PATH="$attest_dir:$PATH"
     export METADATA_ROOT="$TEST_DIR/meta"

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -706,8 +706,10 @@ if [[ "\$1" == "push" ]]; then cat "\$4" >> "$TEST_DIR/pushed"; exit 0; fi
 printf '{\n  "signed": '; cat "\$2"; printf '}\n'
 STUB
     chmod +x "$TEST_DIR/bnd"
+    # TEST_DIR first so the stub bnd wins; the real bnd is co-located with
+    # wrangle-attest in WRANGLE_BIN_DIR and would otherwise shadow the stub.
     local attest_dir; attest_dir="$(dirname "$ATTEST_BIN")"
-    export PATH="$attest_dir:$TEST_DIR:$PATH"
+    export PATH="$TEST_DIR:$attest_dir:$PATH"
     export METADATA_ROOT="$TEST_DIR/meta"
     export GITHUB_REPOSITORY="o/r"
     export OCI_TARGET=""
@@ -716,9 +718,10 @@ STUB
     printf '{"provenance":1}\n' > "$bundle"
     run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
     [[ "$status" -eq 0 ]]
-    # The SBOM statement was appended to the bundle (provenance line + SBOM line).
-    # The stub bnd wraps the signed statement under .signed.
+    # The seeded provenance line plus exactly one appended SPDX statement; the
+    # stub bnd wraps the signed statement under .signed.
     [[ "$(wc -l < "$bundle")" -eq 2 ]]
+    [[ "$(grep -c '"https://spdx.dev/Document"' "$bundle")" -eq 1 ]]
     [[ "$(tail -1 "$bundle" | jq -r '.signed.predicateType')" == "https://spdx.dev/Document" ]]
     # The signed statement reached the store, bound to the single sha256 subject.
     [[ "$(jq -r '.signed.subject[0].digest.sha256' "$TEST_DIR/pushed")" == "$(printf '0%.0s' {1..64})" ]]

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -78,7 +78,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
+    - uses: TomHennen/wrangle/actions/verify@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -78,7 +78,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+    - uses: TomHennen/wrangle/actions/verify@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,6 +87,9 @@ runs:
         # Empty for container (provenance comes from the oci collector).
         bundle-in: ${{ inputs.oci-target == '' && 'provenance/provenance.jsonl' || '' }}
         bundle-out: ${{ steps.names.outputs.metadata-dir }}
+        # wrangle-attest walks this for the sbom manifest, appending one signed
+        # SBOM statement per subject to each bundle.
+        metadata-dir: ${{ steps.names.outputs.metadata-dir }}
         artifact-name: ${{ steps.names.outputs.metadata }}
         context: ${{ inputs.context }}
         oci-target: ${{ inputs.oci-target }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -78,7 +78,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@a74d68cde50879dc3927c11920de93ea5c1d4d57 # feat/wrangle-attest-sbom-on-469 2026-06-19
+    - uses: TomHennen/wrangle/actions/verify@36c75f81a774c44709ac5a619c0889d96c5b05b1 # feat/wrangle-attest-sbom-on-469 2026-06-19
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -78,7 +78,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@a261f7d1c71c8269e90d191e48ec14930241b7ad # feat/wrangle-attest-sbom-on-469 2026-06-19
+    - uses: TomHennen/wrangle/actions/verify@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -244,11 +244,8 @@ runs:
         METADATA_DIR: ${{ steps.meta_dir.outputs.metadata-dir }}
       run: |
         set -euo pipefail
-        SBOM_PATH="${METADATA_DIR}/sbom.spdx.json"
-        # Reference by digest, not tag — the :latest tag only exists on
-        # main-branch builds, so bare image name fails on other branches.
-        docker buildx imagetools inspect "${IMAGE}@${DIGEST}" --format "{{ json .SBOM.SPDX }}" > "$SBOM_PATH"
-        printf 'sbom=%s\n' "$SBOM_PATH" >> "$GITHUB_OUTPUT"
+        "${{ github.action_path }}/extract_sbom.sh" \
+            "${IMAGE}@${DIGEST}" "${METADATA_DIR}" "$GITHUB_OUTPUT"
 
     - name: Generate summary
       if: always()

--- a/build/actions/container/extract_sbom.sh
+++ b/build/actions/container/extract_sbom.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — handles image refs and paths
+# Extract the SPDX SBOM from a built image and write the wrangle-attest manifest
+# next to it so the verify-stage engine produces an SBOM attestation.
+#
+# Usage: extract_sbom.sh <image-ref> <metadata-dir> <github-output>
+#   <image-ref>     image referenced by digest (tag-only refs miss non-main builds)
+#   <metadata-dir>  dir the SBOM + manifest.json are written to
+#   <github-output> $GITHUB_OUTPUT to record the sbom path on
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRANGLE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+main() {
+    if [[ "$#" -ne 3 ]]; then
+        printf 'Usage: %s <image-ref> <metadata-dir> <github-output>\n' "${0##*/}" >&2
+        return 2
+    fi
+    local image_ref="$1" metadata_dir="$2" github_output="$3"
+    local sbom_path="${metadata_dir}/sbom.spdx.json"
+
+    docker buildx imagetools inspect "$image_ref" --format "{{ json .SBOM.SPDX }}" > "$sbom_path"
+    "$WRANGLE_ROOT/lib/write_attest_manifest.sh" \
+        "$metadata_dir" "https://spdx.dev/Document" "sbom.spdx.json"
+    printf 'sbom=%s\n' "$sbom_path" >> "$github_output"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/build/actions/container/extract_sbom.sh
+++ b/build/actions/container/extract_sbom.sh
@@ -6,7 +6,7 @@ set -f  # disable globbing — handles image refs and paths
 #
 # Usage: extract_sbom.sh <image-ref> <metadata-dir> <github-output>
 #   <image-ref>     image referenced by digest (tag-only refs miss non-main builds)
-#   <metadata-dir>  dir the SBOM + manifest.json are written to
+#   <metadata-dir>  dir the SBOM + wrangle_attestation_metadata.json are written to
 #   <github-output> $GITHUB_OUTPUT to record the sbom path on
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -292,9 +292,9 @@ FAKE
     [[ "$status" -eq 0 ]]
     run jq -e '.spdxVersion' "$meta/sbom.spdx.json"
     [[ "$status" -eq 0 ]]
-    run jq -r '."predicate-type"' "$meta/manifest.json"
+    run jq -r '."predicate-type"' "$meta/wrangle_attestation_metadata.json"
     [[ "$output" == "https://spdx.dev/Document" ]]
-    run jq -r '."result-file"' "$meta/manifest.json"
+    run jq -r '."result-file"' "$meta/wrangle_attestation_metadata.json"
     [[ "$output" == "sbom.spdx.json" ]]
     grep -Fq "sbom=$meta/sbom.spdx.json" "$out"
     rm -rf "$fakebin" "$meta" "$out"

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -278,6 +278,33 @@ teardown() {
     [[ "$status" -eq 0 ]]
 }
 
+@test "container: extract_sbom.sh writes the SBOM, the attest manifest, and the output" {
+    # Fake docker so the test needs no real image; it echoes the SBOM JSON.
+    fakebin="$(mktemp -d)"
+    cat > "$fakebin/docker" << 'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' '{"spdxVersion":"SPDX-2.3","name":"img"}'
+FAKE
+    chmod +x "$fakebin/docker"
+    meta="$(mktemp -d)"
+    out="$(mktemp)"
+    PATH="$fakebin:$PATH" run "$ACTION_DIR/extract_sbom.sh" "img@sha256:abc" "$meta" "$out"
+    [[ "$status" -eq 0 ]]
+    run jq -e '.spdxVersion' "$meta/sbom.spdx.json"
+    [[ "$status" -eq 0 ]]
+    run jq -r '."predicate-type"' "$meta/manifest.json"
+    [[ "$output" == "https://spdx.dev/Document" ]]
+    run jq -r '."result-file"' "$meta/manifest.json"
+    [[ "$output" == "sbom.spdx.json" ]]
+    grep -Fq "sbom=$meta/sbom.spdx.json" "$out"
+    rm -rf "$fakebin" "$meta" "$out"
+}
+
+@test "container: extract_sbom.sh usage error on wrong arg count" {
+    run "$ACTION_DIR/extract_sbom.sh" "img@sha256:abc"
+    [[ "$status" -eq 2 ]]
+}
+
 @test "container: action.yml exposes metadata-dir output" {
     run grep -E '^[[:space:]]+metadata-dir:' "$ACTION_DIR/action.yml"
     [[ "$status" -eq 0 ]]

--- a/build/actions/go/release/action.yml
+++ b/build/actions/go/release/action.yml
@@ -219,11 +219,14 @@ runs:
       env:
         INPUT_PATH: ${{ inputs.path }}
         METADATA_DIR: ${{ steps.metadata.outputs.metadata-dir }}
+        WRANGLE_ROOT: ${{ github.action_path }}/../../../..
       run: |
         set -euo pipefail
         mkdir -p "$METADATA_DIR"
-        "${{ github.action_path }}/../../../../tools/syft/generate_sbom.sh" \
+        "$WRANGLE_ROOT/tools/syft/generate_sbom.sh" \
             "$INPUT_PATH" "$METADATA_DIR/sbom.spdx.json"
+        "$WRANGLE_ROOT/lib/write_attest_manifest.sh" \
+            "$METADATA_DIR" "https://spdx.dev/Document" "sbom.spdx.json"
 
     - name: Generate summary
       if: always()

--- a/build/actions/npm/action.yml
+++ b/build/actions/npm/action.yml
@@ -180,6 +180,7 @@ runs:
       env:
         INPUT_PATH: ${{ inputs.path }}
         METADATA_DIR: ${{ steps.metadata.outputs.metadata-dir }}
+        WRANGLE_ROOT: ${{ github.action_path }}/../../..
       # syft over the project source. Same tool wrangle's python build
       # type uses; OWASP-known-conformant for SPDX. (Earlier SPEC drafts
       # picked the npm-CLI's in-tree SBOM command, but its conformance
@@ -194,6 +195,8 @@ runs:
         SBOM_PATH="${METADATA_DIR}/sbom.spdx.json"
         BIN_DIR="${WRANGLE_BIN_DIR:-${RUNNER_TEMP:-.}/.wrangle/bin}"
         "$BIN_DIR/syft" dir:"$INPUT_PATH" -o spdx-json > "$SBOM_PATH"
+        "$WRANGLE_ROOT/lib/write_attest_manifest.sh" \
+            "$METADATA_DIR" "https://spdx.dev/Document" "sbom.spdx.json"
         printf 'SBOM written to %s\n' "$SBOM_PATH"
 
     - name: Generate summary

--- a/build/actions/python/action.yml
+++ b/build/actions/python/action.yml
@@ -192,11 +192,14 @@ runs:
       env:
         INPUT_PATH: ${{ inputs.path }}
         METADATA_DIR: ${{ steps.metadata.outputs.metadata-dir }}
+        WRANGLE_ROOT: ${{ github.action_path }}/../../..
       run: |
         set -euo pipefail
         SBOM_PATH="${METADATA_DIR}/sbom.spdx.json"
         BIN_DIR="${WRANGLE_BIN_DIR:-${RUNNER_TEMP:-.}/.wrangle/bin}"
         "$BIN_DIR/syft" dir:"$INPUT_PATH" -o spdx-json > "$SBOM_PATH"
+        "$WRANGLE_ROOT/lib/write_attest_manifest.sh" \
+            "$METADATA_DIR" "https://spdx.dev/Document" "sbom.spdx.json"
         printf 'SBOM written to %s\n' "$SBOM_PATH"
 
     - name: Generate summary

--- a/lib/write_attest_manifest.sh
+++ b/lib/write_attest_manifest.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — handles path arguments
+# lib/write_attest_manifest.sh — write the manifest.json a producer leaves for
+# the wrangle-attest engine to discover, next to its native result file.
+#
+# The manifest is the tool↔engine contract: predicate-type implies the result
+# format, result-file is relative to the manifest's own dir. Tools never set
+# subjects — the engine owns those.
+#
+# Usage: write_attest_manifest.sh <metadata_dir> <predicate-type> <result-file>
+#   <metadata_dir>   dir holding the result file; the manifest is written here
+#   <predicate-type> the in-toto predicate type URI
+#   <result-file>    result filename, relative to <metadata_dir>
+#
+# tool/result fields (only the wrangle scan/v1 predicate needs them) are added
+# by the scan adapters, not this helper — SBOM/OSV/scorecard are passthrough.
+
+main() {
+    if [[ "$#" -ne 3 ]]; then
+        printf 'Usage: %s <metadata_dir> <predicate-type> <result-file>\n' "${0##*/}" >&2
+        return 2
+    fi
+    local metadata_dir="$1" predicate_type="$2" result_file="$3"
+    mkdir -p "$metadata_dir"
+    # jq -n builds the JSON so a result-file or URI with a quote/backslash is
+    # escaped, never breaking the manifest the engine parses strictly.
+    jq -n \
+        --arg pt "$predicate_type" \
+        --arg rf "$result_file" \
+        '{"predicate-type": $pt, "result-file": $rf}' \
+        > "$metadata_dir/manifest.json"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/lib/write_attest_manifest.sh
+++ b/lib/write_attest_manifest.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 set -f  # disable globbing — handles path arguments
-# lib/write_attest_manifest.sh — write the manifest.json a producer leaves for
-# the wrangle-attest engine to discover, next to its native result file.
+# lib/write_attest_manifest.sh — write the wrangle_attestation_metadata.json a
+# producer leaves for the wrangle-attest engine to discover, next to its native
+# result file.
 #
 # The manifest is the tool↔engine contract: predicate-type implies the result
 # format, result-file is relative to the manifest's own dir. Tools never set
@@ -29,7 +30,7 @@ main() {
         --arg pt "$predicate_type" \
         --arg rf "$result_file" \
         '{"predicate-type": $pt, "result-file": $rf}' \
-        > "$metadata_dir/manifest.json"
+        > "$metadata_dir/wrangle_attestation_metadata.json"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/test/keyless_attest.sh
+++ b/test/keyless_attest.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# Run the tag-gated keyless-signing integration test for wrangle-attest. Pins
+# Go's proxy + sum database (lib/env.sh) so the build can't skip integrity
+# checks; the ambient GitHub OIDC token the signer exchanges at Fulcio comes
+# from the calling job's id-token: write.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=../lib/env.sh
+source "$REPO_ROOT/lib/env.sh"
+
+go -C "$REPO_ROOT/tools" test -tags keyless_integration -run TestRunSignKeyless ./wrangle-attest/...

--- a/test/test_write_attest_manifest.bats
+++ b/test/test_write_attest_manifest.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 # Tests for lib/write_attest_manifest.sh — the producer-side helper that writes
-# the manifest.json the wrangle-attest engine discovers.
+# the wrangle_attestation_metadata.json the wrangle-attest engine discovers.
 
 setup() {
     SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../lib" && pwd)/write_attest_manifest.sh"
@@ -15,19 +15,19 @@ teardown() {
 @test "write_attest_manifest: writes the pinned schema for an SBOM" {
     run "$SCRIPT" "$TEST_DIR/meta" "https://spdx.dev/Document" "sbom.spdx.json"
     [[ "$status" -eq 0 ]]
-    run jq -r '."predicate-type"' "$TEST_DIR/meta/manifest.json"
+    run jq -r '."predicate-type"' "$TEST_DIR/meta/wrangle_attestation_metadata.json"
     [[ "$output" == "https://spdx.dev/Document" ]]
-    run jq -r '."result-file"' "$TEST_DIR/meta/manifest.json"
+    run jq -r '."result-file"' "$TEST_DIR/meta/wrangle_attestation_metadata.json"
     [[ "$output" == "sbom.spdx.json" ]]
     # Passthrough manifests carry no tool/result fields.
-    run jq -e 'has("tool") or has("result")' "$TEST_DIR/meta/manifest.json"
+    run jq -e 'has("tool") or has("result")' "$TEST_DIR/meta/wrangle_attestation_metadata.json"
     [[ "$status" -ne 0 ]]
 }
 
 @test "write_attest_manifest: creates the metadata dir if absent" {
     run "$SCRIPT" "$TEST_DIR/nested/dir" "https://spdx.dev/Document" "sbom.spdx.json"
     [[ "$status" -eq 0 ]]
-    [[ -f "$TEST_DIR/nested/dir/manifest.json" ]]
+    [[ -f "$TEST_DIR/nested/dir/wrangle_attestation_metadata.json" ]]
 }
 
 @test "write_attest_manifest: jq-escapes a value with quotes (no broken JSON)" {
@@ -35,7 +35,7 @@ teardown() {
     # parses strictly; jq -n escapes it.
     run "$SCRIPT" "$TEST_DIR/meta" 'https://spdx.dev/Document' 'we"ird.json'
     [[ "$status" -eq 0 ]]
-    run jq -r '."result-file"' "$TEST_DIR/meta/manifest.json"
+    run jq -r '."result-file"' "$TEST_DIR/meta/wrangle_attestation_metadata.json"
     [[ "$output" == 'we"ird.json' ]]
 }
 

--- a/test/test_write_attest_manifest.bats
+++ b/test/test_write_attest_manifest.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+# Tests for lib/write_attest_manifest.sh — the producer-side helper that writes
+# the manifest.json the wrangle-attest engine discovers.
+
+setup() {
+    SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../lib" && pwd)/write_attest_manifest.sh"
+    TEST_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "write_attest_manifest: writes the pinned schema for an SBOM" {
+    run "$SCRIPT" "$TEST_DIR/meta" "https://spdx.dev/Document" "sbom.spdx.json"
+    [[ "$status" -eq 0 ]]
+    run jq -r '."predicate-type"' "$TEST_DIR/meta/manifest.json"
+    [[ "$output" == "https://spdx.dev/Document" ]]
+    run jq -r '."result-file"' "$TEST_DIR/meta/manifest.json"
+    [[ "$output" == "sbom.spdx.json" ]]
+    # Passthrough manifests carry no tool/result fields.
+    run jq -e 'has("tool") or has("result")' "$TEST_DIR/meta/manifest.json"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "write_attest_manifest: creates the metadata dir if absent" {
+    run "$SCRIPT" "$TEST_DIR/nested/dir" "https://spdx.dev/Document" "sbom.spdx.json"
+    [[ "$status" -eq 0 ]]
+    [[ -f "$TEST_DIR/nested/dir/manifest.json" ]]
+}
+
+@test "write_attest_manifest: jq-escapes a value with quotes (no broken JSON)" {
+    # A pathological result-file name must not break the manifest the engine
+    # parses strictly; jq -n escapes it.
+    run "$SCRIPT" "$TEST_DIR/meta" 'https://spdx.dev/Document' 'we"ird.json'
+    [[ "$status" -eq 0 ]]
+    run jq -r '."result-file"' "$TEST_DIR/meta/manifest.json"
+    [[ "$output" == 'we"ird.json' ]]
+}
+
+@test "write_attest_manifest: usage error on wrong arg count" {
+    run "$SCRIPT" "$TEST_DIR/meta" "https://spdx.dev/Document"
+    [[ "$status" -eq 2 ]]
+    [[ "$output" == *"Usage:"* ]]
+}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -16,6 +16,8 @@ require (
 	github.com/carabiner-dev/signer v0.5.2
 	github.com/in-toto/attestation v1.2.0
 	github.com/owenrumney/go-sarif/v3 v3.3.0
+	github.com/sigstore/protobuf-specs v0.5.1
+	github.com/sigstore/sigstore-go v1.2.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -380,11 +382,9 @@ require (
 	github.com/sigstore/cosign/v3 v3.0.6 // indirect
 	github.com/sigstore/fulcio v1.8.5 // indirect
 	github.com/sigstore/gitsign v0.16.0 // indirect
-	github.com/sigstore/protobuf-specs v0.5.1 // indirect
 	github.com/sigstore/rekor v1.5.2 // indirect
 	github.com/sigstore/rekor-tiles/v2 v2.2.2-0.20260601073857-5d098a2b6443 // indirect
 	github.com/sigstore/sigstore v1.10.8 // indirect
-	github.com/sigstore/sigstore-go v1.2.0 // indirect
 	github.com/sigstore/sigstore/pkg/signature/kms/aws v1.10.8 // indirect
 	github.com/sigstore/sigstore/pkg/signature/kms/azure v1.10.8 // indirect
 	github.com/sigstore/sigstore/pkg/signature/kms/gcp v1.10.8 // indirect

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -13,6 +13,7 @@ tool (
 )
 
 require (
+	github.com/carabiner-dev/signer v0.5.2
 	github.com/in-toto/attestation v1.2.0
 	github.com/owenrumney/go-sarif/v3 v3.3.0
 	google.golang.org/protobuf v1.36.11
@@ -133,7 +134,6 @@ require (
 	github.com/carabiner-dev/policy v0.5.1 // indirect
 	github.com/carabiner-dev/predicates v0.5.0 // indirect
 	github.com/carabiner-dev/sbomfs v0.1.0 // indirect
-	github.com/carabiner-dev/signer v0.5.2 // indirect
 	github.com/carabiner-dev/termtable v1.1.0 // indirect
 	github.com/carabiner-dev/vcslocator v0.4.4 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,6 +3,7 @@ module github.com/TomHennen/wrangle/tools
 go 1.26.4
 
 tool (
+	github.com/TomHennen/wrangle/tools/wrangle-attest
 	github.com/TomHennen/wrangle/tools/wrangle-lint
 	github.com/carabiner-dev/ampel/cmd/ampel
 	github.com/carabiner-dev/bnd
@@ -12,7 +13,9 @@ tool (
 )
 
 require (
+	github.com/in-toto/attestation v1.2.0
 	github.com/owenrumney/go-sarif/v3 v3.3.0
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -272,7 +275,6 @@ require (
 	github.com/hjson/hjson-go/v4 v4.6.0 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20251118225945-96ee0021ea0f // indirect
 	github.com/icholy/digest v1.1.0 // indirect
-	github.com/in-toto/attestation v1.2.0 // indirect
 	github.com/in-toto/in-toto-golang v0.11.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
@@ -469,7 +471,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260608224507-4308a22a1bab // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260608224507-4308a22a1bab // indirect
 	google.golang.org/grpc v1.81.1 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.2 // indirect

--- a/tools/wrangle-attest/SPEC.md
+++ b/tools/wrangle-attest/SPEC.md
@@ -56,8 +56,11 @@ wrangle-attest --metadata-root <dir>... --subject sha256:<hex> \
     [--commit <hex-sha>] --out <file>
 ```
 
-Walks each `--metadata-root` for `manifest.json`, builds one unsigned Statement
-per manifest bound to `--subject`, and writes them all to `--out` as JSONL.
+Honors only the canonical top-level `<root>/manifest.json` for each
+`--metadata-root`; any other `manifest.json` deeper in the tree is ignored (a
+build-time dependency could plant one to forge a wrangle-signed attestation).
+Builds one unsigned Statement per honored manifest bound to `--subject`, and
+writes them all to `--out` as JSONL.
 `--commit` is woven into the `scan/v1` envelope only; passthrough predicates
 ignore it. All statements are built into a buffer before `--out` is touched, so a
 failure on the Nth manifest never leaves a partially-written file. Exit 0 on

--- a/tools/wrangle-attest/SPEC.md
+++ b/tools/wrangle-attest/SPEC.md
@@ -1,10 +1,10 @@
 # wrangle-attest — shared attestation engine
 
 `wrangle-attest` turns the inert result files scan/build tools leave behind into
-**unsigned** in-toto v1 Statements, ready for `bnd` to sign in the trusted
-post-build context (`actions/verify`). It is the single producer-side engine:
-adding the Nth attestation type is a new manifest + (for a novel predicate
-shape) a new case here, never new signing code.
+in-toto v1 Statements and, with `--sign`, keyless-signs each into a Sigstore
+bundle in the trusted post-build context (`actions/verify`). It is the single
+producer-side engine: adding the Nth attestation type is a new manifest + (for a
+novel predicate shape) a new case here, never new signing code.
 
 ## Tools declare, the engine decides
 
@@ -21,7 +21,7 @@ is the only tool↔engine contract:
 ```
 
 There is **no `format`** field (the predicate-type implies it) and tools **never
-set subjects** — the engine owns the subject. A malformed manifest, an unknown
+set subjects** — the engine owns the subject (see Engine-owned subject). A malformed manifest, an unknown
 predicate-type, a missing/absolute/`..` result-file, or an unknown field fails
 the whole run closed; scan output is untrusted input.
 
@@ -42,8 +42,9 @@ later producer PRs are manifest-only.
 
 ## Engine-owned subject
 
-Every statement is bound to the **single sha256 artifact subject** passed via
-`--subject`. The GitHub attestation store (`bnd push github`) keys by subject
+Every statement is bound to the **single sha256 artifact subject**, given as a
+digest via `--subject` (e.g. a container image) or self-digested from a file via
+`--artifact`. The GitHub attestation store (`bnd push github`) keys by subject
 digest and rejects a multi-digest subject, so a single sha256 is the only shape
 that round-trips through the store — and it is the same digest `run_verify.sh`
 binds the VSA to, so a policy resolving by artifact digest finds both. Binding
@@ -52,28 +53,31 @@ the scanned git commit as a second subject is deferred to the source-scan PRs.
 ## CLI
 
 ```
-wrangle-attest --metadata-root <dir>... --subject sha256:<hex> \
-    [--commit <hex-sha>] --out <file>
+wrangle-attest --metadata-root <dir>... (--subject sha256:<hex> | --artifact <file>) \
+    [--commit <hex-sha>] [--sign] --out <file>
 ```
 
 Honors only the canonical top-level `<root>/wrangle_attestation_metadata.json` for each
 `--metadata-root`; any other `wrangle_attestation_metadata.json` deeper in the tree is ignored (a
 build-time dependency could plant one to forge a wrangle-signed attestation).
-Builds one unsigned Statement per honored manifest bound to `--subject`, and
-writes them all to `--out` as JSONL.
-`--commit` is woven into the `scan/v1` envelope only; passthrough predicates
-ignore it. All statements are built into a buffer before `--out` is touched, so a
-failure on the Nth manifest never leaves a partially-written file. Exit 0 on
-success; non-zero (fail closed) on any error.
+Builds one Statement per honored manifest bound to the subject and writes them
+all to `--out` as JSONL. `--commit` is woven into the `scan/v1` envelope only;
+passthrough predicates ignore it.
 
-Signing is **not** here: `run_verify.sh` bnd-signs each emitted statement in the
-same trusted process as the VSA, so the engine has no Sigstore code and is fully
-offline-unit-testable.
+With `--sign` each statement is keyless-signed (one shared signer — ambient
+GitHub OIDC → Fulcio → Rekor; the bundle is byte-identical to `bnd statement`)
+and the compact Sigstore bundle is emitted; without it the statements are
+emitted unsigned (fully offline-unit-testable). Statements are built and signed
+into a buffer before `--out` is touched, so a failure on the Nth manifest — a
+malformed manifest or a signing failure — never leaves a partial/unsigned file.
+Exit 0 on success; non-zero (fail closed) on any error.
 
 ## Testing
 
 `go test ./wrangle-attest/` — table-driven manifest parse/validate (fail-closed
-cases), subject parsing (single sha256, fail-closed on multi/short/wrong-algo),
-and golden Statements (`testdata/`) for the SBOM passthrough and the SARIF
-thin-envelope shapes. Regenerate goldens with `go test ./wrangle-attest/
--update`. The `actions/verify` bats cover the `run_verify.sh` glue.
+cases), subject parsing (single sha256, fail-closed on multi/short/wrong-algo;
+`--artifact` self-digest), golden Statements (`testdata/`) for the SBOM
+passthrough and the SARIF thin-envelope shapes, and hermetic `--sign` (local
+ephemeral key: DSSE shape + signature + fail-closed). Regenerate goldens with
+`go test ./wrangle-attest/ -update`. The real keyless path is covered by the
+dispatch e2e (`actions/verify` bats cover the `run_verify.sh` glue).

--- a/tools/wrangle-attest/SPEC.md
+++ b/tools/wrangle-attest/SPEC.md
@@ -8,7 +8,7 @@ shape) a new case here, never new signing code.
 
 ## Tools declare, the engine decides
 
-A producer writes a `manifest.json` next to its native result file. The manifest
+A producer writes a `wrangle_attestation_metadata.json` next to its native result file. The manifest
 is the only tool↔engine contract:
 
 ```jsonc
@@ -56,8 +56,8 @@ wrangle-attest --metadata-root <dir>... --subject sha256:<hex> \
     [--commit <hex-sha>] --out <file>
 ```
 
-Honors only the canonical top-level `<root>/manifest.json` for each
-`--metadata-root`; any other `manifest.json` deeper in the tree is ignored (a
+Honors only the canonical top-level `<root>/wrangle_attestation_metadata.json` for each
+`--metadata-root`; any other `wrangle_attestation_metadata.json` deeper in the tree is ignored (a
 build-time dependency could plant one to forge a wrangle-signed attestation).
 Builds one unsigned Statement per honored manifest bound to `--subject`, and
 writes them all to `--out` as JSONL.

--- a/tools/wrangle-attest/SPEC.md
+++ b/tools/wrangle-attest/SPEC.md
@@ -1,0 +1,76 @@
+# wrangle-attest — shared attestation engine
+
+`wrangle-attest` turns the inert result files scan/build tools leave behind into
+**unsigned** in-toto v1 Statements, ready for `bnd` to sign in the trusted
+post-build context (`actions/verify`). It is the single producer-side engine:
+adding the Nth attestation type is a new manifest + (for a novel predicate
+shape) a new case here, never new signing code.
+
+## Tools declare, the engine decides
+
+A producer writes a `manifest.json` next to its native result file. The manifest
+is the only tool↔engine contract:
+
+```jsonc
+{
+  "predicate-type": "<URI>",           // required; implies the result-file format
+  "result-file":    "<relative-path>", // required; relative to the manifest's own dir
+  "tool":   { "name": "<str>", "version": "<str>" },  // .../wrangle/attestation/scan/v1 only
+  "result": "clean" | "findings"                       // .../wrangle/attestation/scan/v1 only
+}
+```
+
+There is **no `format`** field (the predicate-type implies it) and tools **never
+set subjects** — the engine owns the subject. A malformed manifest, an unknown
+predicate-type, a missing/absolute/`..` result-file, or an unknown field fails
+the whole run closed; scan output is untrusted input.
+
+## Predicate-type → handling
+
+| predicate-type | result-file | handling |
+|---|---|---|
+| `https://spdx.dev/Document` | `sbom.spdx.json` | passthrough (SPDX is the predicate) |
+| `https://ossf.github.io/osv-schema/results` | OSV JSON | passthrough |
+| `https://scorecard.dev/result/v0.1` | scorecard JSON | passthrough |
+| `https://github.com/TomHennen/wrangle/attestation/scan/v1` | `output.sarif` | thin envelope `{tool, scannedCommit, result, sarif}` |
+
+Passthrough embeds the result file verbatim as the predicate (it must be a JSON
+object). The thin envelope hoists `tool`/`result`/`scannedCommit` to the top
+level so policy filters on `predicate.tool.name` / `predicate.result` without
+parsing nested SARIF. v1 ships SBOM; the OSV/scorecard/SARIF cases are wired so
+later producer PRs are manifest-only.
+
+## Engine-owned subject
+
+Every statement is bound to the **single sha256 artifact subject** passed via
+`--subject`. The GitHub attestation store (`bnd push github`) keys by subject
+digest and rejects a multi-digest subject, so a single sha256 is the only shape
+that round-trips through the store — and it is the same digest `run_verify.sh`
+binds the VSA to, so a policy resolving by artifact digest finds both. Binding
+the scanned git commit as a second subject is deferred to the source-scan PRs.
+
+## CLI
+
+```
+wrangle-attest --metadata-root <dir>... --subject sha256:<hex> \
+    [--commit <hex-sha>] --out <file>
+```
+
+Walks each `--metadata-root` for `manifest.json`, builds one unsigned Statement
+per manifest bound to `--subject`, and writes them all to `--out` as JSONL.
+`--commit` is woven into the `scan/v1` envelope only; passthrough predicates
+ignore it. All statements are built into a buffer before `--out` is touched, so a
+failure on the Nth manifest never leaves a partially-written file. Exit 0 on
+success; non-zero (fail closed) on any error.
+
+Signing is **not** here: `run_verify.sh` bnd-signs each emitted statement in the
+same trusted process as the VSA, so the engine has no Sigstore code and is fully
+offline-unit-testable.
+
+## Testing
+
+`go test ./wrangle-attest/` — table-driven manifest parse/validate (fail-closed
+cases), subject parsing (single sha256, fail-closed on multi/short/wrong-algo),
+and golden Statements (`testdata/`) for the SBOM passthrough and the SARIF
+thin-envelope shapes. Regenerate goldens with `go test ./wrangle-attest/
+-update`. The `actions/verify` bats cover the `run_verify.sh` glue.

--- a/tools/wrangle-attest/main.go
+++ b/tools/wrangle-attest/main.go
@@ -5,8 +5,9 @@
 // attestation type is a new manifest + (for a novel predicate shape) a new case
 // here, never new signing code.
 //
-// Tools declare, the engine decides. Each producer writes a manifest.json next
-// to its native result (sbom.spdx.json, results.json, output.sarif, …):
+// Tools declare, the engine decides. Each producer writes a
+// wrangle_attestation_metadata.json next to its native result (sbom.spdx.json,
+// results.json, output.sarif, …):
 //
 //	{
 //	  "predicate-type": "<URI>",           // required; implies the result format
@@ -15,7 +16,7 @@
 //	  "result": "clean" | "findings"                    // .../scan/v1 only
 //	}
 //
-// The engine walks --metadata-root for manifest.json files and builds one
+// The engine walks --metadata-root for wrangle_attestation_metadata.json files and builds one
 // Statement per manifest:
 //   - passthrough predicates (SPDX, OSV, scorecard) embed the result file
 //     verbatim as the predicate;

--- a/tools/wrangle-attest/main.go
+++ b/tools/wrangle-attest/main.go
@@ -1,9 +1,9 @@
 // Command wrangle-attest is the shared attestation engine: it turns the inert
-// result files that scan/build tools leave behind into UNSIGNED in-toto v1
-// Statements, ready for `bnd` to sign in the trusted post-build context
-// (actions/verify). It is the single producer-side engine: adding the Nth
-// attestation type is a new manifest + (for a novel predicate shape) a new case
-// here, never new signing code.
+// result files that scan/build tools leave behind into in-toto v1 Statements
+// and, with --sign, keyless-signs each into a Sigstore bundle in the trusted
+// post-build context (actions/verify). It is the single producer-side engine:
+// adding the Nth attestation type is a new manifest + (for a novel predicate
+// shape) a new case here, never new signing code.
 //
 // Tools declare, the engine decides. Each producer writes a
 // wrangle_attestation_metadata.json next to its native result (sbom.spdx.json,
@@ -25,18 +25,20 @@
 //     filter on predicate.tool.name / predicate.result without parsing SARIF.
 //
 // The engine OWNS the subject: every statement is bound to the SINGLE sha256
-// subject passed via --subject (the same artifact digest the run's VSA binds
-// to). The GitHub attestation store rejects a multi-digest subject, so a single
+// subject, passed via --subject (a digest, e.g. a container image) or computed
+// by self-digesting --artifact. It is the same digest the run's VSA binds to.
+// The GitHub attestation store rejects a multi-digest subject, so a single
 // sha256 is the only shape that round-trips through `bnd push github`. Binding
 // the scanned commit as a second subject is deferred to the source-scan PRs.
 //
-// All output is UNSIGNED. Signing stays in actions/verify/run_verify.sh, which
-// bnd-signs each emitted statement in the same trusted process as the VSA — so
-// this engine has no Sigstore code and is fully offline-unit-testable.
+// With --sign each statement is keyless-signed via one shared signer (ambient
+// GitHub OIDC -> Fulcio -> Rekor), producing a Sigstore bundle. Without it the
+// statements are emitted unsigned (offline-unit-testable).
 //
 // Fail closed: a malformed/missing manifest, an unknown predicate-type, a
-// missing result file, or a malformed subject aborts with a non-zero exit
-// BEFORE any output is written, so a partial/corrupt bundle is never produced.
+// missing result file, a malformed subject, or a signing failure aborts with a
+// non-zero exit BEFORE any output is written, so a partial/unsigned/corrupt
+// bundle is never produced.
 package main
 
 import "os"

--- a/tools/wrangle-attest/main.go
+++ b/tools/wrangle-attest/main.go
@@ -1,0 +1,45 @@
+// Command wrangle-attest is the shared attestation engine: it turns the inert
+// result files that scan/build tools leave behind into UNSIGNED in-toto v1
+// Statements, ready for `bnd` to sign in the trusted post-build context
+// (actions/verify). It is the single producer-side engine: adding the Nth
+// attestation type is a new manifest + (for a novel predicate shape) a new case
+// here, never new signing code.
+//
+// Tools declare, the engine decides. Each producer writes a manifest.json next
+// to its native result (sbom.spdx.json, results.json, output.sarif, …):
+//
+//	{
+//	  "predicate-type": "<URI>",           // required; implies the result format
+//	  "result-file":    "<relative-path>", // required; relative to the manifest dir
+//	  "tool":   {"name": "<str>", "version": "<str>"}, // .../scan/v1 only
+//	  "result": "clean" | "findings"                    // .../scan/v1 only
+//	}
+//
+// The engine walks --metadata-root for manifest.json files and builds one
+// Statement per manifest:
+//   - passthrough predicates (SPDX, OSV, scorecard) embed the result file
+//     verbatim as the predicate;
+//   - the wrangle scan predicate (.../wrangle/attestation/scan/v1) wraps SARIF
+//     in a thin envelope {tool, scannedCommit, result, sarif} so policy can
+//     filter on predicate.tool.name / predicate.result without parsing SARIF.
+//
+// The engine OWNS the subject: every statement is bound to the SINGLE sha256
+// subject passed via --subject (the same artifact digest the run's VSA binds
+// to). The GitHub attestation store rejects a multi-digest subject, so a single
+// sha256 is the only shape that round-trips through `bnd push github`. Binding
+// the scanned commit as a second subject is deferred to the source-scan PRs.
+//
+// All output is UNSIGNED. Signing stays in actions/verify/run_verify.sh, which
+// bnd-signs each emitted statement in the same trusted process as the VSA — so
+// this engine has no Sigstore code and is fully offline-unit-testable.
+//
+// Fail closed: a malformed/missing manifest, an unknown predicate-type, a
+// missing result file, or a malformed subject aborts with a non-zero exit
+// BEFORE any output is written, so a partial/corrupt bundle is never produced.
+package main
+
+import "os"
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stderr))
+}

--- a/tools/wrangle-attest/manifest.go
+++ b/tools/wrangle-attest/manifest.go
@@ -48,7 +48,7 @@ func (m *manifest) validate() error {
 		return errors.New("missing result-file")
 	}
 	// A result-file is a name within the manifest's dir, never an escape.
-	if filepath.IsAbs(m.ResultFile) || containsDotDot(m.ResultFile) {
+	if !filepath.IsLocal(m.ResultFile) {
 		return fmt.Errorf("result-file %q must be a path within the manifest directory", m.ResultFile)
 	}
 	switch m.PredicateType {
@@ -65,15 +65,6 @@ func (m *manifest) validate() error {
 		return fmt.Errorf("unknown predicate-type %q", m.PredicateType)
 	}
 	return nil
-}
-
-func containsDotDot(p string) bool {
-	for _, seg := range strings.Split(filepath.ToSlash(p), "/") {
-		if seg == ".." {
-			return true
-		}
-	}
-	return false
 }
 
 // resultPath is the absolute path to the manifest's native result file.

--- a/tools/wrangle-attest/manifest.go
+++ b/tools/wrangle-attest/manifest.go
@@ -81,10 +81,12 @@ func (m *manifest) resultPath() string {
 	return filepath.Join(m.dir, m.ResultFile)
 }
 
-// discoverManifests walks each root for manifest.json files, parses and
-// validates each, and returns them sorted by path for deterministic output.
-// Any malformed manifest fails the whole run (fail closed). A root with no
-// manifests is not an error — a build may legitimately produce none.
+// discoverManifests honors only the canonical top-level <root>/manifest.json
+// for each root; any other manifest.json in the tree is ignored, not signed,
+// since a build-time dependency could plant one to forge a wrangle-signed
+// attestation. Results are sorted by dir for deterministic output. A missing
+// canonical manifest is not an error — a build may legitimately produce none;
+// a malformed canonical manifest fails the whole run (fail closed).
 func discoverManifests(roots []string) ([]manifest, error) {
 	var found []manifest
 	for _, root := range roots {
@@ -95,23 +97,18 @@ func discoverManifests(roots []string) ([]manifest, error) {
 		if !info.IsDir() {
 			return nil, fmt.Errorf("metadata-root %q is not a directory", root)
 		}
-		err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
+		path := filepath.Join(root, "manifest.json")
+		if _, err := os.Stat(path); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
 			}
-			if d.IsDir() || d.Name() != "manifest.json" {
-				return nil
-			}
-			m, err := parseManifest(path)
-			if err != nil {
-				return fmt.Errorf("%s: %w", path, err)
-			}
-			found = append(found, m)
-			return nil
-		})
-		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%s: %w", path, err)
 		}
+		m, err := parseManifest(path)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		found = append(found, m)
 	}
 	sort.Slice(found, func(i, j int) bool { return found[i].dir < found[j].dir })
 	return found, nil

--- a/tools/wrangle-attest/manifest.go
+++ b/tools/wrangle-attest/manifest.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Predicate types the engine knows how to build. A manifest naming any other
+// type fails closed — an unrecognized type would otherwise pass an unvalidated
+// blob through as a signed attestation.
+const (
+	predicateSPDX      = "https://spdx.dev/Document"
+	predicateOSV       = "https://ossf.github.io/osv-schema/results"
+	predicateScorecard = "https://scorecard.dev/result/v0.1"
+	predicateScanV1    = "https://github.com/TomHennen/wrangle/attestation/scan/v1"
+)
+
+// manifest is the tool↔engine contract written next to each native result.
+// `result-file` is resolved relative to the manifest's own directory so a
+// producer cannot escape its metadata dir or reach an absolute path.
+type manifest struct {
+	PredicateType string `json:"predicate-type"`
+	ResultFile    string `json:"result-file"`
+	Tool          *struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	} `json:"tool"`
+	Result string `json:"result"`
+
+	// dir is the manifest's own directory; set on discovery, not from JSON.
+	dir string
+}
+
+// validate enforces the pinned manifest schema, treating the manifest as
+// untrusted scan output. tool/result are required ONLY for the scan/v1 thin
+// envelope and ignored for passthrough predicates.
+func (m *manifest) validate() error {
+	if m.PredicateType == "" {
+		return errors.New("missing predicate-type")
+	}
+	if m.ResultFile == "" {
+		return errors.New("missing result-file")
+	}
+	// A result-file is a name within the manifest's dir, never an escape.
+	if filepath.IsAbs(m.ResultFile) || containsDotDot(m.ResultFile) {
+		return fmt.Errorf("result-file %q must be a path within the manifest directory", m.ResultFile)
+	}
+	switch m.PredicateType {
+	case predicateSPDX, predicateOSV, predicateScorecard:
+		// Passthrough: the result file IS the predicate; no extra fields.
+	case predicateScanV1:
+		if m.Tool == nil || m.Tool.Name == "" {
+			return fmt.Errorf("%s requires tool.name", predicateScanV1)
+		}
+		if m.Result != "clean" && m.Result != "findings" {
+			return fmt.Errorf("%s requires result clean|findings, got %q", predicateScanV1, m.Result)
+		}
+	default:
+		return fmt.Errorf("unknown predicate-type %q", m.PredicateType)
+	}
+	return nil
+}
+
+func containsDotDot(p string) bool {
+	for _, seg := range strings.Split(filepath.ToSlash(p), "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+// resultPath is the absolute path to the manifest's native result file.
+func (m *manifest) resultPath() string {
+	return filepath.Join(m.dir, m.ResultFile)
+}
+
+// discoverManifests walks each root for manifest.json files, parses and
+// validates each, and returns them sorted by path for deterministic output.
+// Any malformed manifest fails the whole run (fail closed). A root with no
+// manifests is not an error — a build may legitimately produce none.
+func discoverManifests(roots []string) ([]manifest, error) {
+	var found []manifest
+	for _, root := range roots {
+		info, err := os.Stat(root)
+		if err != nil {
+			return nil, fmt.Errorf("metadata-root %q: %w", root, err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("metadata-root %q is not a directory", root)
+		}
+		err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || d.Name() != "manifest.json" {
+				return nil
+			}
+			m, err := parseManifest(path)
+			if err != nil {
+				return fmt.Errorf("%s: %w", path, err)
+			}
+			found = append(found, m)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	sort.Slice(found, func(i, j int) bool { return found[i].dir < found[j].dir })
+	return found, nil
+}
+
+func parseManifest(path string) (manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return manifest{}, err
+	}
+	var m manifest
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&m); err != nil {
+		return manifest{}, fmt.Errorf("invalid manifest JSON: %w", err)
+	}
+	m.dir = filepath.Dir(path)
+	if err := m.validate(); err != nil {
+		return manifest{}, err
+	}
+	return m, nil
+}

--- a/tools/wrangle-attest/manifest.go
+++ b/tools/wrangle-attest/manifest.go
@@ -81,8 +81,9 @@ func (m *manifest) resultPath() string {
 	return filepath.Join(m.dir, m.ResultFile)
 }
 
-// discoverManifests honors only the canonical top-level <root>/manifest.json
-// for each root; any other manifest.json in the tree is ignored, not signed,
+// discoverManifests honors only the canonical top-level
+// <root>/wrangle_attestation_metadata.json for each root; any other such file
+// in the tree is ignored, not signed,
 // since a build-time dependency could plant one to forge a wrangle-signed
 // attestation. Results are sorted by dir for deterministic output. A missing
 // canonical manifest is not an error — a build may legitimately produce none;
@@ -97,7 +98,7 @@ func discoverManifests(roots []string) ([]manifest, error) {
 		if !info.IsDir() {
 			return nil, fmt.Errorf("metadata-root %q is not a directory", root)
 		}
-		path := filepath.Join(root, "manifest.json")
+		path := filepath.Join(root, "wrangle_attestation_metadata.json")
 		if _, err := os.Stat(path); err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				continue

--- a/tools/wrangle-attest/manifest_test.go
+++ b/tools/wrangle-attest/manifest_test.go
@@ -96,26 +96,63 @@ func TestParseManifestFailClosed(t *testing.T) {
 	}
 }
 
-func TestDiscoverManifestsSortedAndFailClosed(t *testing.T) {
-	root := t.TempDir()
-	writeFile(t, root, "go/b/manifest.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
-	writeFile(t, root, "go/a/manifest.json", `{"predicate-type":"https://ossf.github.io/osv-schema/results","result-file":"results.json"}`)
-	got, err := discoverManifests([]string{root})
+func TestDiscoverManifestsCanonicalOnly(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	writeFile(t, rootA, "manifest.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, rootB, "manifest.json", `{"predicate-type":"https://ossf.github.io/osv-schema/results","result-file":"results.json"}`)
+	got, err := discoverManifests([]string{rootB, rootA})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(got) != 2 {
 		t.Fatalf("expected 2 manifests, got %d", len(got))
 	}
-	// Deterministic order: a before b.
-	if filepath.Base(got[0].dir) != "a" || filepath.Base(got[1].dir) != "b" {
+	// Deterministic order by dir regardless of root order.
+	if got[0].dir > got[1].dir {
 		t.Fatalf("manifests not sorted by dir: %s, %s", got[0].dir, got[1].dir)
 	}
+}
 
-	// A second malformed manifest fails the whole walk.
-	writeFile(t, root, "go/c/manifest.json", `{"bad`)
+// A manifest.json planted below the root (e.g. by a build-time dependency) is
+// ignored — not signed and not an error — while the canonical top-level
+// manifest is still honored.
+func TestDiscoverManifestsIgnoresStrays(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "manifest.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, root, "sub/manifest.json", `{"predicate-type":"https://evil.example/x","result-file":"r.json"}`)
+	writeFile(t, root, "other/manifest.json", `{"predicate-type":"https://evil.example/y","result-file":"r.json"}`)
+	got, err := discoverManifests([]string{root})
+	if err != nil {
+		t.Fatalf("strays must not cause an error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected only the canonical manifest, got %d", len(got))
+	}
+	if got[0].PredicateType != predicateSPDX {
+		t.Fatalf("expected canonical SPDX manifest, got %q", got[0].PredicateType)
+	}
+}
+
+// A malformed canonical manifest fails the whole run (fail closed).
+func TestDiscoverManifestsFailClosed(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "manifest.json", `{"bad`)
 	if _, err := discoverManifests([]string{root}); err == nil {
-		t.Fatal("expected discovery to fail closed on a malformed manifest")
+		t.Fatal("expected discovery to fail closed on a malformed canonical manifest")
+	}
+}
+
+// A root with no canonical manifest contributes none and is not an error.
+func TestDiscoverManifestsEmptyRoot(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "sub/manifest.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	got, err := discoverManifests([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no manifests, got %d", len(got))
 	}
 }
 

--- a/tools/wrangle-attest/manifest_test.go
+++ b/tools/wrangle-attest/manifest_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, name)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseManifestFailClosed(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		wantErr bool
+	}{
+		{
+			name:    "valid spdx passthrough",
+			content: `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`,
+		},
+		{
+			name:    "valid scan/v1 with tool and result",
+			content: `{"predicate-type":"https://github.com/TomHennen/wrangle/attestation/scan/v1","result-file":"output.sarif","tool":{"name":"zizmor","version":"1.0"},"result":"findings"}`,
+		},
+		{
+			name:    "missing predicate-type",
+			content: `{"result-file":"sbom.spdx.json"}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing result-file",
+			content: `{"predicate-type":"https://spdx.dev/Document"}`,
+			wantErr: true,
+		},
+		{
+			name:    "unknown predicate-type",
+			content: `{"predicate-type":"https://evil.example/x","result-file":"r.json"}`,
+			wantErr: true,
+		},
+		{
+			name:    "scan/v1 missing tool",
+			content: `{"predicate-type":"https://github.com/TomHennen/wrangle/attestation/scan/v1","result-file":"output.sarif","result":"clean"}`,
+			wantErr: true,
+		},
+		{
+			name:    "scan/v1 invalid result value",
+			content: `{"predicate-type":"https://github.com/TomHennen/wrangle/attestation/scan/v1","result-file":"output.sarif","tool":{"name":"z"},"result":"maybe"}`,
+			wantErr: true,
+		},
+		{
+			name:    "result-file path traversal",
+			content: `{"predicate-type":"https://spdx.dev/Document","result-file":"../../etc/passwd"}`,
+			wantErr: true,
+		},
+		{
+			name:    "result-file nested traversal",
+			content: `{"predicate-type":"https://spdx.dev/Document","result-file":"sub/../../etc/passwd"}`,
+			wantErr: true,
+		},
+		{
+			name:    "result-file absolute path",
+			content: `{"predicate-type":"https://spdx.dev/Document","result-file":"/etc/passwd"}`,
+			wantErr: true,
+		},
+		{
+			name:    "unknown manifest field",
+			content: `{"predicate-type":"https://spdx.dev/Document","result-file":"r.json","format":"spdx"}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed json",
+			content: `{not json`,
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "manifest.json", tc.content)
+			_, err := parseManifest(filepath.Join(dir, "manifest.json"))
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDiscoverManifestsSortedAndFailClosed(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "go/b/manifest.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, root, "go/a/manifest.json", `{"predicate-type":"https://ossf.github.io/osv-schema/results","result-file":"results.json"}`)
+	got, err := discoverManifests([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 manifests, got %d", len(got))
+	}
+	// Deterministic order: a before b.
+	if filepath.Base(got[0].dir) != "a" || filepath.Base(got[1].dir) != "b" {
+		t.Fatalf("manifests not sorted by dir: %s, %s", got[0].dir, got[1].dir)
+	}
+
+	// A second malformed manifest fails the whole walk.
+	writeFile(t, root, "go/c/manifest.json", `{"bad`)
+	if _, err := discoverManifests([]string{root}); err == nil {
+		t.Fatal("expected discovery to fail closed on a malformed manifest")
+	}
+}
+
+func TestDiscoverManifestsMissingRoot(t *testing.T) {
+	if _, err := discoverManifests([]string{filepath.Join(t.TempDir(), "nope")}); err == nil {
+		t.Fatal("expected error for missing metadata-root")
+	}
+}

--- a/tools/wrangle-attest/manifest_test.go
+++ b/tools/wrangle-attest/manifest_test.go
@@ -84,8 +84,8 @@ func TestParseManifestFailClosed(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			writeFile(t, dir, "manifest.json", tc.content)
-			_, err := parseManifest(filepath.Join(dir, "manifest.json"))
+			writeFile(t, dir, "wrangle_attestation_metadata.json", tc.content)
+			_, err := parseManifest(filepath.Join(dir, "wrangle_attestation_metadata.json"))
 			if tc.wantErr && err == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -99,8 +99,8 @@ func TestParseManifestFailClosed(t *testing.T) {
 func TestDiscoverManifestsCanonicalOnly(t *testing.T) {
 	rootA := t.TempDir()
 	rootB := t.TempDir()
-	writeFile(t, rootA, "manifest.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
-	writeFile(t, rootB, "manifest.json", `{"predicate-type":"https://ossf.github.io/osv-schema/results","result-file":"results.json"}`)
+	writeFile(t, rootA, "wrangle_attestation_metadata.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, rootB, "wrangle_attestation_metadata.json", `{"predicate-type":"https://ossf.github.io/osv-schema/results","result-file":"results.json"}`)
 	got, err := discoverManifests([]string{rootB, rootA})
 	if err != nil {
 		t.Fatal(err)
@@ -114,14 +114,14 @@ func TestDiscoverManifestsCanonicalOnly(t *testing.T) {
 	}
 }
 
-// A manifest.json planted below the root (e.g. by a build-time dependency) is
+// A wrangle_attestation_metadata.json planted below the root (e.g. by a build-time dependency) is
 // ignored — not signed and not an error — while the canonical top-level
 // manifest is still honored.
 func TestDiscoverManifestsIgnoresStrays(t *testing.T) {
 	root := t.TempDir()
-	writeFile(t, root, "manifest.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
-	writeFile(t, root, "sub/manifest.json", `{"predicate-type":"https://evil.example/x","result-file":"r.json"}`)
-	writeFile(t, root, "other/manifest.json", `{"predicate-type":"https://evil.example/y","result-file":"r.json"}`)
+	writeFile(t, root, "wrangle_attestation_metadata.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, root, "sub/wrangle_attestation_metadata.json", `{"predicate-type":"https://evil.example/x","result-file":"r.json"}`)
+	writeFile(t, root, "other/wrangle_attestation_metadata.json", `{"predicate-type":"https://evil.example/y","result-file":"r.json"}`)
 	got, err := discoverManifests([]string{root})
 	if err != nil {
 		t.Fatalf("strays must not cause an error: %v", err)
@@ -137,7 +137,7 @@ func TestDiscoverManifestsIgnoresStrays(t *testing.T) {
 // A malformed canonical manifest fails the whole run (fail closed).
 func TestDiscoverManifestsFailClosed(t *testing.T) {
 	root := t.TempDir()
-	writeFile(t, root, "manifest.json", `{"bad`)
+	writeFile(t, root, "wrangle_attestation_metadata.json", `{"bad`)
 	if _, err := discoverManifests([]string{root}); err == nil {
 		t.Fatal("expected discovery to fail closed on a malformed canonical manifest")
 	}
@@ -146,7 +146,7 @@ func TestDiscoverManifestsFailClosed(t *testing.T) {
 // A root with no canonical manifest contributes none and is not an error.
 func TestDiscoverManifestsEmptyRoot(t *testing.T) {
 	root := t.TempDir()
-	writeFile(t, root, "sub/manifest.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, root, "sub/wrangle_attestation_metadata.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
 	got, err := discoverManifests([]string{root})
 	if err != nil {
 		t.Fatal(err)

--- a/tools/wrangle-attest/run.go
+++ b/tools/wrangle-attest/run.go
@@ -27,7 +27,7 @@ func run(args []string, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 
 	var roots metadataRoots
-	fs.Var(&roots, "metadata-root", "directory to walk for manifest.json (repeatable)")
+	fs.Var(&roots, "metadata-root", "directory holding a top-level manifest.json (repeatable)")
 	subject := fs.String("subject", "", "artifact subject digest sha256:<hex> every statement binds to")
 	commit := fs.String("commit", "", "scanned git commit, woven into the scan/v1 envelope only")
 	out := fs.String("out", "", "file the UNSIGNED in-toto JSONL statements are written to")

--- a/tools/wrangle-attest/run.go
+++ b/tools/wrangle-attest/run.go
@@ -18,10 +18,12 @@ func (r *metadataRoots) Set(v string) error {
 }
 
 // run is the testable entry point. It discovers manifests, binds each to the
-// single artifact subject, builds one unsigned Statement per manifest, and
-// writes them all to --out as JSONL. The file is written whole (buffer first)
-// so a mid-run failure never leaves a half-written line. run_verify.sh signs
-// each emitted line in the trusted post-build context.
+// single artifact subject, builds one Statement per manifest, and writes them
+// all to --out as JSONL. With --sign each statement is keyless-signed (one
+// shared signer, so the OIDC+Fulcio flow runs once) and the Sigstore bundle is
+// emitted; without it the statements are emitted unsigned. The file is written
+// whole (buffer first) so a mid-run failure — including a Fulcio error on the
+// Nth statement — never leaves a partial/unsigned bundle on disk.
 func run(args []string, stderr io.Writer) int {
 	fs := flag.NewFlagSet("wrangle-attest", flag.ContinueOnError)
 	fs.SetOutput(stderr)
@@ -29,54 +31,89 @@ func run(args []string, stderr io.Writer) int {
 	var roots metadataRoots
 	fs.Var(&roots, "metadata-root", "directory holding a top-level wrangle_attestation_metadata.json (repeatable)")
 	subject := fs.String("subject", "", "artifact subject digest sha256:<hex> every statement binds to")
+	artifact := fs.String("artifact", "", "file to self-digest into the sha256 subject (alternative to --subject)")
 	commit := fs.String("commit", "", "scanned git commit, woven into the scan/v1 envelope only")
-	out := fs.String("out", "", "file the UNSIGNED in-toto JSONL statements are written to")
+	sign := fs.Bool("sign", false, "keyless-sign each statement and emit the Sigstore bundle")
+	out := fs.String("out", "", "file the in-toto JSONL statements are written to")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 
-	if err := validateFlags(roots, *subject, *out); err != nil {
-		fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
-		return 2
+	subjectArg, err := resolveSubject(*subject, *artifact)
+	if err != nil {
+		return failClosed(stderr, err)
+	}
+	if err := validateFlags(roots, subjectArg, *out); err != nil {
+		return failClosed(stderr, err)
 	}
 
-	subj, err := newSubject(*subject)
+	subj, err := newSubject(subjectArg)
 	if err != nil {
-		fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
-		return 2
+		return failClosed(stderr, err)
 	}
 
 	manifests, err := discoverManifests(roots)
 	if err != nil {
-		fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
-		return 2
+		return failClosed(stderr, err)
 	}
 
-	// Build every statement into a buffer first; only touch --out once all
-	// succeed, so an error on the Nth manifest can't corrupt the output.
+	var sg statementSigner
+	if *sign {
+		s, closeFn, err := newSigner()
+		if err != nil {
+			return failClosed(stderr, err)
+		}
+		defer closeFn()
+		sg = s
+	}
+
+	// Build (and sign) every statement into a buffer first; only touch --out
+	// once all succeed, so an error on the Nth manifest — including a Fulcio
+	// signing failure — can't corrupt or partially write the output.
 	var buf bytes.Buffer
 	for _, m := range manifests {
 		stmt, err := buildStatement(m, subj, *commit)
 		if err != nil {
-			fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
-			return 2
+			return failClosed(stderr, err)
 		}
 		line, err := marshalStatement(stmt)
 		if err != nil {
-			fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
-			return 2
+			return failClosed(stderr, err)
+		}
+		if sg != nil {
+			line, err = sg.sign(line)
+			if err != nil {
+				return failClosed(stderr, err)
+			}
 		}
 		buf.Write(line)
 		buf.WriteByte('\n')
 	}
 
 	if err := os.WriteFile(*out, buf.Bytes(), 0o644); err != nil {
-		fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
-		return 2
+		return failClosed(stderr, err)
 	}
 	fmt.Fprintf(stderr, "wrangle-attest: wrote %d statement(s) to %s\n", len(manifests), *out)
 	return 0
+}
+
+func failClosed(stderr io.Writer, err error) int {
+	fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
+	return 2
+}
+
+// resolveSubject yields the sha256 subject from exactly one of --subject (a
+// passed digest, e.g. a container image) or --artifact (a file we self-digest).
+func resolveSubject(subject, artifact string) (string, error) {
+	switch {
+	case subject != "" && artifact != "":
+		return "", fmt.Errorf("pass only one of --subject or --artifact")
+	case artifact != "":
+		return digestArtifact(artifact)
+	default:
+		return subject, nil
+	}
 }
 
 func validateFlags(roots []string, subject, out string) error {
@@ -84,7 +121,7 @@ func validateFlags(roots []string, subject, out string) error {
 		return fmt.Errorf("at least one --metadata-root is required")
 	}
 	if subject == "" {
-		return fmt.Errorf("--subject is required")
+		return fmt.Errorf("--subject or --artifact is required")
 	}
 	if out == "" {
 		return fmt.Errorf("--out is required")

--- a/tools/wrangle-attest/run.go
+++ b/tools/wrangle-attest/run.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+// metadataRoots collects repeated --metadata-root flags.
+type metadataRoots []string
+
+func (r *metadataRoots) String() string { return fmt.Sprint([]string(*r)) }
+func (r *metadataRoots) Set(v string) error {
+	*r = append(*r, v)
+	return nil
+}
+
+// run is the testable entry point. It discovers manifests, binds each to the
+// single artifact subject, builds one unsigned Statement per manifest, and
+// writes them all to --out as JSONL. The file is written whole (buffer first)
+// so a mid-run failure never leaves a half-written line. run_verify.sh signs
+// each emitted line in the trusted post-build context.
+func run(args []string, stderr io.Writer) int {
+	fs := flag.NewFlagSet("wrangle-attest", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	var roots metadataRoots
+	fs.Var(&roots, "metadata-root", "directory to walk for manifest.json (repeatable)")
+	subject := fs.String("subject", "", "artifact subject digest sha256:<hex> every statement binds to")
+	commit := fs.String("commit", "", "scanned git commit, woven into the scan/v1 envelope only")
+	out := fs.String("out", "", "file the UNSIGNED in-toto JSONL statements are written to")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if err := validateFlags(roots, *subject, *out); err != nil {
+		fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
+		return 2
+	}
+
+	subj, err := newSubject(*subject)
+	if err != nil {
+		fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
+		return 2
+	}
+
+	manifests, err := discoverManifests(roots)
+	if err != nil {
+		fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
+		return 2
+	}
+
+	// Build every statement into a buffer first; only touch --out once all
+	// succeed, so an error on the Nth manifest can't corrupt the output.
+	var buf bytes.Buffer
+	for _, m := range manifests {
+		stmt, err := buildStatement(m, subj, *commit)
+		if err != nil {
+			fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
+			return 2
+		}
+		line, err := marshalStatement(stmt)
+		if err != nil {
+			fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
+			return 2
+		}
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+
+	if err := os.WriteFile(*out, buf.Bytes(), 0o644); err != nil {
+		fmt.Fprintf(stderr, "wrangle-attest: %v\nwrangle-attest: failing closed.\n", err)
+		return 2
+	}
+	fmt.Fprintf(stderr, "wrangle-attest: wrote %d statement(s) to %s\n", len(manifests), *out)
+	return 0
+}
+
+func validateFlags(roots []string, subject, out string) error {
+	if len(roots) == 0 {
+		return fmt.Errorf("at least one --metadata-root is required")
+	}
+	if subject == "" {
+		return fmt.Errorf("--subject is required")
+	}
+	if out == "" {
+		return fmt.Errorf("--out is required")
+	}
+	return nil
+}

--- a/tools/wrangle-attest/run.go
+++ b/tools/wrangle-attest/run.go
@@ -27,7 +27,7 @@ func run(args []string, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 
 	var roots metadataRoots
-	fs.Var(&roots, "metadata-root", "directory holding a top-level manifest.json (repeatable)")
+	fs.Var(&roots, "metadata-root", "directory holding a top-level wrangle_attestation_metadata.json (repeatable)")
 	subject := fs.String("subject", "", "artifact subject digest sha256:<hex> every statement binds to")
 	commit := fs.String("commit", "", "scanned git commit, woven into the scan/v1 envelope only")
 	out := fs.String("out", "", "file the UNSIGNED in-toto JSONL statements are written to")

--- a/tools/wrangle-attest/run_test.go
+++ b/tools/wrangle-attest/run_test.go
@@ -14,9 +14,9 @@ var update = flag.Bool("update", false, "regenerate golden files")
 
 func TestRunWritesSBOMStatement(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, dir, "meta/go/foo/manifest.json",
+	writeFile(t, dir, "meta/manifest.json",
 		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
-	writeFile(t, dir, "meta/go/foo/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3","name":"x"}`)
+	writeFile(t, dir, "meta/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3","name":"x"}`)
 	out := filepath.Join(dir, "sbom.intoto.jsonl")
 
 	var stderr bytes.Buffer
@@ -60,9 +60,9 @@ func TestRunWritesSBOMStatement(t *testing.T) {
 
 func TestRunFlagValidation(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, dir, "meta/foo/manifest.json",
+	writeFile(t, dir, "meta/manifest.json",
 		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
-	writeFile(t, dir, "meta/foo/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3"}`)
+	writeFile(t, dir, "meta/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3"}`)
 	meta := filepath.Join(dir, "meta")
 	out := filepath.Join(dir, "b.jsonl")
 
@@ -88,17 +88,18 @@ func TestRunFlagValidation(t *testing.T) {
 // A failure on any manifest must not leave a partially-written --out file.
 func TestRunFailClosedNoOutput(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, dir, "meta/ok/manifest.json",
+	writeFile(t, dir, "ok/manifest.json",
 		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
-	writeFile(t, dir, "meta/ok/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3"}`)
-	// Second manifest names a result file that does not exist -> build fails.
-	writeFile(t, dir, "meta/broken/manifest.json",
+	writeFile(t, dir, "ok/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3"}`)
+	// Second root's canonical manifest names a result file that does not exist -> build fails.
+	writeFile(t, dir, "broken/manifest.json",
 		`{"predicate-type":"https://spdx.dev/Document","result-file":"missing.json"}`)
 	out := filepath.Join(dir, "out.jsonl")
 
 	var stderr bytes.Buffer
 	rc := run([]string{
-		"--metadata-root", filepath.Join(dir, "meta"),
+		"--metadata-root", filepath.Join(dir, "ok"),
+		"--metadata-root", filepath.Join(dir, "broken"),
 		"--subject", testArtifactDigest,
 		"--out", out,
 	}, &stderr)

--- a/tools/wrangle-attest/run_test.go
+++ b/tools/wrangle-attest/run_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var update = flag.Bool("update", false, "regenerate golden files")
+
+func TestRunWritesSBOMStatement(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "meta/go/foo/manifest.json",
+		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, dir, "meta/go/foo/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3","name":"x"}`)
+	out := filepath.Join(dir, "sbom.intoto.jsonl")
+
+	var stderr bytes.Buffer
+	rc := run([]string{
+		"--metadata-root", filepath.Join(dir, "meta"),
+		"--subject", testArtifactDigest,
+		"--out", out,
+	}, &stderr)
+	if rc != 0 {
+		t.Fatalf("run rc=%d stderr=%s", rc, stderr.String())
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 statement line, got %d:\n%s", len(lines), data)
+	}
+
+	var stmt struct {
+		Type          string `json:"_type"`
+		PredicateType string `json:"predicateType"`
+		Subject       []struct {
+			Digest map[string]string `json:"digest"`
+		} `json:"subject"`
+	}
+	if err := json.Unmarshal([]byte(lines[0]), &stmt); err != nil {
+		t.Fatalf("statement is not valid JSON: %v", err)
+	}
+	if stmt.PredicateType != "https://spdx.dev/Document" {
+		t.Fatalf("wrong predicateType: %q", stmt.PredicateType)
+	}
+	// Single sha256 subject — the store rejects multi-digest.
+	if len(stmt.Subject) != 1 || len(stmt.Subject[0].Digest) != 1 ||
+		stmt.Subject[0].Digest["sha256"] != "011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95" {
+		t.Fatalf("expected single sha256 subject, got %+v", stmt.Subject)
+	}
+}
+
+func TestRunFlagValidation(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "meta/foo/manifest.json",
+		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, dir, "meta/foo/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3"}`)
+	meta := filepath.Join(dir, "meta")
+	out := filepath.Join(dir, "b.jsonl")
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"no metadata-root", []string{"--subject", testArtifactDigest, "--out", out}},
+		{"no subject", []string{"--metadata-root", meta, "--out", out}},
+		{"no out", []string{"--metadata-root", meta, "--subject", testArtifactDigest}},
+		{"bad subject", []string{"--metadata-root", meta, "--subject", "notadigest", "--out", out}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			if rc := run(tc.args, &stderr); rc == 0 {
+				t.Fatalf("expected non-zero exit, got 0")
+			}
+		})
+	}
+}
+
+// A failure on any manifest must not leave a partially-written --out file.
+func TestRunFailClosedNoOutput(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "meta/ok/manifest.json",
+		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, dir, "meta/ok/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3"}`)
+	// Second manifest names a result file that does not exist -> build fails.
+	writeFile(t, dir, "meta/broken/manifest.json",
+		`{"predicate-type":"https://spdx.dev/Document","result-file":"missing.json"}`)
+	out := filepath.Join(dir, "out.jsonl")
+
+	var stderr bytes.Buffer
+	rc := run([]string{
+		"--metadata-root", filepath.Join(dir, "meta"),
+		"--subject", testArtifactDigest,
+		"--out", out,
+	}, &stderr)
+	if rc == 0 {
+		t.Fatal("expected fail-closed exit")
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatalf("expected no output file on a failed run, stat err=%v", err)
+	}
+}

--- a/tools/wrangle-attest/run_test.go
+++ b/tools/wrangle-attest/run_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"os"
@@ -55,6 +57,68 @@ func TestRunWritesSBOMStatement(t *testing.T) {
 	if len(stmt.Subject) != 1 || len(stmt.Subject[0].Digest) != 1 ||
 		stmt.Subject[0].Digest["sha256"] != "011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95" {
 		t.Fatalf("expected single sha256 subject, got %+v", stmt.Subject)
+	}
+}
+
+// --artifact self-digests the file into the subject; the bound digest must be
+// a plain sha256 of the artifact bytes (the same the VSA binds to).
+func TestRunArtifactSelfDigest(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "meta/wrangle_attestation_metadata.json",
+		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, dir, "meta/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3","name":"x"}`)
+	artifact := filepath.Join(dir, "pkg.tgz")
+	if err := os.WriteFile(artifact, []byte("PKGBYTES"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256([]byte("PKGBYTES"))
+	want := hex.EncodeToString(sum[:])
+	out := filepath.Join(dir, "out.jsonl")
+
+	var stderr bytes.Buffer
+	rc := run([]string{
+		"--metadata-root", filepath.Join(dir, "meta"),
+		"--artifact", artifact,
+		"--out", out,
+	}, &stderr)
+	if rc != 0 {
+		t.Fatalf("run rc=%d stderr=%s", rc, stderr.String())
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stmt struct {
+		Subject []struct {
+			Digest map[string]string `json:"digest"`
+		} `json:"subject"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &stmt); err != nil {
+		t.Fatal(err)
+	}
+	if len(stmt.Subject) != 1 || stmt.Subject[0].Digest["sha256"] != want {
+		t.Fatalf("expected self-digest %q, got %+v", want, stmt.Subject)
+	}
+}
+
+func TestRunArtifactAndSubjectConflict(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "meta/wrangle_attestation_metadata.json",
+		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, dir, "meta/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3"}`)
+	artifact := filepath.Join(dir, "pkg.tgz")
+	if err := os.WriteFile(artifact, []byte("X"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	rc := run([]string{
+		"--metadata-root", filepath.Join(dir, "meta"),
+		"--subject", testArtifactDigest,
+		"--artifact", artifact,
+		"--out", filepath.Join(dir, "out.jsonl"),
+	}, &stderr)
+	if rc == 0 {
+		t.Fatal("expected error when both --subject and --artifact are passed")
 	}
 }
 

--- a/tools/wrangle-attest/run_test.go
+++ b/tools/wrangle-attest/run_test.go
@@ -14,7 +14,7 @@ var update = flag.Bool("update", false, "regenerate golden files")
 
 func TestRunWritesSBOMStatement(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, dir, "meta/manifest.json",
+	writeFile(t, dir, "meta/wrangle_attestation_metadata.json",
 		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
 	writeFile(t, dir, "meta/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3","name":"x"}`)
 	out := filepath.Join(dir, "sbom.intoto.jsonl")
@@ -60,7 +60,7 @@ func TestRunWritesSBOMStatement(t *testing.T) {
 
 func TestRunFlagValidation(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, dir, "meta/manifest.json",
+	writeFile(t, dir, "meta/wrangle_attestation_metadata.json",
 		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
 	writeFile(t, dir, "meta/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3"}`)
 	meta := filepath.Join(dir, "meta")
@@ -88,11 +88,11 @@ func TestRunFlagValidation(t *testing.T) {
 // A failure on any manifest must not leave a partially-written --out file.
 func TestRunFailClosedNoOutput(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, dir, "ok/manifest.json",
+	writeFile(t, dir, "ok/wrangle_attestation_metadata.json",
 		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
 	writeFile(t, dir, "ok/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3"}`)
 	// Second root's canonical manifest names a result file that does not exist -> build fails.
-	writeFile(t, dir, "broken/manifest.json",
+	writeFile(t, dir, "broken/wrangle_attestation_metadata.json",
 		`{"predicate-type":"https://spdx.dev/Document","result-file":"missing.json"}`)
 	out := filepath.Join(dir, "out.jsonl")
 

--- a/tools/wrangle-attest/sign.go
+++ b/tools/wrangle-attest/sign.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/carabiner-dev/signer"
+	"github.com/carabiner-dev/signer/options"
+)
+
+// statementSigner signs one in-toto statement and returns its canonical
+// serialized bundle/envelope bytes. Mirrors `bnd statement`: one shared
+// Signer across statements so the OIDC + Fulcio flow runs once.
+type statementSigner interface {
+	sign(statement []byte) ([]byte, error)
+}
+
+// newSigner builds the shared signer for --sign and a closer to release it.
+// Overridden by the hermetic unit test with a local-key signer.
+var newSigner = func() (statementSigner, func(), error) {
+	ks, err := newKeylessSigner()
+	if err != nil {
+		return nil, nil, err
+	}
+	return ks, func() { _ = ks.close() }, nil
+}
+
+// keylessSigner is the production sigstore backend: ambient GitHub OIDC ->
+// Fulcio cert -> Rekor, producing a Sigstore bundle byte-identical to
+// `bnd statement`.
+type keylessSigner struct {
+	sg *signer.Signer
+}
+
+// newKeylessSigner builds the shared sigstore signer from the bnd defaults.
+func newKeylessSigner() (*keylessSigner, error) {
+	sg, err := signer.NewSignerFromSet(options.DefaultSignerSet())
+	if err != nil {
+		return nil, fmt.Errorf("building signer: %w", err)
+	}
+	return &keylessSigner{sg: sg}, nil
+}
+
+func (k *keylessSigner) sign(statement []byte) ([]byte, error) {
+	art, err := k.sg.SignStatement(statement)
+	if err != nil {
+		return nil, fmt.Errorf("signing statement: %w", err)
+	}
+	var buf bytes.Buffer
+	if _, err := art.WriteTo(&buf); err != nil {
+		return nil, fmt.Errorf("serializing signed statement: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func (k *keylessSigner) close() error { return k.sg.Close() }

--- a/tools/wrangle-attest/sign_keyless_integration_test.go
+++ b/tools/wrangle-attest/sign_keyless_integration_test.go
@@ -1,0 +1,96 @@
+//go:build keyless_integration
+
+// Real keyless signing against Fulcio/Rekor with ambient GitHub OIDC. Compiled
+// only under -tags keyless_integration and run in the dedicated id-token: write
+// CI job — never in the unit suite, so that suite stays hermetic. The bnd push
+// github + ampel round-trip is proven by the dispatch e2e (the real validator).
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunSignKeyless(t *testing.T) {
+	// In CI this job has id-token: write; a missing token is a real gap, not a
+	// skip — keyless must actually run here.
+	if os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL") == "" {
+		t.Fatal("ACTIONS_ID_TOKEN_REQUEST_URL unset; keyless signing needs ambient GitHub OIDC")
+	}
+
+	dir := t.TempDir()
+	writeFile(t, dir, "meta/wrangle_attestation_metadata.json",
+		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, dir, "meta/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3","name":"keyless"}`)
+	out := filepath.Join(dir, "sbom.intoto.jsonl")
+
+	var stderr testWriter
+	rc := run([]string{
+		"--metadata-root", filepath.Join(dir, "meta"),
+		"--subject", testArtifactDigest,
+		"--sign",
+		"--out", out,
+	}, &stderr)
+	if rc != 0 {
+		t.Fatalf("keyless run rc=%d stderr=%s", rc, stderr.b)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The keyless artifact is a Sigstore bundle: one compact line carrying a
+	// verificationMaterial (the Fulcio cert) and the inner DSSE envelope.
+	var bundle struct {
+		MediaType            string          `json:"mediaType"`
+		VerificationMaterial json.RawMessage `json:"verificationMaterial"`
+		DSSEEnvelope         struct {
+			Payload     string `json:"payload"`
+			PayloadType string `json:"payloadType"`
+			Signatures  []struct {
+				Sig string `json:"sig"`
+			} `json:"signatures"`
+		} `json:"dsseEnvelope"`
+	}
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		t.Fatalf("output is not a Sigstore bundle: %v\n%s", err, data)
+	}
+	if len(bundle.VerificationMaterial) == 0 {
+		t.Fatal("bundle carries no verificationMaterial (Fulcio cert)")
+	}
+	if len(bundle.DSSEEnvelope.Signatures) == 0 || bundle.DSSEEnvelope.Signatures[0].Sig == "" {
+		t.Fatal("bundle's DSSE envelope carries no signature")
+	}
+	// The keyless path uses the in-toto media type, NOT the statement URI.
+	if got := bundle.DSSEEnvelope.PayloadType; got != "application/vnd.in-toto+json" {
+		t.Fatalf("payloadType = %q, want application/vnd.in-toto+json", got)
+	}
+
+	payload, err := base64.StdEncoding.DecodeString(bundle.DSSEEnvelope.Payload)
+	if err != nil {
+		t.Fatalf("payload not base64: %v", err)
+	}
+	var stmt struct {
+		PredicateType string `json:"predicateType"`
+		Subject       []struct {
+			Digest map[string]string `json:"digest"`
+		} `json:"subject"`
+	}
+	if err := json.Unmarshal(payload, &stmt); err != nil {
+		t.Fatalf("payload is not the in-toto statement: %v", err)
+	}
+	if stmt.PredicateType != "https://spdx.dev/Document" {
+		t.Fatalf("wrong predicateType: %q", stmt.PredicateType)
+	}
+	if len(stmt.Subject) != 1 || stmt.Subject[0].Digest["sha256"] == "" {
+		t.Fatalf("expected the single sha256 subject, got %+v", stmt.Subject)
+	}
+}
+
+type testWriter struct{ b []byte }
+
+func (w *testWriter) Write(p []byte) (int, error) { w.b = append(w.b, p...); return len(p), nil }

--- a/tools/wrangle-attest/sign_keyless_integration_test.go
+++ b/tools/wrangle-attest/sign_keyless_integration_test.go
@@ -7,11 +7,15 @@
 package main
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/carabiner-dev/signer"
+	"github.com/carabiner-dev/signer/options"
+	intoto "github.com/in-toto/attestation/go/v1"
+	sbundle "github.com/sigstore/sigstore-go/pkg/bundle"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func TestRunSignKeyless(t *testing.T) {
@@ -43,52 +47,98 @@ func TestRunSignKeyless(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The keyless artifact is a Sigstore bundle: one compact line carrying a
-	// verificationMaterial (the Fulcio cert) and the inner DSSE envelope.
-	var bundle struct {
-		MediaType            string          `json:"mediaType"`
-		VerificationMaterial json.RawMessage `json:"verificationMaterial"`
-		DSSEEnvelope         struct {
-			Payload     string `json:"payload"`
-			PayloadType string `json:"payloadType"`
-			Signatures  []struct {
-				Sig string `json:"sig"`
-			} `json:"signatures"`
-		} `json:"dsseEnvelope"`
-	}
-	if err := json.Unmarshal(data, &bundle); err != nil {
+	// The keyless artifact is a Sigstore bundle carrying the Fulcio cert in
+	// verificationMaterial and the in-toto statement in an inner DSSE envelope.
+	// Parse it with the upstream sigstore-go bundle type so the shape checks
+	// can't drift from the real schema.
+	var bundle sbundle.Bundle
+	if err := bundle.UnmarshalJSON(data); err != nil {
 		t.Fatalf("output is not a Sigstore bundle: %v\n%s", err, data)
 	}
-	if len(bundle.VerificationMaterial) == 0 {
+	if bundle.GetVerificationMaterial() == nil {
 		t.Fatal("bundle carries no verificationMaterial (Fulcio cert)")
 	}
-	if len(bundle.DSSEEnvelope.Signatures) == 0 || bundle.DSSEEnvelope.Signatures[0].Sig == "" {
+	env := bundle.GetDsseEnvelope()
+	if env == nil {
+		t.Fatal("bundle carries no DSSE envelope")
+	}
+	if len(env.GetSignatures()) == 0 || len(env.GetSignatures()[0].GetSig()) == 0 {
 		t.Fatal("bundle's DSSE envelope carries no signature")
 	}
 	// The keyless path uses the in-toto media type, NOT the statement URI.
-	if got := bundle.DSSEEnvelope.PayloadType; got != "application/vnd.in-toto+json" {
+	if got := env.GetPayloadType(); got != "application/vnd.in-toto+json" {
 		t.Fatalf("payloadType = %q, want application/vnd.in-toto+json", got)
 	}
 
-	payload, err := base64.StdEncoding.DecodeString(bundle.DSSEEnvelope.Payload)
-	if err != nil {
-		t.Fatalf("payload not base64: %v", err)
-	}
-	var stmt struct {
-		PredicateType string `json:"predicateType"`
-		Subject       []struct {
-			Digest map[string]string `json:"digest"`
-		} `json:"subject"`
-	}
-	if err := json.Unmarshal(payload, &stmt); err != nil {
+	var stmt intoto.Statement
+	if err := protojson.Unmarshal(env.GetPayload(), &stmt); err != nil {
 		t.Fatalf("payload is not the in-toto statement: %v", err)
 	}
-	if stmt.PredicateType != "https://spdx.dev/Document" {
-		t.Fatalf("wrong predicateType: %q", stmt.PredicateType)
+	if stmt.GetPredicateType() != "https://spdx.dev/Document" {
+		t.Fatalf("wrong predicateType: %q", stmt.GetPredicateType())
 	}
-	if len(stmt.Subject) != 1 || stmt.Subject[0].Digest["sha256"] == "" {
-		t.Fatalf("expected the single sha256 subject, got %+v", stmt.Subject)
+	if subs := stmt.GetSubject(); len(subs) != 1 || subs[0].GetDigest()["sha256"] == "" {
+		t.Fatalf("expected the single sha256 subject, got %+v", stmt.GetSubject())
 	}
+
+	// Cryptographically verify the bundle against the Sigstore trust root: the
+	// signature must be valid for this Fulcio identity over the signed payload.
+	// A tampered payload or signature fails here.
+	verifyKeylessBundle(t, data)
+}
+
+// verifyKeylessBundle verifies the signed bundle bytes with the upstream
+// carabiner-dev/signer verifier against the embedded Sigstore trust root,
+// asserting the GitHub Actions OIDC identity and proving the signature is
+// valid. It re-verifies a tampered copy to confirm the check actually fails.
+func verifyKeylessBundle(t *testing.T, bundleBytes []byte) {
+	t.Helper()
+
+	verifier, err := signer.NewVerifierFromSet(options.DefaultVerifierSet())
+	if err != nil {
+		t.Fatalf("building verifier: %v", err)
+	}
+
+	// The signer is the GitHub Actions OIDC identity of this workflow run;
+	// match the well-known issuer and constrain the SAN to this repo's actions.
+	issuerRegex := `^https://token\.actions\.githubusercontent\.com$`
+	sanRegex := `^https://github\.com/TomHennen/wrangle/`
+	res, err := verifier.VerifyInlineBundle(bundleBytes,
+		options.WithExpectedIdentityRegex(issuerRegex, sanRegex))
+	if err != nil {
+		t.Fatalf("verifying keyless bundle: %v", err)
+	}
+	if res == nil {
+		t.Fatal("verification returned no result")
+	}
+
+	// A flipped byte in the signed payload must fail verification — proves the
+	// assertion above is load-bearing, not a no-op.
+	tampered := tamperPayload(t, bundleBytes)
+	if _, err := verifier.VerifyInlineBundle(tampered,
+		options.WithExpectedIdentityRegex(issuerRegex, sanRegex)); err == nil {
+		t.Fatal("tampered bundle verified; signature check is not load-bearing")
+	}
+}
+
+// tamperPayload flips one byte of the DSSE payload and returns the re-serialized
+// bundle, which no longer matches its signature.
+func tamperPayload(t *testing.T, bundleBytes []byte) []byte {
+	t.Helper()
+	var b sbundle.Bundle
+	if err := b.UnmarshalJSON(bundleBytes); err != nil {
+		t.Fatalf("re-parsing bundle to tamper: %v", err)
+	}
+	payload := b.GetDsseEnvelope().GetPayload()
+	if len(payload) == 0 {
+		t.Fatal("no payload to tamper")
+	}
+	payload[0] ^= 0xff
+	out, err := protojson.Marshal(&b)
+	if err != nil {
+		t.Fatalf("re-marshaling tampered bundle: %v", err)
+	}
+	return out
 }
 
 type testWriter struct{ b []byte }

--- a/tools/wrangle-attest/sign_test.go
+++ b/tools/wrangle-attest/sign_test.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -12,6 +10,9 @@ import (
 	"github.com/carabiner-dev/signer"
 	"github.com/carabiner-dev/signer/key"
 	"github.com/carabiner-dev/signer/options"
+	intoto "github.com/in-toto/attestation/go/v1"
+	sdsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // localKeySigner signs with an ephemeral local key (DSSE envelope backend),
@@ -69,39 +70,24 @@ func TestRunSignEmitsSignedStatement(t *testing.T) {
 		t.Fatal(err)
 	}
 	// The local-key backend emits a single DSSE envelope (indented protojson);
-	// keyless emits a compact bundle. Parse the whole artifact as one object.
-	var env struct {
-		Payload     string `json:"payload"`
-		PayloadType string `json:"payloadType"`
-		Signatures  []struct {
-			Sig string `json:"sig"`
-		} `json:"signatures"`
-	}
-	if err := json.Unmarshal(bytes.TrimSpace(data), &env); err != nil {
+	// keyless emits a compact bundle. Parse via the upstream DSSE envelope type.
+	var env sdsse.Envelope
+	if err := protojson.Unmarshal(bytes.TrimSpace(data), &env); err != nil {
 		t.Fatalf("signed output is not a DSSE envelope: %v", err)
 	}
-	if len(env.Signatures) == 0 || env.Signatures[0].Sig == "" {
-		t.Fatalf("envelope carries no signature: %+v", env.Signatures)
+	if len(env.GetSignatures()) == 0 || len(env.GetSignatures()[0].GetSig()) == 0 {
+		t.Fatalf("envelope carries no signature: %+v", env.GetSignatures())
 	}
 
-	payload, err := base64.StdEncoding.DecodeString(env.Payload)
-	if err != nil {
-		t.Fatalf("payload is not base64: %v", err)
-	}
-	var stmt struct {
-		PredicateType string `json:"predicateType"`
-		Subject       []struct {
-			Digest map[string]string `json:"digest"`
-		} `json:"subject"`
-	}
-	if err := json.Unmarshal(payload, &stmt); err != nil {
+	var stmt intoto.Statement
+	if err := protojson.Unmarshal(env.GetPayload(), &stmt); err != nil {
 		t.Fatalf("payload is not the in-toto statement: %v", err)
 	}
-	if stmt.PredicateType != "https://spdx.dev/Document" {
-		t.Fatalf("wrong predicateType: %q", stmt.PredicateType)
+	if stmt.GetPredicateType() != "https://spdx.dev/Document" {
+		t.Fatalf("wrong predicateType: %q", stmt.GetPredicateType())
 	}
-	if len(stmt.Subject) != 1 || stmt.Subject[0].Digest["sha256"] == "" {
-		t.Fatalf("expected the single sha256 subject, got %+v", stmt.Subject)
+	if subs := stmt.GetSubject(); len(subs) != 1 || subs[0].GetDigest()["sha256"] == "" {
+		t.Fatalf("expected the single sha256 subject, got %+v", stmt.GetSubject())
 	}
 }
 

--- a/tools/wrangle-attest/sign_test.go
+++ b/tools/wrangle-attest/sign_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/carabiner-dev/signer"
+	"github.com/carabiner-dev/signer/key"
+	"github.com/carabiner-dev/signer/options"
+)
+
+// localKeySigner signs with an ephemeral local key (DSSE envelope backend),
+// exercising the same SignStatement/WriteTo path as keyless without any
+// network, OIDC, or Fulcio.
+type localKeySigner struct {
+	sg  *signer.Signer
+	key key.PrivateKeyProvider
+}
+
+func newLocalKeySigner(t *testing.T) *localKeySigner {
+	t.Helper()
+	k, err := key.NewGenerator().GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	return &localKeySigner{sg: signer.NewSigner(), key: k}
+}
+
+func (l *localKeySigner) sign(statement []byte) ([]byte, error) {
+	art, err := l.sg.SignStatement(statement, options.WithKey(l.key))
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if _, err := art.WriteTo(&buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func TestRunSignEmitsSignedStatement(t *testing.T) {
+	ks := newLocalKeySigner(t)
+	swapSigner(t, func() (statementSigner, func(), error) { return ks, func() {}, nil })
+
+	dir := t.TempDir()
+	writeFile(t, dir, "meta/wrangle_attestation_metadata.json",
+		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, dir, "meta/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3","name":"x"}`)
+	out := filepath.Join(dir, "sbom.intoto.jsonl")
+
+	var stderr bytes.Buffer
+	rc := run([]string{
+		"--metadata-root", filepath.Join(dir, "meta"),
+		"--subject", testArtifactDigest,
+		"--sign",
+		"--out", out,
+	}, &stderr)
+	if rc != 0 {
+		t.Fatalf("run rc=%d stderr=%s", rc, stderr.String())
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The local-key backend emits a single DSSE envelope (indented protojson);
+	// keyless emits a compact bundle. Parse the whole artifact as one object.
+	var env struct {
+		Payload     string `json:"payload"`
+		PayloadType string `json:"payloadType"`
+		Signatures  []struct {
+			Sig string `json:"sig"`
+		} `json:"signatures"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(data), &env); err != nil {
+		t.Fatalf("signed output is not a DSSE envelope: %v", err)
+	}
+	if len(env.Signatures) == 0 || env.Signatures[0].Sig == "" {
+		t.Fatalf("envelope carries no signature: %+v", env.Signatures)
+	}
+
+	payload, err := base64.StdEncoding.DecodeString(env.Payload)
+	if err != nil {
+		t.Fatalf("payload is not base64: %v", err)
+	}
+	var stmt struct {
+		PredicateType string `json:"predicateType"`
+		Subject       []struct {
+			Digest map[string]string `json:"digest"`
+		} `json:"subject"`
+	}
+	if err := json.Unmarshal(payload, &stmt); err != nil {
+		t.Fatalf("payload is not the in-toto statement: %v", err)
+	}
+	if stmt.PredicateType != "https://spdx.dev/Document" {
+		t.Fatalf("wrong predicateType: %q", stmt.PredicateType)
+	}
+	if len(stmt.Subject) != 1 || stmt.Subject[0].Digest["sha256"] == "" {
+		t.Fatalf("expected the single sha256 subject, got %+v", stmt.Subject)
+	}
+}
+
+// A signing failure on any statement must leave no output (no partial/unsigned
+// bundle) — the buffer-then-write fail-closed discipline must hold for --sign.
+func TestRunSignFailClosedNoOutput(t *testing.T) {
+	swapSigner(t, func() (statementSigner, func(), error) {
+		return failingSigner{}, func() {}, nil
+	})
+
+	dir := t.TempDir()
+	writeFile(t, dir, "meta/wrangle_attestation_metadata.json",
+		`{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, dir, "meta/sbom.spdx.json", `{"spdxVersion":"SPDX-2.3"}`)
+	out := filepath.Join(dir, "out.jsonl")
+
+	var stderr bytes.Buffer
+	rc := run([]string{
+		"--metadata-root", filepath.Join(dir, "meta"),
+		"--subject", testArtifactDigest,
+		"--sign",
+		"--out", out,
+	}, &stderr)
+	if rc == 0 {
+		t.Fatal("expected fail-closed exit on a signing failure")
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatalf("expected no output file after a signing failure, stat err=%v", err)
+	}
+}
+
+type failingSigner struct{}
+
+func (failingSigner) sign([]byte) ([]byte, error) { return nil, errors.New("boom") }
+
+func swapSigner(t *testing.T, fn func() (statementSigner, func(), error)) {
+	t.Helper()
+	orig := newSigner
+	newSigner = fn
+	t.Cleanup(func() { newSigner = orig })
+}

--- a/tools/wrangle-attest/statement.go
+++ b/tools/wrangle-attest/statement.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	intoto "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// buildStatement turns one manifest into an unsigned in-toto v1 Statement bound
+// to the single artifact subject. The predicate is either the result file
+// verbatim (passthrough) or a thin SARIF envelope, per predicate-type. commit
+// is woven into the scan/v1 envelope only; passthrough predicates ignore it.
+func buildStatement(m manifest, subject *intoto.ResourceDescriptor, commit string) (*intoto.Statement, error) {
+	pred, err := buildPredicate(m, commit)
+	if err != nil {
+		return nil, err
+	}
+	stmt := &intoto.Statement{
+		Type:          intoto.StatementTypeUri,
+		Subject:       []*intoto.ResourceDescriptor{subject},
+		PredicateType: m.PredicateType,
+		Predicate:     pred,
+	}
+	if err := stmt.Validate(); err != nil {
+		return nil, fmt.Errorf("statement for %s: %w", m.PredicateType, err)
+	}
+	return stmt, nil
+}
+
+// buildPredicate reads the manifest's result file and shapes it for the
+// statement. Passthrough types embed the JSON object as-is; the scan/v1 type
+// wraps SARIF in {tool, scannedCommit, result, sarif}.
+func buildPredicate(m manifest, commit string) (*structpb.Struct, error) {
+	raw, err := os.ReadFile(m.resultPath())
+	if err != nil {
+		return nil, fmt.Errorf("result-file: %w", err)
+	}
+	switch m.PredicateType {
+	case predicateSPDX, predicateOSV, predicateScorecard:
+		return jsonObjectToStruct(raw)
+	case predicateScanV1:
+		var sarif json.RawMessage
+		if err := json.Unmarshal(raw, &sarif); err != nil {
+			return nil, fmt.Errorf("result-file is not valid JSON: %w", err)
+		}
+		envelope := map[string]any{
+			"tool":          map[string]any{"name": m.Tool.Name, "version": m.Tool.Version},
+			"scannedCommit": commit,
+			"result":        m.Result,
+			"sarif":         sarif,
+		}
+		enc, err := json.Marshal(envelope)
+		if err != nil {
+			return nil, err
+		}
+		return jsonObjectToStruct(enc)
+	default:
+		// validate() already rejects unknown types; defensive belt-and-braces.
+		return nil, fmt.Errorf("unknown predicate-type %q", m.PredicateType)
+	}
+}
+
+// jsonObjectToStruct decodes a JSON object into a structpb.Struct. A predicate
+// MUST be a JSON object (in-toto requires it); a top-level array/scalar fails
+// closed rather than producing a malformed statement.
+func jsonObjectToStruct(raw []byte) (*structpb.Struct, error) {
+	s := &structpb.Struct{}
+	if err := protojson.Unmarshal(raw, s); err != nil {
+		return nil, fmt.Errorf("predicate must be a JSON object: %w", err)
+	}
+	return s, nil
+}
+
+// marshalStatement renders a Statement as a single compact JSONL line. protojson
+// emits the in-toto-canonical field names (`_type`, `predicateType`); compacting
+// through encoding/json strips protojson's non-deterministic whitespace so the
+// output is one object per line.
+func marshalStatement(stmt *intoto.Statement) ([]byte, error) {
+	js, err := protojson.Marshal(stmt)
+	if err != nil {
+		return nil, err
+	}
+	var canonical any
+	if err := json.Unmarshal(js, &canonical); err != nil {
+		return nil, err
+	}
+	return json.Marshal(canonical)
+}

--- a/tools/wrangle-attest/statement_test.go
+++ b/tools/wrangle-attest/statement_test.go
@@ -38,9 +38,9 @@ func TestBuildStatementGolden(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			writeFile(t, dir, "manifest.json", tc.manifest)
+			writeFile(t, dir, "wrangle_attestation_metadata.json", tc.manifest)
 			writeFile(t, dir, tc.resultName, tc.result)
-			m, err := parseManifest(filepath.Join(dir, "manifest.json"))
+			m, err := parseManifest(filepath.Join(dir, "wrangle_attestation_metadata.json"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -63,8 +63,8 @@ func TestBuildStatementGolden(t *testing.T) {
 
 func TestBuildStatementFailClosed(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, dir, "manifest.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
-	m, err := parseManifest(filepath.Join(dir, "manifest.json"))
+	writeFile(t, dir, "wrangle_attestation_metadata.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	m, err := parseManifest(filepath.Join(dir, "wrangle_attestation_metadata.json"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/wrangle-attest/statement_test.go
+++ b/tools/wrangle-attest/statement_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// goldenStatement asserts that building a statement from a manifest + the fixed
+// subject produces exactly the golden JSON. Golden files pin the on-the-wire
+// shape both consumers (policy CEL) and the later SARIF-producer PRs depend on;
+// regenerate with -update when the contract intentionally changes.
+func TestBuildStatementGolden(t *testing.T) {
+	cases := []struct {
+		name       string
+		manifest   string
+		resultName string
+		result     string
+		golden     string
+	}{
+		{
+			name:       "sbom passthrough",
+			manifest:   `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`,
+			resultName: "sbom.spdx.json",
+			result:     `{"spdxVersion":"SPDX-2.3","name":"test","SPDXID":"SPDXRef-DOCUMENT","packages":[{"name":"pkg","SPDXID":"SPDXRef-pkg"}]}`,
+			golden:     "testdata/sbom.statement.json",
+		},
+		{
+			name:       "scan/v1 sarif envelope",
+			manifest:   `{"predicate-type":"https://github.com/TomHennen/wrangle/attestation/scan/v1","result-file":"output.sarif","tool":{"name":"zizmor","version":"1.13.0"},"result":"findings"}`,
+			resultName: "output.sarif",
+			result:     `{"version":"2.1.0","$schema":"https://json.schemastore.org/sarif-2.1.0.json","runs":[{"tool":{"driver":{"name":"zizmor"}},"results":[]}]}`,
+			golden:     "testdata/scan.statement.json",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "manifest.json", tc.manifest)
+			writeFile(t, dir, tc.resultName, tc.result)
+			m, err := parseManifest(filepath.Join(dir, "manifest.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			subj, err := newSubject(testArtifactDigest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stmt, err := buildStatement(m, subj, "5741a1afbdffa5eb9ab95dd212ce8c310631e355")
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := marshalStatement(stmt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertGolden(t, tc.golden, got)
+		})
+	}
+}
+
+func TestBuildStatementFailClosed(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "manifest.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	m, err := parseManifest(filepath.Join(dir, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	subj, _ := newSubject(testArtifactDigest)
+
+	// Missing result file.
+	if _, err := buildStatement(m, subj, ""); err == nil {
+		t.Fatal("expected error for missing result file")
+	}
+
+	// A predicate that is a JSON array, not an object, must fail.
+	writeFile(t, dir, "sbom.spdx.json", `[1,2,3]`)
+	if _, err := buildStatement(m, subj, ""); err == nil {
+		t.Fatal("expected error for non-object predicate")
+	}
+}
+
+// assertGolden compares got to the golden file, normalizing both through a
+// generic JSON round-trip so formatting differences don't cause spurious fails.
+// Run `go test -update` to (re)write golden files.
+func assertGolden(t *testing.T, path string, got []byte) {
+	t.Helper()
+	if *update {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		pretty := mustIndent(t, got)
+		if err := os.WriteFile(path, pretty, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s: %v (run go test -update)", path, err)
+	}
+	if !jsonEqual(t, got, want) {
+		t.Fatalf("statement mismatch for %s:\ngot:  %s\nwant: %s", path, mustIndent(t, got), want)
+	}
+}
+
+func jsonEqual(t *testing.T, a, b []byte) bool {
+	t.Helper()
+	var av, bv any
+	if err := json.Unmarshal(a, &av); err != nil {
+		t.Fatalf("unmarshal got: %v", err)
+	}
+	if err := json.Unmarshal(b, &bv); err != nil {
+		t.Fatalf("unmarshal want: %v", err)
+	}
+	ab, _ := json.Marshal(av)
+	bb, _ := json.Marshal(bv)
+	return string(ab) == string(bb)
+}
+
+func mustIndent(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatal(err)
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(out, '\n')
+}

--- a/tools/wrangle-attest/subjects.go
+++ b/tools/wrangle-attest/subjects.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	intoto "github.com/in-toto/attestation/go/v1"
+)
+
+// The artifact subject is a single sha256 digest. The GitHub attestation store
+// (bnd push github) keys by subject digest and rejects a multi-digest subject,
+// so sha256 is the only algorithm the engine binds to. run_verify.sh already
+// computes this same digest for the VSA subject, so the SBOM and the VSA share
+// one subject and a policy resolving by artifact digest finds both.
+var sha256DigestRe = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// newSubject parses the single --subject digest (sha256:<hex>) into the
+// in-toto descriptor every statement is bound to. A malformed digest fails
+// closed rather than producing an unbound or wrongly-bound attestation.
+func newSubject(subject string) (*intoto.ResourceDescriptor, error) {
+	if !sha256DigestRe.MatchString(subject) {
+		return nil, fmt.Errorf("subject %q must be sha256:<64-hex>", subject)
+	}
+	hex := strings.TrimPrefix(subject, "sha256:")
+	return &intoto.ResourceDescriptor{
+		Digest: map[string]string{"sha256": hex},
+	}, nil
+}

--- a/tools/wrangle-attest/subjects.go
+++ b/tools/wrangle-attest/subjects.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
+	"os"
 	"regexp"
 	"strings"
 
@@ -22,8 +26,23 @@ func newSubject(subject string) (*intoto.ResourceDescriptor, error) {
 	if !sha256DigestRe.MatchString(subject) {
 		return nil, fmt.Errorf("subject %q must be sha256:<64-hex>", subject)
 	}
-	hex := strings.TrimPrefix(subject, "sha256:")
+	h := strings.TrimPrefix(subject, "sha256:")
 	return &intoto.ResourceDescriptor{
-		Digest: map[string]string{"sha256": hex},
+		Digest: map[string]string{"sha256": h},
 	}, nil
+}
+
+// digestArtifact hashes a file to sha256:<hex>, the same digest run_verify.sh
+// binds the VSA to. A missing/unreadable file fails closed.
+func digestArtifact(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("artifact: %w", err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hashing artifact: %w", err)
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/tools/wrangle-attest/subjects_test.go
+++ b/tools/wrangle-attest/subjects_test.go
@@ -1,8 +1,40 @@
 package main
 
-import "testing"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 const testArtifactDigest = "sha256:011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95"
+
+// digestArtifact must equal a plain sha256 of the bytes — the same digest the
+// VSA binds to for the same file.
+func TestDigestArtifact(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "artifact.bin")
+	content := []byte("wrangle artifact bytes\n")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(content)
+	want := "sha256:" + hex.EncodeToString(sum[:])
+	got, err := digestArtifact(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("digest mismatch: got %q want %q", got, want)
+	}
+}
+
+func TestDigestArtifactMissingFailsClosed(t *testing.T) {
+	if _, err := digestArtifact(filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Fatal("expected error for a missing artifact")
+	}
+}
 
 func TestNewSubject(t *testing.T) {
 	d, err := newSubject(testArtifactDigest)

--- a/tools/wrangle-attest/subjects_test.go
+++ b/tools/wrangle-attest/subjects_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+const testArtifactDigest = "sha256:011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95"
+
+func TestNewSubject(t *testing.T) {
+	d, err := newSubject(testArtifactDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := d.Digest["sha256"]; got != "011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95" {
+		t.Fatalf("subject digest wrong: %q", got)
+	}
+	// Exactly one algorithm — the store rejects multi-digest subjects.
+	if len(d.Digest) != 1 {
+		t.Fatalf("expected a single-digest subject, got %d entries", len(d.Digest))
+	}
+}
+
+func TestNewSubjectFailClosed(t *testing.T) {
+	cases := []string{
+		"",
+		"sha256:",
+		"011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95", // no algo prefix
+		"sha512:011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95",
+		"sha256:nothex",
+		"sha256:011b95c8", // too short
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			if _, err := newSubject(c); err == nil {
+				t.Fatalf("expected error for subject %q", c)
+			}
+		})
+	}
+}

--- a/tools/wrangle-attest/testdata/sbom.statement.json
+++ b/tools/wrangle-attest/testdata/sbom.statement.json
@@ -1,0 +1,22 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "predicate": {
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "test",
+    "packages": [
+      {
+        "SPDXID": "SPDXRef-pkg",
+        "name": "pkg"
+      }
+    ],
+    "spdxVersion": "SPDX-2.3"
+  },
+  "predicateType": "https://spdx.dev/Document",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95"
+      }
+    }
+  ]
+}

--- a/tools/wrangle-attest/testdata/scan.statement.json
+++ b/tools/wrangle-attest/testdata/scan.statement.json
@@ -1,0 +1,33 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "predicate": {
+    "result": "findings",
+    "sarif": {
+      "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+      "runs": [
+        {
+          "results": [],
+          "tool": {
+            "driver": {
+              "name": "zizmor"
+            }
+          }
+        }
+      ],
+      "version": "2.1.0"
+    },
+    "scannedCommit": "5741a1afbdffa5eb9ab95dd212ce8c310631e355",
+    "tool": {
+      "name": "zizmor",
+      "version": "1.13.0"
+    }
+  },
+  "predicateType": "https://github.com/TomHennen/wrangle/attestation/scan/v1",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Rebases the wrangle-attest engine + SBOM attestation (originally #465, stacked on the now-superseded store-vsa branch) onto #469's unified-metadata layout (branch `feat/469-unify-metadata-artifact`). Supersedes #465.

## What this adds
- `tools/wrangle-attest/` — the shared Go engine. Walks `--metadata-root` for `manifest.json` files and emits one UNSIGNED in-toto v1 Statement per manifest, bound to the single sha256 `--subject` (the same digest the run's VSA binds to, so the store accepts it and a digest-keyed policy finds both). v1 ships the SBOM passthrough (`predicateType https://spdx.dev/Document`). Fails closed on any malformed/missing input.
- `lib/write_attest_manifest.sh` — each build type writes `manifest.json` next to `sbom.spdx.json` in `metadata/<type>[/<shortname>]/`.
- Verify wiring — the trusted `verify` job runs `wrangle-attest` over the metadata, bnd-signs each statement, appends it to the per-artifact bundle, and pushes it to the attestation store.

## Composition with #469
#469 made the trailing `verify` job own the unified `<type>-metadata-<sn>` upload: it downloads `-premeta-` (SBOM + `scan/`) into the metadata dir, writes the bundle there (`bundle-out: metadata-dir`), and uploads the whole dir. This PR threads `metadata-dir` into the verify action as `METADATA_ROOT`, so the engine runs over the SBOM manifest already staged in that dir and appends the SBOM statement to the bundle BEFORE #469's upload. The SBOM statement therefore lands in BOTH the bundle (inside the unified metadata artifact + release asset) AND the attestation store. No separate metadata download is needed — #469 already stages it.

The SBOM producer output (`https://spdx.dev/Document`, single-sha256 subject) satisfies the `sbom-exists` tenet.

## Tests
`./test.sh quick` green (1093 bats + go unit tests); shellcheck, actionlint, zizmor clean; `check_pin_ancestry` passes. The dispatch e2e is the real proof (SBOM produced, signed, delivered into the unified metadata + store).

Part of #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)