### PR TITLE
chore: bump self-ref pins to main post-#476

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
 
   gate:
     needs: [guard]
@@ -120,7 +120,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -153,7 +153,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -184,7 +184,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      uses: TomHennen/wrangle/build/actions/container@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -284,7 +284,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         with:
           build-type: container
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
 
   gate:
     needs: [guard]
@@ -171,7 +171,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -195,7 +195,7 @@ jobs:
 
       # Shared name derivation so the scan and release jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -203,7 +203,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -236,7 +236,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/checks@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -302,7 +302,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/go/release@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: release
         with:
           path: ${{ inputs.path }}
@@ -326,7 +326,7 @@ jobs:
           printf 'module=%s\n' "$(go -C "$INPUT_PATH" list -m | head -n1)" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: names
         with:
           build-type: go
@@ -400,7 +400,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: attest
         with:
           build-type: go
@@ -429,7 +429,7 @@ jobs:
       attestation-bundle-name: ${{ needs.release.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         with:
           build-type: go
           shortname: ${{ needs.release.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -139,7 +139,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
 
   gate:
     needs: [guard]
@@ -150,7 +150,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -174,7 +174,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -182,7 +182,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -221,7 +221,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/npm@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: build
         with:
           path: ${{ inputs.path }}
@@ -230,7 +230,7 @@ jobs:
           ignore-scripts: ${{ inputs.ignore-scripts }}
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: names
         with:
           build-type: npm
@@ -302,7 +302,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: attest
         with:
           build-type: npm
@@ -328,7 +328,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         with:
           build-type: npm
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -116,7 +116,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -131,7 +131,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/release_gate@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -155,7 +155,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -202,7 +202,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/build/actions/python@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: build
         with:
           path: ${{ inputs.path }}
@@ -231,7 +231,7 @@ jobs:
           printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: names
         with:
           build-type: python
@@ -295,7 +295,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/attest_provenance@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         id: attest
         with:
           build-type: python
@@ -321,7 +321,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/verify_release@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         with:
           build-type: python
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/scan@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+        uses: TomHennen/wrangle/build/actions/shell@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
 
   check-change:
     needs: [guard]
@@ -51,7 +51,7 @@ jobs:
       # (root path), so the shortname is empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+        uses: TomHennen/wrangle/actions/scan@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         with:
           tools: ${{ inputs.tools }}
           artifact-name: scan

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -99,7 +99,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      uses: TomHennen/wrangle/tools/zizmor@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      uses: TomHennen/wrangle/tools/scorecard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+      uses: TomHennen/wrangle/tools/dependency-review@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -78,7 +78,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@86a4848607f685cd129890ae73b07df101a1be9b # feat/phase2-scan-attest-420 2026-06-19
+    - uses: TomHennen/wrangle/actions/verify@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}


### PR DESCRIPTION
Post-merge pin bump completing #476 (Phase-2 scan attestations, squash-merged to `main` at `6ddb817`).

The squash orphaned #476's pre-merge branch SHA, leaving the workflows' `TomHennen/wrangle/actions/*` self-ref bootstrap pins unreachable from `main`. This repoints all of them to `main` HEAD (`6ddb817`) via `tools/bump_action_pins.sh`, restoring `check_pin_ancestry`.

Same lifecycle as #490 (after #475) and #488 (after #478).

- 8 files bumped (build/publish workflows, `check_source_change`, `actions/scan`, `actions/verify_release`)
- `tools/check_pin_ancestry.sh` passes; `./test.sh quick` green (1133/1133); actionlint clean