### PR TITLE
chore: bump self-ref pins to main post-#522 (convergence cycle 2)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -110,7 +110,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         id: prep
         with:
           build-type: container
@@ -129,7 +129,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -157,7 +157,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      uses: TomHennen/wrangle/build/actions/container@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -257,7 +257,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -168,7 +168,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         id: prep
         with:
           build-type: go
@@ -187,7 +187,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -221,7 +221,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/go/checks@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/go/release@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         id: release
         with:
           path: ${{ inputs.path }}
@@ -373,7 +373,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         id: attest
         with:
           build-type: go
@@ -402,7 +402,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -145,7 +145,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         id: prep
         with:
           build-type: npm
@@ -164,7 +164,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -200,7 +200,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/npm@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         id: build
         with:
           path: ${{ inputs.path }}
@@ -274,7 +274,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         id: attest
         with:
           build-type: npm
@@ -300,7 +300,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -122,7 +122,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         id: prep
         with:
           build-type: python
@@ -141,7 +141,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -175,7 +175,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/python@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         id: build
         with:
           path: ${{ inputs.path }}
@@ -261,7 +261,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         id: attest
         with:
           build-type: python
@@ -287,7 +287,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+        uses: TomHennen/wrangle/build/actions/shell@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+        uses: TomHennen/wrangle/actions/scan@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/prep/action.yml
+++ b/actions/prep/action.yml
@@ -59,18 +59,18 @@ runs:
     # Refuse unsafe triggers first, so a refused invocation fails prep and
     # every downstream `needs: [prep]` job skips.
     # TODO: replace with $/actions/preflight_guard when $/ syntax ships (#136)
-    - uses: TomHennen/wrangle/actions/preflight_guard@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+    - uses: TomHennen/wrangle/actions/preflight_guard@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
 
     # Gate + names run only for a real build type; guard-only mode skips them.
     # TODO: replace with $/actions/release_gate when $/ syntax ships (#136)
-    - uses: TomHennen/wrangle/actions/release_gate@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+    - uses: TomHennen/wrangle/actions/release_gate@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
       id: gate
       if: ${{ inputs.build-type != '' }}
       with:
         events: ${{ inputs.release-events }}
 
     # TODO: replace with $/actions/package_metadata when $/ syntax ships (#136)
-    - uses: TomHennen/wrangle/actions/package_metadata@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+    - uses: TomHennen/wrangle/actions/package_metadata@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
       id: names
       if: ${{ inputs.build-type != '' }}
       with:

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      uses: TomHennen/wrangle/tools/zizmor@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      uses: TomHennen/wrangle/tools/scorecard@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+      uses: TomHennen/wrangle/tools/dependency-review@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -82,7 +82,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@df26c2c314e81e1d9df29f2e1f282e53a5b762a4 # main 2026-06-20
+    - uses: TomHennen/wrangle/actions/verify@0cc2ea9d13e4ad1616fa4f425258d9580d8ed69a # main 2026-06-20
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}


### PR DESCRIPTION
Convergence cycle 2 completing #519+#516. #522 made the merged commit nest `verify@df26c2c`/`scorecard@df26c2c` (reachable); this points the workflow-level `verify_release@`/`scan@` pins at #522's merge (0cc2ea9) so the `@main` showcase resolves through to those fixes. After this, `check_pin_ancestry` is green and the nested chains fully converge — no further cycle needed. Mechanical pin-bump completing the LGTM'd #519/#516 merges.