### PR TITLE
refactor: fold the checkout into the scan composite

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -129,7 +129,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@1a88f8d6c755caf27fb6516332dd04a5d482f9c9 # bootstrap: PR head until post-merge bump
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -128,15 +128,11 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        if: ${{ inputs.scan-tools != '' }}
-        with:
-          persist-credentials: false
-
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
+          checkout: "true"
           tools: ${{ inputs.scan-tools }}
           # The build job folds this into the unified container-metadata.
           artifact-name: ${{ needs.prep.outputs.scan }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -187,7 +187,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@1a88f8d6c755caf27fb6516332dd04a5d482f9c9 # bootstrap: PR head until post-merge bump
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -186,16 +186,12 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        if: ${{ inputs.scan-tools != '' }}
-        with:
-          persist-credentials: false
-          ref: ${{ inputs.ref || '' }}
-
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
+          checkout: "true"
+          ref: ${{ inputs.ref || '' }}
           tools: ${{ inputs.scan-tools }}
           # The release job folds this into the unified go-metadata.
           artifact-name: ${{ needs.prep.outputs.scan }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -163,16 +163,12 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        if: ${{ inputs.scan-tools != '' }}
-        with:
-          persist-credentials: false
-          ref: ${{ inputs.ref || '' }}
-
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
+          checkout: "true"
+          ref: ${{ inputs.ref || '' }}
           tools: ${{ inputs.scan-tools }}
           # The build job folds this into the unified npm-metadata.
           artifact-name: ${{ needs.prep.outputs.scan }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -164,7 +164,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@1a88f8d6c755caf27fb6516332dd04a5d482f9c9 # bootstrap: PR head until post-merge bump
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -141,7 +141,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@1a88f8d6c755caf27fb6516332dd04a5d482f9c9 # bootstrap: PR head until post-merge bump
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -140,16 +140,12 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        if: ${{ inputs.scan-tools != '' }}
-        with:
-          persist-credentials: false
-          ref: ${{ inputs.ref || '' }}
-
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
+          checkout: "true"
+          ref: ${{ inputs.ref || '' }}
           tools: ${{ inputs.scan-tools }}
           # The build job folds this into the unified python-metadata.
           artifact-name: ${{ needs.prep.outputs.scan }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -77,18 +77,11 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        if: ${{ inputs.scan-tools != '' }}
-        with:
-          persist-credentials: false
-
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      # Bootstrap pin (docs/e2e_testing.md): scan must resolve the branch
-      # version so its dependency-review wrapper honors the repo's native
-      # config file. Bump to main post-merge via tools/bump_action_pins.sh.
       - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
+          checkout: "true"
           tools: ${{ inputs.scan-tools }}
           go-cache: ${{ inputs.go-cache }}
 

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@1a88f8d6c755caf27fb6516332dd04a5d482f9c9 # bootstrap: PR head until post-merge bump
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -38,19 +38,17 @@ jobs:
       security-events: write # SARIF upload to Security tab
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
       # The scan action runs adapter-pattern tools (via run.sh) and
-      # action-pattern tools (zizmor, scorecard) via uses: internally.
-      # Standalone scan: there is no build to fold into, so the artifact is
-      # the consumer-facing scan-<sn>. This workflow scans the whole repo
-      # (root path), so the shortname is empty and the name is just "scan".
+      # action-pattern tools (zizmor, scorecard) via uses: internally, and
+      # checks out the repo itself (checkout: true). Standalone scan: there is
+      # no build to fold into, so the artifact is the consumer-facing scan-<sn>.
+      # This workflow scans the whole repo (root path), so the shortname is
+      # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
         uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
         with:
+          checkout: "true"
           tools: ${{ inputs.tools }}
           artifact-name: scan
           go-cache: ${{ inputs.go-cache }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@428325083b9ffed4b41fa5ad9abc146bcb8aded8 # main 2026-06-20
+        uses: TomHennen/wrangle/actions/scan@1a88f8d6c755caf27fb6516332dd04a5d482f9c9 # bootstrap: PR head until post-merge bump
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -32,10 +32,34 @@ inputs:
       scan/ subtree's contents, no scan/ prefix.
     required: false
     default: "wrangle-scan-results"
+  checkout:
+    description: >
+      When "true", check out the calling repo before scanning, so a caller
+      whose scan job does nothing else can drop its own checkout step.
+      Default "false": the caller is responsible for the checkout (the tools
+      scan $GITHUB_WORKSPACE, which must already hold the source).
+    required: false
+    default: "false"
+  ref:
+    description: >
+      Git ref to check out when checkout is "true". Empty (default) uses the
+      triggering SHA. Ignored when checkout is "false".
+    required: false
+    default: ""
 
 runs:
   using: "composite"
   steps:
+    # Checked-out source must exist before any tool runs (they scan
+    # $GITHUB_WORKSPACE); opt-in so callers that check out themselves don't
+    # double-checkout.
+    - name: Check out source
+      if: inputs.checkout == 'true'
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+        ref: ${{ inputs.ref }}
+
     - name: Set up wrangle
       shell: bash
       env:

--- a/actions/scan/test.bats
+++ b/actions/scan/test.bats
@@ -75,6 +75,30 @@ setup() {
     [[ "$output" == *'default: "wrangle-scan-results"'* ]]
 }
 
+@test "scan: optional checkout is opt-in, gated on the checkout input" {
+    run grep -F "if: inputs.checkout == 'true'" "$ACTION_DIR/action.yml"
+    [ "$status" -eq 0 ]
+    run grep -F 'persist-credentials: false' "$ACTION_DIR/action.yml"
+    [ "$status" -eq 0 ]
+    run grep -F 'ref: ${{ inputs.ref }}' "$ACTION_DIR/action.yml"
+    [ "$status" -eq 0 ]
+}
+
+@test "scan: checkout defaults to false so self-checkout callers don't double-checkout" {
+    run bash -c "grep -A10 '^  checkout:' '$ACTION_DIR/action.yml' | grep -m1 'default:'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'default: "false"'* ]]
+}
+
+@test "scan: checkout step precedes the tool steps (source exists before scanning)" {
+    # The tools scan $GITHUB_WORKSPACE, so an opt-in checkout must run before
+    # the wrangle setup + tool steps.
+    checkout_line="$(grep -n 'Check out source' "$ACTION_DIR/action.yml" | head -1 | cut -d: -f1)"
+    setup_line="$(grep -n 'Set up wrangle' "$ACTION_DIR/action.yml" | head -1 | cut -d: -f1)"
+    [ -n "$checkout_line" ] && [ -n "$setup_line" ]
+    [ "$checkout_line" -lt "$setup_line" ]
+}
+
 @test "scan: references zizmor action" {
     run grep 'uses:.*tools/zizmor' "$ACTION_DIR/action.yml"
     [ "$status" -eq 0 ]

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -131,7 +131,7 @@ teardown() {
 }
 
 @test "container: scan steps are gated on scan-tools so empty disables scanning" {
-    # scan-tools: "" skips both steps; the scan job then concludes success
+    # scan-tools: "" skips the scan step; the scan job then concludes success
     # and never blocks the build/push.
     local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
     run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$wf\" | grep -E \"if:.*inputs.scan-tools != ''\""

--- a/build/actions/go/test.bats
+++ b/build/actions/go/test.bats
@@ -654,7 +654,7 @@ func main() {}
 }
 
 @test "go: scan steps are gated on scan-tools so empty disables scanning (job concludes success)" {
-    # The behavior contract: scan-tools: "" skips both steps, so the scan
+    # The behavior contract: scan-tools: "" skips the scan step, so the scan
     # job succeeds and never blocks release.
     section="$(awk '/^  [a-z][a-z_-]*:$/ { in_section = ($0 == "  scan:") } in_section' "$WORKFLOW")"
     grep -qE "if:.*inputs\\.scan-tools != ''" <<<"$section"

--- a/build/actions/npm/test.bats
+++ b/build/actions/npm/test.bats
@@ -724,7 +724,7 @@ write_pkg_json() {
 }
 
 @test "npm: scan steps are gated on scan-tools so empty disables scanning" {
-    # scan-tools: "" skips both steps; the scan job then concludes success
+    # scan-tools: "" skips the scan step; the scan job then concludes success
     # and never blocks the attest/publish path.
     run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E \"if:.*inputs.scan-tools != ''\""
     [[ "$status" -eq 0 ]]

--- a/build/actions/python/test.bats
+++ b/build/actions/python/test.bats
@@ -411,7 +411,7 @@ write_pyproject() {
 }
 
 @test "python: scan steps are gated on scan-tools so empty disables scanning" {
-    # scan-tools: "" skips both steps; the scan job then concludes success
+    # scan-tools: "" skips the scan step; the scan job then concludes success
     # and never blocks the attest/publish path.
     run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E \"if:.*inputs.scan-tools != ''\""
     [[ "$status" -eq 0 ]]

--- a/build/actions/shell/test.bats
+++ b/build/actions/shell/test.bats
@@ -50,7 +50,7 @@ setup() {
 }
 
 @test "shell: scan steps are gated on scan-tools so empty disables scanning" {
-    # scan-tools: "" skips both steps; the scan job then concludes success.
+    # scan-tools: "" skips the scan step; the scan job then concludes success.
     local wf="$REPO_ROOT/.github/workflows/build_shell.yml"
     run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$wf\" | grep -E \"if:.*inputs.scan-tools != ''\""
     [[ "$status" -eq 0 ]]


### PR DESCRIPTION
## What

Adds an opt-in `checkout` input (plus `ref`) to `actions/scan`. When `checkout: "true"`, the scan composite checks out the calling repo as its **first** step (the tools scan `$GITHUB_WORKSPACE`), so a caller whose scan job does nothing else drops its own `actions/checkout` step. The scan job collapses to a single `uses: scan` step across all six callers:

- `build_and_publish_{container,go,npm,python}.yml`
- `build_shell.yml`, `check_source_change.yml`

This is the second half of the scan-collapse discussed alongside #479 (PR1 = the `prep` job, #504).

## Why

- One step per scan job instead of `checkout` + `scan`; removes an `actions/checkout` pin from each scan-only job (concentrated once inside the composite).
- The composite now owns "get the source + scan it" end to end.

## Backward compatibility

`checkout` defaults to `"false"` — external adopters (and any caller that checks out itself) are unaffected; only wrangle's own scan jobs opt in. `ref` is ignored when `checkout` is false.

## Notes for review

- **Bootstrap pin:** `scan` gained the `checkout`/`ref` inputs, so the main-pinned `scan` would ignore `checkout: "true"` and scan an empty workspace. The six `scan@` references are bootstrap-pinned to this branch's commit; bump to the merge SHA post-merge per `docs/e2e_testing.md`. (Also needs the usual post-merge `bump_action_pins` + a required-checks-green merge.)
- The checkout uses the repo-uniform `actions/checkout@…v6.0.3` pin with `persist-credentials: false`, matching the steps it replaces.

## Test

New `actions/scan/test.bats` coverage: checkout is opt-in (gated on the input), defaults to false, and precedes the tool steps. `actionlint`, all build-action suites, and the pin-consistency/ancestry suites pass locally; ran the full local `bats` sweep (only ast-grep/Sigstore-dependent suites skip for lack of those tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)