### PR TITLE
refactor(#479): collapse guard/gate/names into a shared prep job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       - "/actions/attest_provenance"
       - "/actions/package_metadata"
       - "/actions/preflight_guard"
+      - "/actions/prep"
       - "/actions/release_gate"
       - "/actions/scan"
       - "/actions/verify"

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -110,7 +110,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@89ff2eb2523c6475e53f337e6d67e7ca0a78522d # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@664df2f26c43826bf2e42be001d7b8a5df5ff362 # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: container

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -97,13 +97,10 @@ on:
         value: ${{ jobs.prep.outputs.should-release }}
 
 jobs:
-  # Refuse unsafe triggers, decide should-release, and derive the shared
-  # package names — once, as job outputs every downstream job reads. The
-  # guard runs first inside prep, so prep MUST stay first under `jobs:` and
-  # every other job lists `prep` in its `needs:` so a refused invocation
-  # skips the entire workflow — critical for the container build type, whose
-  # docker push happens mid-composite (no verify step could roll back a
-  # pushed image). Full trigger contract: docs/SPEC.md#trigger-model.
+  # MUST stay first under `jobs:`: prep's guard refuses unsafe triggers
+  # before any other job runs, and every job `needs: [prep]`. prep also
+  # decides should-release and derives the shared package names.
+  # docs/SPEC.md#trigger-model.
   prep:
     runs-on: ubuntu-latest
     permissions: {}    # guard/gate/names read env only — no workspace, no API, no secrets
@@ -148,9 +145,6 @@ jobs:
           go-cache: ${{ needs.prep.outputs.should-release == 'true' && '' || inputs.go-cache }}
 
   build:
-    # needs `prep` so the build can read should-release and disable the
-    # BuildKit cache for release builds (SLSA L3 isolation — see the
-    # `cache:` input below and docs/SLSA_L3_AUDIT.md Finding 2).
     # needs `scan` so a load-bearing finding blocks the mid-composite push.
     needs: [prep, scan]
     permissions:

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -94,63 +94,47 @@ on:
           "true" if the current event matches release-events; "false" otherwise.
           Wrangle gates the attest and verify jobs on this internally; callers can
           gate downstream release-time jobs on it too.
-        value: ${{ jobs.gate.outputs.should-release }}
+        value: ${{ jobs.prep.outputs.should-release }}
 
 jobs:
-  # Refuse trigger patterns known to expose this workflow to supply-chain
-  # attack classes (pull_request_target, workflow_run via pull_request_target).
-  # The guard MUST stay first under `jobs:`; every other job lists `guard`
-  # in its `needs:` so a refused invocation skips the entire workflow —
-  # critical for the container build type, whose docker push happens
-  # mid-composite (no verify step could roll back a pushed image).
-  # Full trigger contract: docs/SPEC.md#trigger-model.
-  guard:
+  # Refuse unsafe triggers, decide should-release, and derive the shared
+  # package names — once, as job outputs every downstream job reads. The
+  # guard runs first inside prep, so prep MUST stay first under `jobs:` and
+  # every other job lists `prep` in its `needs:` so a refused invocation
+  # skips the entire workflow — critical for the container build type, whose
+  # docker push happens mid-composite (no verify step could roll back a
+  # pushed image). Full trigger contract: docs/SPEC.md#trigger-model.
+  prep:
     runs-on: ubuntu-latest
-    permissions: {}    # reads env only — no workspace, no API, no secrets
-    steps:
-      # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-
-  gate:
-    needs: [guard]
-    runs-on: ubuntu-latest
-    permissions: {}    # release_gate reads only env; no workspace, no API
+    permissions: {}    # guard/gate/names read env only — no workspace, no API, no secrets
     outputs:
-      should-release: ${{ steps.gate.outputs.should-release }}
+      should-release: ${{ steps.prep.outputs.should-release }}
+      shortname: ${{ steps.prep.outputs.shortname }}
+      scan: ${{ steps.prep.outputs.scan }}
     steps:
-      # No checkout: release_gate resolves via ${{ github.action_path }}.
-      # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-        id: gate
+      # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
+      - uses: TomHennen/wrangle/actions/prep@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+        id: prep
         with:
-          events: ${{ inputs.release-events }}
+          build-type: container
+          path: ${{ inputs.path }}
+          release-events: ${{ inputs.release-events }}
 
   # Source scan. The container push happens mid-composite in `build` and
   # is not release-gated, so a load-bearing (:fail) finding must block
   # `build` itself on every event — hence `build` needs `scan`.
   scan:
-    needs: [guard, gate]
+    needs: [prep]
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
-    outputs:
-      artifact-name: ${{ steps.names.outputs.scan }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         if: ${{ inputs.scan-tools != '' }}
         with:
           persist-credentials: false
-
-      # Shared name derivation so the scan and build jobs can't drift.
-      # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-        id: names
-        if: ${{ inputs.scan-tools != '' }}
-        with:
-          build-type: container
-          path: ${{ inputs.path }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/scan@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
@@ -158,24 +142,23 @@ jobs:
         with:
           tools: ${{ inputs.scan-tools }}
           # The build job folds this into the unified container-metadata.
-          artifact-name: ${{ steps.names.outputs.scan }}
+          artifact-name: ${{ needs.prep.outputs.scan }}
           # Cold on release: the scan gates an attested build, so a
           # poisoned tool cache must not be able to forge a passing scan.
-          go-cache: ${{ needs.gate.outputs.should-release == 'true' && '' || inputs.go-cache }}
+          go-cache: ${{ needs.prep.outputs.should-release == 'true' && '' || inputs.go-cache }}
 
   build:
-    # needs `gate` so the build can read should-release and disable the
+    # needs `prep` so the build can read should-release and disable the
     # BuildKit cache for release builds (SLSA L3 isolation — see the
     # `cache:` input below and docs/SLSA_L3_AUDIT.md Finding 2).
     # needs `scan` so a load-bearing finding blocks the mid-composite push.
-    needs: [guard, gate, scan]
+    needs: [prep, scan]
     permissions:
       contents: read
       packages: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
       imagename: ${{ steps.build.outputs.imagename }}
-      shortname: ${{ steps.build.outputs.shortname }}
       metadata-artifact-name: ${{ steps.build.outputs.metadata-artifact-name }}
       metadata-pre-artifact-name: ${{ steps.build.outputs.metadata-pre-artifact-name }}
       metadata-dir: ${{ steps.build.outputs.metadata-dir }}
@@ -201,14 +184,14 @@ jobs:
         # `pr-cache` policy, which defaults to "isolated" (per-PR scope,
         # so PRs cannot poison each other) and can be widened to a fully
         # shared cache or tightened to read-only / disabled.
-        cache: ${{ needs.gate.outputs.should-release == 'true' && 'disabled' || inputs.pr-cache }}
+        cache: ${{ needs.prep.outputs.should-release == 'true' && 'disabled' || inputs.pr-cache }}
 
     # Fold the untrusted scan job's output into the metadata dir as inert data.
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       if: ${{ always() && inputs.scan-tools != '' }}
       continue-on-error: true   # scan upload is best-effort
       with:
-        name: ${{ needs.scan.outputs.artifact-name }}
+        name: ${{ needs.prep.outputs.scan }}
         path: ${{ steps.build.outputs.metadata-dir }}/scan/
 
     # Non-release: this is the final unified metadata (sbom + scan/). On
@@ -216,7 +199,7 @@ jobs:
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
-        name: ${{ needs.gate.outputs.should-release == 'true' && steps.build.outputs.metadata-pre-artifact-name || steps.build.outputs.metadata-artifact-name }}
+        name: ${{ needs.prep.outputs.should-release == 'true' && steps.build.outputs.metadata-pre-artifact-name || steps.build.outputs.metadata-artifact-name }}
         path: ${{ steps.build.outputs.metadata-dir }}/
         if-no-files-found: warn
 
@@ -224,8 +207,8 @@ jobs:
   # reusable workflow as builder.id (its job_workflow_ref) and the Sigstore
   # signing identity
   attest:
-    if: ${{ needs.gate.outputs.should-release == 'true' }}
-    needs: [guard, gate, build]
+    if: ${{ needs.prep.outputs.should-release == 'true' }}
+    needs: [prep, build]
     runs-on: ubuntu-latest
     permissions:
       id-token: write       # OIDC for Sigstore keyless signing
@@ -254,8 +237,8 @@ jobs:
   # downstream caller jobs) rather than rolling back the live image. Needs
   # `attest` so the provenance referrer the collector reads already exists.
   verify:
-    if: ${{ needs.gate.outputs.should-release == 'true' }}
-    needs: [guard, gate, build, attest]
+    if: ${{ needs.prep.outputs.should-release == 'true' }}
+    needs: [prep, build, attest]
     runs-on: ubuntu-latest
     # No contents: write — the container caller grants only contents: read, so
     # requesting it here would be a startup-failing escalation; the bundle ships
@@ -287,7 +270,7 @@ jobs:
       - uses: TomHennen/wrangle/actions/verify_release@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         with:
           build-type: container
-          shortname: ${{ needs.build.outputs.shortname }}
+          shortname: ${{ needs.prep.outputs.shortname }}
           subjects: ${{ needs.build.outputs.digest }}
           policy: policies/wrangle-provenance-container-v1.hjson
           collector: oci:${{ needs.build.outputs.imagename }}@${{ needs.build.outputs.digest }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -113,7 +113,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@1546eddfe43e1b74cbc27618cb48c91d96726579 # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: container

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -110,7 +110,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@664df2f26c43826bf2e42be001d7b8a5df5ff362 # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@731eb4e95e4c53cce9dd8d57f0ba5c626517b39f # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: container

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -110,7 +110,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@1546eddfe43e1b74cbc27618cb48c91d96726579 # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@89ff2eb2523c6475e53f337e6d67e7ca0a78522d # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: container

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -168,7 +168,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@89ff2eb2523c6475e53f337e6d67e7ca0a78522d # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@664df2f26c43826bf2e42be001d7b8a5df5ff362 # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: go

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -151,11 +151,10 @@ on:
         value: ${{ jobs.prep.outputs.should-release }}
 
 jobs:
-  # Refuse unsafe triggers, decide should-release, and derive the shared
-  # package names — once, as job outputs every downstream job reads. The
-  # guard runs first inside prep, so prep MUST stay first under `jobs:` and
-  # every other job lists `prep` in its `needs:` so a refused invocation
-  # skips the entire workflow. Full trigger contract: docs/SPEC.md#trigger-model.
+  # MUST stay first under `jobs:`: prep's guard refuses unsafe triggers
+  # before any other job runs, and every job `needs: [prep]`. prep also
+  # decides should-release and derives the shared package names.
+  # docs/SPEC.md#trigger-model.
   prep:
     runs-on: ubuntu-latest
     permissions: {}    # guard/gate/names read env only — no workspace, no API, no secrets

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -134,7 +134,7 @@ on:
         value: ${{ jobs.release.outputs.version }}
       dist-artifact-name:
         description: "Name of the uploaded dist/ artifact (download with this name to retrieve binaries + checksums.txt)"
-        value: ${{ jobs.release.outputs.dist-artifact-name }}
+        value: ${{ jobs.prep.outputs.dist }}
       provenance-artifact-name:
         description: "Name of the workflow artifact containing the SLSA provenance bundle — one JSON object per line, covering all dist subjects. Empty when should-release is false."
         value: ${{ jobs.attest.outputs.bundle-artifact-name }}
@@ -143,44 +143,44 @@ on:
         value: ${{ jobs.verify.outputs.attestation-bundle-name }}
       metadata-artifact-name:
         description: "Name of the unified metadata workflow artifact. Format: `go-metadata[-<shortname>]`. Contents and layout: docs/metadata_layout.md."
-        value: ${{ jobs.release.outputs.metadata-artifact-name }}
+        value: ${{ jobs.prep.outputs.metadata }}
       should-release:
         description: |
           "true" if the current event matches release-events; "false"
           otherwise. Wrangle gates the attest and verify jobs on this internally.
-        value: ${{ jobs.gate.outputs.should-release }}
+        value: ${{ jobs.prep.outputs.should-release }}
 
 jobs:
-  # Refuse trigger patterns known to expose this workflow to supply-chain
-  # attack classes (pull_request_target, workflow_run via
-  # pull_request_target). The guard MUST stay first under `jobs:`;
-  # every other job lists `guard` in its `needs:` so a refused
-  # invocation skips the entire workflow.
-  guard:
+  # Refuse unsafe triggers, decide should-release, and derive the shared
+  # package names — once, as job outputs every downstream job reads. The
+  # guard runs first inside prep, so prep MUST stay first under `jobs:` and
+  # every other job lists `prep` in its `needs:` so a refused invocation
+  # skips the entire workflow. Full trigger contract: docs/SPEC.md#trigger-model.
+  prep:
     runs-on: ubuntu-latest
-    permissions: {}    # reads env only — no workspace, no API, no secrets
-    steps:
-      # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-
-  gate:
-    needs: [guard]
-    runs-on: ubuntu-latest
-    permissions: {}    # release_gate reads only env; no workspace, no API
+    permissions: {}    # guard/gate/names read env only — no workspace, no API, no secrets
     outputs:
-      should-release: ${{ steps.gate.outputs.should-release }}
+      should-release: ${{ steps.prep.outputs.should-release }}
+      shortname: ${{ steps.prep.outputs.shortname }}
+      dist: ${{ steps.prep.outputs.dist }}
+      scan: ${{ steps.prep.outputs.scan }}
+      checks: ${{ steps.prep.outputs.checks }}
+      metadata: ${{ steps.prep.outputs.metadata }}
+      metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
-      # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-        id: gate
+      # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
+      - uses: TomHennen/wrangle/actions/prep@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+        id: prep
         with:
-          events: ${{ inputs.release-events }}
+          build-type: go
+          path: ${{ inputs.path }}
+          release-events: ${{ inputs.release-events }}
 
   # Source scan. A load-bearing (:fail) finding fails this job, which
   # blocks the release on release events (see release.if) — decoupled
   # scan/build runs can't gate publish.
   scan:
-    needs: [guard, gate]
+    needs: [prep]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -193,40 +193,30 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.ref || '' }}
 
-      # Shared name derivation so the scan and release jobs can't drift.
-      # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-        id: names
-        if: ${{ inputs.scan-tools != '' }}
-        with:
-          build-type: go
-          path: ${{ inputs.path }}
-
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/scan@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
           # The release job folds this into the unified go-metadata.
-          artifact-name: ${{ steps.names.outputs.scan }}
+          artifact-name: ${{ needs.prep.outputs.scan }}
           # Cold on release: the scan gates an attested build, so a
           # poisoned tool cache must not be able to forge a passing scan.
-          go-cache: ${{ needs.gate.outputs.should-release == 'true' && '' || inputs.go-cache }}
+          go-cache: ${{ needs.prep.outputs.should-release == 'true' && '' || inputs.go-cache }}
 
   # Quality gates with `contents: read` only. `go test` executes
   # arbitrary adopter test code; the minimum-permissions posture
   # denies it any write capability against the repo.
   checks:
     if: ${{ inputs.run-tests }}
-    needs: [guard, gate]
+    needs: [prep]
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
       # Internal transient: the release job folds govulncheck.json into the
-      # unified go-metadata under scan/govulncheck/. Root build ('.') has an
-      # empty shortname, so the name stays suffix-less.
-      checks-artifact-name: ${{ steps.checks.outputs.shortname && format('go-checks-{0}', steps.checks.outputs.shortname) || 'go-checks' }}
+      # unified go-metadata under scan/govulncheck/.
+      checks-artifact-name: ${{ needs.prep.outputs.checks }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -248,13 +238,13 @@ jobs:
           # derived compiled output without re-derivation (same shape as
           # the uv-cache L3 gap). PR builds keep caching for fast
           # iteration; no provenance is produced.
-          cache: ${{ needs.gate.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
+          cache: ${{ needs.prep.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
 
       # Transient handoff to the release job, which folds govulncheck.json into
       # the unified metadata under scan/govulncheck/.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ steps.checks.outputs.shortname && format('go-checks-{0}', steps.checks.outputs.shortname) || 'go-checks' }}
+          name: ${{ needs.prep.outputs.checks }}
           path: ${{ steps.checks.outputs.metadata-dir }}/
           if-no-files-found: warn   # govulncheck JSON is informational; not having it is OK
 
@@ -269,15 +259,14 @@ jobs:
   # run-tests: false would cascade through release/provenance/verify
   # and nothing would build. Documented behavior is "checks skipped,
   # release proceeds with quality gates unenforced," so allow skipped
-  # explicitly. A failed guard or gate still blocks release.
+  # explicitly. A failed prep still blocks release.
   release:
-    needs: [guard, gate, checks, scan]
+    needs: [prep, checks, scan]
     if: >
       always() && !cancelled() &&
-      needs.guard.result == 'success' &&
-      needs.gate.result == 'success' &&
+      needs.prep.result == 'success' &&
       (needs.checks.result == 'success' || needs.checks.result == 'skipped') &&
-      (needs.scan.result == 'success' || needs.gate.outputs.should-release != 'true')
+      (needs.scan.result == 'success' || needs.prep.outputs.should-release != 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write    # goreleaser creates the GitHub Release
@@ -285,10 +274,6 @@ jobs:
       hashes: ${{ steps.release.outputs.hashes }}
       version: ${{ steps.release.outputs.version }}
       module: ${{ steps.module.outputs.module }}
-      shortname: ${{ steps.release.outputs.shortname }}
-      dist-artifact-name: ${{ steps.names.outputs.dist }}
-      metadata-artifact-name: ${{ steps.names.outputs.metadata }}
-      metadata-pre-artifact-name: ${{ steps.names.outputs.metadata-pre }}
       metadata-dir: ${{ steps.release.outputs.metadata-dir }}
       # JSON array of dist filenames the verify job binds one VSA to each.
       dist-files: ${{ steps.distfiles.outputs.files }}
@@ -310,8 +295,8 @@ jobs:
           # publish == AND of (release-events gate) AND (tag push).
           # Both must hold for goreleaser to do a full publish; otherwise
           # it builds in --snapshot mode without uploading anything.
-          publish: ${{ needs.gate.outputs.should-release == 'true' && startsWith(github.ref, 'refs/tags/') }}
-          cache: ${{ needs.gate.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
+          publish: ${{ needs.prep.outputs.should-release == 'true' && startsWith(github.ref, 'refs/tags/') }}
+          cache: ${{ needs.prep.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
           install-zig: ${{ inputs.install-zig }}
 
       # The module path is the VSA resourceUri purl namespace; read it from the
@@ -324,13 +309,6 @@ jobs:
         run: |
           set -euo pipefail
           printf 'module=%s\n' "$(go -C "$INPUT_PATH" list -m | head -n1)" >> "$GITHUB_OUTPUT"
-
-      # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-        id: names
-        with:
-          build-type: go
-          shortname: ${{ steps.release.outputs.shortname }}
 
       # Emit the dist filenames as a JSON array; the verify job binds one VSA per file.
       # Derived from the build's base64 `hashes` output (the "<sha256>  <name>" lines the
@@ -353,7 +331,7 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ steps.names.outputs.dist }}
+          name: ${{ needs.prep.outputs.dist }}
           path: ${{ inputs.path }}/dist/
           if-no-files-found: error
 
@@ -362,7 +340,7 @@ jobs:
         if: ${{ inputs.scan-tools != '' }}
         continue-on-error: true   # scan upload is best-effort
         with:
-          name: ${{ steps.names.outputs.scan }}
+          name: ${{ needs.prep.outputs.scan }}
           path: ${{ steps.release.outputs.metadata-dir }}/scan/
 
       # Fold govulncheck.json (from the checks job) into scan/govulncheck/.
@@ -371,14 +349,14 @@ jobs:
         if: ${{ inputs.run-tests }}
         continue-on-error: true
         with:
-          name: ${{ steps.names.outputs.checks }}
+          name: ${{ needs.prep.outputs.checks }}
           path: ${{ steps.release.outputs.metadata-dir }}/scan/govulncheck/
 
       # Non-release: this is the final unified metadata (sbom + scan/). On
       # release the verify job appends the bundle and owns the final upload.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ needs.gate.outputs.should-release == 'true' && steps.names.outputs.metadata-pre || steps.names.outputs.metadata }}
+          name: ${{ needs.prep.outputs.should-release == 'true' && needs.prep.outputs.metadata-pre || needs.prep.outputs.metadata }}
           path: ${{ steps.release.outputs.metadata-dir }}/
           if-no-files-found: error
 
@@ -386,8 +364,8 @@ jobs:
   # reusable workflow as builder.id (its job_workflow_ref) and the Sigstore
   # signing identity
   attest:
-    if: ${{ needs.gate.outputs.should-release == 'true' }}
-    needs: [guard, gate, release]
+    if: ${{ needs.prep.outputs.should-release == 'true' }}
+    needs: [prep, release]
     runs-on: ubuntu-latest
     permissions:
       id-token: write       # OIDC for Sigstore keyless signing
@@ -404,7 +382,7 @@ jobs:
         id: attest
         with:
           build-type: go
-          shortname: ${{ needs.release.outputs.shortname }}
+          shortname: ${{ needs.prep.outputs.shortname }}
           subject-checksums: dist/checksums.txt
 
   # Emit one signed SLSA Verification Summary Attestation (VSA) per dist archive
@@ -418,21 +396,21 @@ jobs:
   # job gated on this reusable workflow is blocked, and (b) surfaces a
   # policy/tooling regression loudly. Keep fail: true for both effects.
   verify:
-    if: ${{ needs.gate.outputs.should-release == 'true' }}
-    needs: [guard, gate, release, attest]
+    if: ${{ needs.prep.outputs.should-release == 'true' }}
+    needs: [prep, release, attest]
     runs-on: ubuntu-latest
     permissions:
       id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
       attestations: write   # post each VSA to the GitHub attestation store
       contents: write       # attach the bundle to the release on tag pushes
     outputs:
-      attestation-bundle-name: ${{ needs.release.outputs.metadata-artifact-name }}
+      attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify_release@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         with:
           build-type: go
-          shortname: ${{ needs.release.outputs.shortname }}
+          shortname: ${{ needs.prep.outputs.shortname }}
           dist-files: ${{ needs.release.outputs.dist-files }}
           policy: policies/wrangle-provenance-go-v1.hjson
           collector: jsonl:provenance/provenance.jsonl

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -168,7 +168,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@1546eddfe43e1b74cbc27618cb48c91d96726579 # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@89ff2eb2523c6475e53f337e6d67e7ca0a78522d # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: go

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -169,7 +169,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@1546eddfe43e1b74cbc27618cb48c91d96726579 # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: go

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -168,7 +168,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@664df2f26c43826bf2e42be001d7b8a5df5ff362 # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@731eb4e95e4c53cce9dd8d57f0ba5c626517b39f # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: go

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -145,7 +145,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@1546eddfe43e1b74cbc27618cb48c91d96726579 # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@89ff2eb2523c6475e53f337e6d67e7ca0a78522d # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: npm

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -145,7 +145,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@664df2f26c43826bf2e42be001d7b8a5df5ff362 # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@731eb4e95e4c53cce9dd8d57f0ba5c626517b39f # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: npm

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -146,7 +146,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@1546eddfe43e1b74cbc27618cb48c91d96726579 # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: npm

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -110,7 +110,7 @@ on:
         value: ${{ jobs.build.outputs.tarball }}
       dist-artifact-name:
         description: "Name of the uploaded dist/ artifact (download with this name to publish)"
-        value: ${{ jobs.build.outputs.dist-artifact-name }}
+        value: ${{ jobs.prep.outputs.dist }}
       provenance-artifact-name:
         description: "Name of the workflow artifact containing the SLSA provenance bundle — one JSON object per line, covering all dist subjects. Empty when should-release is false."
         value: ${{ jobs.attest.outputs.bundle-artifact-name }}
@@ -119,47 +119,45 @@ on:
         value: ${{ jobs.verify.outputs.attestation-bundle-name }}
       metadata-artifact-name:
         description: "Name of the unified metadata workflow artifact. Format: `npm-metadata[-<shortname>]`. Contents and layout: docs/metadata_layout.md."
-        value: ${{ jobs.build.outputs.metadata-artifact-name }}
+        value: ${{ jobs.prep.outputs.metadata }}
       should-release:
         description: |
           "true" if the current event matches release-events and the caller
           should perform release-time actions (publish, attestation upload,
           etc.); "false" otherwise. Wrangle gates the attest and verify jobs on
           this internally; the caller's publish job should gate on it too.
-        value: ${{ jobs.gate.outputs.should-release }}
+        value: ${{ jobs.prep.outputs.should-release }}
 
 jobs:
-  # Refuse trigger patterns known to expose this workflow to supply-chain
-  # attack classes (pull_request_target, workflow_run via pull_request_target).
-  # The guard MUST stay first under `jobs:`; every other job lists `guard`
-  # in its `needs:` so a refused invocation skips the entire workflow.
-  # Full trigger contract: docs/SPEC.md#trigger-model.
-  guard:
+  # Refuse unsafe triggers, decide should-release, and derive the shared
+  # package names — once, as job outputs every downstream job reads. The
+  # guard runs first inside prep, so prep MUST stay first under `jobs:` and
+  # every other job lists `prep` in its `needs:` so a refused invocation
+  # skips the entire workflow. Full trigger contract: docs/SPEC.md#trigger-model.
+  prep:
     runs-on: ubuntu-latest
-    permissions: {}    # reads env only — no workspace, no API, no secrets
-    steps:
-      # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-
-  gate:
-    needs: [guard]
-    runs-on: ubuntu-latest
-    permissions: {}    # release_gate reads only env; no workspace, no API
+    permissions: {}    # guard/gate/names read env only — no workspace, no API, no secrets
     outputs:
-      should-release: ${{ steps.gate.outputs.should-release }}
+      should-release: ${{ steps.prep.outputs.should-release }}
+      shortname: ${{ steps.prep.outputs.shortname }}
+      dist: ${{ steps.prep.outputs.dist }}
+      scan: ${{ steps.prep.outputs.scan }}
+      metadata: ${{ steps.prep.outputs.metadata }}
+      metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
-      # No checkout: release_gate resolves via ${{ github.action_path }}.
-      # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-        id: gate
+      # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
+      - uses: TomHennen/wrangle/actions/prep@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+        id: prep
         with:
-          events: ${{ inputs.release-events }}
+          build-type: npm
+          path: ${{ inputs.path }}
+          release-events: ${{ inputs.release-events }}
 
   # Source scan. A load-bearing (:fail) finding fails this job, failing
   # the run so the caller's publish (gated on this workflow via needs:)
   # is blocked — decoupled scan/build runs can't gate publish.
   scan:
-    needs: [guard, gate]
+    needs: [prep]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -172,30 +170,22 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.ref || '' }}
 
-      # Shared name derivation so the scan and build jobs can't drift.
-      # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-        id: names
-        if: ${{ inputs.scan-tools != '' }}
-        with:
-          build-type: npm
-          path: ${{ inputs.path }}
-
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/scan@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
           # The build job folds this into the unified npm-metadata.
-          artifact-name: ${{ steps.names.outputs.scan }}
+          artifact-name: ${{ needs.prep.outputs.scan }}
           # Cold on release: the scan gates an attested build, so a
           # poisoned tool cache must not be able to forge a passing scan.
-          go-cache: ${{ needs.gate.outputs.should-release == 'true' && '' || inputs.go-cache }}
+          go-cache: ${{ needs.prep.outputs.should-release == 'true' && '' || inputs.go-cache }}
 
   build:
-    # needs `gate` to read should-release for the conditional metadata upload,
-    # and `scan` to fold the untrusted scan output into the metadata dir.
-    needs: [guard, gate, scan]
+    # needs `prep` to read should-release (conditional metadata upload) and
+    # the shared artifact names, and `scan` to fold the untrusted scan output
+    # into the metadata dir.
+    needs: [prep, scan]
     runs-on: ubuntu-latest
     permissions:
       contents: read    # minimal — no OIDC, no publish
@@ -207,10 +197,6 @@ jobs:
       # the VSA's resourceUri and the workflow re-exports it for publish gates.
       resource-uri: pkg:npm/${{ steps.pkgname.outputs.name }}@${{ steps.build.outputs.version }}
       tarball: ${{ steps.build.outputs.tarball }}
-      shortname: ${{ steps.build.outputs.shortname }}
-      dist-artifact-name: ${{ steps.names.outputs.dist }}
-      metadata-artifact-name: ${{ steps.names.outputs.metadata }}
-      metadata-pre-artifact-name: ${{ steps.names.outputs.metadata-pre }}
       metadata-dir: ${{ steps.build.outputs.metadata-dir }}
       # JSON array of dist filenames the verify job binds one VSA to each.
       dist-files: ${{ steps.distfiles.outputs.files }}
@@ -228,13 +214,6 @@ jobs:
           node-version: ${{ inputs.node-version }}
           run-tests: ${{ inputs.run-tests }}
           ignore-scripts: ${{ inputs.ignore-scripts }}
-
-      # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-        id: names
-        with:
-          build-type: npm
-          shortname: ${{ steps.build.outputs.shortname }}
 
       # The npm composite doesn't emit the package name; read it from
       # package.json for the VSA resourceUri purl. Scoped names (@scope/pkg) pass through.
@@ -267,7 +246,7 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ steps.names.outputs.dist }}
+          name: ${{ needs.prep.outputs.dist }}
           path: ${{ inputs.path }}/dist/
 
       # Fold the untrusted scan job's output into the metadata dir as inert data.
@@ -275,14 +254,14 @@ jobs:
         if: ${{ inputs.scan-tools != '' }}
         continue-on-error: true   # scan upload is best-effort
         with:
-          name: ${{ steps.names.outputs.scan }}
+          name: ${{ needs.prep.outputs.scan }}
           path: ${{ steps.build.outputs.metadata-dir }}/scan/
 
       # Non-release: this is the final unified metadata (sbom + scan/). On
       # release the verify job appends the bundle and owns the final upload.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ needs.gate.outputs.should-release == 'true' && steps.names.outputs.metadata-pre || steps.names.outputs.metadata }}
+          name: ${{ needs.prep.outputs.should-release == 'true' && needs.prep.outputs.metadata-pre || needs.prep.outputs.metadata }}
           path: ${{ steps.build.outputs.metadata-dir }}/
           if-no-files-found: error
 
@@ -290,9 +269,9 @@ jobs:
   # reusable workflow as builder.id (its job_workflow_ref) and the Sigstore
   # signing identity
   attest:
-    if: ${{ needs.gate.outputs.should-release == 'true' }}
+    if: ${{ needs.prep.outputs.should-release == 'true' }}
     # needs `scan` so a load-bearing finding blocks attestation + the caller's publish.
-    needs: [guard, gate, build, scan]
+    needs: [prep, build, scan]
     runs-on: ubuntu-latest
     permissions:
       id-token: write       # OIDC for Sigstore keyless signing
@@ -306,7 +285,7 @@ jobs:
         id: attest
         with:
           build-type: npm
-          shortname: ${{ needs.build.outputs.shortname }}
+          shortname: ${{ needs.prep.outputs.shortname }}
           subject-path: dist/*
 
   # Emit one signed SLSA Verification Summary Attestation (VSA) per dist artifact
@@ -317,21 +296,21 @@ jobs:
   # tenets follow once those are produced as signed attestations a registered
   # identity covers.
   verify:
-    if: ${{ needs.gate.outputs.should-release == 'true' }}
-    needs: [guard, gate, build, attest]
+    if: ${{ needs.prep.outputs.should-release == 'true' }}
+    needs: [prep, build, attest]
     runs-on: ubuntu-latest
     permissions:
       id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
       attestations: write   # post each VSA to the GitHub attestation store
       contents: write       # attach the bundle to the release on tag pushes
     outputs:
-      attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
+      attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify_release@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         with:
           build-type: npm
-          shortname: ${{ needs.build.outputs.shortname }}
+          shortname: ${{ needs.prep.outputs.shortname }}
           dist-files: ${{ needs.build.outputs.dist-files }}
           policy: policies/wrangle-provenance-npm-v1.hjson
           collector: jsonl:provenance/provenance.jsonl

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -129,11 +129,10 @@ on:
         value: ${{ jobs.prep.outputs.should-release }}
 
 jobs:
-  # Refuse unsafe triggers, decide should-release, and derive the shared
-  # package names — once, as job outputs every downstream job reads. The
-  # guard runs first inside prep, so prep MUST stay first under `jobs:` and
-  # every other job lists `prep` in its `needs:` so a refused invocation
-  # skips the entire workflow. Full trigger contract: docs/SPEC.md#trigger-model.
+  # MUST stay first under `jobs:`: prep's guard refuses unsafe triggers
+  # before any other job runs, and every job `needs: [prep]`. prep also
+  # decides should-release and derives the shared package names.
+  # docs/SPEC.md#trigger-model.
   prep:
     runs-on: ubuntu-latest
     permissions: {}    # guard/gate/names read env only — no workspace, no API, no secrets
@@ -182,9 +181,7 @@ jobs:
           go-cache: ${{ needs.prep.outputs.should-release == 'true' && '' || inputs.go-cache }}
 
   build:
-    # needs `prep` to read should-release (conditional metadata upload) and
-    # the shared artifact names, and `scan` to fold the untrusted scan output
-    # into the metadata dir.
+    # needs `scan` to fold the untrusted scan output into the metadata dir.
     needs: [prep, scan]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -145,7 +145,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@89ff2eb2523c6475e53f337e6d67e7ca0a78522d # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@664df2f26c43826bf2e42be001d7b8a5df5ff362 # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: npm

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -87,7 +87,7 @@ on:
         value: ${{ jobs.build.outputs.resource-uri }}
       dist-artifact-name:
         description: "Name of the uploaded dist/ artifact (download with this name to publish)"
-        value: ${{ jobs.build.outputs.dist-artifact-name }}
+        value: ${{ jobs.prep.outputs.dist }}
       provenance-artifact-name:
         description: "Name of the workflow artifact containing the SLSA provenance bundle — one JSON object per line, covering all dist subjects. Empty when should-release is false."
         value: ${{ jobs.attest.outputs.bundle-artifact-name }}
@@ -96,51 +96,45 @@ on:
         value: ${{ jobs.verify.outputs.attestation-bundle-name }}
       metadata-artifact-name:
         description: "Name of the unified metadata workflow artifact. Format: `python-metadata[-<shortname>]`. Contents and layout: docs/metadata_layout.md."
-        value: ${{ jobs.build.outputs.metadata-artifact-name }}
+        value: ${{ jobs.prep.outputs.metadata }}
       should-release:
         description: |
           "true" if the current event matches release-events and the caller
           should perform release-time actions (publish, attestation upload,
           etc.); "false" otherwise. Wrangle gates the attest and verify jobs on
           this internally; the caller's publish job should gate on it too.
-        value: ${{ jobs.gate.outputs.should-release }}
+        value: ${{ jobs.prep.outputs.should-release }}
 
 jobs:
-  # Refuse trigger patterns known to expose this workflow to supply-chain
-  # attack classes (pull_request_target, workflow_run via pull_request_target).
-  # The guard MUST stay first under `jobs:`; every other job lists `guard`
-  # in its `needs:` so a refused invocation skips the entire workflow.
-  # Full trigger contract: docs/SPEC.md#trigger-model.
-  guard:
+  # Refuse unsafe triggers, decide should-release, and derive the shared
+  # package names — once, as job outputs every downstream job reads. The
+  # guard runs first inside prep, so prep MUST stay first under `jobs:` and
+  # every other job lists `prep` in its `needs:` so a refused invocation
+  # skips the entire workflow. Full trigger contract: docs/SPEC.md#trigger-model.
+  prep:
     runs-on: ubuntu-latest
-    permissions: {}    # reads env only — no workspace, no API, no secrets
-    steps:
-      # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-
-  # Decide whether release-time actions (provenance, publish) should run
-  # for this event. Cheap separate job so the result is available to
-  # both the attest/verify jobs below and the caller's publish job via
-  # outputs.should-release.
-  gate:
-    needs: [guard]
-    runs-on: ubuntu-latest
-    permissions: {}    # release_gate reads only env; no workspace, no API
+    permissions: {}    # guard/gate/names read env only — no workspace, no API, no secrets
     outputs:
-      should-release: ${{ steps.gate.outputs.should-release }}
+      should-release: ${{ steps.prep.outputs.should-release }}
+      shortname: ${{ steps.prep.outputs.shortname }}
+      dist: ${{ steps.prep.outputs.dist }}
+      scan: ${{ steps.prep.outputs.scan }}
+      metadata: ${{ steps.prep.outputs.metadata }}
+      metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
-      # No checkout: release_gate resolves via ${{ github.action_path }}.
-      # TODO: replace with $/actions/release_gate when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/release_gate@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-        id: gate
+      # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
+      - uses: TomHennen/wrangle/actions/prep@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+        id: prep
         with:
-          events: ${{ inputs.release-events }}
+          build-type: python
+          path: ${{ inputs.path }}
+          release-events: ${{ inputs.release-events }}
 
   # Source scan. A load-bearing (:fail) finding fails this job, failing
   # the run so the caller's publish (gated on this workflow via needs:)
   # is blocked — decoupled scan/build runs can't gate publish.
   scan:
-    needs: [guard, gate]
+    needs: [prep]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -153,33 +147,24 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.ref || '' }}
 
-      # Shared name derivation so the scan and build jobs can't drift.
-      # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-        id: names
-        if: ${{ inputs.scan-tools != '' }}
-        with:
-          build-type: python
-          path: ${{ inputs.path }}
-
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/scan@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
           # The build job folds this into the unified python-metadata.
-          artifact-name: ${{ steps.names.outputs.scan }}
+          artifact-name: ${{ needs.prep.outputs.scan }}
           # Cold on release: the scan gates an attested build, so a
           # poisoned tool cache must not be able to forge a passing scan.
-          go-cache: ${{ needs.gate.outputs.should-release == 'true' && '' || inputs.go-cache }}
+          go-cache: ${{ needs.prep.outputs.should-release == 'true' && '' || inputs.go-cache }}
 
   build:
-    # needs `gate` so the build can read should-release and disable the
-    # uv cache for release builds (SLSA L3 isolation — see the `cache:`
-    # input below and docs/SLSA_L3_AUDIT.md Finding 1). needs `scan` so the
-    # untrusted scan job's output can be folded into the unified metadata
-    # dir as inert data before upload.
-    needs: [guard, gate, scan]
+    # needs `prep` to read should-release (disables the uv cache for release
+    # builds — SLSA L3 isolation, see the `cache:` input below and
+    # docs/SLSA_L3_AUDIT.md Finding 1) and the shared artifact names. needs
+    # `scan` so the untrusted scan job's output can be folded into the
+    # unified metadata dir as inert data before upload.
+    needs: [prep, scan]
     runs-on: ubuntu-latest
     permissions:
       contents: read    # minimal — no OIDC, no publish
@@ -188,10 +173,6 @@ jobs:
       name: ${{ steps.build.outputs.name }}
       version: ${{ steps.build.outputs.version }}
       resource-uri: ${{ steps.purl.outputs.resource-uri }}
-      shortname: ${{ steps.build.outputs.shortname }}
-      dist-artifact-name: ${{ steps.names.outputs.dist }}
-      metadata-artifact-name: ${{ steps.names.outputs.metadata }}
-      metadata-pre-artifact-name: ${{ steps.names.outputs.metadata-pre }}
       metadata-dir: ${{ steps.build.outputs.metadata-dir }}
       # JSON array of dist filenames the verify job binds one VSA to each.
       dist-files: ${{ steps.distfiles.outputs.files }}
@@ -214,7 +195,7 @@ jobs:
           # docs/SLSA_L3_AUDIT.md Finding 1. PR builds keep the cache for
           # fast iteration; they produce no provenance, so cache poisoning
           # is not an L3 concern at that layer.
-          cache: ${{ needs.gate.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
+          cache: ${{ needs.prep.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
 
       # Compose the VSA resourceUri purl. PyPI's purl type normalizes the
       # name per PEP 503 (lowercase; runs of . _ - collapse to -), so the
@@ -229,13 +210,6 @@ jobs:
           set -euo pipefail
           normalized="$(printf '%s' "$NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[._-]+/-/g')"
           printf 'resource-uri=pkg:pypi/%s@%s\n' "$normalized" "$VERSION" >> "$GITHUB_OUTPUT"
-
-      # TODO: replace with $/actions/package_metadata when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
-        id: names
-        with:
-          build-type: python
-          shortname: ${{ steps.build.outputs.shortname }}
 
       # Emit the dist filenames as a JSON array; the verify job binds one VSA per file.
       # Derived from the build's base64 `hashes` output (the "<sha256>  <name>" lines the
@@ -258,7 +232,7 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ steps.names.outputs.dist }}
+          name: ${{ needs.prep.outputs.dist }}
           path: ${{ inputs.path }}/dist/
 
       # Fold the untrusted scan job's output into the metadata dir as inert
@@ -267,7 +241,7 @@ jobs:
         if: ${{ inputs.scan-tools != '' }}
         continue-on-error: true   # scan upload is best-effort (continue-on-error in the scan job)
         with:
-          name: ${{ steps.names.outputs.scan }}
+          name: ${{ needs.prep.outputs.scan }}
           path: ${{ steps.build.outputs.metadata-dir }}/scan/
 
       # Non-release: this is the final unified metadata (sbom + scan/). On
@@ -275,7 +249,7 @@ jobs:
       # so build only stages sbom + scan/ as a transient for verify.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ needs.gate.outputs.should-release == 'true' && steps.names.outputs.metadata-pre || steps.names.outputs.metadata }}
+          name: ${{ needs.prep.outputs.should-release == 'true' && needs.prep.outputs.metadata-pre || needs.prep.outputs.metadata }}
           path: ${{ steps.build.outputs.metadata-dir }}/
           if-no-files-found: error
 
@@ -283,9 +257,9 @@ jobs:
   # reusable workflow as builder.id (its job_workflow_ref) and the Sigstore
   # signing identity
   attest:
-    if: ${{ needs.gate.outputs.should-release == 'true' }}
+    if: ${{ needs.prep.outputs.should-release == 'true' }}
     # needs `scan` so a load-bearing finding blocks attestation + the caller's publish.
-    needs: [guard, gate, build, scan]
+    needs: [prep, build, scan]
     runs-on: ubuntu-latest
     permissions:
       id-token: write       # OIDC for Sigstore keyless signing
@@ -299,7 +273,7 @@ jobs:
         id: attest
         with:
           build-type: python
-          shortname: ${{ needs.build.outputs.shortname }}
+          shortname: ${{ needs.prep.outputs.shortname }}
           subject-path: dist/*
 
   # Emit one signed SLSA Verification Summary Attestation (VSA) per dist artifact
@@ -310,21 +284,21 @@ jobs:
   # tenets follow once those are produced as signed attestations a registered
   # identity covers.
   verify:
-    if: ${{ needs.gate.outputs.should-release == 'true' }}
-    needs: [guard, gate, build, attest]
+    if: ${{ needs.prep.outputs.should-release == 'true' }}
+    needs: [prep, build, attest]
     runs-on: ubuntu-latest
     permissions:
       id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
       attestations: write   # post each VSA to the GitHub attestation store
       contents: write       # attach the bundle to the release on tag pushes
     outputs:
-      attestation-bundle-name: ${{ needs.build.outputs.metadata-artifact-name }}
+      attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify_release@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
         with:
           build-type: python
-          shortname: ${{ needs.build.outputs.shortname }}
+          shortname: ${{ needs.prep.outputs.shortname }}
           dist-files: ${{ needs.build.outputs.dist-files }}
           policy: policies/wrangle-provenance-python-v1.hjson
           collector: jsonl:provenance/provenance.jsonl

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -123,7 +123,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@1546eddfe43e1b74cbc27618cb48c91d96726579 # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: python

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -122,7 +122,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@664df2f26c43826bf2e42be001d7b8a5df5ff362 # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@731eb4e95e4c53cce9dd8d57f0ba5c626517b39f # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: python

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -122,7 +122,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@1546eddfe43e1b74cbc27618cb48c91d96726579 # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@89ff2eb2523c6475e53f337e6d67e7ca0a78522d # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: python

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -122,7 +122,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@89ff2eb2523c6475e53f337e6d67e7ca0a78522d # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@664df2f26c43826bf2e42be001d7b8a5df5ff362 # bootstrap: PR head until post-merge bump
         id: prep
         with:
           build-type: python

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -106,11 +106,10 @@ on:
         value: ${{ jobs.prep.outputs.should-release }}
 
 jobs:
-  # Refuse unsafe triggers, decide should-release, and derive the shared
-  # package names — once, as job outputs every downstream job reads. The
-  # guard runs first inside prep, so prep MUST stay first under `jobs:` and
-  # every other job lists `prep` in its `needs:` so a refused invocation
-  # skips the entire workflow. Full trigger contract: docs/SPEC.md#trigger-model.
+  # MUST stay first under `jobs:`: prep's guard refuses unsafe triggers
+  # before any other job runs, and every job `needs: [prep]`. prep also
+  # decides should-release and derives the shared package names.
+  # docs/SPEC.md#trigger-model.
   prep:
     runs-on: ubuntu-latest
     permissions: {}    # guard/gate/names read env only — no workspace, no API, no secrets
@@ -159,10 +158,7 @@ jobs:
           go-cache: ${{ needs.prep.outputs.should-release == 'true' && '' || inputs.go-cache }}
 
   build:
-    # needs `prep` to read should-release (disables the uv cache for release
-    # builds — SLSA L3 isolation, see the `cache:` input below and
-    # docs/SLSA_L3_AUDIT.md Finding 1) and the shared artifact names. needs
-    # `scan` so the untrusted scan job's output can be folded into the
+    # needs `scan` so the untrusted scan job's output can be folded into the
     # unified metadata dir as inert data before upload.
     needs: [prep, scan]
     runs-on: ubuntu-latest

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@664df2f26c43826bf2e42be001d7b8a5df5ff362 # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@731eb4e95e4c53cce9dd8d57f0ba5c626517b39f # bootstrap: PR head until post-merge bump
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@89ff2eb2523c6475e53f337e6d67e7ca0a78522d # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@664df2f26c43826bf2e42be001d7b8a5df5ff362 # bootstrap: PR head until post-merge bump
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -57,22 +57,20 @@ on:
         default: ""
 
 jobs:
-  # Refuse trigger patterns known to expose this workflow to supply-chain
-  # attack classes (pull_request_target, workflow_run via pull_request_target).
-  # The guard MUST stay first under `jobs:`; every other job lists `guard`
-  # in its `needs:` so a refused invocation skips the entire workflow.
-  # Full trigger contract: docs/SPEC.md#trigger-model.
-  guard:
+  # MUST stay first under `jobs:`: prep's guard refuses unsafe triggers
+  # before any other job runs, and every job `needs: [prep]`. No build-type,
+  # so prep is guard-only (no release gate, no names). docs/SPEC.md#trigger-model.
+  prep:
     runs-on: ubuntu-latest
-    permissions: {}    # reads env only — no workspace, no API, no secrets
+    permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
-      # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+      # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
+      - uses: TomHennen/wrangle/actions/prep@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
   scan:
-    needs: [guard]
+    needs: [prep]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -95,7 +93,7 @@ jobs:
           go-cache: ${{ inputs.go-cache }}
 
   shell-build:
-    needs: [guard]
+    needs: [prep]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@89ff2eb2523c6475e53f337e6d67e7ca0a78522d # bootstrap: PR head until post-merge bump
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@89ff2eb2523c6475e53f337e6d67e7ca0a78522d # bootstrap: PR head until post-merge bump
 
   check-change:
     needs: [prep]

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@89ff2eb2523c6475e53f337e6d67e7ca0a78522d # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@664df2f26c43826bf2e42be001d7b8a5df5ff362 # bootstrap: PR head until post-merge bump
 
   check-change:
     needs: [prep]

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -20,20 +20,18 @@ on:
         default: ""
 
 jobs:
-  # Refuse trigger patterns known to expose this workflow to supply-chain
-  # attack classes (pull_request_target, workflow_run via pull_request_target).
-  # The guard MUST stay first under `jobs:`; every other job lists `guard`
-  # in its `needs:` so a refused invocation skips the entire workflow.
-  # Full trigger contract: docs/SPEC.md#trigger-model.
-  guard:
+  # MUST stay first under `jobs:`: prep's guard refuses unsafe triggers
+  # before any other job runs, and every job `needs: [prep]`. No build-type,
+  # so prep is guard-only (no release gate, no names). docs/SPEC.md#trigger-model.
+  prep:
     runs-on: ubuntu-latest
-    permissions: {}    # reads env only — no workspace, no API, no secrets
+    permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
-      # TODO: replace with $/actions/preflight_guard when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+      # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
+      - uses: TomHennen/wrangle/actions/prep@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
 
   check-change:
-    needs: [guard]
+    needs: [prep]
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@664df2f26c43826bf2e42be001d7b8a5df5ff362 # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@731eb4e95e4c53cce9dd8d57f0ba5c626517b39f # bootstrap: PR head until post-merge bump
 
   check-change:
     needs: [prep]

--- a/actions/prep/action.yml
+++ b/actions/prep/action.yml
@@ -1,17 +1,20 @@
 name: Wrangle Prep
 description: >
-  The shared head-of-pipeline job for wrangle's reusable build workflows.
-  Runs the preflight guard (refuse unsafe triggers), the release gate
-  (decide should-release), and package-name derivation in one job, then
-  exposes the results as outputs every downstream job reads uniformly —
-  so the build type's shared values are computed once, not re-derived per
-  job. Needs no permissions and no checkout: every step resolves via
+  The shared head-of-pipeline job for wrangle's reusable workflows. Always
+  refuses unsafe triggers (the preflight guard). When a build-type is given
+  it also decides should-release (the release gate) and derives the shared
+  package names, exposing them as outputs every downstream job reads
+  uniformly. An empty build-type is the guard-only mode for scan/CI
+  workflows that release nothing: the gate and name derivation are skipped,
+  should-release is false, and the name outputs are empty. Needs no
+  permissions and no checkout: every step resolves via
   ${{ github.action_path }} and reads env only.
 
 inputs:
   build-type:
-    description: "Build type the names are namespaced under (go, python, npm, container)."
-    required: true
+    description: "Build type the names are namespaced under (go, python, npm, container). Empty = guard-only mode."
+    required: false
+    default: ""
   path:
     description: "Path the shortname is derived from."
     required: false
@@ -23,8 +26,8 @@ inputs:
 
 outputs:
   should-release:
-    description: "true if release-time actions (provenance, publish, verify) should run."
-    value: ${{ steps.gate.outputs.should-release }}
+    description: "true if release-time actions (provenance, publish, verify) should run; false in guard-only mode."
+    value: ${{ steps.gate.outputs.should-release || 'false' }}
   shortname:
     description: "The path-derived shortname namespacing per-build artifacts."
     value: ${{ steps.names.outputs.shortname }}
@@ -58,15 +61,18 @@ runs:
     # TODO: replace with $/actions/preflight_guard when $/ syntax ships (#136)
     - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
 
+    # Gate + names run only for a real build type; guard-only mode skips them.
     # TODO: replace with $/actions/release_gate when $/ syntax ships (#136)
     - uses: TomHennen/wrangle/actions/release_gate@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
       id: gate
+      if: ${{ inputs.build-type != '' }}
       with:
         events: ${{ inputs.release-events }}
 
     # TODO: replace with $/actions/package_metadata when $/ syntax ships (#136)
     - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
       id: names
+      if: ${{ inputs.build-type != '' }}
       with:
         build-type: ${{ inputs.build-type }}
         path: ${{ inputs.path }}

--- a/actions/prep/action.yml
+++ b/actions/prep/action.yml
@@ -1,0 +1,72 @@
+name: Wrangle Prep
+description: >
+  The shared head-of-pipeline job for wrangle's reusable build workflows.
+  Runs the preflight guard (refuse unsafe triggers), the release gate
+  (decide should-release), and package-name derivation in one job, then
+  exposes the results as outputs every downstream job reads uniformly —
+  so the build type's shared values are computed once, not re-derived per
+  job. Needs no permissions and no checkout: every step resolves via
+  ${{ github.action_path }} and reads env only.
+
+inputs:
+  build-type:
+    description: "Build type the names are namespaced under (go, python, npm, container)."
+    required: true
+  path:
+    description: "Path the shortname is derived from."
+    required: false
+    default: "."
+  release-events:
+    description: "Which events trigger release-time actions; passed to release_gate."
+    required: false
+    default: non-pull-request
+
+outputs:
+  should-release:
+    description: "true if release-time actions (provenance, publish, verify) should run."
+    value: ${{ steps.gate.outputs.should-release }}
+  shortname:
+    description: "The path-derived shortname namespacing per-build artifacts."
+    value: ${{ steps.names.outputs.shortname }}
+  dist:
+    description: "Name of the dist/ product artifact."
+    value: ${{ steps.names.outputs.dist }}
+  scan:
+    description: "Name of the source-scan output transient folded into the metadata."
+    value: ${{ steps.names.outputs.scan }}
+  checks:
+    description: "Name of the checks-job transient (go: govulncheck.json) folded into the metadata."
+    value: ${{ steps.names.outputs.checks }}
+  metadata:
+    description: "Name of the unified metadata artifact (sbom + scan/ + bundle)."
+    value: ${{ steps.names.outputs.metadata }}
+  metadata-pre:
+    description: "Name of the build job's pre-verify metadata transient (release runs)."
+    value: ${{ steps.names.outputs.metadata-pre }}
+  provenance-bundle:
+    description: "Name of the attest job's raw provenance bundle transient."
+    value: ${{ steps.names.outputs.provenance-bundle }}
+  metadata-dir:
+    description: "The unified metadata dir (metadata/<type>[/<shortname>]) the bundle and sbom + scan/ live under."
+    value: ${{ steps.names.outputs.metadata-dir }}
+
+runs:
+  using: composite
+  steps:
+    # Refuse unsafe triggers first, so a refused invocation fails prep and
+    # every downstream `needs: [prep]` job skips.
+    # TODO: replace with $/actions/preflight_guard when $/ syntax ships (#136)
+    - uses: TomHennen/wrangle/actions/preflight_guard@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+
+    # TODO: replace with $/actions/release_gate when $/ syntax ships (#136)
+    - uses: TomHennen/wrangle/actions/release_gate@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+      id: gate
+      with:
+        events: ${{ inputs.release-events }}
+
+    # TODO: replace with $/actions/package_metadata when $/ syntax ships (#136)
+    - uses: TomHennen/wrangle/actions/package_metadata@6ddb817cf528110aff86879ca7fbf4ff84c52669 # main 2026-06-20
+      id: names
+      with:
+        build-type: ${{ inputs.build-type }}
+        path: ${{ inputs.path }}

--- a/actions/prep/action.yml
+++ b/actions/prep/action.yml
@@ -7,8 +7,8 @@ description: >
   uniformly. An empty build-type is the guard-only mode for scan/CI
   workflows that release nothing: the gate and name derivation are skipped,
   should-release is false, and the name outputs are empty. Needs no
-  permissions and no checkout: every step resolves via
-  ${{ github.action_path }} and reads env only.
+  permissions and no checkout: every step reads env only and resolves from
+  the action's own path.
 
 inputs:
   build-type:

--- a/actions/prep/test.bats
+++ b/actions/prep/test.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+# Structural tests for actions/prep/action.yml — the shared head-of-pipeline
+# composite the reusable build workflows run as their first job. Asserts the
+# three sub-actions are wired in the guard-first order and that the gate and
+# names outputs are surfaced for downstream jobs.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    ACTION="$REPO_ROOT/actions/prep/action.yml"
+}
+
+@test "prep: runs preflight_guard before the gate and names steps" {
+    guard_line="$(grep -n 'actions/preflight_guard@' "$ACTION" | head -1 | cut -d: -f1)"
+    gate_line="$(grep -n 'actions/release_gate@' "$ACTION" | head -1 | cut -d: -f1)"
+    names_line="$(grep -n 'actions/package_metadata@' "$ACTION" | head -1 | cut -d: -f1)"
+    [ -n "$guard_line" ] && [ -n "$gate_line" ] && [ -n "$names_line" ]
+    [ "$guard_line" -lt "$gate_line" ]
+    [ "$gate_line" -lt "$names_line" ]
+}
+
+@test "prep: gate reads the release-events input" {
+    run grep -F 'events: ${{ inputs.release-events }}' "$ACTION"
+    [ "$status" -eq 0 ]
+}
+
+@test "prep: names derives from build-type + path" {
+    run grep -F 'build-type: ${{ inputs.build-type }}' "$ACTION"
+    [ "$status" -eq 0 ]
+    run grep -F 'path: ${{ inputs.path }}' "$ACTION"
+    [ "$status" -eq 0 ]
+}
+
+@test "prep: surfaces should-release from the gate step" {
+    run grep -F 'value: ${{ steps.gate.outputs.should-release }}' "$ACTION"
+    [ "$status" -eq 0 ]
+}
+
+@test "prep: surfaces shortname and the metadata names from the names step" {
+    for out in shortname dist scan checks metadata metadata-pre provenance-bundle metadata-dir; do
+        run grep -F "value: \${{ steps.names.outputs.$out }}" "$ACTION"
+        [ "$status" -eq 0 ]
+    done
+}

--- a/actions/prep/test.bats
+++ b/actions/prep/test.bats
@@ -1,9 +1,9 @@
 #!/usr/bin/env bats
 
 # Structural tests for actions/prep/action.yml — the shared head-of-pipeline
-# composite the reusable build workflows run as their first job. Asserts the
-# three sub-actions are wired in the guard-first order and that the gate and
-# names outputs are surfaced for downstream jobs.
+# composite every reusable workflow runs as its first job. Asserts the three
+# sub-actions are wired in the guard-first order, that the gate and names
+# outputs are surfaced, and that an empty build-type is guard-only.
 
 setup() {
     REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
@@ -24,15 +24,23 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "prep: gate and names are skipped in guard-only mode (empty build-type)" {
+    # Both the gate and names steps must be gated on a non-empty build-type
+    # so a scan/CI workflow heads with prep without deriving release/names.
+    run grep -cF "if: \${{ inputs.build-type != '' }}" "$ACTION"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 2 ]
+}
+
+@test "prep: should-release falls back to false when the gate is skipped" {
+    run grep -F "value: \${{ steps.gate.outputs.should-release || 'false' }}" "$ACTION"
+    [ "$status" -eq 0 ]
+}
+
 @test "prep: names derives from build-type + path" {
     run grep -F 'build-type: ${{ inputs.build-type }}' "$ACTION"
     [ "$status" -eq 0 ]
     run grep -F 'path: ${{ inputs.path }}' "$ACTION"
-    [ "$status" -eq 0 ]
-}
-
-@test "prep: surfaces should-release from the gate step" {
-    run grep -F 'value: ${{ steps.gate.outputs.should-release }}' "$ACTION"
     [ "$status" -eq 0 ]
 }
 

--- a/test/test_action_manifest_no_header_expressions.bats
+++ b/test/test_action_manifest_no_header_expressions.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+# Every composite/action manifest's header (the `name:` and `description:`
+# fields, before inputs/outputs/runs) must contain no `${{ ... }}`
+# expression. GitHub evaluates expressions in those manifest fields at load
+# time, where step contexts like `github.action_path` are not defined — so a
+# stray `${{ ... }}` there makes the whole action fail to load with
+# "Unrecognized named-value", and only surfaces when the action is actually
+# invoked (e.g. a dogfooded job), not in actionlint. This guards the header
+# fields, where literal expressions are never legitimate.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+}
+
+@test "action manifests: no \${{ }} in the name/description header" {
+    local bad=0
+    while IFS= read -r -d '' manifest; do
+        # Header = lines before the first of inputs:/outputs:/runs: (the
+        # fields GitHub evaluates as literals at manifest load).
+        header="$(awk '/^(inputs|outputs|runs):/ { exit } { print }' "$manifest")"
+        if printf '%s\n' "$header" | grep -qF '${{'; then
+            printf 'Expression in manifest header of %s:\n' "$manifest" >&2
+            printf '%s\n' "$header" | grep -nF '${{' >&2
+            bad=1
+        fi
+    done < <(find "$REPO_ROOT/actions" "$REPO_ROOT/build" "$REPO_ROOT/tools" \
+        -name action.yml -type f -print0 2>/dev/null)
+    [[ "$bad" -eq 0 ]]
+}

--- a/test/test_refuse_pull_request_target.bats
+++ b/test/test_refuse_pull_request_target.bats
@@ -3,20 +3,19 @@
 # Structural tests asserting that every reusable workflow in
 # .github/workflows/ wires the preflight guard correctly. The guard's
 # own refusal-logic tests live next to the action source in
-# actions/preflight_guard/test.bats — this file only checks the
-# workflow-level wiring:
+# actions/preflight_guard/test.bats; prep's guard-first ordering is in
+# actions/prep/test.bats. This file only checks the workflow-level
+# wiring — every reusable workflow heads with the `prep` job:
 #
-#   1. The first job under `jobs:` is the head job — `guard` (runs the
-#      guard directly) or `prep` (runs the guard as its first step; see
-#      actions/prep/test.bats for the ordering guarantee).
-#   2. The head job has `permissions: {}` (least privilege).
-#   3. The head job invokes preflight_guard (guard) or prep via `uses:`.
-#   4. Every other job lists the head job in its `needs:` so a refused
+#   1. The first job under `jobs:` is `prep`.
+#   2. The `prep` job has `permissions: {}` (least privilege).
+#   3. The `prep` job invokes `actions/prep` via `uses:`.
+#   4. Every other job lists `prep` in its `needs:` so a refused
 #      invocation skips the entire workflow.
 #
 # Grep-based; doesn't parse YAML. Tests break loudly if anyone refactors
 # the guard wiring out or accidentally adds a new job without the
-# head-job dependency.
+# `needs: [prep]` dependency.
 
 setup() {
     REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
@@ -38,16 +37,6 @@ setup() {
     done < <(find "$WORKFLOWS_DIR" -maxdepth 1 -name '*.yml' -type f -print0 | sort -z)
 }
 
-# First job under `jobs:` — the head job that gates the rest.
-head_job() {
-    awk '
-        /^jobs:$/                                  { in_jobs=1; next }
-        in_jobs && /^  [a-zA-Z][a-zA-Z0-9_-]*:$/   {
-            name=$1; sub(":", "", name); print name; exit
-        }
-    ' "$1"
-}
-
 # The `<job>:` block (its lines, up to the next top-level job).
 job_block() {
     awk -v j="$2" '
@@ -66,52 +55,54 @@ job_block() {
     }
 }
 
-@test "wiring: first job in each reusable workflow is the guard or prep head job" {
+@test "wiring: first job in each reusable workflow is prep" {
     # Defense against accidentally reordering the guard below a job that
     # could side-effect before the refusal fires.
     for wf in "${REUSABLE_WORKFLOWS[@]}"; do
-        first_job="$(head_job "$WORKFLOWS_DIR/$wf")"
-        [[ "$first_job" == "guard" || "$first_job" == "prep" ]] || {
-            printf "First job in %s is '%s' not 'guard' or 'prep'\n" "$wf" "$first_job" >&2
+        first_job=$(awk '
+            /^jobs:$/                                  { in_jobs=1; next }
+            in_jobs && /^  [a-zA-Z][a-zA-Z0-9_-]*:$/   {
+                name=$1; sub(":", "", name); print name; exit
+            }
+        ' "$WORKFLOWS_DIR/$wf")
+        [[ "$first_job" == "prep" ]] || {
+            printf "First job in %s is '%s' not 'prep'\n" "$wf" "$first_job" >&2
             return 1
         }
     done
 }
 
-@test "wiring: head job invokes preflight_guard or prep via uses:" {
-    # The guard runs directly (guard job) or as prep's first step. prep's
-    # guard-first ordering is asserted in actions/prep/test.bats.
+@test "wiring: prep job invokes actions/prep via uses:" {
+    # The preflight guard runs as prep's first step (asserted in
+    # actions/prep/test.bats).
     for wf in "${REUSABLE_WORKFLOWS[@]}"; do
-        head="$(head_job "$WORKFLOWS_DIR/$wf")"
-        block="$(job_block "$WORKFLOWS_DIR/$wf" "$head")"
-        echo "$block" | grep -qE 'uses:[[:space:]]*TomHennen/wrangle/actions/(preflight_guard|prep)@' || {
-            printf 'head job in %s does not use preflight_guard or prep\n' "$wf" >&2
+        block="$(job_block "$WORKFLOWS_DIR/$wf" prep)"
+        echo "$block" | grep -qE 'uses:[[:space:]]*TomHennen/wrangle/actions/prep@' || {
+            printf 'prep job in %s does not use TomHennen/wrangle/actions/prep\n' "$wf" >&2
             printf '%s\n' "$block" >&2
             return 1
         }
     done
 }
 
-@test "wiring: head job has permissions: {}" {
+@test "wiring: prep job has permissions: {}" {
     for wf in "${REUSABLE_WORKFLOWS[@]}"; do
-        head="$(head_job "$WORKFLOWS_DIR/$wf")"
-        block="$(job_block "$WORKFLOWS_DIR/$wf" "$head")"
+        block="$(job_block "$WORKFLOWS_DIR/$wf" prep)"
         echo "$block" | grep -qE 'permissions: \{\}' || {
-            printf 'head job in %s missing permissions: {}\n' "$wf" >&2
+            printf 'prep job in %s missing permissions: {}\n' "$wf" >&2
             printf '%s\n' "$block" >&2
             return 1
         }
     done
 }
 
-@test "wiring: every non-head job lists the head job in its needs" {
+@test "wiring: every non-prep job lists prep in its needs" {
     # Failing the guard must skip every downstream job. The cheapest
-    # invariant to grep is "every non-head job's needs: includes the head
-    # job". Transitive gating would also work, but the explicit form is
-    # easier to audit at a glance and breaks loudly if a later job is
-    # added without the head-job dependency.
+    # invariant to grep is "every non-prep job's needs: includes prep".
+    # Transitive gating would also work, but the explicit form is easier
+    # to audit at a glance and breaks loudly if a later job is added
+    # without the prep dependency.
     for wf in "${REUSABLE_WORKFLOWS[@]}"; do
-        head="$(head_job "$WORKFLOWS_DIR/$wf")"
         jobs=$(awk '
             /^jobs:$/                                  { in_jobs=1; next }
             in_jobs && /^[a-zA-Z]/                     { in_jobs=0 }
@@ -124,10 +115,10 @@ job_block() {
             return 1
         }
         for job in $jobs; do
-            [[ "$job" == "$head" ]] && continue
+            [[ "$job" == "prep" ]] && continue
             block="$(job_block "$WORKFLOWS_DIR/$wf" "$job")"
-            echo "$block" | grep -qE "^[[:space:]]*needs:.*\[.*\b${head}\b.*\]" || {
-                printf "Job '%s' in %s does not list '%s' in its needs:\n" "$job" "$wf" "$head" >&2
+            echo "$block" | grep -qE '^[[:space:]]*needs:.*\[.*\bprep\b.*\]' || {
+                printf "Job '%s' in %s does not list 'prep' in its needs:\n" "$job" "$wf" >&2
                 printf '%s\n' "$block" >&2
                 return 1
             }

--- a/test/test_refuse_pull_request_target.bats
+++ b/test/test_refuse_pull_request_target.bats
@@ -6,15 +6,17 @@
 # actions/preflight_guard/test.bats — this file only checks the
 # workflow-level wiring:
 #
-#   1. The first job under `jobs:` is `guard:`.
-#   2. The `guard:` job has `permissions: {}` (least privilege).
-#   3. The `guard:` job invokes `actions/preflight_guard` via `uses:`.
-#   4. Every other job lists `guard` in its `needs:` so a refused
+#   1. The first job under `jobs:` is the head job — `guard` (runs the
+#      guard directly) or `prep` (runs the guard as its first step; see
+#      actions/prep/test.bats for the ordering guarantee).
+#   2. The head job has `permissions: {}` (least privilege).
+#   3. The head job invokes preflight_guard (guard) or prep via `uses:`.
+#   4. Every other job lists the head job in its `needs:` so a refused
 #      invocation skips the entire workflow.
 #
 # Grep-based; doesn't parse YAML. Tests break loudly if anyone refactors
 # the guard wiring out or accidentally adds a new job without the
-# `needs: [guard]` dependency.
+# head-job dependency.
 
 setup() {
     REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
@@ -36,6 +38,25 @@ setup() {
     done < <(find "$WORKFLOWS_DIR" -maxdepth 1 -name '*.yml' -type f -print0 | sort -z)
 }
 
+# First job under `jobs:` — the head job that gates the rest.
+head_job() {
+    awk '
+        /^jobs:$/                                  { in_jobs=1; next }
+        in_jobs && /^  [a-zA-Z][a-zA-Z0-9_-]*:$/   {
+            name=$1; sub(":", "", name); print name; exit
+        }
+    ' "$1"
+}
+
+# The `<job>:` block (its lines, up to the next top-level job).
+job_block() {
+    awk -v j="$2" '
+        $0 == "  " j ":"                        { in_block=1; print; next }
+        in_block && /^  [a-zA-Z][a-zA-Z0-9_-]*:$/ { in_block=0 }
+        in_block                                { print }
+    ' "$1"
+}
+
 @test "wiring: reusable-workflow discovery is non-empty" {
     # Fail closed: a broken glob or wrong dir would otherwise make every
     # per-workflow assertion below pass vacuously over an empty list.
@@ -45,60 +66,52 @@ setup() {
     }
 }
 
-@test "wiring: first job in each reusable workflow is guard" {
+@test "wiring: first job in each reusable workflow is the guard or prep head job" {
     # Defense against accidentally reordering the guard below a job that
     # could side-effect before the refusal fires.
     for wf in "${REUSABLE_WORKFLOWS[@]}"; do
-        first_job=$(awk '
-            /^jobs:$/                                  { in_jobs=1; next }
-            in_jobs && /^  [a-zA-Z][a-zA-Z0-9_-]*:$/   {
-                name=$1; sub(":", "", name); print name; exit
-            }
-        ' "$WORKFLOWS_DIR/$wf")
-        [[ "$first_job" == "guard" ]] || {
-            printf "First job in %s is '%s' not 'guard'\n" "$wf" "$first_job" >&2
+        first_job="$(head_job "$WORKFLOWS_DIR/$wf")"
+        [[ "$first_job" == "guard" || "$first_job" == "prep" ]] || {
+            printf "First job in %s is '%s' not 'guard' or 'prep'\n" "$wf" "$first_job" >&2
             return 1
         }
     done
 }
 
-@test "wiring: guard job invokes actions/preflight_guard via uses:" {
+@test "wiring: head job invokes preflight_guard or prep via uses:" {
+    # The guard runs directly (guard job) or as prep's first step. prep's
+    # guard-first ordering is asserted in actions/prep/test.bats.
     for wf in "${REUSABLE_WORKFLOWS[@]}"; do
-        guard_block=$(awk '
-            /^  guard:$/             { in_block=1; print; next }
-            in_block && /^  [a-z]/   { in_block=0 }
-            in_block                 { print }
-        ' "$WORKFLOWS_DIR/$wf")
-        echo "$guard_block" | grep -qE 'uses:[[:space:]]*TomHennen/wrangle/actions/preflight_guard@' || {
-            printf 'guard job in %s does not use TomHennen/wrangle/actions/preflight_guard\n' "$wf" >&2
-            printf '%s\n' "$guard_block" >&2
+        head="$(head_job "$WORKFLOWS_DIR/$wf")"
+        block="$(job_block "$WORKFLOWS_DIR/$wf" "$head")"
+        echo "$block" | grep -qE 'uses:[[:space:]]*TomHennen/wrangle/actions/(preflight_guard|prep)@' || {
+            printf 'head job in %s does not use preflight_guard or prep\n' "$wf" >&2
+            printf '%s\n' "$block" >&2
             return 1
         }
     done
 }
 
-@test "wiring: guard job has permissions: {}" {
+@test "wiring: head job has permissions: {}" {
     for wf in "${REUSABLE_WORKFLOWS[@]}"; do
-        guard_block=$(awk '
-            /^  guard:$/             { in_block=1; print; next }
-            in_block && /^  [a-z]/   { in_block=0 }
-            in_block                 { print }
-        ' "$WORKFLOWS_DIR/$wf")
-        echo "$guard_block" | grep -qE 'permissions: \{\}' || {
-            printf 'guard job in %s missing permissions: {}\n' "$wf" >&2
-            printf '%s\n' "$guard_block" >&2
+        head="$(head_job "$WORKFLOWS_DIR/$wf")"
+        block="$(job_block "$WORKFLOWS_DIR/$wf" "$head")"
+        echo "$block" | grep -qE 'permissions: \{\}' || {
+            printf 'head job in %s missing permissions: {}\n' "$wf" >&2
+            printf '%s\n' "$block" >&2
             return 1
         }
     done
 }
 
-@test "wiring: every non-guard job lists guard in its needs" {
+@test "wiring: every non-head job lists the head job in its needs" {
     # Failing the guard must skip every downstream job. The cheapest
-    # invariant to grep is "every non-guard job's needs: includes guard".
-    # Transitive gating via gate/build would also work, but the explicit
-    # form is easier to audit at a glance and breaks loudly if a later
-    # job is added without the guard dependency.
+    # invariant to grep is "every non-head job's needs: includes the head
+    # job". Transitive gating would also work, but the explicit form is
+    # easier to audit at a glance and breaks loudly if a later job is
+    # added without the head-job dependency.
     for wf in "${REUSABLE_WORKFLOWS[@]}"; do
+        head="$(head_job "$WORKFLOWS_DIR/$wf")"
         jobs=$(awk '
             /^jobs:$/                                  { in_jobs=1; next }
             in_jobs && /^[a-zA-Z]/                     { in_jobs=0 }
@@ -111,14 +124,10 @@ setup() {
             return 1
         }
         for job in $jobs; do
-            [[ "$job" == "guard" ]] && continue
-            block=$(awk -v j="$job" '
-                $0 == "  " j ":"                       { in_job=1; print; next }
-                in_job && /^  [a-zA-Z][a-zA-Z0-9_-]*:$/ { in_job=0 }
-                in_job                                 { print }
-            ' "$WORKFLOWS_DIR/$wf")
-            echo "$block" | grep -qE '^[[:space:]]*needs:.*\[.*\bguard\b.*\]' || {
-                printf "Job '%s' in %s does not list 'guard' in its needs:\n" "$job" "$wf" >&2
+            [[ "$job" == "$head" ]] && continue
+            block="$(job_block "$WORKFLOWS_DIR/$wf" "$job")"
+            echo "$block" | grep -qE "^[[:space:]]*needs:.*\[.*\b${head}\b.*\]" || {
+                printf "Job '%s' in %s does not list '%s' in its needs:\n" "$job" "$wf" "$head" >&2
                 printf '%s\n' "$block" >&2
                 return 1
             }


### PR DESCRIPTION
## What

Introduces a single `prep` composite action (`actions/prep`) that runs the preflight guard, the release gate, and package-name derivation in one job, then exposes the results as outputs every downstream job reads uniformly. Replaces the per-workflow `guard` + `gate` jobs and the per-job `package_metadata` name derivation across all four `build_and_publish_*.yml`.

Implements the refactor proposed in #479 (surfaced in the #472 review).

## Why

- Removes the duplicated `names`/shortname wiring — `package_metadata` was invoked **twice** per workflow in go/npm/python (scan job + build job).
- One obvious source for the shared values; every downstream job reads `needs.prep.outputs.*` instead of re-deriving or round-tripping through `build.outputs`.
- Cuts the `build.outputs` round-tripping reviewers flagged as confusing.

Build-produced values (`hashes`, `version`, `resource-uri`, `dist-files`, image `digest`/`imagename`) genuinely come from the build job and stay there — so this reduces cross-job `needs`, it doesn't eliminate it (per the constraint noted in #479).

## Result

Per-file wrangle self-reference pins drop: **container 6→4, go 9→6, npm 8→5, python 8→5**. Net −292/+331 lines despite adding a new action.

## Notes for review

- **`prep` runs the guard first** (`permissions: {}`, no checkout — all three sub-actions resolve via `github.action_path`). The guard-first ordering inside `prep` is asserted in `actions/prep/test.bats`; the workflow-level "head job gates everything" wiring test (`test/test_refuse_pull_request_target.bats`) was generalized to accept a `guard`- or `prep`-named head job.
- **Bootstrap pin:** the nested `actions/prep@<sha>` self-reference in the four workflows is pinned to this branch's SHA (last commit), because `prep` is not on `main` yet — without it the integration test would resolve the old (prep-less) main. Bump to the merge SHA post-merge per `docs/e2e_testing.md`.
- The `scan`-job collapse (folding `checkout` into the `scan` composite) is intentionally **out of scope** here — it carries its own bootstrap pin and lands as a follow-up PR.

## Test

`actionlint` clean, `wrangle-workflow-lint` clean, `actions/*/*.bats` 169/169, pin-consistency / self-ref-path / pin-ancestry / guard-wiring suites green.

Fixes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)