### PR TITLE
feat(#420 Phase 2): scan attestations for zizmor, wrangle-lint, dependency-review

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
 
   gate:
     needs: [guard]
@@ -120,7 +120,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -153,7 +153,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -184,7 +184,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      uses: TomHennen/wrangle/build/actions/container@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -284,7 +284,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         with:
           build-type: container
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
 
   gate:
     needs: [guard]
@@ -171,7 +171,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -195,7 +195,7 @@ jobs:
 
       # Shared name derivation so the scan and release jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -203,7 +203,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -236,7 +236,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/checks@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -302,7 +302,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/release@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: release
         with:
           path: ${{ inputs.path }}
@@ -326,7 +326,7 @@ jobs:
           printf 'module=%s\n' "$(go -C "$INPUT_PATH" list -m | head -n1)" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: names
         with:
           build-type: go
@@ -400,7 +400,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: attest
         with:
           build-type: go
@@ -429,7 +429,7 @@ jobs:
       attestation-bundle-name: ${{ needs.release.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         with:
           build-type: go
           shortname: ${{ needs.release.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -139,7 +139,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
 
   gate:
     needs: [guard]
@@ -150,7 +150,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -174,7 +174,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -182,7 +182,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -221,7 +221,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/npm@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -230,7 +230,7 @@ jobs:
           ignore-scripts: ${{ inputs.ignore-scripts }}
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: names
         with:
           build-type: npm
@@ -302,7 +302,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: attest
         with:
           build-type: npm
@@ -328,7 +328,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         with:
           build-type: npm
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -116,7 +116,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -131,7 +131,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -155,7 +155,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -202,7 +202,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/python@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -231,7 +231,7 @@ jobs:
           printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: names
         with:
           build-type: python
@@ -295,7 +295,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         id: attest
         with:
           build-type: python
@@ -321,7 +321,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         with:
           build-type: python
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+        uses: TomHennen/wrangle/build/actions/shell@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
 
   check-change:
     needs: [guard]
@@ -51,7 +51,7 @@ jobs:
       # (root path), so the shortname is empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+        uses: TomHennen/wrangle/actions/scan@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
         with:
           tools: ${{ inputs.tools }}
           artifact-name: scan

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -99,7 +99,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      uses: TomHennen/wrangle/tools/zizmor@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      uses: TomHennen/wrangle/tools/scorecard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+      uses: TomHennen/wrangle/tools/dependency-review@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -78,7 +78,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@d6e681577cf88a4596db4a502c4498dc30c6eb67 # main 2026-06-19
+    - uses: TomHennen/wrangle/actions/verify@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/lib/write_scan_manifest.sh
+++ b/lib/write_scan_manifest.sh
@@ -33,6 +33,14 @@ main() {
     metadata_dir="$(dirname "$sarif_path")"
     result_file="$(basename "$sarif_path")"
 
+    # Action-pattern tools (zizmor, dependency-review) write an error marker
+    # when the run failed and any SARIF on disk is an empty fallback. Don't
+    # attest that: an attestation must claim a real scan result. (run.sh's
+    # adapter path gates on tool_status and never calls here on error.)
+    if [[ -f "$metadata_dir/error" ]]; then
+        return 0
+    fi
+
     # result and version come from the SARIF: results count is the same signal
     # the gate reads (clean|findings); version is the driver's reported version.
     local count result version

--- a/run.sh
+++ b/run.sh
@@ -230,12 +230,13 @@ for tool in "${adapter_tools[@]}"; do
     # Write the scan/v1 attestation manifest next to output.sarif so the
     # trusted verify job's wrangle-attest engine wraps + signs it. Only on a
     # clean run or findings (not error/missing SARIF): an attestation must
-    # claim a real scan result. The scanner name differs from the orchestrator
-    # token (osv -> osv-scanner); keyed per tool here so Phase 2 adds a line.
+    # claim a real scan result. The scanner name can differ from the
+    # orchestrator token (osv -> osv-scanner); keyed per tool, one line each.
     if [[ "$tool_status" != "error" ]] && [[ -f "${tool_output_dir}/output.sarif" ]]; then
         scanner_name=""
         case "$tool" in
             osv) scanner_name="osv-scanner" ;;
+            wrangle-lint) scanner_name="wrangle-lint" ;;
         esac
         if [[ -n "$scanner_name" ]]; then
             "$SCRIPT_DIR/lib/write_scan_manifest.sh" "$scanner_name" \

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -189,6 +189,19 @@ exit 0
 ADAPT
     chmod +x "$MOCK_TOOLS/osv/adapter.sh"
 
+    # Mock wrangle-lint adapter: like osv, run.sh writes a scan/v1 manifest for
+    # the wrangle-lint token. Its SARIF driver name is wrangle-lint.
+    mkdir -p "$MOCK_TOOLS/wrangle-lint"
+    cat > "$MOCK_TOOLS/wrangle-lint/adapter.sh" << 'ADAPT'
+#!/bin/bash
+set -euo pipefail
+cat > "$2/output.sarif" << 'SARIF'
+{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"wrangle-lint","version":"1.2.3"}},"results":[]}]}
+SARIF
+exit 0
+ADAPT
+    chmod +x "$MOCK_TOOLS/wrangle-lint/adapter.sh"
+
     # Create test source and output directories
     mkdir -p "$TEST_DIR/src" "$TEST_DIR/output"
 }
@@ -526,7 +539,20 @@ FAKEGO
     [[ "$output" == "findings" ]]
 }
 
-@test "orchestrator: writes no scan manifest for a non-osv adapter (Phase 2 not wired)" {
+@test "orchestrator: writes a wrangle-lint scan/v1 manifest next to output.sarif" {
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "wrangle-lint"
+    [ "$status" -eq 0 ]
+    manifest="$TEST_DIR/output/wrangle-lint/manifest.json"
+    [ -f "$manifest" ]
+    run jq -r '.tool.name' "$manifest"
+    [[ "$output" == "wrangle-lint" ]]
+    run jq -r '.tool.version' "$manifest"
+    [[ "$output" == "1.2.3" ]]
+    run jq -r '.result' "$manifest"
+    [[ "$output" == "clean" ]]
+}
+
+@test "orchestrator: writes no scan manifest for an unwired adapter" {
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
     [ "$status" -eq 0 ]
     [ ! -f "$TEST_DIR/output/clean-tool/wrangle_attestation_metadata.json" ]

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -542,7 +542,7 @@ FAKEGO
 @test "orchestrator: writes a wrangle-lint scan/v1 manifest next to output.sarif" {
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "wrangle-lint"
     [ "$status" -eq 0 ]
-    manifest="$TEST_DIR/output/wrangle-lint/manifest.json"
+    manifest="$TEST_DIR/output/wrangle-lint/wrangle_attestation_metadata.json"
     [ -f "$manifest" ]
     run jq -r '.tool.name' "$manifest"
     [[ "$output" == "wrangle-lint" ]]

--- a/test/test_write_scan_manifest.bats
+++ b/test/test_write_scan_manifest.bats
@@ -68,6 +68,14 @@ EOF
     [[ "$status" -eq 2 ]]
 }
 
+@test "write_scan_manifest: skips (no manifest, exit 0) when an error marker is present" {
+    write_sarif '' "2.3.8"
+    printf 'tool error\n' > "$TEST_DIR/osv/error"
+    run "$SCRIPT" osv-scanner "$SARIF"
+    [[ "$status" -eq 0 ]]
+    [[ ! -f "$TEST_DIR/osv/manifest.json" ]]
+}
+
 @test "write_scan_manifest: usage error on wrong arg count" {
     run "$SCRIPT" osv-scanner
     [[ "$status" -eq 2 ]]

--- a/tools/dependency-review/action.yml
+++ b/tools/dependency-review/action.yml
@@ -113,15 +113,13 @@ runs:
     # Leave the scan/v1 manifest the trusted verify job's wrangle-attest engine
     # wraps + signs. Runs after mark_error.sh so write_scan_manifest.sh sees the
     # marker and skips on a tool error; the action is PR-only, so off-PR runs
-    # never reach here and no manifest is written for a skipped tool.
+    # never reach here and no manifest is written for a skipped tool. Gated on
+    # the SARIF existing so the step stays a single script call (no inline if).
     - name: Write scan manifest
-      if: always()
+      if: always() && hashFiles('.wrangle/metadata/dependency-review/output.sarif') != ''
       shell: bash
       env:
         WRANGLE_ROOT: ${{ github.action_path }}/../..
+        SARIF: ${{ github.workspace }}/.wrangle/metadata/dependency-review/output.sarif
       run: |
-        set -euo pipefail
-        SARIF="${GITHUB_WORKSPACE}/.wrangle/metadata/dependency-review/output.sarif"
-        if [[ -f "$SARIF" ]]; then
-          "$WRANGLE_ROOT/lib/write_scan_manifest.sh" dependency-review "$SARIF"
-        fi
+        "$WRANGLE_ROOT/lib/write_scan_manifest.sh" dependency-review "$SARIF"

--- a/tools/dependency-review/action.yml
+++ b/tools/dependency-review/action.yml
@@ -111,10 +111,12 @@ runs:
         "$TOOL_DIR/mark_error.sh"
 
     # Leave the scan/v1 manifest the trusted verify job's wrangle-attest engine
-    # wraps + signs. Runs after mark_error.sh so write_scan_manifest.sh sees the
-    # marker and skips on a tool error; the action is PR-only, so off-PR runs
-    # never reach here and no manifest is written for a skipped tool. Gated on
-    # the SARIF existing so the step stays a single script call (no inline if).
+    # wraps + signs. The "don't attest an errored audit" gating lives in the
+    # script: write_scan_manifest.sh runs after mark_error.sh and skips when the
+    # error marker is present. The hashFiles guard here only suppresses the "tool
+    # didn't run" case (no SARIF), keeping the step a single script call.
+    # PR-only: the sign/verify flow runs on release/push, never on a PR, so this
+    # manifest is produced but never signed — inert on a PR by construction.
     - name: Write scan manifest
       if: always() && hashFiles('.wrangle/metadata/dependency-review/output.sarif') != ''
       shell: bash

--- a/tools/dependency-review/action.yml
+++ b/tools/dependency-review/action.yml
@@ -109,3 +109,19 @@ runs:
         VULNERABLE_CHANGES: ${{ steps.depreview.outputs.vulnerable-changes }}
       run: |
         "$TOOL_DIR/mark_error.sh"
+
+    # Leave the scan/v1 manifest the trusted verify job's wrangle-attest engine
+    # wraps + signs. Runs after mark_error.sh so write_scan_manifest.sh sees the
+    # marker and skips on a tool error; the action is PR-only, so off-PR runs
+    # never reach here and no manifest is written for a skipped tool.
+    - name: Write scan manifest
+      if: always()
+      shell: bash
+      env:
+        WRANGLE_ROOT: ${{ github.action_path }}/../..
+      run: |
+        set -euo pipefail
+        SARIF="${GITHUB_WORKSPACE}/.wrangle/metadata/dependency-review/output.sarif"
+        if [[ -f "$SARIF" ]]; then
+          "$WRANGLE_ROOT/lib/write_scan_manifest.sh" dependency-review "$SARIF"
+        fi

--- a/tools/dependency-review/test.bats
+++ b/tools/dependency-review/test.bats
@@ -129,6 +129,17 @@ teardown() {
     [ -x "$TOOL_DIR/mark_error.sh" ]
 }
 
+@test "dependency-review: action.yml writes the scan/v1 manifest, gated and via env" {
+    # The manifest step must exist, gate on the SARIF via hashFiles (skipped
+    # when the tool didn't run), thread the SARIF path through env: (no ${{ }}
+    # in run:), and call write_scan_manifest.sh with the dependency-review token.
+    grep -q "hashFiles('.wrangle/metadata/dependency-review/output.sarif') != ''" "$TOOL_DIR/action.yml"
+    grep -Eq 'write_scan_manifest\.sh" dependency-review ' "$TOOL_DIR/action.yml"
+    run awk '/^    - name: Write scan manifest/{flag=1;next} flag && /^    - name:/{flag=0} flag' "$TOOL_DIR/action.yml"
+    [ "$status" -eq 0 ]
+    ! printf '%s\n' "$output" | grep -q 'run:.*\${{'
+}
+
 @test "mark_error: empty VULNERABLE_CHANGES writes error marker" {
     META="$TMP_DIR/meta-err-empty"
     METADATA_DIR="$META" OUTCOME=failure VULNERABLE_CHANGES='' \

--- a/tools/wrangle-attest/SPEC.md
+++ b/tools/wrangle-attest/SPEC.md
@@ -37,9 +37,13 @@ the whole run closed; scan output is untrusted input.
 Passthrough embeds the result file verbatim as the predicate (it must be a JSON
 object). The thin envelope hoists `tool`/`result`/`scannedCommit` to the top
 level so policy filters on `predicate.tool.name` / `predicate.result` without
-parsing nested SARIF. SBOM (passthrough) and OSV (scan/v1 envelope) ship with
-producers; the scorecard passthrough is wired so a later producer PR is
-manifest-only.
+parsing nested SARIF. SBOM (passthrough) and the SARIF tools osv, zizmor,
+wrangle-lint, and dependency-review (scan/v1 envelope) ship with producers; the
+scorecard passthrough is wired so a later producer PR is manifest-only.
+
+dependency-review runs only on `pull_request`; the sign/verify flow runs on
+release/push. Its manifest is therefore produced on a PR but never signed —
+inert by construction, not a gap.
 
 ## Engine-owned subject
 

--- a/tools/zizmor/action.yml
+++ b/tools/zizmor/action.yml
@@ -66,9 +66,10 @@ runs:
         fi
 
     # Leave the scan/v1 manifest the trusted verify job's wrangle-attest engine
-    # wraps + signs. write_scan_manifest.sh skips when collect_sarif.sh wrote an
-    # error marker, so a failed audit is never attested. Gated on the SARIF
-    # existing so the step stays a single script call (no inline if).
+    # wraps + signs. The "don't attest an errored audit" gating lives in the
+    # script: write_scan_manifest.sh skips when collect_sarif.sh wrote an error
+    # marker. The hashFiles guard here only suppresses the "tool didn't run"
+    # case (no SARIF), keeping the step a single script call (no inline if).
     - name: Write scan manifest
       if: always() && hashFiles('.wrangle/metadata/zizmor/output.sarif') != ''
       shell: bash

--- a/tools/zizmor/action.yml
+++ b/tools/zizmor/action.yml
@@ -67,15 +67,13 @@ runs:
 
     # Leave the scan/v1 manifest the trusted verify job's wrangle-attest engine
     # wraps + signs. write_scan_manifest.sh skips when collect_sarif.sh wrote an
-    # error marker, so a failed audit is never attested.
+    # error marker, so a failed audit is never attested. Gated on the SARIF
+    # existing so the step stays a single script call (no inline if).
     - name: Write scan manifest
-      if: always()
+      if: always() && hashFiles('.wrangle/metadata/zizmor/output.sarif') != ''
       shell: bash
       env:
         WRANGLE_ROOT: ${{ github.action_path }}/../..
+        SARIF: ${{ github.workspace }}/.wrangle/metadata/zizmor/output.sarif
       run: |
-        set -euo pipefail
-        SARIF="${GITHUB_WORKSPACE}/.wrangle/metadata/zizmor/output.sarif"
-        if [[ -f "$SARIF" ]]; then
-          "$WRANGLE_ROOT/lib/write_scan_manifest.sh" zizmor "$SARIF"
-        fi
+        "$WRANGLE_ROOT/lib/write_scan_manifest.sh" zizmor "$SARIF"

--- a/tools/zizmor/action.yml
+++ b/tools/zizmor/action.yml
@@ -64,3 +64,18 @@ runs:
         if [[ -f "$SARIF" ]]; then
           "$WRANGLE_ROOT/lib/sarif_to_md.sh" "$SARIF" > "$MD"
         fi
+
+    # Leave the scan/v1 manifest the trusted verify job's wrangle-attest engine
+    # wraps + signs. write_scan_manifest.sh skips when collect_sarif.sh wrote an
+    # error marker, so a failed audit is never attested.
+    - name: Write scan manifest
+      if: always()
+      shell: bash
+      env:
+        WRANGLE_ROOT: ${{ github.action_path }}/../..
+      run: |
+        set -euo pipefail
+        SARIF="${GITHUB_WORKSPACE}/.wrangle/metadata/zizmor/output.sarif"
+        if [[ -f "$SARIF" ]]; then
+          "$WRANGLE_ROOT/lib/write_scan_manifest.sh" zizmor "$SARIF"
+        fi

--- a/tools/zizmor/test.bats
+++ b/tools/zizmor/test.bats
@@ -116,6 +116,17 @@ make_sarif() {
     ! grep -E 'run:.*\$\{\{ *steps\.zizmor' "$TOOL_DIR/action.yml"
 }
 
+@test "zizmor: action.yml writes the scan/v1 manifest, gated and via env" {
+    # The manifest step must exist, gate on the SARIF via hashFiles (so it's
+    # skipped when the tool didn't run), thread the SARIF path through env:
+    # (no ${{ }} in run:), and call write_scan_manifest.sh with the zizmor token.
+    grep -q "hashFiles('.wrangle/metadata/zizmor/output.sarif') != ''" "$TOOL_DIR/action.yml"
+    grep -Eq 'write_scan_manifest\.sh" zizmor ' "$TOOL_DIR/action.yml"
+    run awk '/^    - name: Write scan manifest/{flag=1;next} flag && /^    - name:/{flag=0} flag' "$TOOL_DIR/action.yml"
+    [ "$status" -eq 0 ]
+    ! printf '%s\n' "$output" | grep -q 'run:.*\${{'
+}
+
 @test "zizmor: collect_sarif.sh exists and is executable" {
     [ -x "$TOOL_DIR/collect_sarif.sh" ]
 }


### PR DESCRIPTION
## Phase 2 — scan attestations for the remaining SARIF tools

Stacks on #475 (the generic scan/v1 mechanism: `lib/write_scan_manifest.sh` + the wrangle-attest engine's scan/v1 case + the verify job that walks manifests and signs them). Adding a SARIF tool is one manifest-producing line/step.

### Tools wired (each emits a `scan/v1` thin-envelope manifest → engine wraps as `{tool, scannedCommit, result, sarif}` → bnd-signed in the trusted verify job)

- **wrangle-lint** — adapter; one `case` line in `run.sh` (same path as osv). Manifest at `<tool>/manifest.json`, driver name `wrangle-lint`.
- **zizmor** — action-pattern (runs always); leaves the manifest from its `action.yml` after `collect_sarif.sh`. `write_scan_manifest.sh` now skips on a sibling `error` marker, so a failed audit is never attested.
- **dependency-review** — action-pattern, **PR-only**; leaves the manifest from its `action.yml` after `mark_error.sh`. Off-PR the whole action is skipped, so no manifest is written for a tool that did not run; on a tool error the marker makes the lib skip.

Both action-pattern steps gate on a step-level `hashFiles()` SARIF-presence condition (the same gate the SARIF-upload steps use) so each manifest step is a single script call — `dependency-review`'s "no inline conditionals" test stays green.

### scorecard — NOT wired (option (a) requires a second invocation; stopped per instructions)

scorecard is `:info`, non-PR-only, and its strict tenet `wrangle-scorecard-min-score` (#328-tracked wiring) gates on the **aggregate score** `predicates[0].data.score` from the `https://scorecard.dev/result/v0.1` predicate. A SARIF findings file does **not** carry that score, so a generic scan/v1 SARIF attestation (option b) would lose it.

Option (a) — emit scorecard's score-bearing JSON and attest it as a passthrough `https://scorecard.dev/result/v0.1` manifest (the engine already supports this predicate) — is preferred, **but** the upstream `ossf/scorecard-action` takes a single `results_format` (`sarif` **or** `json`) and a single `results_file`: getting both requires a **second full scorecard invocation**. That's the documented STOP condition, so scorecard is left unwired pending an owner decision: (a) add a second scorecard run emitting JSON for the passthrough attestation, or (b) accept the scan/v1 SARIF envelope (records "scorecard ran + findings" but not the score).

### Tenet wiring

`verifiedLevels` / tenet wiring (e.g. requiring these attestations) is **#328**, unchanged here — this is the producer side.

### Tests

`./test.sh quick` green (actionlint, shellcheck, wrangle-shell-lint, wrangle-workflow-lint, go test, bats — incl. `check_pin_ancestry`); `./test.sh lint` + `./test.sh zizmor` clean. New coverage: orchestrator wrangle-lint manifest, `write_scan_manifest` error-marker skip. Bootstrap pins re-pointed to HEAD so the dispatch e2e exercises the new tool actions.

Part of #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)