### PR TITLE
Rationalize GitHub-release assets: flat dist + bundle verify-pair + metadata zip

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
 
   gate:
     needs: [guard]
@@ -120,7 +120,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/release_gate@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -153,7 +153,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -184,7 +184,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      uses: TomHennen/wrangle/build/actions/container@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -284,7 +284,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         with:
           build-type: container
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
 
   gate:
     needs: [guard]
@@ -120,7 +120,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/release_gate@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -153,7 +153,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -184,7 +184,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      uses: TomHennen/wrangle/build/actions/container@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -284,7 +284,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         with:
           build-type: container
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
 
   gate:
     needs: [guard]
@@ -120,7 +120,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/release_gate@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -145,7 +145,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -153,7 +153,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -184,7 +184,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      uses: TomHennen/wrangle/build/actions/container@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -284,7 +284,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         with:
           build-type: container
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
 
   gate:
     needs: [guard]
@@ -171,7 +171,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/release_gate@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -195,7 +195,7 @@ jobs:
 
       # Shared name derivation so the scan and release jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -203,7 +203,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -236,7 +236,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/go/checks@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -302,7 +302,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/go/release@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: release
         with:
           path: ${{ inputs.path }}
@@ -326,7 +326,7 @@ jobs:
           printf 'module=%s\n' "$(go -C "$INPUT_PATH" list -m | head -n1)" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: names
         with:
           build-type: go
@@ -400,7 +400,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: attest
         with:
           build-type: go
@@ -429,7 +429,7 @@ jobs:
       attestation-bundle-name: ${{ needs.release.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         with:
           build-type: go
           shortname: ${{ needs.release.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
 
   gate:
     needs: [guard]
@@ -171,7 +171,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/release_gate@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -195,7 +195,7 @@ jobs:
 
       # Shared name derivation so the scan and release jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -203,7 +203,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -236,7 +236,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/go/checks@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -302,7 +302,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/go/release@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: release
         with:
           path: ${{ inputs.path }}
@@ -326,7 +326,7 @@ jobs:
           printf 'module=%s\n' "$(go -C "$INPUT_PATH" list -m | head -n1)" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: names
         with:
           build-type: go
@@ -400,7 +400,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: attest
         with:
           build-type: go
@@ -429,7 +429,7 @@ jobs:
       attestation-bundle-name: ${{ needs.release.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         with:
           build-type: go
           shortname: ${{ needs.release.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
 
   gate:
     needs: [guard]
@@ -171,7 +171,7 @@ jobs:
       should-release: ${{ steps.gate.outputs.should-release }}
     steps:
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/release_gate@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -195,7 +195,7 @@ jobs:
 
       # Shared name derivation so the scan and release jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -203,7 +203,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -236,7 +236,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/go/checks@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -302,7 +302,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/go/release@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: release
         with:
           path: ${{ inputs.path }}
@@ -326,7 +326,7 @@ jobs:
           printf 'module=%s\n' "$(go -C "$INPUT_PATH" list -m | head -n1)" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: names
         with:
           build-type: go
@@ -400,7 +400,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: attest
         with:
           build-type: go
@@ -429,7 +429,7 @@ jobs:
       attestation-bundle-name: ${{ needs.release.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         with:
           build-type: go
           shortname: ${{ needs.release.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -139,7 +139,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
 
   gate:
     needs: [guard]
@@ -150,7 +150,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/release_gate@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -174,7 +174,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -182,7 +182,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -221,7 +221,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/npm@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: build
         with:
           path: ${{ inputs.path }}
@@ -230,7 +230,7 @@ jobs:
           ignore-scripts: ${{ inputs.ignore-scripts }}
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: names
         with:
           build-type: npm
@@ -302,7 +302,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: attest
         with:
           build-type: npm
@@ -328,7 +328,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         with:
           build-type: npm
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -139,7 +139,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
 
   gate:
     needs: [guard]
@@ -150,7 +150,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/release_gate@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -174,7 +174,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -182,7 +182,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -221,7 +221,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/npm@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: build
         with:
           path: ${{ inputs.path }}
@@ -230,7 +230,7 @@ jobs:
           ignore-scripts: ${{ inputs.ignore-scripts }}
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: names
         with:
           build-type: npm
@@ -302,7 +302,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: attest
         with:
           build-type: npm
@@ -328,7 +328,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         with:
           build-type: npm
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -139,7 +139,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
 
   gate:
     needs: [guard]
@@ -150,7 +150,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/release_gate@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -174,7 +174,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -182,7 +182,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -221,7 +221,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/npm@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: build
         with:
           path: ${{ inputs.path }}
@@ -230,7 +230,7 @@ jobs:
           ignore-scripts: ${{ inputs.ignore-scripts }}
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: names
         with:
           build-type: npm
@@ -302,7 +302,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: attest
         with:
           build-type: npm
@@ -328,7 +328,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         with:
           build-type: npm
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -116,7 +116,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -131,7 +131,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/release_gate@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -155,7 +155,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -202,7 +202,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/python@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: build
         with:
           path: ${{ inputs.path }}
@@ -231,7 +231,7 @@ jobs:
           printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: names
         with:
           build-type: python
@@ -295,7 +295,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         id: attest
         with:
           build-type: python
@@ -321,7 +321,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         with:
           build-type: python
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -116,7 +116,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -131,7 +131,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/release_gate@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -155,7 +155,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -202,7 +202,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/python@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: build
         with:
           path: ${{ inputs.path }}
@@ -231,7 +231,7 @@ jobs:
           printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: names
         with:
           build-type: python
@@ -295,7 +295,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         id: attest
         with:
           build-type: python
@@ -321,7 +321,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         with:
           build-type: python
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -116,7 +116,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
 
   # Decide whether release-time actions (provenance, publish) should run
   # for this event. Cheap separate job so the result is available to
@@ -131,7 +131,7 @@ jobs:
     steps:
       # No checkout: release_gate resolves via ${{ github.action_path }}.
       # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/release_gate@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: gate
         with:
           events: ${{ inputs.release-events }}
@@ -155,7 +155,7 @@ jobs:
 
       # Shared name derivation so the scan and build jobs can't drift.
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: names
         if: ${{ inputs.scan-tools != '' }}
         with:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -202,7 +202,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/python@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: build
         with:
           path: ${{ inputs.path }}
@@ -231,7 +231,7 @@ jobs:
           printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
 
       # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/package_metadata@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: names
         with:
           build-type: python
@@ -295,7 +295,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         id: attest
         with:
           build-type: python
@@ -321,7 +321,7 @@ jobs:
       attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         with:
           build-type: python
           shortname: ${{ needs.build.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+        uses: TomHennen/wrangle/build/actions/shell@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+        uses: TomHennen/wrangle/build/actions/shell@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -67,7 +67,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -88,7 +88,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -121,7 +121,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+        uses: TomHennen/wrangle/build/actions/shell@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
 
   check-change:
     needs: [guard]
@@ -51,7 +51,7 @@ jobs:
       # (root path), so the shortname is empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+        uses: TomHennen/wrangle/actions/scan@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
         with:
           tools: ${{ inputs.tools }}
           artifact-name: scan

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
 
   check-change:
     needs: [guard]
@@ -51,7 +51,7 @@ jobs:
       # (root path), so the shortname is empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+        uses: TomHennen/wrangle/actions/scan@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
         with:
           tools: ${{ inputs.tools }}
           artifact-name: scan

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -30,7 +30,7 @@ jobs:
     permissions: {}    # reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/preflight_guard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
 
   check-change:
     needs: [guard]
@@ -51,7 +51,7 @@ jobs:
       # (root path), so the shortname is empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+        uses: TomHennen/wrangle/actions/scan@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
         with:
           tools: ${{ inputs.tools }}
           artifact-name: scan

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Each build produces two workflow artifacts (zipfiles):
 
 The reusable workflow exposes both names as the `dist-artifact-name` and `metadata-artifact-name` outputs so you don't have to hardcode them. For the full file layout — and which `scan/` subdirs appear on a given event — see [docs/metadata_layout.md](docs/metadata_layout.md).
 
+On a **tag push with a GitHub Release**, wrangle also attaches each dist `<artifact>` and its `<artifact>.intoto.jsonl` bundle (a flat verify-pair) plus one `<type>-metadata-<sn>.zip` holding the SBOM + scan results. Go's dist + `checksums.txt` come from goreleaser. See [docs/verifying_artifacts.md](docs/verifying_artifacts.md); suppress with the verify action's `attach-release-assets: false`.
+
 To find them in the UI: click **Actions** → your wrangle workflow → the run → scroll to **Artifacts**. The URL looks like `https://github.com/<owner>/<repo>/actions/runs/<id>#artifacts`. For a live example, see a run in the [wrangle-test companion repo](https://github.com/TomHennen/wrangle-test/actions). Per-ecosystem details are in the [ecosystem READMEs](#ecosystems) above.
 
 ## How Wrangle Works

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -99,7 +99,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      uses: TomHennen/wrangle/tools/zizmor@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      uses: TomHennen/wrangle/tools/scorecard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+      uses: TomHennen/wrangle/tools/dependency-review@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -99,7 +99,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      uses: TomHennen/wrangle/tools/zizmor@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      uses: TomHennen/wrangle/tools/scorecard@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+      uses: TomHennen/wrangle/tools/dependency-review@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -99,7 +99,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      uses: TomHennen/wrangle/tools/zizmor@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      uses: TomHennen/wrangle/tools/scorecard@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+      uses: TomHennen/wrangle/tools/dependency-review@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
 
     - name: Generate step summary
       if: always()

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -75,9 +75,21 @@ inputs:
     required: false
     default: "true"
   attach-to-release:
-    description: 'When "true" (default) and the run is a tag push, attach the bundle to the release.'
+    description: 'When "true" (default) and the run is a tag push, attach the rationalized asset set to the release.'
     required: false
     default: "true"
+  attach-release-assets:
+    description: 'When "true" (default) attach the per-subject dist + bundle and the metadata zip. Set "false" to suppress the release-asset attach.'
+    required: false
+    default: "true"
+  build-type:
+    description: "Build type (go/python/npm/container) — for go, goreleaser owns the dist on the release so wrangle attaches the bundle + metadata zip only."
+    required: false
+    default: ""
+  dist-dir:
+    description: "Directory holding the dist files, attached per subject alongside their bundles."
+    required: false
+    default: "dist"
   metadata-dir:
     description: >
       Directory holding the build's metadata (the build job's metadata artifact:
@@ -151,14 +163,17 @@ runs:
         path: ${{ inputs.bundle-out }}/
         if-no-files-found: error
 
-    # On a tag push, attach every bundle to the GitHub release if one exists
-    # (wrangle does not create releases).
-    - name: Attach bundles to release
-      if: github.ref_type == 'tag' && inputs.attach-to-release == 'true'
+    # On a tag push, attach the rationalized asset set to the GitHub release if
+    # one exists (wrangle does not create releases).
+    - name: Attach assets to release
+      if: github.ref_type == 'tag' && inputs.attach-to-release == 'true' && inputs.attach-release-assets == 'true'
       shell: bash
       env:
         WRANGLE_ROOT: ${{ github.action_path }}/../..
         BUNDLE_OUT: ${{ inputs.bundle-out }}
+        BUILD_TYPE: ${{ inputs.build-type }}
+        DIST_DIR: ${{ inputs.dist-dir }}
+        METADATA_ZIP_NAME: ${{ inputs.artifact-name }}.zip
         GH_TOKEN: ${{ github.token }}
       run: |
         "$WRANGLE_ROOT/actions/verify/run_verify.sh" attach

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -173,6 +173,7 @@ runs:
         BUNDLE_OUT: ${{ inputs.bundle-out }}
         BUILD_TYPE: ${{ inputs.build-type }}
         DIST_DIR: ${{ inputs.dist-dir }}
+        METADATA_ROOT: ${{ inputs.metadata-dir }}
         METADATA_ZIP_NAME: ${{ inputs.artifact-name }}.zip
         GH_TOKEN: ${{ github.token }}
       run: |

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -9,7 +9,8 @@
 #          OCI_TARGET set it is additionally pushed as its own OCI referrer.
 #   attach upload the rationalized asset set (per-subject dist + bundle, and one
 #          <type>-metadata-<sn>.zip) to the GitHub release for the current tag,
-#          if one exists. Inputs: BUILD_TYPE, DIST_DIR, METADATA_ZIP_NAME.
+#          if one exists. Inputs: BUNDLE_OUT, BUILD_TYPE, DIST_DIR,
+#          METADATA_ROOT (zipped into the metadata asset), METADATA_ZIP_NAME.
 #
 # Arg-builder functions are pure so unit tests can assert the CLI shape offline.
 # Inputs arrive as env vars: SUBJECTS (newline-separated), POLICY, COLLECTOR,
@@ -344,6 +345,15 @@ wrangle_attach_release() {
         printf 'wrangle: failed to enumerate bundles under %s\n' "$BUNDLE_OUT" >&2
         return 1
     fi
+    # Fail closed before any upload if two bundles share a basename: assets attach
+    # by basename, so a collision would clobber or cross-wire a release asset.
+    local dup
+    dup="$(tr '\0' '\n' < "$listing" | sed 's#.*/##' | sort | uniq -d | head -n1)"
+    if [[ -n "$dup" ]]; then
+        rm -f "$listing"
+        printf 'wrangle: duplicate release-asset basename %s — refusing to clobber\n' "$dup" >&2
+        return 1
+    fi
     while IFS= read -r -d '' bundle; do
         gh release upload "$ref" "$bundle" --clobber
         # Attach the dist sibling alongside its bundle (skip go — goreleaser owns it).
@@ -369,7 +379,7 @@ wrangle_attach_metadata_zip() {
     local ref="$1" zip
     zip="${RUNNER_TEMP:-/tmp}/$METADATA_ZIP_NAME"
     rm -f "$zip"
-    ( cd "$BUNDLE_OUT" && zip -r -q "$zip" . )
+    ( cd "$METADATA_ROOT" && zip -r -q "$zip" . )
     gh release upload "$ref" "$zip" --clobber
     rm -f "$zip"
 }

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -7,7 +7,9 @@
 #          never lives on disk across a step boundary. Each signed VSA is also
 #          posted to the GitHub attestation store (by-digest discovery); with
 #          OCI_TARGET set it is additionally pushed as its own OCI referrer.
-#   attach upload every bundle to the GitHub release for the current tag, if any.
+#   attach upload the rationalized asset set (per-subject dist + bundle, and one
+#          <type>-metadata-<sn>.zip) to the GitHub release for the current tag,
+#          if one exists. Inputs: BUILD_TYPE, DIST_DIR, METADATA_ZIP_NAME.
 #
 # Arg-builder functions are pure so unit tests can assert the CLI shape offline.
 # Inputs arrive as env vars: SUBJECTS (newline-separated), POLICY, COLLECTOR,
@@ -320,16 +322,22 @@ wrangle_run() {
     rm -f "$tmp_vsa" "$vsa_line" "$seed"
 }
 
-# Attach every bundle to the current tag's GitHub release, if one exists
-# (wrangle never creates releases). Enumerate via a temp file, not a process
-# substitution, so a find that dies mid-traversal fails closed.
+# Attach the rationalized asset set to the current tag's GitHub release, if one
+# exists (wrangle never creates releases). Per subject: the <artifact> dist file
+# and its <artifact>.intoto.jsonl bundle (flat); once per build: a
+# <type>-metadata-<sn>.zip of the metadata dir (sbom + scan/ + bundles). The
+# dist is attached alongside its bundle so no bundle is orphaned without its
+# artifact. For the go build type goreleaser owns the dist + checksums.txt on
+# the release (#463), so wrangle attaches the bundle + metadata zip only.
+# Enumerate via a temp file, not a process substitution, so a find that dies
+# mid-traversal fails closed.
 wrangle_attach_release() {
     local ref="$GITHUB_REF_NAME"
     if ! gh release view "$ref" >/dev/null 2>&1; then
         printf 'wrangle: no GitHub release for %s; the bundles are the workflow artifact only.\n' "$ref" >&2
         return 0
     fi
-    local listing bundle
+    local listing bundle base dist rc=0
     listing="$(mktemp "${RUNNER_TEMP:-/tmp}/bundles.XXXXXX")"
     if ! find "$BUNDLE_OUT" -type f -name '*.intoto.jsonl' -print0 | sort -z > "$listing"; then
         rm -f "$listing"
@@ -338,8 +346,32 @@ wrangle_attach_release() {
     fi
     while IFS= read -r -d '' bundle; do
         gh release upload "$ref" "$bundle" --clobber
+        # Attach the dist sibling alongside its bundle (skip go — goreleaser owns it).
+        [[ "${BUILD_TYPE:-}" == "go" ]] && continue
+        base="${bundle##*/}"
+        dist="${DIST_DIR:-dist}/${base%.intoto.jsonl}"
+        if [[ -f "$dist" ]]; then
+            gh release upload "$ref" "$dist" --clobber
+        else
+            printf 'wrangle: dist file %s for bundle %s not found\n' "$dist" "$bundle" >&2
+            rc=1
+            break
+        fi
     done < "$listing"
     rm -f "$listing"
+    [[ "$rc" -ne 0 ]] && return "$rc"
+    wrangle_attach_metadata_zip "$ref"
+}
+
+# Zip the metadata dir (sbom + scan/ + bundles) and attach it once per build as
+# <type>-metadata-<sn>.zip. The SBOM rides inside this zip, not as a flat asset.
+wrangle_attach_metadata_zip() {
+    local ref="$1" zip
+    zip="${RUNNER_TEMP:-/tmp}/$METADATA_ZIP_NAME"
+    rm -f "$zip"
+    ( cd "$BUNDLE_OUT" && zip -r -q "$zip" . )
+    gh release upload "$ref" "$zip" --clobber
+    rm -f "$zip"
 }
 
 main() {

--- a/actions/verify/test_action_structure.bats
+++ b/actions/verify/test_action_structure.bats
@@ -47,6 +47,13 @@ tool_block_has() {
     grep -q 'OCI_TARGET: ${{ inputs.oci-target }}' "$ACTION"
 }
 
+@test "attach step is gated on both attach-to-release and attach-release-assets and threads the asset env" {
+    grep -Fq "inputs.attach-to-release == 'true' && inputs.attach-release-assets == 'true'" "$ACTION"
+    grep -Fq 'BUILD_TYPE: ${{ inputs.build-type }}' "$ACTION"
+    grep -Fq 'DIST_DIR: ${{ inputs.dist-dir }}' "$ACTION"
+    grep -Fq 'METADATA_ZIP_NAME: ${{ inputs.artifact-name }}.zip' "$ACTION"
+}
+
 @test "verify does not build the whole tool set or the scan-only binaries" {
     # `go install tool` would rebuild osv-scanner et al. that verify never runs.
     ! grep -Eq 'install[[:space:]]+tool([[:space:]]|$)' "$ACTION"

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -811,13 +811,16 @@ SHIM
     export GITHUB_REF_NAME="v1.2.3"
 }
 
-# Stage the metadata dir (bundles) + a dist dir whose <artifact> files match
-# each bundle's <artifact>.intoto.jsonl name, plus the env the attach reads.
+# Stage the metadata dir (bundles + sbom) + a dist dir whose <artifact> files
+# match each bundle's <artifact>.intoto.jsonl name, plus the env the attach
+# reads. Production wires bundle-out and metadata-dir to the same dir, so the
+# sbom (and the metadata zip's other contents) live under METADATA_ROOT.
 _stage_release_assets() {
+    export METADATA_ROOT="$BUNDLE_OUT"
     mkdir -p "$BUNDLE_OUT" "$TEST_DIR/dist"
     : > "$BUNDLE_OUT/a.tgz.intoto.jsonl"
     : > "$BUNDLE_OUT/b.whl.intoto.jsonl"
-    : > "$BUNDLE_OUT/sbom.spdx.json"
+    : > "$METADATA_ROOT/sbom.spdx.json"
     : > "$TEST_DIR/dist/a.tgz"
     : > "$TEST_DIR/dist/b.whl"
     export DIST_DIR="$TEST_DIR/dist"
@@ -886,6 +889,42 @@ _require_zip() {
     run zip -sf "$GH_KEEP_ZIP"
     [[ "$output" == *"a.tgz.intoto.jsonl"* ]]
     [[ "$output" == *"sbom.spdx.json"* ]]
+}
+
+# The metadata zip is sourced from METADATA_ROOT, not BUNDLE_OUT: a sbom that
+# lives only under METADATA_ROOT must still land in the zip.
+@test "run_verify attach: the metadata zip is taken from METADATA_ROOT, not BUNDLE_OUT" {
+    _require_zip
+    _install_gh_shim
+    _stage_release_assets
+    export METADATA_ROOT="$TEST_DIR/meta"
+    mkdir -p "$METADATA_ROOT"
+    : > "$METADATA_ROOT/sbom.spdx.json"
+    mkdir -p "$METADATA_ROOT/scan/osv"
+    : > "$METADATA_ROOT/scan/osv/output.sarif"
+    rm -f "$BUNDLE_OUT/sbom.spdx.json"
+    export BUILD_TYPE="python"
+    export GH_VIEW_SEQ="0"
+    export GH_KEEP_ZIP="$TEST_DIR/kept.zip"
+    run "$SCRIPT" attach
+    [[ "$status" -eq 0 ]]
+    run zip -sf "$GH_KEEP_ZIP"
+    [[ "$output" == *"sbom.spdx.json"* ]]
+    [[ "$output" == *"scan/osv/output.sarif"* ]]
+}
+
+# Two subjects resolving to the same bundle basename would clobber/cross-wire on
+# upload (assets attach by basename) — fail closed before any upload.
+@test "run_verify attach: duplicate bundle basename fails closed" {
+    _install_gh_shim
+    _stage_release_assets
+    mkdir -p "$BUNDLE_OUT/sub"
+    : > "$BUNDLE_OUT/sub/a.tgz.intoto.jsonl"   # same basename as $BUNDLE_OUT/a.tgz.intoto.jsonl
+    export BUILD_TYPE="python"
+    export GH_VIEW_SEQ="0"
+    run "$SCRIPT" attach
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"duplicate release-asset basename"* ]]
 }
 
 @test "run_verify attach: missing release skips create and upload, exits 0" {

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -798,7 +798,9 @@ case "$1 $2" in
     n=$(cat "$GH_VIEW_N" 2>/dev/null || echo 0); n=$((n + 1)); printf '%s' "$n" > "$GH_VIEW_N"
     code=$(printf '%s' "$GH_VIEW_SEQ" | cut -d' ' -f"$n"); exit "${code:-1}" ;;
   "release create") exit "${GH_CREATE_CODE:-0}" ;;
-  "release upload") exit "${GH_UPLOAD_CODE:-0}" ;;
+  "release upload")
+    [[ -n "${GH_KEEP_ZIP:-}" && "$4" == *.zip ]] && cp "$4" "$GH_KEEP_ZIP"
+    exit "${GH_UPLOAD_CODE:-0}" ;;
 esac
 exit 0
 SHIM
@@ -809,23 +811,87 @@ SHIM
     export GITHUB_REF_NAME="v1.2.3"
 }
 
-@test "run_verify attach: every per-artifact bundle is uploaded to the existing release" {
-    _install_gh_shim
-    mkdir -p "$BUNDLE_OUT"
+# Stage the metadata dir (bundles) + a dist dir whose <artifact> files match
+# each bundle's <artifact>.intoto.jsonl name, plus the env the attach reads.
+_stage_release_assets() {
+    mkdir -p "$BUNDLE_OUT" "$TEST_DIR/dist"
     : > "$BUNDLE_OUT/a.tgz.intoto.jsonl"
     : > "$BUNDLE_OUT/b.whl.intoto.jsonl"
-    export GH_VIEW_SEQ="0"            # first view succeeds (release exists)
+    : > "$BUNDLE_OUT/sbom.spdx.json"
+    : > "$TEST_DIR/dist/a.tgz"
+    : > "$TEST_DIR/dist/b.whl"
+    export DIST_DIR="$TEST_DIR/dist"
+    export METADATA_ZIP_NAME="python-metadata.zip"
+}
+
+# zip is the only external command the metadata-zip step needs that the unit
+# host may lack; gate the asserts that exercise it.
+_require_zip() {
+    command -v zip >/dev/null 2>&1 || skip_or_fail "zip not installed"
+}
+
+@test "run_verify attach: per subject uploads the dist artifact and its bundle, plus one metadata zip" {
+    _require_zip
+    _install_gh_shim
+    _stage_release_assets
+    export BUILD_TYPE="python"
+    export GH_VIEW_SEQ="0"            # release exists
     run "$SCRIPT" attach
     [[ "$status" -eq 0 ]]
     grep -qx "release upload v1.2.3 $BUNDLE_OUT/a.tgz.intoto.jsonl --clobber" "$GH_LOG"
     grep -qx "release upload v1.2.3 $BUNDLE_OUT/b.whl.intoto.jsonl --clobber" "$GH_LOG"
-    ! grep -q "release create" "$GH_LOG"   # create must be skipped
+    grep -qx "release upload v1.2.3 $DIST_DIR/a.tgz --clobber" "$GH_LOG"
+    grep -qx "release upload v1.2.3 $DIST_DIR/b.whl --clobber" "$GH_LOG"
+    grep -q "release upload v1.2.3 .*python-metadata.zip --clobber" "$GH_LOG"
+    ! grep -q "release create" "$GH_LOG"   # wrangle never creates the release
+}
+
+@test "run_verify attach: go skips the dist (goreleaser owns it) but still attaches bundle + metadata zip" {
+    _require_zip
+    _install_gh_shim
+    _stage_release_assets
+    export BUILD_TYPE="go"
+    export GH_VIEW_SEQ="0"
+    run "$SCRIPT" attach
+    [[ "$status" -eq 0 ]]
+    grep -qx "release upload v1.2.3 $BUNDLE_OUT/a.tgz.intoto.jsonl --clobber" "$GH_LOG"
+    grep -q "release upload v1.2.3 .*python-metadata.zip --clobber" "$GH_LOG"
+    # The dist itself is goreleaser's to attach — wrangle must not double-attach.
+    ! grep -q "release upload v1.2.3 $DIST_DIR/a.tgz --clobber" "$GH_LOG"
+    ! grep -q "release upload v1.2.3 $DIST_DIR/b.whl --clobber" "$GH_LOG"
+}
+
+@test "run_verify attach: a bundle whose dist is missing fails closed (no orphan bundle)" {
+    _install_gh_shim
+    _stage_release_assets
+    export BUILD_TYPE="python"
+    rm -f "$DIST_DIR/a.tgz"          # orphan: bundle present, dist gone
+    export GH_VIEW_SEQ="0"
+    run "$SCRIPT" attach
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"not found"* ]]
+}
+
+@test "run_verify attach: the metadata zip carries the bundles and the sbom" {
+    _require_zip
+    _install_gh_shim
+    _stage_release_assets
+    export BUILD_TYPE="python"
+    export GH_VIEW_SEQ="0"
+    # The gh shim copies the uploaded metadata zip aside so its contents can be
+    # asserted without re-zipping or needing unzip (`zip -sf` lists in-place).
+    export GH_KEEP_ZIP="$TEST_DIR/kept.zip"
+    run "$SCRIPT" attach
+    [[ "$status" -eq 0 ]]
+    run zip -sf "$GH_KEEP_ZIP"
+    [[ "$output" == *"a.tgz.intoto.jsonl"* ]]
+    [[ "$output" == *"sbom.spdx.json"* ]]
 }
 
 @test "run_verify attach: missing release skips create and upload, exits 0" {
     _install_gh_shim
-    mkdir -p "$BUNDLE_OUT"
-    : > "$BUNDLE_OUT/a.tgz.intoto.jsonl"
+    _stage_release_assets
+    export BUILD_TYPE="python"
     export GH_VIEW_SEQ="1"            # view fails (no release)
     run "$SCRIPT" attach
     [[ "$status" -eq 0 ]]            # no release is not an error — bundle stays the artifact

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -44,7 +44,11 @@ inputs:
     required: false
     default: ""
   attach-to-release:
-    description: 'When "true" (default) and the run is a tag push, attach the bundle to the release.'
+    description: 'When "true" (default) and the run is a tag push, attach the rationalized asset set to the release.'
+    required: false
+    default: "true"
+  attach-release-assets:
+    description: 'When "true" (default) attach the per-subject dist + bundle and the metadata zip. Set "false" to suppress.'
     required: false
     default: "true"
 
@@ -94,4 +98,8 @@ runs:
         context: ${{ inputs.context }}
         oci-target: ${{ inputs.oci-target }}
         attach-to-release: ${{ inputs.attach-to-release }}
+        attach-release-assets: ${{ inputs.attach-release-assets }}
+        # go's dist is owned by goreleaser on the release; wrangle skips it.
+        build-type: ${{ inputs.build-type }}
+        dist-dir: dist
         fail: "true"

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -82,7 +82,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@e2c02faae2a71abf78a65cb7df5fae4bb00f7597 # main 2026-06-20
+    - uses: TomHennen/wrangle/actions/verify@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -82,7 +82,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@101e5e1f688d904c8dd08c7ce878540f1aef9790 # rationalize-release-assets-489 2026-06-20
+    - uses: TomHennen/wrangle/actions/verify@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -82,7 +82,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@6b0927ce2930018873c5470d41d1ba09491569de # rationalize-release-assets-489 2026-06-20
+    - uses: TomHennen/wrangle/actions/verify@d6e78fa6b948ef8fad7d68bc9690ef987683d07f # rationalize-release-assets-489 2026-06-20
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/test.bats
+++ b/actions/verify_release/test.bats
@@ -44,3 +44,11 @@ setup() {
     run grep -F "inputs.oci-target == '' && 'provenance/provenance.jsonl'" "$ACTION"
     [ "$status" -eq 0 ]
 }
+
+@test "verify_release: threads build-type and attach-release-assets to the release attach" {
+    run grep -F 'attach-release-assets: ${{ inputs.attach-release-assets }}' "$ACTION"
+    [ "$status" -eq 0 ]
+    # build-type drives the go-vs-others dist distinction in the attach step.
+    run grep -F 'build-type: ${{ inputs.build-type }}' "$ACTION"
+    [ "$status" -eq 0 ]
+}

--- a/build/actions/go/README.md
+++ b/build/actions/go/README.md
@@ -44,7 +44,7 @@ Push a `v`-prefixed semver tag (e.g. `v1.2.3`) and wrangle runs the full pipelin
 - **Checks before bytes ship** — gofmt, `go vet`, `go test`, govulncheck run in a read-only job; a failure blocks the release job.
 - **An SPDX SBOM, scan findings (incl. govulncheck), and the signed bundle** in one `go-metadata-<sn>` workflow artifact ([what's in it](../../../docs/metadata_layout.md)).
 - **SLSA Build L3 provenance** tying each artifact to the workflow that built it ([the requirements it meets](../../../docs/REQUIREMENTS_MAPPING.md)).
-- **A signed VSA** attached to the release, so downstream users can verify your artifacts with one command.
+- **Release assets on tag pushes** — goreleaser attaches the dist archives + `checksums.txt`; wrangle adds each `<archive>.intoto.jsonl` bundle (signed VSA + provenance) and a `go-metadata-<sn>.zip` with the SBOM + scan results. Downstream users verify with one command.
 
 ## Good to know
 

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -41,7 +41,7 @@ These steps set up [npm Trusted Publishing](https://docs.npmjs.com/trusted-publi
 - **Source scan** built in — vulnerable dependencies (OSV), unsafe workflow patterns (Zizmor), and more ([details](../../../actions/scan/README.md)); a load-bearing finding blocks publish.
 - **An SPDX SBOM, scan findings, and the signed bundle** in one `npm-metadata-<sn>` workflow artifact ([what's in it](../../../docs/metadata_layout.md)).
 - **SLSA Build L3 provenance** ([the requirements it meets](../../../docs/REQUIREMENTS_MAPPING.md)), in addition to the L2 attestation `npm publish --provenance` writes to the registry.
-- **A signed VSA** attached to the release on tag pushes, so downstream users can verify the tarball with one command.
+- **Release assets on tag pushes** — the tarball and its `<tarball>.intoto.jsonl` bundle (signed VSA + provenance) as a flat verify-pair, plus an `npm-metadata-<sn>.zip` with the SBOM + scan results. Downstream users verify with one command.
 
 ## Your publish job
 

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -41,7 +41,7 @@ These steps set up [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publi
 - **Source scan** built in — vulnerable dependencies (OSV), unsafe workflow patterns (Zizmor), and more ([details](../../../actions/scan/README.md)); a load-bearing finding blocks publish.
 - **An SPDX SBOM, scan findings, and the signed bundle** in one `python-metadata-<sn>` workflow artifact ([what's in it](../../../docs/metadata_layout.md)).
 - **SLSA Build L3 provenance** ([the requirements it meets](../../../docs/REQUIREMENTS_MAPPING.md)), plus PEP 740 attestations on PyPI from the publish step.
-- **A signed VSA** attached to the release on tag pushes, so downstream users can verify your dist files with one command.
+- **Release assets on tag pushes** — each dist file and its `<dist-file>.intoto.jsonl` bundle (signed VSA + provenance) as a flat verify-pair, plus a `python-metadata-<sn>.zip` with the SBOM + scan results. Downstream users verify with one command.
 
 ## Your publish job
 

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -33,6 +33,18 @@ you trust one signature instead of re-running the policy engine.
 | npm | GitHub release, `<artifact>.intoto.jsonl` | `pkg:npm/<name>@<version>` (scoped names verbatim, e.g. `pkg:npm/@scope/pkg@1.2.3`) | `build_and_publish_npm.yml` |
 | Container | VSA as its own OCI referrer on the image digest; combined `<artifact>.intoto.jsonl` (workflow artifact) | `<imagename>@sha256:<digest>` | `build_and_publish_container.yml` |
 
+## What's on the GitHub release
+
+For Go, Python, and npm, a tag push attaches a flat verify-pair per artifact —
+the dist `<artifact>` and its `<artifact>.intoto.jsonl` bundle — so a consumer
+downloads both by name and verifies. The build's SBOM and scan results ride in
+a single `<type>-metadata-<sn>.zip` (the same [unified metadata
+layout](metadata_layout.md)), not as separate flat assets. (Go's dist archives
+and `checksums.txt` are attached by goreleaser; wrangle adds the bundle + zip.)
+Container builds publish no release — the VSA is an OCI referrer on the image
+digest (see below). Adopters can suppress the attach with the verify action's
+`attach-release-assets: false`.
+
 ## Recommended: `ampel verify` (one command)
 
 [ampel](https://github.com/carabiner-dev/ampel) ≥ v1.3.0 (one Go binary)

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -28,18 +28,18 @@ you trust one signature instead of re-running the policy engine.
 
 | Build type | VSA location | `resourceUri` to expect | Signing workflow |
 |---|---|---|---|
-| Go | GitHub release, flat `<artifact>` + `<artifact>.intoto.jsonl` (+ `<type>-metadata-<sn>.zip`) | `pkg:golang/<module-path>@<version>` (the `module` directive in `go.mod`) | `build_and_publish_go.yml` |
-| Python | GitHub release, flat `<artifact>` + `<artifact>.intoto.jsonl` (+ `<type>-metadata-<sn>.zip`) | `pkg:pypi/<name>@<version>` (name [PEP 503-normalized](https://peps.python.org/pep-0503/#normalized-names)) | `build_and_publish_python.yml` |
-| npm | GitHub release, flat `<artifact>` + `<artifact>.intoto.jsonl` (+ `<type>-metadata-<sn>.zip`) | `pkg:npm/<name>@<version>` (scoped names verbatim, e.g. `pkg:npm/@scope/pkg@1.2.3`) | `build_and_publish_npm.yml` |
+| Go | GitHub release, `<artifact>.intoto.jsonl` | `pkg:golang/<module-path>@<version>` (the `module` directive in `go.mod`) | `build_and_publish_go.yml` |
+| Python | GitHub release, `<artifact>.intoto.jsonl` | `pkg:pypi/<name>@<version>` (name [PEP 503-normalized](https://peps.python.org/pep-0503/#normalized-names)) | `build_and_publish_python.yml` |
+| npm | GitHub release, `<artifact>.intoto.jsonl` | `pkg:npm/<name>@<version>` (scoped names verbatim, e.g. `pkg:npm/@scope/pkg@1.2.3`) | `build_and_publish_npm.yml` |
 | Container | VSA as its own OCI referrer on the image digest; combined `<artifact>.intoto.jsonl` (workflow artifact) | `<imagename>@sha256:<digest>` | `build_and_publish_container.yml` |
 
 ## What's on the GitHub release
 
-For Go, Python, and npm, a tag push attaches a flat verify-pair per artifact —
+For Go, Python, and npm, a tag push attaches a verify-pair per artifact —
 the dist `<artifact>` and its `<artifact>.intoto.jsonl` bundle — so a consumer
 downloads both by name and verifies. The build's SBOM and scan results ride in
 a single `<type>-metadata-<sn>.zip` (the same [unified metadata
-layout](metadata_layout.md)), not as separate flat assets. (Go's dist archives
+layout](metadata_layout.md)), not as separate assets. (Go's dist archives
 and `checksums.txt` are attached by goreleaser; wrangle adds the bundle + zip.)
 Container builds publish no release — the VSA is an OCI referrer on the image
 digest (see below). Adopters can suppress the attach with the verify action's

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -28,9 +28,9 @@ you trust one signature instead of re-running the policy engine.
 
 | Build type | VSA location | `resourceUri` to expect | Signing workflow |
 |---|---|---|---|
-| Go | GitHub release, `<artifact>.intoto.jsonl` | `pkg:golang/<module-path>@<version>` (the `module` directive in `go.mod`) | `build_and_publish_go.yml` |
-| Python | GitHub release, `<artifact>.intoto.jsonl` | `pkg:pypi/<name>@<version>` (name [PEP 503-normalized](https://peps.python.org/pep-0503/#normalized-names)) | `build_and_publish_python.yml` |
-| npm | GitHub release, `<artifact>.intoto.jsonl` | `pkg:npm/<name>@<version>` (scoped names verbatim, e.g. `pkg:npm/@scope/pkg@1.2.3`) | `build_and_publish_npm.yml` |
+| Go | GitHub release, flat `<artifact>` + `<artifact>.intoto.jsonl` (+ `<type>-metadata-<sn>.zip`) | `pkg:golang/<module-path>@<version>` (the `module` directive in `go.mod`) | `build_and_publish_go.yml` |
+| Python | GitHub release, flat `<artifact>` + `<artifact>.intoto.jsonl` (+ `<type>-metadata-<sn>.zip`) | `pkg:pypi/<name>@<version>` (name [PEP 503-normalized](https://peps.python.org/pep-0503/#normalized-names)) | `build_and_publish_python.yml` |
+| npm | GitHub release, flat `<artifact>` + `<artifact>.intoto.jsonl` (+ `<type>-metadata-<sn>.zip`) | `pkg:npm/<name>@<version>` (scoped names verbatim, e.g. `pkg:npm/@scope/pkg@1.2.3`) | `build_and_publish_npm.yml` |
 | Container | VSA as its own OCI referrer on the image digest; combined `<artifact>.intoto.jsonl` (workflow artifact) | `<imagename>@sha256:<digest>` | `build_and_publish_container.yml` |
 
 ## What's on the GitHub release

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update -q && \
         libc6-dev \
         python3 \
         python3-venv \
+        zip \
     && rm -rf /var/lib/apt/lists/*
 
 # python3 + python3-venv host the isolated, hash-pinned venvs that zizmor,


### PR DESCRIPTION
## What

Extends the unified-metadata layout rationalization (#469/#472) to the **GitHub-release assets**. On a tag push where a Release exists, wrangle now attaches a clean, predictable set per build (default-on; suppress with `attach-release-assets: false`).

### Before → after (release asset set)

**Before:** only `<artifact>.intoto.jsonl` bundle(s) flat. The dist itself and the SBOM/scan were attached (inconsistently) by a companion-repo glue job — bundles could ship orphaned without their dist (pnpm/uv).

**After**, per build:
- `<artifact>` — the dist file, flat, per subject (npm/python; **go's dist + `checksums.txt` stay goreleaser-owned**, #463).
- `<artifact>.intoto.jsonl` — the per-subject bundle, flat (unchanged name — the consumer-fetch contract, #314).
- `<type>-metadata-<sn>.zip` — once per build, a zip of the metadata dir (SBOM + `scan/<tool>/` + bundles). The **SBOM rides inside this zip** — no separate flat `*-sbom.spdx.json`.

So a consumer gets the flat `<artifact>` + `<artifact>.intoto.jsonl` verify-pair by name, plus the zip for sbom/scan.

## How

- `wrangle_attach_release` now uploads, per bundle, its dist sibling from `dist/` (skipped for go), and once per build a `zip -r` of the metadata dir. Keeps `--clobber` and the "only when a Release already exists; wrangle never creates the release" behavior.
- **Orphan fix:** the dist is attached wherever its `.intoto.jsonl` is — a missing dist sibling **fails closed** rather than shipping an orphan bundle.
- **go/goreleaser (#463):** goreleaser already attaches go's dist archives + `checksums.txt`, so for go wrangle attaches the bundle + metadata zip only (no double-attach). Threaded via `build-type`.
- New input `attach-release-assets` (default `"true"`) on `actions/verify` + `actions/verify_release`, gating the attach step. Container passes `attach-to-release: false` (no Release) — unchanged.

## Closes / refs

Closes #489
Closes #228 (wrangle now owns the dist + SBOM attach)
Refs #463 #449 #314

The companion-repo `release-assets` glue job (in `tomhennen/wrangle-test`'s `showcase.yml`) is now redundant and should be deleted as the dogfood validation (not touched here).

## Tests

- bats for `wrangle_attach_release`: per-subject dist + bundle upload, the once-per-build metadata zip (driven through real `zip`, added to the test container), the go-skips-dist distinction, and the orphan-fail. Structure guards for the attach env wiring + verify_release threading.
- `./test.sh quick` (1138 bats), zizmor, shellcheck, `go -C tools test ./wrangle-attest/...`, `check_pin_ancestry.sh` all green.
- The dispatch e2e does real tag-push releases — the true validator. I expect it to now attach the rationalized set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)