### PR TITLE
feat: attest_provenance composite — DRY the provenance attest job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     # A new composite needs an entry here (a divergence test backstops a miss).
     directories:
       - "/"
+      - "/actions/attest_provenance"
       - "/actions/package_metadata"
       - "/actions/preflight_guard"
       - "/actions/release_gate"

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -120,7 +120,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -153,7 +153,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -184,7 +184,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/build/actions/container@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -284,7 +284,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         with:
           build-type: container
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -395,38 +395,18 @@ jobs:
       attestations: write   # write the attestation to GitHub's store
       contents: read        # download-artifact reads the same-run dist
     outputs:
-      bundle-artifact-name: ${{ needs.release.outputs.provenance-bundle-artifact-name }}
+      bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ needs.release.outputs.dist-artifact-name }}
-          path: dist/
-
       # Subjects come from dist/checksums.txt, not a dist/* glob: goreleaser
-      # writes non-artifact bookkeeping (artifacts.json/config.yaml/metadata.json)
-      # and per-target build subdirs into dist/, which are not released artifacts.
-      # This is the same canonical subject set the VSA binds to.
-      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      # writes non-artifact bookkeeping into dist/ that is not released. This is
+      # the same canonical subject set the VSA binds to.
+      # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
+      - uses: TomHennen/wrangle/actions/attest_provenance@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
         id: attest
         with:
+          build-type: go
+          shortname: ${{ needs.release.outputs.shortname }}
           subject-checksums: dist/checksums.txt
-
-      # Stage the signed provenance bundle as a workflow artifact for the verify
-      # job; jq -c normalizes it to one JSON object per line for ampel's jsonl:
-      # collector. One multi-subject bundle, covering every checksums entry.
-      - name: Stage the provenance bundle for the VSA
-        env:
-          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
-        run: |
-          set -euo pipefail
-          set -f
-          jq -c . "$BUNDLE_PATH" > "$RUNNER_TEMP/provenance.jsonl"
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ needs.release.outputs.provenance-bundle-artifact-name }}
-          path: ${{ runner.temp }}/provenance.jsonl
-          if-no-files-found: error
 
   # Emit one signed SLSA Verification Summary Attestation (VSA) per dist archive
   # and append it to the SLSA provenance, producing one per-artifact

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -171,7 +171,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -195,7 +195,7 @@ jobs:
 
       # Shared name derivation so the scan and release jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -203,7 +203,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -236,7 +236,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/checks@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -302,7 +302,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/release@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: release
         with:
           path: ${{ inputs.path }}
@@ -326,7 +326,7 @@ jobs:
           printf 'module=%s\n' "$(go -C "$INPUT_PATH" list -m | head -n1)" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: names
         with:
           build-type: go
@@ -400,7 +400,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: attest
         with:
           build-type: go
@@ -429,7 +429,7 @@ jobs:
       attestation-bundle-name: ${{ needs.release.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         with:
           build-type: go
           shortname: ${{ needs.release.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -289,7 +289,6 @@ jobs:
       dist-artifact-name: ${{ steps.names.outputs.dist }}
       metadata-artifact-name: ${{ steps.names.outputs.metadata }}
       metadata-pre-artifact-name: ${{ steps.names.outputs.metadata-pre }}
-      provenance-bundle-artifact-name: ${{ steps.names.outputs.provenance-bundle }}
       metadata-dir: ${{ steps.release.outputs.metadata-dir }}
       # JSON array of dist filenames the verify job binds one VSA to each.
       dist-files: ${{ steps.distfiles.outputs.files }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -139,7 +139,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
 
   gate:
     needs: [guard]
@@ -150,7 +150,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -174,7 +174,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -182,7 +182,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -221,7 +221,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/npm@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -230,7 +230,7 @@ jobs:
           ignore-scripts: ${{ inputs.ignore-scripts }}
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: names
         with:
           build-type: npm
@@ -302,7 +302,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: attest
         with:
           build-type: npm
@@ -328,7 +328,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         with:
           build-type: npm
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -211,7 +211,6 @@ jobs:
       dist-artifact-name: ${{ steps.names.outputs.dist }}
       metadata-artifact-name: ${{ steps.names.outputs.metadata }}
       metadata-pre-artifact-name: ${{ steps.names.outputs.metadata-pre }}
-      provenance-bundle-artifact-name: ${{ steps.names.outputs.provenance-bundle }}
       metadata-dir: ${{ steps.build.outputs.metadata-dir }}
       # JSON array of dist filenames the verify job binds one VSA to each.
       dist-files: ${{ steps.distfiles.outputs.files }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -300,34 +300,15 @@ jobs:
       attestations: write   # write the attestation to GitHub's store
       contents: read        # download-artifact reads the same-run dist
     outputs:
-      bundle-artifact-name: ${{ needs.build.outputs.provenance-bundle-artifact-name }}
+      bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ needs.build.outputs.dist-artifact-name }}
-          path: dist/
-
-      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
+      - uses: TomHennen/wrangle/actions/attest_provenance@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
         id: attest
         with:
+          build-type: npm
+          shortname: ${{ needs.build.outputs.shortname }}
           subject-path: dist/*
-
-      # Stage the signed provenance bundle as a workflow artifact for the verify
-      # job; jq -c normalizes it to one JSON object per line for ampel's jsonl:
-      # collector.
-      - name: Stage the provenance bundle for the VSA
-        env:
-          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
-        run: |
-          set -euo pipefail
-          set -f
-          jq -c . "$BUNDLE_PATH" > "$RUNNER_TEMP/provenance.jsonl"
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ needs.build.outputs.provenance-bundle-artifact-name }}
-          path: ${{ runner.temp }}/provenance.jsonl
-          if-no-files-found: error
 
   # Emit one signed SLSA Verification Summary Attestation (VSA) per dist artifact
   # and append it to the SLSA provenance, producing one per-artifact

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -293,34 +293,15 @@ jobs:
       attestations: write   # write the attestation to GitHub's store
       contents: read        # download-artifact reads the same-run dist
     outputs:
-      bundle-artifact-name: ${{ needs.build.outputs.provenance-bundle-artifact-name }}
+      bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ needs.build.outputs.dist-artifact-name }}
-          path: dist/
-
-      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
+      - uses: TomHennen/wrangle/actions/attest_provenance@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
         id: attest
         with:
+          build-type: python
+          shortname: ${{ needs.build.outputs.shortname }}
           subject-path: dist/*
-
-      # Stage the signed provenance bundle as a workflow artifact for the verify
-      # job; jq -c normalizes it to one JSON object per line for ampel's jsonl:
-      # collector.
-      - name: Stage the provenance bundle for the VSA
-        env:
-          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
-        run: |
-          set -euo pipefail
-          set -f
-          jq -c . "$BUNDLE_PATH" > "$RUNNER_TEMP/provenance.jsonl"
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ needs.build.outputs.provenance-bundle-artifact-name }}
-          path: ${{ runner.temp }}/provenance.jsonl
-          if-no-files-found: error
 
   # Emit one signed SLSA Verification Summary Attestation (VSA) per dist artifact
   # and append it to the SLSA provenance, producing one per-artifact

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -192,7 +192,6 @@ jobs:
       dist-artifact-name: ${{ steps.names.outputs.dist }}
       metadata-artifact-name: ${{ steps.names.outputs.metadata }}
       metadata-pre-artifact-name: ${{ steps.names.outputs.metadata-pre }}
-      provenance-bundle-artifact-name: ${{ steps.names.outputs.provenance-bundle }}
       metadata-dir: ${{ steps.build.outputs.metadata-dir }}
       # JSON array of dist filenames the verify job binds one VSA to each.
       dist-files: ${{ steps.distfiles.outputs.files }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -116,7 +116,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -131,7 +131,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -155,7 +155,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -202,7 +202,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/python@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: build
         with:
           path: ${{ inputs.path }}
@@ -231,7 +231,7 @@ jobs:
           printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: names
         with:
           build-type: python
@@ -295,7 +295,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@720c44bcd275740f0c232f4d64dc0eec7c05f7a2 # feat/469-unify-metadata-artifact 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         id: attest
         with:
           build-type: python
@@ -321,7 +321,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         with:
           build-type: python
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+        uses: TomHennen/wrangle/build/actions/shell@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
 
   check-change:
     needs: [guard]
@@ -51,7 +51,7 @@ jobs:
       # (root path), so the shortname is empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+        uses: TomHennen/wrangle/actions/scan@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
         with:
           tools: ${{ inputs.tools }}
           artifact-name: scan

--- a/actions/attest_provenance/action.yml
+++ b/actions/attest_provenance/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: ""
   subject-checksums:
-    description: "Checksums file whose entries are the provenance subjects (go). Mutually exclusive with subject-path."
+    description: "Path to a standard sha256sum-format checksums file (one '<sha256>  <filename>' line per artifact) whose entries are the provenance subjects. Not go-specific (go passes goreleaser's dist/checksums.txt). Mutually exclusive with subject-path."
     required: false
     default: ""
   subject-path:

--- a/actions/attest_provenance/action.yml
+++ b/actions/attest_provenance/action.yml
@@ -1,0 +1,87 @@
+name: Wrangle Attest Provenance
+description: >
+  Own the attest-job wiring the go/npm/python reusable build workflows shared:
+  download the build's dist, generate SLSA L3 build provenance via GitHub's
+  attestation API, stage the signed bundle as one-JSON-per-line jsonl, and
+  upload it as the provenance-bundle workflow artifact the verify job reads.
+  The dist and provenance-bundle artifact names are computed here from
+  build-type + shortname (lib/shortname.sh via the action_path), so callers
+  don't pass them.
+
+  Pass exactly one subject: subject-checksums (go: dist/checksums.txt, the
+  canonical subject set the VSA binds to) or subject-path (npm/python:
+  dist/*). Container is its own OCI variant and does not use this composite.
+
+inputs:
+  build-type:
+    description: "Build type (go, npm, python) — namespaces the computed artifact names."
+    required: true
+  shortname:
+    description: "The build composite's path-derived shortname (empty at the repo root)."
+    required: false
+    default: ""
+  subject-checksums:
+    description: "Checksums file whose entries are the provenance subjects (go). Mutually exclusive with subject-path."
+    required: false
+    default: ""
+  subject-path:
+    description: "Glob of files to attest as provenance subjects (npm/python). Mutually exclusive with subject-checksums."
+    required: false
+    default: ""
+
+outputs:
+  bundle-artifact-name:
+    description: "Name of the provenance-bundle workflow artifact the verify job downloads."
+    value: ${{ steps.names.outputs.provenance-bundle }}
+
+runs:
+  using: composite
+  steps:
+    - id: validate
+      shell: bash
+      env:
+        SUBJECT_CHECKSUMS: ${{ inputs.subject-checksums }}
+        SUBJECT_PATH: ${{ inputs.subject-path }}
+      run: |
+        set -euo pipefail
+        set -f
+        if [[ -n "$SUBJECT_CHECKSUMS" && -n "$SUBJECT_PATH" ]] || [[ -z "$SUBJECT_CHECKSUMS" && -z "$SUBJECT_PATH" ]]; then
+            printf 'attest_provenance: pass exactly one of subject-checksums or subject-path\n' >&2
+            exit 1
+        fi
+
+    - id: names
+      shell: bash
+      env:
+        BUILD_TYPE: ${{ inputs.build-type }}
+        SHORTNAME: ${{ inputs.shortname }}
+      run: '"${{ github.action_path }}/../package_metadata/derive_names.sh" "$BUILD_TYPE" "$SHORTNAME"'
+
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ${{ steps.names.outputs.dist }}
+        path: dist/
+
+    - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      id: attest
+      with:
+        subject-checksums: ${{ inputs.subject-checksums }}
+        subject-path: ${{ inputs.subject-path }}
+
+    # Stage the signed provenance bundle as a workflow artifact for the verify
+    # job; jq -c normalizes it to one JSON object per line for ampel's jsonl:
+    # collector.
+    - name: Stage the provenance bundle for the VSA
+      shell: bash
+      env:
+        BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+      run: |
+        set -euo pipefail
+        set -f
+        jq -c . "$BUNDLE_PATH" > "$RUNNER_TEMP/provenance.jsonl"
+
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ steps.names.outputs.provenance-bundle }}
+        path: ${{ runner.temp }}/provenance.jsonl
+        if-no-files-found: error

--- a/actions/attest_provenance/action.yml
+++ b/actions/attest_provenance/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: ""
   subject-checksums:
-    description: "Path to a standard sha256sum-format checksums file (one '<sha256>  <filename>' line per artifact) whose entries are the provenance subjects. Not go-specific (go passes goreleaser's dist/checksums.txt). Mutually exclusive with subject-path."
+    description: "Path to a standard sha256sum-format checksums file (one '<sha256>  <filename>' line per artifact) whose entries are the provenance subjects; go passes goreleaser's dist/checksums.txt. Mutually exclusive with subject-path."
     required: false
     default: ""
   subject-path:

--- a/actions/attest_provenance/test.bats
+++ b/actions/attest_provenance/test.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+# Tests for actions/attest_provenance/action.yml — the composite that owns the
+# attest-job wiring the go/npm/python reusable build workflows shared.
+# Structural assertions: the names computation, the dist download, the
+# attest-build-provenance call, the jsonl staging, and the bundle upload.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    ACTION="$REPO_ROOT/actions/attest_provenance/action.yml"
+}
+
+@test "attest_provenance: computes names via package_metadata's derive_names.sh" {
+    run grep -F 'package_metadata/derive_names.sh' "$ACTION"
+    [ "$status" -eq 0 ]
+}
+
+@test "attest_provenance: downloads dist and attests via attest-build-provenance" {
+    run grep -F 'name: ${{ steps.names.outputs.dist }}' "$ACTION"
+    [ "$status" -eq 0 ]
+    run grep -F 'actions/attest-build-provenance@' "$ACTION"
+    [ "$status" -eq 0 ]
+}
+
+@test "attest_provenance: threads both subject inputs to attest-build-provenance" {
+    # go passes subject-checksums, npm/python pass subject-path; the unused one
+    # is empty and ignored by the upstream action.
+    run grep -F 'subject-checksums: ${{ inputs.subject-checksums }}' "$ACTION"
+    [ "$status" -eq 0 ]
+    run grep -F 'subject-path: ${{ inputs.subject-path }}' "$ACTION"
+    [ "$status" -eq 0 ]
+}
+
+@test "attest_provenance: rejects zero or both subjects" {
+    bash -c '
+        set -euo pipefail
+        SUBJECT_CHECKSUMS="a"; SUBJECT_PATH="b"
+        if [[ -n "$SUBJECT_CHECKSUMS" && -n "$SUBJECT_PATH" ]] || [[ -z "$SUBJECT_CHECKSUMS" && -z "$SUBJECT_PATH" ]]; then exit 1; fi
+    ' && status=0 || status=$?
+    [ "$status" -eq 1 ]
+    bash -c '
+        set -euo pipefail
+        SUBJECT_CHECKSUMS=""; SUBJECT_PATH=""
+        if [[ -n "$SUBJECT_CHECKSUMS" && -n "$SUBJECT_PATH" ]] || [[ -z "$SUBJECT_CHECKSUMS" && -z "$SUBJECT_PATH" ]]; then exit 1; fi
+    ' && status=0 || status=$?
+    [ "$status" -eq 1 ]
+    bash -c '
+        set -euo pipefail
+        SUBJECT_CHECKSUMS="a"; SUBJECT_PATH=""
+        if [[ -n "$SUBJECT_CHECKSUMS" && -n "$SUBJECT_PATH" ]] || [[ -z "$SUBJECT_CHECKSUMS" && -z "$SUBJECT_PATH" ]]; then exit 1; fi
+    ' && status=0 || status=$?
+    [ "$status" -eq 0 ]
+}
+
+@test "attest_provenance: stages jsonl and uploads the provenance-bundle artifact" {
+    run grep -F 'jq -c . "$BUNDLE_PATH" > "$RUNNER_TEMP/provenance.jsonl"' "$ACTION"
+    [ "$status" -eq 0 ]
+    run grep -F 'name: ${{ steps.names.outputs.provenance-bundle }}' "$ACTION"
+    [ "$status" -eq 0 ]
+}
+
+@test "attest_provenance: outputs the provenance-bundle artifact name" {
+    run grep -F 'value: ${{ steps.names.outputs.provenance-bundle }}' "$ACTION"
+    [ "$status" -eq 0 ]
+}

--- a/actions/attest_provenance/test.bats
+++ b/actions/attest_provenance/test.bats
@@ -50,6 +50,12 @@ setup() {
         if [[ -n "$SUBJECT_CHECKSUMS" && -n "$SUBJECT_PATH" ]] || [[ -z "$SUBJECT_CHECKSUMS" && -z "$SUBJECT_PATH" ]]; then exit 1; fi
     ' && status=0 || status=$?
     [ "$status" -eq 0 ]
+    bash -c '
+        set -euo pipefail
+        SUBJECT_CHECKSUMS=""; SUBJECT_PATH="b"
+        if [[ -n "$SUBJECT_CHECKSUMS" && -n "$SUBJECT_PATH" ]] || [[ -z "$SUBJECT_CHECKSUMS" && -z "$SUBJECT_PATH" ]]; then exit 1; fi
+    ' && status=0 || status=$?
+    [ "$status" -eq 0 ]
 }
 
 @test "attest_provenance: stages jsonl and uploads the provenance-bundle artifact" {

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -99,7 +99,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/tools/zizmor@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/tools/scorecard@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+      uses: TomHennen/wrangle/tools/dependency-review@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -78,7 +78,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@e5936f0dfb78c4899c84bac8ad4d3922112d669e # feat/wrangle-attest-sbom-on-469 2026-06-19
+    - uses: TomHennen/wrangle/actions/verify@2a1ef9006c71461d61e0f1be8561d7fb875e3cc5 # feat/attest-provenance-composite-on-469 2026-06-19
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/go/test.bats
+++ b/build/actions/go/test.bats
@@ -1339,10 +1339,10 @@ func TestFails(t *testing.T) {
 
 # --- attest-build-provenance (wrangle builder identity, #316) ---
 
-@test "go: workflow has attest job producing GitHub attest-build-provenance" {
-    run grep -E '^  attest:' "$WORKFLOW"
+@test "go: attest job delegates to attest_provenance with go checksums subject" {
+    run bash -c "sed -n '/^  attest:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -F 'TomHennen/wrangle/actions/attest_provenance@'"
     [[ "$status" -eq 0 ]]
-    run grep 'actions/attest-build-provenance@' "$WORKFLOW"
+    run bash -c "sed -n '/^  attest:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -F 'subject-checksums: dist/checksums.txt'"
     [[ "$status" -eq 0 ]]
 }
 
@@ -1379,10 +1379,10 @@ func TestFails(t *testing.T) {
     [[ "$status" -eq 0 ]]
 }
 
-@test "go: attest job uploads the provenance bundle the verify job needs" {
-    # The verify job depends on attest and reads its uploaded bundle artifact.
-    # The bundle name is the release job's lib-derived provenance-bundle output.
-    run bash -c "sed -n '/^  attest:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E 'name: \\\$\\{\\{ needs.release.outputs.provenance-bundle-artifact-name \\}\\}'"
+@test "go: attest job exposes the bundle name the verify job needs" {
+    # attest_provenance uploads the bundle; the job re-exports its name and the
+    # verify job depends on attest.
+    run bash -c "sed -n '/^  attest:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -F 'bundle-artifact-name: \${{ steps.attest.outputs.bundle-artifact-name }}'"
     [[ "$status" -eq 0 ]]
     run bash -c "sed -n '/^  verify:/,\$p' \"$WORKFLOW\" | grep -E 'needs:.*attest'"
     [[ "$status" -eq 0 ]]

--- a/build/actions/npm/test.bats
+++ b/build/actions/npm/test.bats
@@ -892,10 +892,10 @@ write_pkg_json() {
 
 # --- attest-build-provenance (wrangle builder identity, #316) ---
 
-@test "npm: workflow has attest job producing GitHub attest-build-provenance" {
-    run grep -E '^  attest:' "$WORKFLOW"
+@test "npm: attest job delegates to attest_provenance with dist/* subject" {
+    run bash -c "sed -n '/^  attest:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -F 'TomHennen/wrangle/actions/attest_provenance@'"
     [[ "$status" -eq 0 ]]
-    run grep 'actions/attest-build-provenance@' "$WORKFLOW"
+    run bash -c "sed -n '/^  attest:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -F 'subject-path: dist/*'"
     [[ "$status" -eq 0 ]]
 }
 
@@ -932,11 +932,10 @@ write_pkg_json() {
     [[ "$status" -eq 0 ]]
 }
 
-@test "npm: attest job uploads the provenance bundle the verify job needs" {
-    # The verify job depends on attest and reads its uploaded bundle artifact.
-    # The name is the build job's provenance-bundle output (suffix-less at
-    # root, not a trailing-dash npm-provenance-bundle- — #469).
-    run bash -c "sed -n '/^  attest:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -F 'name: \${{ needs.build.outputs.provenance-bundle-artifact-name }}'"
+@test "npm: attest job exposes the bundle name the verify job needs" {
+    # attest_provenance uploads the bundle; the job re-exports its name and the
+    # verify job depends on attest.
+    run bash -c "sed -n '/^  attest:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -F 'bundle-artifact-name: \${{ steps.attest.outputs.bundle-artifact-name }}'"
     [[ "$status" -eq 0 ]]
     run bash -c "sed -n '/^  verify:/,\$p' \"$WORKFLOW\" | grep -E 'needs:.*attest'"
     [[ "$status" -eq 0 ]]

--- a/build/actions/python/test.bats
+++ b/build/actions/python/test.bats
@@ -651,10 +651,10 @@ write_pyproject() {
 
 # --- attest-build-provenance (wrangle builder identity, #316) ---
 
-@test "python: workflow has attest job producing GitHub attest-build-provenance" {
-    run grep -E '^  attest:' "$WORKFLOW"
+@test "python: attest job delegates to attest_provenance with dist/* subject" {
+    run bash -c "sed -n '/^  attest:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -F 'TomHennen/wrangle/actions/attest_provenance@'"
     [[ "$status" -eq 0 ]]
-    run grep 'actions/attest-build-provenance@' "$WORKFLOW"
+    run bash -c "sed -n '/^  attest:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -F 'subject-path: dist/*'"
     [[ "$status" -eq 0 ]]
 }
 
@@ -691,11 +691,10 @@ write_pyproject() {
     [[ "$status" -eq 0 ]]
 }
 
-@test "python: attest job uploads the provenance bundle the verify job needs" {
-    # The verify job depends on attest and reads its uploaded bundle artifact.
-    # The name is the build job's provenance-bundle output (suffix-less at
-    # root, not a trailing-dash python-provenance-bundle- — #469).
-    run bash -c "sed -n '/^  attest:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -F 'name: \${{ needs.build.outputs.provenance-bundle-artifact-name }}'"
+@test "python: attest job exposes the bundle name the verify job needs" {
+    # attest_provenance uploads the bundle; the job re-exports its name and the
+    # verify job depends on attest.
+    run bash -c "sed -n '/^  attest:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -F 'bundle-artifact-name: \${{ steps.attest.outputs.bundle-artifact-name }}'"
     [[ "$status" -eq 0 ]]
     run bash -c "sed -n '/^  verify:/,\$p' \"$WORKFLOW\" | grep -E 'needs:.*attest'"
     [[ "$status" -eq 0 ]]


### PR DESCRIPTION
Consolidates the triplicated go/npm/python `attest` job into one composite,
`actions/attest_provenance`. Each `attest` job is now a thin call to the
composite; the download → attest-build-provenance → jsonl-stage → upload
sequence lives in one place.

## What the composite owns
- Downloads the build's `dist/` artifact, runs `actions/attest-build-provenance`,
  stages the signed bundle as one-JSON-per-line `provenance.jsonl`, and uploads
  it as the provenance-bundle workflow artifact the verify job reads.
- Computes the `dist` and `provenance-bundle` artifact names internally via the
  `package_metadata` composite's `derive_names.sh` (sourced through
  `${{ github.action_path }}`, same pattern `verify_release` uses) — callers
  pass `build-type` + `shortname`, not names.
- Outputs `bundle-artifact-name`; each `attest` job re-exports it, preserving the
  workflows' `provenance-artifact-name` output wiring.

## Subject difference
The one real difference between build types is the provenance subject: go uses
`subject-checksums: dist/checksums.txt` (goreleaser writes non-artifact
bookkeeping into `dist/`, so the checksums file is the canonical subject set),
npm/python use `subject-path: dist/*`. The composite takes both as optional
inputs, validates exactly one is set, and threads both to
`attest-build-provenance` (the unused one is empty and ignored upstream).

## Out of scope
- **Container** stays inline: its attest job is a genuinely different 2-step OCI
  shape (ghcr login + `subject-name`), not the file sequence the three share.
- The go `release`-job staging and all other jobs are untouched — only the
  go/npm/python `attest` jobs changed (each keeps its `permissions`, `needs`,
  `if`, and `bundle-artifact-name` output).

Stacked on #472 (`feat/469-unify-metadata-artifact`). Part of #420.