### PR TITLE
fix(verify): set GH_REPO so the release-asset attach resolves the repo (attach never ran without it)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -257,7 +257,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@44a586de9766492f29ae171a2a24feb0ec681957 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@3717eb0edf693150036b9525102202bade61b2d8 # fix-verify-gh-repo 2026-06-20
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -402,7 +402,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@44a586de9766492f29ae171a2a24feb0ec681957 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@3717eb0edf693150036b9525102202bade61b2d8 # fix-verify-gh-repo 2026-06-20
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -300,7 +300,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@44a586de9766492f29ae171a2a24feb0ec681957 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@3717eb0edf693150036b9525102202bade61b2d8 # fix-verify-gh-repo 2026-06-20
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -287,7 +287,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@44a586de9766492f29ae171a2a24feb0ec681957 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@3717eb0edf693150036b9525102202bade61b2d8 # fix-verify-gh-repo 2026-06-20
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -176,5 +176,8 @@ runs:
         METADATA_ROOT: ${{ inputs.metadata-dir }}
         METADATA_ZIP_NAME: ${{ inputs.artifact-name }}.zip
         GH_TOKEN: ${{ github.token }}
+        # The verify job has no checkout, so gh has no git remote to infer the
+        # base repo from; set it explicitly or every gh release call no-ops.
+        GH_REPO: ${{ github.repository }}
       run: |
         "$WRANGLE_ROOT/actions/verify/run_verify.sh" attach

--- a/actions/verify/test_action_structure.bats
+++ b/actions/verify/test_action_structure.bats
@@ -52,6 +52,8 @@ tool_block_has() {
     grep -Fq 'BUILD_TYPE: ${{ inputs.build-type }}' "$ACTION"
     grep -Fq 'DIST_DIR: ${{ inputs.dist-dir }}' "$ACTION"
     grep -Fq 'METADATA_ZIP_NAME: ${{ inputs.artifact-name }}.zip' "$ACTION"
+    # No checkout in the verify job, so gh needs GH_REPO to resolve the release.
+    grep -Fq 'GH_REPO: ${{ github.repository }}' "$ACTION"
 }
 
 @test "verify does not build the whole tool set or the scan-only binaries" {

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -939,6 +939,34 @@ _require_zip() {
     if grep -q "release upload" "$GH_LOG"; then return 1; fi
 }
 
+# The verify job has no checkout, so gh resolves the base repo from GH_REPO
+# alone; without it `release view` can't find the release and the attach
+# silently no-ops even when a release exists. Drive a gh shim whose `release
+# view` succeeds ONLY when GH_REPO names the expected repo, and prove the attach
+# proceeds to upload (rather than hitting the no-release branch).
+@test "run_verify attach: resolves the release via GH_REPO and proceeds to upload" {
+    _require_zip
+    cat > "$TEST_DIR/gh" <<'SHIM'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+case "$1 $2" in
+  "release view") [[ "${GH_REPO:-}" == "o/r" ]] && exit 0 || exit 1 ;;
+esac
+exit 0
+SHIM
+    chmod +x "$TEST_DIR/gh"
+    export PATH="$TEST_DIR:$PATH"
+    export GH_LOG="$TEST_DIR/gh.log"; : > "$GH_LOG"
+    export GITHUB_REF_NAME="v1.2.3"
+    export GH_REPO="o/r"
+    _stage_release_assets
+    export BUILD_TYPE="python"
+    run "$SCRIPT" attach
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"workflow artifact only"* ]]
+    grep -qx "release upload v1.2.3 $BUNDLE_OUT/a.tgz.intoto.jsonl --clobber" "$GH_LOG"
+}
+
 # --- wrangle_retry_once -----------------------------------------------------
 
 # Shim whose first invocation fails after partial output and whose second

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -82,7 +82,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@44a586de9766492f29ae171a2a24feb0ec681957 # main 2026-06-20
+    - uses: TomHennen/wrangle/actions/verify@91a78a5fa46b92a1d42ae16fd32968a97f1d9f5b # fix-verify-gh-repo 2026-06-20
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}


### PR DESCRIPTION
## Root cause

`actions/verify/action.yml`'s "Attach assets to release" step set `GH_TOKEN` but **not** `GH_REPO`. The verify composite has no `actions/checkout` of the adopter repo, so `$GITHUB_WORKSPACE` carries no git remote for `gh` to infer the base repository from. Without `GH_REPO`, `run_verify.sh`'s `wrangle_attach_release` can't resolve the repo: `gh release view "$ref"` fails, the function hits its `no GitHub release for $ref; … return 0` branch, and the attach **silently no-ops** — even when a published, non-draft release for the tag exists.

This is why the release-asset attach (the #501 work) has **never worked** in the showcase: a published release existed at verify time, yet every build logged "no GitHub release". It also breaks real adopters (relates to #407).

## Fix

Add `GH_REPO: ${{ github.repository }}` to the attach step's `env:` (the showcase's own create-release job already uses this exact pattern). The "run" step uses only `bnd`/`GITHUB_TOKEN` (no `gh` — confirmed by grepping all `gh ` invocations in `run_verify.sh`, which are all `gh release view`/`gh release upload` in the attach path), so it needs no change. `run_verify.sh` logic is unchanged.

## Regression test

- `test_run_verify.bats`: a new attach test drives a `gh` shim whose `release view` succeeds **only** when `GH_REPO` names the expected repo, and asserts the attach proceeds to `release upload` rather than no-opping — locking that the attach can resolve the repo.
- `test_action_structure.bats`: asserts the attach step's env contains `GH_REPO: ${{ github.repository }}`.

## Bootstrap pin (nested-pin lifecycle, #382)

The integration test resolves verify through `build_and_publish_*.yml` → `verify_release` → `verify`. To exercise this branch's verify, the nested pins are bootstrapped to branch shas:
- `actions/verify_release/action.yml`'s `verify@<sha>` → the fix commit (`91a78a5`)
- the four `build_and_publish_*.yml` `verify_release@<sha>` pins → the verify_release-bump commit (`3717eb0`)

`tools/check_pin_ancestry.sh` passes (all pins reachable from HEAD). Pre-existing main pins on `actions/prep` and `actions/scan` were left untouched. **Post-merge: re-bump verify_release→verify and the workflow→verify_release pins to a main sha** (`tools/bump_action_pins.sh <main-sha>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
