### PR TITLE
chore: bump self-ref pins to main post-#519

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -257,7 +257,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3717eb0edf693150036b9525102202bade61b2d8 # fix-verify-gh-repo 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@6288b9dd41452f805f67b3f936d4e8f141149b5c # main 2026-06-20
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -402,7 +402,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3717eb0edf693150036b9525102202bade61b2d8 # fix-verify-gh-repo 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@6288b9dd41452f805f67b3f936d4e8f141149b5c # main 2026-06-20
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -300,7 +300,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3717eb0edf693150036b9525102202bade61b2d8 # fix-verify-gh-repo 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@6288b9dd41452f805f67b3f936d4e8f141149b5c # main 2026-06-20
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -287,7 +287,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3717eb0edf693150036b9525102202bade61b2d8 # fix-verify-gh-repo 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@6288b9dd41452f805f67b3f936d4e8f141149b5c # main 2026-06-20
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -82,7 +82,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@91a78a5fa46b92a1d42ae16fd32968a97f1d9f5b # fix-verify-gh-repo 2026-06-20
+    - uses: TomHennen/wrangle/actions/verify@6288b9dd41452f805f67b3f936d4e8f141149b5c # main 2026-06-20
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}


### PR DESCRIPTION
Bumps the verify_release→verify and workflow→verify_release self-ref pins to main after #519's squash-merge orphaned the branch shas.

Note: the nested 2-level chain (workflow→verify_release→verify) only fully converges off branch shas after this merges. If `check_pin_ancestry` still shows the verify_release→verify pin pointing at a non-main sha after this lands, a follow-up bump may be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)