### PR TITLE
feat(osv): OSV scan attestation via the generic scan/v1 SARIF envelope

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
 
   gate:
     needs: [guard]
@@ -120,7 +120,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -153,7 +153,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -184,7 +184,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      uses: TomHennen/wrangle/build/actions/container@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -284,7 +284,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         with:
           build-type: container
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
 
   gate:
     needs: [guard]
@@ -120,7 +120,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -153,7 +153,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -184,7 +184,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      uses: TomHennen/wrangle/build/actions/container@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -284,7 +284,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         with:
           build-type: container
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
 
   gate:
     needs: [guard]
@@ -171,7 +171,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -195,7 +195,7 @@ jobs:
 
       # Shared name derivation so the scan and release jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -203,7 +203,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -236,7 +236,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/checks@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -302,7 +302,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/release@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: release
         with:
           path: ${{ inputs.path }}
@@ -326,7 +326,7 @@ jobs:
           printf 'module=%s\n' "$(go -C "$INPUT_PATH" list -m | head -n1)" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         with:
           build-type: go
@@ -400,7 +400,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: attest
         with:
           build-type: go
@@ -429,7 +429,7 @@ jobs:
       attestation-bundle-name: ${{ needs.release.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         with:
           build-type: go
           shortname: ${{ needs.release.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
 
   gate:
     needs: [guard]
@@ -171,7 +171,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -195,7 +195,7 @@ jobs:
 
       # Shared name derivation so the scan and release jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -203,7 +203,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -236,7 +236,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/checks@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -302,7 +302,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/release@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: release
         with:
           path: ${{ inputs.path }}
@@ -326,7 +326,7 @@ jobs:
           printf 'module=%s\n' "$(go -C "$INPUT_PATH" list -m | head -n1)" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         with:
           build-type: go
@@ -400,7 +400,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: attest
         with:
           build-type: go
@@ -429,7 +429,7 @@ jobs:
       attestation-bundle-name: ${{ needs.release.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         with:
           build-type: go
           shortname: ${{ needs.release.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -139,7 +139,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
 
   gate:
     needs: [guard]
@@ -150,7 +150,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -174,7 +174,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -182,7 +182,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -221,7 +221,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/npm@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -230,7 +230,7 @@ jobs:
           ignore-scripts: ${{ inputs.ignore-scripts }}
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         with:
           build-type: npm
@@ -302,7 +302,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: attest
         with:
           build-type: npm
@@ -328,7 +328,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         with:
           build-type: npm
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -139,7 +139,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
 
   gate:
     needs: [guard]
@@ -150,7 +150,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -174,7 +174,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -182,7 +182,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -221,7 +221,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/npm@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -230,7 +230,7 @@ jobs:
           ignore-scripts: ${{ inputs.ignore-scripts }}
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         with:
           build-type: npm
@@ -302,7 +302,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: attest
         with:
           build-type: npm
@@ -328,7 +328,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         with:
           build-type: npm
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -116,7 +116,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -131,7 +131,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -155,7 +155,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -202,7 +202,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/python@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -231,7 +231,7 @@ jobs:
           printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         with:
           build-type: python
@@ -295,7 +295,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: attest
         with:
           build-type: python
@@ -321,7 +321,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         with:
           build-type: python
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -116,7 +116,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -131,7 +131,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -155,7 +155,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -202,7 +202,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/python@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -231,7 +231,7 @@ jobs:
           printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: names
         with:
           build-type: python
@@ -295,7 +295,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         id: attest
         with:
           build-type: python
@@ -321,7 +321,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         with:
           build-type: python
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+        uses: TomHennen/wrangle/build/actions/shell@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+        uses: TomHennen/wrangle/build/actions/shell@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
 
   check-change:
     needs: [guard]
@@ -51,7 +51,7 @@ jobs:
       # (root path), so the shortname is empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+        uses: TomHennen/wrangle/actions/scan@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
         with:
           tools: ${{ inputs.tools }}
           artifact-name: scan

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
 
   check-change:
     needs: [guard]
@@ -51,7 +51,7 @@ jobs:
       # (root path), so the shortname is empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+        uses: TomHennen/wrangle/actions/scan@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
         with:
           tools: ${{ inputs.tools }}
           artifact-name: scan

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -99,7 +99,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      uses: TomHennen/wrangle/tools/zizmor@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      uses: TomHennen/wrangle/tools/scorecard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+      uses: TomHennen/wrangle/tools/dependency-review@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -99,7 +99,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      uses: TomHennen/wrangle/tools/zizmor@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      uses: TomHennen/wrangle/tools/scorecard@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+      uses: TomHennen/wrangle/tools/dependency-review@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
 
     - name: Generate step summary
       if: always()

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -135,6 +135,8 @@ runs:
         BUNDLE_OUT: ${{ inputs.bundle-out }}
         OCI_TARGET: ${{ inputs.oci-target }}
         METADATA_ROOT: ${{ inputs.metadata-dir }}
+        # Scanned commit recorded in each scan/v1 envelope's scannedCommit.
+        COMMIT: ${{ github.sha }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         # bnd push github authenticates to the attestation store with this token;
         # the attestations: write permission rides on it.

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -13,8 +13,9 @@
 # Inputs arrive as env vars: SUBJECTS (newline-separated), POLICY, COLLECTOR,
 # FAIL, CONTEXT, BUNDLE_IN, BUNDLE_OUT, GITHUB_REPOSITORY (store push target),
 # GITHUB_TOKEN (bnd reads it to auth the store push), and optional ATTESTATION,
-# OCI_TARGET, METADATA_ROOT (the build metadata dir holding the top-level SBOM
-# manifest wrangle-attest reads, signed by the engine and appended per subject).
+# OCI_TARGET, METADATA_ROOT (the metadata dir wrangle-attest reads for the
+# top-level SBOM and scan/<tool>/ manifests, signed by the engine and appended
+# per subject), COMMIT (scanned git commit woven into the scan/v1 envelope).
 
 set -euo pipefail
 set -f  # disable globbing — processes external input
@@ -211,13 +212,14 @@ wrangle_push_bundle() {
 # in-toto statements (one signed Sigstore-bundle JSONL line per statement), one
 # arg per line for mapfile. $1 is the pre-formed subject arg (--subject=<digest>
 # or --artifact=<file>); $2 the JSONL output path. METADATA_ROOT holds the
-# build's wrangle_attestation_metadata.json files (sbom.spdx.json + its
-# manifest); --commit is woven into the scan/v1 envelope only, ignored by the
-# SBOM passthrough.
+# build's wrangle_attestation_metadata.json files (the SBOM's, the scan tools'
+# scan/v1); COMMIT is the scanned git commit woven into the scan/v1 envelope
+# only, ignored by the SBOM passthrough.
 wrangle_attest_args() {
     printf '%s\n' \
         --metadata-root="$METADATA_ROOT" \
         "$1" \
+        --commit="${COMMIT:-}" \
         --sign \
         --out="$2"
 }

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -102,11 +102,13 @@ teardown() {
 
 # --- wrangle-attest arg vector ---
 
-@test "run_verify: attest args carry the metadata-root, subject arg, sign, and out" {
+@test "run_verify: attest args carry the metadata-root, subject arg, commit, sign, and out" {
     export METADATA_ROOT="$TEST_DIR/meta"
+    export COMMIT="deadbeef"
     mapfile -t args < <(wrangle_attest_args "--subject=sha256:abc" "$TEST_DIR/out.jsonl")
     printf '%s\n' "${args[@]}" | grep -qx -- "--metadata-root=$TEST_DIR/meta"
     printf '%s\n' "${args[@]}" | grep -qx -- "--subject=sha256:abc"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--commit=deadbeef"
     printf '%s\n' "${args[@]}" | grep -qx -- "--sign"
     printf '%s\n' "${args[@]}" | grep -qx -- "--out=$TEST_DIR/out.jsonl"
 }

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -78,7 +78,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
+    - uses: TomHennen/wrangle/actions/verify@b1ef99a4037ddbbd26da7cbd9718d4a0739651a5 # feat/osv-scan-attest-on-sbom 2026-06-19
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -78,7 +78,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@3aa4d85a088b8458e4aac1266518c0b1909d615c # main 2026-06-19
+    - uses: TomHennen/wrangle/actions/verify@f265c5224529bd865fa5bc5dbc33dd20529a5815 # feat/osv-scan-attest-on-sbom 2026-06-19
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/lib/write_scan_manifest.sh
+++ b/lib/write_scan_manifest.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — handles path arguments
+
+# lib/write_scan_manifest.sh — write the scan/v1 wrangle_attestation_metadata.json
+# a SARIF-emitting tool leaves for the wrangle-attest engine, next to its
+# output.sarif.
+#
+# This is the generic producer for the wrangle scan/v1 thin envelope: every
+# SARIF tool (osv now; zizmor/scorecard/wrangle-lint in Phase 2) writes the same
+# manifest, keyed only by tool name + SARIF path. tool.version and the
+# clean|findings result are derived from the SARIF itself — the same results
+# count the findings gate uses — so producer and gate can never diverge.
+#
+# Usage: write_scan_manifest.sh <tool_name> <sarif_path>
+#   <tool_name>  the scanner's name (e.g. osv-scanner); recorded as tool.name
+#   <sarif_path> the output.sarif; the manifest is written in its directory,
+#                with result-file pointing at it
+
+PREDICATE_SCAN_V1="https://github.com/TomHennen/wrangle/attestation/scan/v1"
+
+main() {
+    if [[ "$#" -ne 2 ]]; then
+        printf 'Usage: %s <tool_name> <sarif_path>\n' "${0##*/}" >&2
+        return 2
+    fi
+    local tool_name="$1" sarif_path="$2"
+    if [[ ! -f "$sarif_path" ]]; then
+        printf 'write_scan_manifest: SARIF not found: %s\n' "$sarif_path" >&2
+        return 2
+    fi
+    local metadata_dir result_file
+    metadata_dir="$(dirname "$sarif_path")"
+    result_file="$(basename "$sarif_path")"
+
+    # result and version come from the SARIF: results count is the same signal
+    # the gate reads (clean|findings); version is the driver's reported version.
+    local count result version
+    if ! count="$(jq '[.runs[].results[]] | length' "$sarif_path" 2>/dev/null)"; then
+        printf 'write_scan_manifest: invalid SARIF: %s\n' "$sarif_path" >&2
+        return 2
+    fi
+    if [[ "$count" -gt 0 ]]; then
+        result="findings"
+    else
+        result="clean"
+    fi
+    version="$(jq -r 'first(.runs[].tool.driver.version) // ""' "$sarif_path" 2>/dev/null || printf '')"
+
+    # jq -n builds the JSON so a tool name or version with a quote/backslash is
+    # escaped, never breaking the manifest the engine parses strictly.
+    jq -n \
+        --arg pt "$PREDICATE_SCAN_V1" \
+        --arg rf "$result_file" \
+        --arg tn "$tool_name" \
+        --arg tv "$version" \
+        --arg rs "$result" \
+        '{"predicate-type": $pt, "result-file": $rf, "tool": {"name": $tn, "version": $tv}, "result": $rs}' \
+        > "$metadata_dir/wrangle_attestation_metadata.json"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/run.sh
+++ b/run.sh
@@ -227,6 +227,23 @@ for tool in "${adapter_tools[@]}"; do
             > "${tool_output_dir}/output.md" 2>/dev/null || true
     fi
 
+    # Write the scan/v1 attestation manifest next to output.sarif so the
+    # trusted verify job's wrangle-attest engine wraps + signs it. Only on a
+    # clean run or findings (not error/missing SARIF): an attestation must
+    # claim a real scan result. The scanner name differs from the orchestrator
+    # token (osv -> osv-scanner); keyed per tool here so Phase 2 adds a line.
+    if [[ "$tool_status" != "error" ]] && [[ -f "${tool_output_dir}/output.sarif" ]]; then
+        scanner_name=""
+        case "$tool" in
+            osv) scanner_name="osv-scanner" ;;
+        esac
+        if [[ -n "$scanner_name" ]]; then
+            "$SCRIPT_DIR/lib/write_scan_manifest.sh" "$scanner_name" \
+                "${tool_output_dir}/output.sarif" \
+                || printf 'wrangle: failed to write %s scan manifest\n' "$tool" >&2
+        fi
+    fi
+
     summary_tools+=("$tool")
     summary_statuses+=("$tool_status")
     printf '::endgroup::\n'

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -162,6 +162,34 @@ exit 0
 ADAPT
     chmod +x "$MOCK_TOOLS/rogue-tool/adapter.sh"
 
+    # Mock osv tool: run.sh writes a scan/v1 manifest for the osv token.
+    # Emits findings or clean per WRANGLE_EXTRA_RESULTS (run.sh strips env but
+    # forwards WRANGLE_EXTRA_*), so both manifest results can be exercised;
+    # version comes from the SARIF driver.
+    mkdir -p "$MOCK_TOOLS/osv"
+    cat > "$MOCK_TOOLS/osv/install.sh" << 'INST'
+#!/bin/bash
+set -euo pipefail
+exit 0
+INST
+    chmod +x "$MOCK_TOOLS/osv/install.sh"
+
+    cat > "$MOCK_TOOLS/osv/adapter.sh" << 'ADAPT'
+#!/bin/bash
+set -euo pipefail
+if [[ "${RESULTS:-}" == "findings" ]]; then
+    cat > "$2/output.sarif" << 'SARIF'
+{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"osv-scanner","version":"9.9.9"}},"results":[{"ruleId":"CVE-1"}]}]}
+SARIF
+    exit 1
+fi
+cat > "$2/output.sarif" << 'SARIF'
+{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"osv-scanner","version":"9.9.9"}},"results":[]}]}
+SARIF
+exit 0
+ADAPT
+    chmod +x "$MOCK_TOOLS/osv/adapter.sh"
+
     # Create test source and output directories
     mkdir -p "$TEST_DIR/src" "$TEST_DIR/output"
 }
@@ -470,4 +498,37 @@ FAKEGO
 
     [ "$status" -eq 0 ]
     [ ! -s "$GO_RECORD" ]
+}
+
+# --- scan/v1 attestation manifest (issue #420) ---
+
+@test "orchestrator: writes an osv scan/v1 manifest next to output.sarif (clean)" {
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv"
+    [ "$status" -eq 0 ]
+    manifest="$TEST_DIR/output/osv/wrangle_attestation_metadata.json"
+    [ -f "$manifest" ]
+    run jq -r '."predicate-type"' "$manifest"
+    [[ "$output" == "https://github.com/TomHennen/wrangle/attestation/scan/v1" ]]
+    run jq -r '.tool.name' "$manifest"
+    [[ "$output" == "osv-scanner" ]]
+    run jq -r '.tool.version' "$manifest"
+    [[ "$output" == "9.9.9" ]]
+    run jq -r '.result' "$manifest"
+    [[ "$output" == "clean" ]]
+    run jq -r '."result-file"' "$manifest"
+    [[ "$output" == "output.sarif" ]]
+}
+
+@test "orchestrator: osv manifest records result=findings when osv reports findings" {
+    WRANGLE_EXTRA_RESULTS=findings run_orchestrator \
+        -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv"
+    [ "$status" -eq 1 ]
+    run jq -r '.result' "$TEST_DIR/output/osv/wrangle_attestation_metadata.json"
+    [[ "$output" == "findings" ]]
+}
+
+@test "orchestrator: writes no scan manifest for a non-osv adapter (Phase 2 not wired)" {
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
+    [ "$status" -eq 0 ]
+    [ ! -f "$TEST_DIR/output/clean-tool/wrangle_attestation_metadata.json" ]
 }

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -9,6 +9,9 @@ setup() {
     ORIG_DIR="$(pwd)"
     export ORIG_DIR
 
+    # Forward the golden-SARIF fixtures dir to the mock osv adapter.
+    export WRANGLE_EXTRA_FIXTURES="$ORIG_DIR/test/fixtures"
+
     # Create a mock tools directory structure that run.sh can find
     export MOCK_TOOLS="$TEST_DIR/tools"
 
@@ -163,9 +166,9 @@ ADAPT
     chmod +x "$MOCK_TOOLS/rogue-tool/adapter.sh"
 
     # Mock osv tool: run.sh writes a scan/v1 manifest for the osv token.
-    # Emits findings or clean per WRANGLE_EXTRA_RESULTS (run.sh strips env but
-    # forwards WRANGLE_EXTRA_*), so both manifest results can be exercised;
-    # version comes from the SARIF driver.
+    # Copies a golden SARIF (findings/empty) per WRANGLE_EXTRA_RESULTS, with the
+    # fixtures dir forwarded as WRANGLE_EXTRA_FIXTURES (run.sh strips env but
+    # forwards WRANGLE_EXTRA_*); tool name/version come from the golden driver.
     mkdir -p "$MOCK_TOOLS/osv"
     cat > "$MOCK_TOOLS/osv/install.sh" << 'INST'
 #!/bin/bash
@@ -178,14 +181,10 @@ INST
 #!/bin/bash
 set -euo pipefail
 if [[ "${RESULTS:-}" == "findings" ]]; then
-    cat > "$2/output.sarif" << 'SARIF'
-{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"osv-scanner","version":"9.9.9"}},"results":[{"ruleId":"CVE-1"}]}]}
-SARIF
+    cp "${FIXTURES}/findings.sarif" "$2/output.sarif"
     exit 1
 fi
-cat > "$2/output.sarif" << 'SARIF'
-{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"osv-scanner","version":"9.9.9"}},"results":[]}]}
-SARIF
+cp "${FIXTURES}/empty.sarif" "$2/output.sarif"
 exit 0
 ADAPT
     chmod +x "$MOCK_TOOLS/osv/adapter.sh"
@@ -512,7 +511,7 @@ FAKEGO
     run jq -r '.tool.name' "$manifest"
     [[ "$output" == "osv-scanner" ]]
     run jq -r '.tool.version' "$manifest"
-    [[ "$output" == "9.9.9" ]]
+    [[ "$output" == "1.0.0" ]]
     run jq -r '.result' "$manifest"
     [[ "$output" == "clean" ]]
     run jq -r '."result-file"' "$manifest"

--- a/test/test_write_scan_manifest.bats
+++ b/test/test_write_scan_manifest.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+
+# Tests for lib/write_scan_manifest.sh — the generic scan/v1 manifest producer.
+# result and tool.version are derived from the SARIF, so the manifest can never
+# disagree with the findings gate (which reads the same results count).
+
+setup() {
+    SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../lib" && pwd)/write_scan_manifest.sh"
+    TEST_DIR="$(mktemp -d)"
+    SARIF="$TEST_DIR/osv/output.sarif"
+    mkdir -p "$TEST_DIR/osv"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+write_sarif() {
+    # $1 = results JSON array body, $2 = version
+    cat > "$SARIF" <<EOF
+{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"osv-scanner","version":"$2"}},"results":[$1]}]}
+EOF
+}
+
+@test "write_scan_manifest: findings SARIF yields result=findings + scan/v1 schema" {
+    write_sarif '{"ruleId":"CVE-1"}' "2.3.8"
+    run "$SCRIPT" osv-scanner "$SARIF"
+    [[ "$status" -eq 0 ]]
+    run jq -r '."predicate-type"' "$TEST_DIR/osv/wrangle_attestation_metadata.json"
+    [[ "$output" == "https://github.com/TomHennen/wrangle/attestation/scan/v1" ]]
+    run jq -r '."result-file"' "$TEST_DIR/osv/wrangle_attestation_metadata.json"
+    [[ "$output" == "output.sarif" ]]
+    run jq -r '.tool.name' "$TEST_DIR/osv/wrangle_attestation_metadata.json"
+    [[ "$output" == "osv-scanner" ]]
+    run jq -r '.tool.version' "$TEST_DIR/osv/wrangle_attestation_metadata.json"
+    [[ "$output" == "2.3.8" ]]
+    run jq -r '.result' "$TEST_DIR/osv/wrangle_attestation_metadata.json"
+    [[ "$output" == "findings" ]]
+}
+
+@test "write_scan_manifest: empty results yields result=clean" {
+    write_sarif '' "2.3.8"
+    run "$SCRIPT" osv-scanner "$SARIF"
+    [[ "$status" -eq 0 ]]
+    run jq -r '.result' "$TEST_DIR/osv/wrangle_attestation_metadata.json"
+    [[ "$output" == "clean" ]]
+}
+
+@test "write_scan_manifest: missing driver version yields empty string, not null" {
+    cat > "$SARIF" <<'EOF'
+{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"osv-scanner"}},"results":[]}]}
+EOF
+    run "$SCRIPT" osv-scanner "$SARIF"
+    [[ "$status" -eq 0 ]]
+    run jq -r '.tool.version' "$TEST_DIR/osv/wrangle_attestation_metadata.json"
+    [[ "$output" == "" ]]
+}
+
+@test "write_scan_manifest: invalid SARIF fails closed (exit 2, no manifest)" {
+    printf 'not json' > "$SARIF"
+    run "$SCRIPT" osv-scanner "$SARIF"
+    [[ "$status" -eq 2 ]]
+    [[ ! -f "$TEST_DIR/osv/wrangle_attestation_metadata.json" ]]
+}
+
+@test "write_scan_manifest: missing SARIF fails (exit 2)" {
+    run "$SCRIPT" osv-scanner "$TEST_DIR/osv/absent.sarif"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "write_scan_manifest: usage error on wrong arg count" {
+    run "$SCRIPT" osv-scanner
+    [[ "$status" -eq 2 ]]
+    [[ "$output" == *"Usage:"* ]]
+}

--- a/tools/wrangle-attest/SPEC.md
+++ b/tools/wrangle-attest/SPEC.md
@@ -37,8 +37,9 @@ the whole run closed; scan output is untrusted input.
 Passthrough embeds the result file verbatim as the predicate (it must be a JSON
 object). The thin envelope hoists `tool`/`result`/`scannedCommit` to the top
 level so policy filters on `predicate.tool.name` / `predicate.result` without
-parsing nested SARIF. v1 ships SBOM; the OSV/scorecard/SARIF cases are wired so
-later producer PRs are manifest-only.
+parsing nested SARIF. SBOM (passthrough) and OSV (scan/v1 envelope) ship with
+producers; the scorecard passthrough is wired so a later producer PR is
+manifest-only.
 
 ## Engine-owned subject
 
@@ -57,9 +58,11 @@ wrangle-attest --metadata-root <dir>... (--subject sha256:<hex> | --artifact <fi
     [--commit <hex-sha>] [--sign] --out <file>
 ```
 
-Honors only the canonical top-level `<root>/wrangle_attestation_metadata.json` for each
-`--metadata-root`; any other `wrangle_attestation_metadata.json` deeper in the tree is ignored (a
-build-time dependency could plant one to forge a wrangle-signed attestation).
+Honors the canonical top-level `<root>/wrangle_attestation_metadata.json` plus,
+for each immediate child dir of `<root>/scan/`, `<root>/scan/<tool>/wrangle_attestation_metadata.json`
+(a bounded one-level lookup, no recursion). Any other `wrangle_attestation_metadata.json`
+deeper in the tree or outside those two locations is ignored (a build-time
+dependency could plant one to forge a wrangle-signed attestation).
 Builds one Statement per honored manifest bound to the subject and writes them
 all to `--out` as JSONL. `--commit` is woven into the `scan/v1` envelope only;
 passthrough predicates ignore it.

--- a/tools/wrangle-attest/manifest.go
+++ b/tools/wrangle-attest/manifest.go
@@ -72,13 +72,17 @@ func (m *manifest) resultPath() string {
 	return filepath.Join(m.dir, m.ResultFile)
 }
 
-// discoverManifests honors only the canonical top-level
-// <root>/wrangle_attestation_metadata.json for each root; any other such file
-// in the tree is ignored, not signed,
-// since a build-time dependency could plant one to forge a wrangle-signed
-// attestation. Results are sorted by dir for deterministic output. A missing
-// canonical manifest is not an error — a build may legitimately produce none;
-// a malformed canonical manifest fails the whole run (fail closed).
+const manifestFile = "wrangle_attestation_metadata.json"
+
+// discoverManifests honors two fixed locations per root: the canonical top-level
+// <root>/wrangle_attestation_metadata.json and, one level down, each
+// <root>/scan/<tool>/wrangle_attestation_metadata.json (a bounded readdir of the
+// immediate children of <root>/scan/, no recursion). Any other such file in the
+// tree — deeper, or outside those locations — is ignored, not signed, since a
+// build-time dependency could plant one to forge a wrangle-signed attestation.
+// Results are sorted by dir for deterministic output. A missing manifest is not
+// an error — a build may legitimately produce none; a malformed manifest at an
+// honored location fails the whole run (fail closed).
 func discoverManifests(roots []string) ([]manifest, error) {
 	var found []manifest
 	for _, root := range roots {
@@ -89,21 +93,62 @@ func discoverManifests(roots []string) ([]manifest, error) {
 		if !info.IsDir() {
 			return nil, fmt.Errorf("metadata-root %q is not a directory", root)
 		}
-		path := filepath.Join(root, "wrangle_attestation_metadata.json")
-		if _, err := os.Stat(path); err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				continue
-			}
-			return nil, fmt.Errorf("%s: %w", path, err)
-		}
-		m, err := parseManifest(path)
+		dirs := []string{root}
+		scanDirs, err := scanToolDirs(root)
 		if err != nil {
-			return nil, fmt.Errorf("%s: %w", path, err)
+			return nil, err
 		}
-		found = append(found, m)
+		dirs = append(dirs, scanDirs...)
+		for _, dir := range dirs {
+			m, ok, err := manifestAt(dir)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				found = append(found, m)
+			}
+		}
 	}
 	sort.Slice(found, func(i, j int) bool { return found[i].dir < found[j].dir })
 	return found, nil
+}
+
+// scanToolDirs returns the immediate child directories of <root>/scan/. A
+// missing scan/ dir is not an error. Non-directory entries are skipped; the
+// lookup never recurses below scan/<tool>/.
+func scanToolDirs(root string) ([]string, error) {
+	scanRoot := filepath.Join(root, "scan")
+	entries, err := os.ReadDir(scanRoot)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%s: %w", scanRoot, err)
+	}
+	var dirs []string
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs = append(dirs, filepath.Join(scanRoot, e.Name()))
+		}
+	}
+	return dirs, nil
+}
+
+// manifestAt parses the canonical manifest in dir, if present. A missing file
+// reports ok=false with no error; a present-but-malformed one fails closed.
+func manifestAt(dir string) (manifest, bool, error) {
+	path := filepath.Join(dir, manifestFile)
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return manifest{}, false, nil
+		}
+		return manifest{}, false, fmt.Errorf("%s: %w", path, err)
+	}
+	m, err := parseManifest(path)
+	if err != nil {
+		return manifest{}, false, fmt.Errorf("%s: %w", path, err)
+	}
+	return m, true, nil
 }
 
 func parseManifest(path string) (manifest, error) {

--- a/tools/wrangle-attest/manifest_test.go
+++ b/tools/wrangle-attest/manifest_test.go
@@ -134,6 +134,56 @@ func TestDiscoverManifestsIgnoresStrays(t *testing.T) {
 	}
 }
 
+// A scan/<tool>/wrangle_attestation_metadata.json is discovered alongside the
+// top-level SBOM manifest (the bounded one-level lookup under <root>/scan/).
+func TestDiscoverManifestsScanSubdir(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "wrangle_attestation_metadata.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, root, "scan/osv/wrangle_attestation_metadata.json", `{"predicate-type":"https://github.com/TomHennen/wrangle/attestation/scan/v1","result-file":"output.sarif","tool":{"name":"osv-scanner","version":"1.0"},"result":"clean"}`)
+	got, err := discoverManifests([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected the SBOM + scan manifests, got %d", len(got))
+	}
+	var sawScan bool
+	for _, m := range got {
+		if m.PredicateType == predicateScanV1 {
+			sawScan = true
+		}
+	}
+	if !sawScan {
+		t.Fatal("scan/osv manifest was not discovered")
+	}
+}
+
+// The scan lookup is one level only: a manifest under scan/<tool>/sub/ is too
+// deep and a top-level non-scan stray (e.g. evil/) is outside the honored
+// locations — both ignored, neither an error.
+func TestDiscoverManifestsScanBounded(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "wrangle_attestation_metadata.json", `{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}`)
+	writeFile(t, root, "scan/osv/sub/wrangle_attestation_metadata.json", `{"predicate-type":"https://evil.example/x","result-file":"r.json"}`)
+	writeFile(t, root, "evil/wrangle_attestation_metadata.json", `{"predicate-type":"https://evil.example/y","result-file":"r.json"}`)
+	got, err := discoverManifests([]string{root})
+	if err != nil {
+		t.Fatalf("strays must not cause an error: %v", err)
+	}
+	if len(got) != 1 || got[0].PredicateType != predicateSPDX {
+		t.Fatalf("expected only the canonical SBOM manifest, got %d", len(got))
+	}
+}
+
+// A malformed manifest at an honored scan/<tool>/ location fails closed.
+func TestDiscoverManifestsScanFailClosed(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "scan/osv/wrangle_attestation_metadata.json", `{"bad`)
+	if _, err := discoverManifests([]string{root}); err == nil {
+		t.Fatal("expected discovery to fail closed on a malformed scan manifest")
+	}
+}
+
 // A malformed canonical manifest fails the whole run (fail closed).
 func TestDiscoverManifestsFailClosed(t *testing.T) {
 	root := t.TempDir()

--- a/tools/wrangle-attest/run_test.go
+++ b/tools/wrangle-attest/run_test.go
@@ -60,6 +60,52 @@ func TestRunWritesSBOMStatement(t *testing.T) {
 	}
 }
 
+// A scan/<tool>/ manifest under the metadata-root is discovered and produces a
+// scan/v1 envelope statement with the threaded scannedCommit — the same
+// unsigned-build path the SBOM uses, no separate handling.
+func TestRunWritesScanStatement(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "meta/scan/osv/wrangle_attestation_metadata.json",
+		`{"predicate-type":"https://github.com/TomHennen/wrangle/attestation/scan/v1","result-file":"output.sarif","tool":{"name":"osv-scanner","version":"1.0"},"result":"clean"}`)
+	writeFile(t, dir, "meta/scan/osv/output.sarif", `{"version":"2.1.0","runs":[]}`)
+	out := filepath.Join(dir, "out.jsonl")
+
+	var stderr bytes.Buffer
+	rc := run([]string{
+		"--metadata-root", filepath.Join(dir, "meta"),
+		"--subject", testArtifactDigest,
+		"--commit", "deadbeef",
+		"--out", out,
+	}, &stderr)
+	if rc != 0 {
+		t.Fatalf("run rc=%d stderr=%s", rc, stderr.String())
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stmt struct {
+		PredicateType string `json:"predicateType"`
+		Predicate     struct {
+			ScannedCommit string `json:"scannedCommit"`
+			Result        string `json:"result"`
+			Tool          struct {
+				Name string `json:"name"`
+			} `json:"tool"`
+		} `json:"predicate"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &stmt); err != nil {
+		t.Fatal(err)
+	}
+	if stmt.PredicateType != predicateScanV1 {
+		t.Fatalf("wrong predicateType: %q", stmt.PredicateType)
+	}
+	if stmt.Predicate.ScannedCommit != "deadbeef" || stmt.Predicate.Result != "clean" ||
+		stmt.Predicate.Tool.Name != "osv-scanner" {
+		t.Fatalf("scan/v1 envelope not populated: %+v", stmt.Predicate)
+	}
+}
+
 // --artifact self-digests the file into the subject; the bound digest must be
 // a plain sha256 of the artifact bytes (the same the VSA binds to).
 func TestRunArtifactSelfDigest(t *testing.T) {


### PR DESCRIPTION
Attests OSV's existing `output.sarif` as the generic wrangle SARIF envelope `https://github.com/TomHennen/wrangle/attestation/scan/v1` — the thin-envelope path the `wrangle-attest` engine already implements. This replaces the obsolete second-scan + `osv-schema` predicate approach (old #466): no second `osv-scanner --format json` run, so the SARIF and JSON can never diverge.

Stacked on #474 (engine + SBOM); base `feat/wrangle-attest-sbom-on-469`.

## What this adds
- **`lib/write_scan_manifest.sh`** — the generic scan/v1 manifest producer, keyed by tool name + SARIF path. It derives `result` (clean|findings) and `tool.version` from the SARIF itself — the same results count the findings gate reads — so producer and gate can never disagree. Phase 2 (zizmor/scorecard/wrangle-lint) is "call it for one more tool"; only OSV is wired here.
- **`run.sh`** — after the OSV adapter runs (clean or findings, never error/missing SARIF), the orchestrator writes `osv/manifest.json` next to `output.sarif`. #469 stages `scan/` into the unified metadata, so the manifest rides along to `metadata/<type>/<sn>/scan/osv/`.
- **`run_verify.sh` / `actions/verify/action.yml`** — thread `--commit` (`github.sha`) so the envelope's `scannedCommit` is populated.

## Engine
No engine change needed — the `scan/v1` case (`{tool, scannedCommit, result, sarif}`, single-sha256 subject) already exists and is golden-tested. The verify job walks `--metadata-root` (the unified metadata), so it discovers the OSV scan manifest alongside the SBOM one, bnd-signs it in the trusted context, appends it to the bundle, and pushes it to the store — the same path SBOM uses.

## Tenet wiring
The old `no-exploitable-vulns` tenet that read the `osv-schema` predicate no longer applies. A SARIF-reading tenet is **#328's** territory; this PR is the producer. The envelope exposes `predicate.tool.name` and `predicate.result` at the top level so a future tenet can gate without parsing nested SARIF.

## Tests
- `test/test_write_scan_manifest.bats` — clean/findings result, version extraction, fail-closed on invalid/missing SARIF.
- `test/test_orchestrator.bats` — OSV manifest emitted (clean + findings); no manifest for a non-OSV adapter.
- `actions/verify/test_run_verify.bats` — `--commit` carried in the attest arg vector.

`./test.sh quick` green (1102 bats + go unit tests); shellcheck, actionlint, zizmor clean; `check_pin_ancestry` passes; bootstrap pins re-pointed to HEAD. The dispatch e2e is the real proof (OSV scan/v1 attestation produced, signed, delivered into the unified metadata + store).

Closes #467
Part of #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)