### PR TITLE
chore: bump self-ref pins + fix workflow-structure tests post-#504

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -110,7 +110,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@731eb4e95e4c53cce9dd8d57f0ba5c626517b39f # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         id: prep
         with:
           build-type: container
@@ -134,7 +134,7 @@ jobs:
           persist-credentials: false
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -161,7 +161,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      uses: TomHennen/wrangle/build/actions/container@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -261,7 +261,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -168,7 +168,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@731eb4e95e4c53cce9dd8d57f0ba5c626517b39f # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         id: prep
         with:
           build-type: go
@@ -193,7 +193,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -225,7 +225,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/go/checks@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -286,7 +286,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/go/release@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         id: release
         with:
           path: ${{ inputs.path }}
@@ -377,7 +377,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         id: attest
         with:
           build-type: go
@@ -406,7 +406,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -145,7 +145,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@731eb4e95e4c53cce9dd8d57f0ba5c626517b39f # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         id: prep
         with:
           build-type: npm
@@ -170,7 +170,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -204,7 +204,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/npm@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         id: build
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         id: attest
         with:
           build-type: npm
@@ -304,7 +304,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -122,7 +122,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@731eb4e95e4c53cce9dd8d57f0ba5c626517b39f # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         id: prep
         with:
           build-type: python
@@ -147,7 +147,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -179,7 +179,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/python@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         id: build
         with:
           path: ${{ inputs.path }}
@@ -265,7 +265,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         id: attest
         with:
           build-type: python
@@ -291,7 +291,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@731eb4e95e4c53cce9dd8d57f0ba5c626517b39f # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -86,7 +86,7 @@ jobs:
       # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
       # version so its dependency-review wrapper honors the repo's native
       # config file. Bump to main post-merge via tools/bump_action_pins.sh.
-      - uses: TomHennen/wrangle/actions/scan@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           tools: ${{ inputs.scan-tools }}
@@ -119,7 +119,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+        uses: TomHennen/wrangle/build/actions/shell@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@731eb4e95e4c53cce9dd8d57f0ba5c626517b39f # bootstrap: PR head until post-merge bump
+      - uses: TomHennen/wrangle/actions/prep@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
 
   check-change:
     needs: [prep]
@@ -49,7 +49,7 @@ jobs:
       # (root path), so the shortname is empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+        uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         with:
           tools: ${{ inputs.tools }}
           artifact-name: scan

--- a/actions/prep/action.yml
+++ b/actions/prep/action.yml
@@ -59,18 +59,18 @@ runs:
     # Refuse unsafe triggers first, so a refused invocation fails prep and
     # every downstream `needs: [prep]` job skips.
     # TODO: replace with $/actions/preflight_guard when $/ syntax ships (#136)
-    - uses: TomHennen/wrangle/actions/preflight_guard@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+    - uses: TomHennen/wrangle/actions/preflight_guard@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
 
     # Gate + names run only for a real build type; guard-only mode skips them.
     # TODO: replace with $/actions/release_gate when $/ syntax ships (#136)
-    - uses: TomHennen/wrangle/actions/release_gate@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+    - uses: TomHennen/wrangle/actions/release_gate@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
       id: gate
       if: ${{ inputs.build-type != '' }}
       with:
         events: ${{ inputs.release-events }}
 
     # TODO: replace with $/actions/package_metadata when $/ syntax ships (#136)
-    - uses: TomHennen/wrangle/actions/package_metadata@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+    - uses: TomHennen/wrangle/actions/package_metadata@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
       id: names
       if: ${{ inputs.build-type != '' }}
       with:

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -99,7 +99,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      uses: TomHennen/wrangle/tools/zizmor@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      uses: TomHennen/wrangle/tools/scorecard@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+      uses: TomHennen/wrangle/tools/dependency-review@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -82,7 +82,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@56aa2ffe4d4b0f48a3c0e09ff2d458e16e25bdcb # main 2026-06-20
+    - uses: TomHennen/wrangle/actions/verify@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -116,9 +116,9 @@ teardown() {
     [[ "$status" -ne 0 ]]
 }
 
-@test "container: build job needs gate so it can read should-release" {
+@test "container: build job needs prep so it can read should-release" {
     local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
-    run bash -c "sed -n '/^  build:/,/^  [a-z]/p' \"$wf\" | grep -E 'needs:.*gate'"
+    run bash -c "sed -n '/^  build:/,/^  [a-z]/p' \"$wf\" | grep -E 'needs:.*prep'"
     [[ "$status" -eq 0 ]]
 }
 
@@ -138,9 +138,9 @@ teardown() {
     [[ "$status" -eq 0 ]]
 }
 
-@test "container: scan job needs gate so go-cache can read should-release" {
+@test "container: scan job needs prep so go-cache can read should-release" {
     local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
-    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$wf\" | grep -E 'needs:.*gate'"
+    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$wf\" | grep -E 'needs:.*prep'"
     [[ "$status" -eq 0 ]]
 }
 
@@ -353,11 +353,11 @@ FAKE
     [[ "$status" -eq 0 ]]
 }
 
-@test "container: reusable workflow has gate job calling release_gate" {
+@test "container: reusable workflow has prep job calling the prep action" {
     local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
-    run grep -E '^  gate:' "$wf"
+    run grep -E '^  prep:' "$wf"
     [[ "$status" -eq 0 ]]
-    run grep -E 'TomHennen/wrangle/actions/release_gate' "$wf"
+    run grep -E 'TomHennen/wrangle/actions/prep@' "$wf"
     [[ "$status" -eq 0 ]]
 }
 

--- a/build/actions/go/test.bats
+++ b/build/actions/go/test.bats
@@ -588,10 +588,11 @@ func main() {}
 
 # --- Reusable workflow tests ---
 
-@test "go: workflow has guard, gate, checks, release, attest, verify jobs" {
-    # attest (attest-build-provenance) + verify replace the removed
+@test "go: workflow has prep, scan, checks, release, attest, verify jobs" {
+    # prep (guard + gate + names) heads the pipeline; attest
+    # (attest-build-provenance) + verify replace the removed
     # slsa-github-generator provenance: and slsa-verifier verify: jobs.
-    for job in guard gate checks release attest verify; do
+    for job in prep scan checks release attest verify; do
         run grep -E "^  ${job}:" "$WORKFLOW"
         [[ "$status" -eq 0 ]]
     done
@@ -608,21 +609,20 @@ func main() {}
     section="$(awk '/^  [a-z][a-z_-]*:$/ { in_section = ($0 == "  release:") } in_section' "$WORKFLOW")"
     grep -qF "needs.checks.result == 'skipped'" <<<"$section"
     # And the if: must NOT be the trivial truthy default that would
-    # let release run even on a failed guard/gate.
-    grep -qE "needs\\.guard\\.result == 'success'" <<<"$section"
-    grep -qE "needs\\.gate\\.result == 'success'" <<<"$section"
+    # let release run even on a failed prep (guard + gate).
+    grep -qE "needs\\.prep\\.result == 'success'" <<<"$section"
 }
 
 @test "go: workflow never sources lib/shortname.sh from the adopter workspace" {
     # The scan/checks/release jobs check out the ADOPTER repo, where
     # lib/shortname.sh does not exist — sourcing it there only worked when
     # the adopter was wrangle itself (#469). The shortname/name derivation is
-    # delegated to the package_metadata composite, which sources the lib from
-    # its OWN action_path; no workflow run: block touches the adopter copy.
+    # delegated to the prep job (which runs package_metadata from its OWN
+    # action_path); no workflow run: block touches the adopter copy.
     run grep -F 'source lib/shortname.sh' "$WORKFLOW"
     [[ "$status" -ne 0 ]]
-    # The scan job derives the scan name via the package_metadata composite.
-    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -F 'TomHennen/wrangle/actions/package_metadata@'"
+    # The prep job derives the names via the prep action.
+    run grep -F 'TomHennen/wrangle/actions/prep@' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
 }
 
@@ -660,9 +660,9 @@ func main() {}
     grep -qE "if:.*inputs\\.scan-tools != ''" <<<"$section"
 }
 
-@test "go: scan job needs gate so go-cache can read should-release" {
+@test "go: scan job needs prep so go-cache can read should-release" {
     section="$(awk '/^  [a-z][a-z_-]*:$/ { in_section = ($0 == "  scan:") } in_section' "$WORKFLOW")"
-    grep -qE 'needs:.*gate' <<<"$section"
+    grep -qE 'needs:.*prep' <<<"$section"
 }
 
 @test "go: scan job forces go-cache off on release" {
@@ -717,12 +717,12 @@ func main() {}
 @test "go: workflow checks + release jobs use namespaced metadata artifact names" {
     # The checks job's govulncheck output is an internal transient
     # (go-checks[-<sn>]) folded into the unified go-metadata[-<sn>] (#469).
-    # Derived inline (no adopter-workspace lib source); root stays clean.
-    run grep -F "format('go-checks-{0}'" "$WORKFLOW"
+    # The name comes from the prep job's checks output.
+    run grep -F 'needs.prep.outputs.checks' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
-    # The release job's packaging names come from the package_metadata
-    # composite, seeded with the build type and the build's shortname output.
-    run grep -F 'TomHennen/wrangle/actions/package_metadata@' "$WORKFLOW"
+    # The release job's packaging names come from the prep job, seeded with
+    # the build type.
+    run grep -F 'TomHennen/wrangle/actions/prep@' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
     run grep -F 'build-type: go' "$WORKFLOW"
     [[ "$status" -eq 0 ]]

--- a/build/actions/npm/test.bats
+++ b/build/actions/npm/test.bats
@@ -735,8 +735,8 @@ write_pkg_json() {
     [[ "$status" -eq 0 ]]
 }
 
-@test "npm: scan job needs gate so go-cache can read should-release" {
-    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E 'needs:.*gate'"
+@test "npm: scan job needs prep so go-cache can read should-release" {
+    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E 'needs:.*prep'"
     [[ "$status" -eq 0 ]]
 }
 
@@ -747,10 +747,10 @@ write_pkg_json() {
     [[ "$status" -eq 0 ]]
 }
 
-@test "npm: workflow has gate job calling release_gate" {
-    run grep -E '^  gate:' "$WORKFLOW"
+@test "npm: workflow has prep job calling the prep action" {
+    run grep -E '^  prep:' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
-    run grep -E 'TomHennen/wrangle/actions/release_gate' "$WORKFLOW"
+    run grep -E 'TomHennen/wrangle/actions/prep@' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
 }
 
@@ -797,13 +797,13 @@ write_pkg_json() {
 
 @test "npm: workflow namespaces artifacts by shortname, suffix-less at root" {
     # The scan/build jobs check out the ADOPTER repo, where lib/shortname.sh
-    # is absent — the workflow must never source the lib (#469). Both the scan
-    # and build jobs get their names from the package_metadata composite, which
-    # sources the lib from the wrangle checkout. Root build ('.') stays
-    # suffix-less.
+    # is absent — the workflow must never source the lib (#469). Name
+    # derivation is delegated to the prep job (which runs package_metadata
+    # from the wrangle checkout); downstream jobs read needs.prep.outputs.*.
+    # Root build ('.') stays suffix-less.
     run grep -F 'source lib/shortname.sh' "$WORKFLOW"
     [[ "$status" -ne 0 ]]
-    run grep -F 'TomHennen/wrangle/actions/package_metadata@' "$WORKFLOW"
+    run grep -F 'TomHennen/wrangle/actions/prep@' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
     run grep -F 'build-type: npm' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
@@ -832,8 +832,8 @@ write_pkg_json() {
     grep -qE '^metadata-dir=metadata/npm/pkg_foo$' "$GITHUB_OUTPUT"
 }
 
-@test "npm: build job exposes shortname output" {
-    run bash -c "sed -n '/^  build:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E '^[[:space:]]*shortname:'"
+@test "npm: prep job exposes shortname output" {
+    run bash -c "sed -n '/^  prep:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E '^[[:space:]]*shortname:'"
     [[ "$status" -eq 0 ]]
 }
 

--- a/build/actions/python/test.bats
+++ b/build/actions/python/test.bats
@@ -422,8 +422,8 @@ write_pyproject() {
     [[ "$status" -eq 0 ]]
 }
 
-@test "python: scan job needs gate so go-cache can read should-release" {
-    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E 'needs:.*gate'"
+@test "python: scan job needs prep so go-cache can read should-release" {
+    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E 'needs:.*prep'"
     [[ "$status" -eq 0 ]]
 }
 
@@ -434,15 +434,15 @@ write_pyproject() {
     [[ "$status" -eq 0 ]]
 }
 
-@test "python: workflow has gate job calling release_gate" {
-    run grep -E '^  gate:' "$WORKFLOW"
+@test "python: workflow has prep job calling the prep action" {
+    run grep -E '^  prep:' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
-    run grep -E 'TomHennen/wrangle/actions/release_gate' "$WORKFLOW"
+    run grep -E 'TomHennen/wrangle/actions/prep@' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
 }
 
-@test "python: build job needs gate so it can read should-release" {
-    run bash -c "sed -n '/^  build:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E 'needs:.*gate'"
+@test "python: build job needs prep so it can read should-release" {
+    run bash -c "sed -n '/^  build:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E 'needs:.*prep'"
     [[ "$status" -eq 0 ]]
 }
 
@@ -496,13 +496,13 @@ write_pyproject() {
 
 @test "python: workflow namespaces artifacts by shortname, suffix-less at root" {
     # The scan/build jobs check out the ADOPTER repo, where lib/shortname.sh
-    # is absent — the workflow must never source the lib (#469). Both the scan
-    # and build jobs get their names from the package_metadata composite, which
-    # sources the lib from the wrangle checkout. Root build ('.') stays
-    # suffix-less.
+    # is absent — the workflow must never source the lib (#469). Name
+    # derivation is delegated to the prep job (which runs package_metadata
+    # from the wrangle checkout); downstream jobs read needs.prep.outputs.*.
+    # Root build ('.') stays suffix-less.
     run grep -F 'source lib/shortname.sh' "$WORKFLOW"
     [[ "$status" -ne 0 ]]
-    run grep -F 'TomHennen/wrangle/actions/package_metadata@' "$WORKFLOW"
+    run grep -F 'TomHennen/wrangle/actions/prep@' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
     run grep -F 'build-type: python' "$WORKFLOW"
     [[ "$status" -eq 0 ]]
@@ -534,9 +534,9 @@ write_pyproject() {
 
 @test "python: scan job passes a per-build artifact-name to the scan action" {
     # The scan action no longer owns wrangle-scan-results; the build job folds
-    # this artifact into the unified metadata. The name is the package_metadata
-    # composite's scan output (path-derived shortname).
-    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E 'artifact-name: \\\$\\{\\{ steps.names.outputs.scan \\}\\}'"
+    # this artifact into the unified metadata. The name is the prep job's scan
+    # output (path-derived shortname).
+    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E 'artifact-name: \\\$\\{\\{ needs.prep.outputs.scan \\}\\}'"
     [[ "$status" -eq 0 ]]
 }
 
@@ -603,8 +603,8 @@ write_pyproject() {
     [[ "$status" -ne 0 ]]
 }
 
-@test "python: build job exposes shortname output" {
-    run bash -c "sed -n '/^  build:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E '^[[:space:]]*shortname:'"
+@test "python: prep job exposes shortname output" {
+    run bash -c "sed -n '/^  prep:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E '^[[:space:]]*shortname:'"
     [[ "$status" -eq 0 ]]
 }
 


### PR DESCRIPTION
Two things, both fallout from #504 (the `prep` refactor):

**1. Self-ref pin bump.** #504 carried bootstrap pins (`actions/prep@<branch-sha>`) since `prep` didn't exist on `main`. This rolls every wrangle self-reference — including `prep`'s nested `preflight_guard`/`release_gate`/`package_metadata` pins — to the squashed merge commit `4283250`, relabelled `# main`. Closes the `check_pin_ancestry` red window.

**2. Workflow-structure test fixes.** The per-build-type `build/actions/{container,go,npm,python}/test.bats` suites still asserted the pre-#504 structure (`guard`/`gate` jobs, `build.outputs.shortname`, `steps.names.outputs.*`). Updated to the `prep` structure (`needs.prep`, `prep` job calls `actions/prep`, names via `needs.prep.outputs.*`).

**Why these slipped through #504:** `make test` runs `gotest` before `bats`. In #504, `gotest` failed on the missing Dependabot entry for `prep` (WL004) and aborted the run — so `bats` never executed and these stale assertions were never surfaced. With the Dependabot entry now present, `bats` runs and the gap shows. Verified locally: all five build-action suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)