### PR TITLE
feat(wrangle-attest): harden manifest trust — scan-tool allowlist, symlink containment, dedup

### DIFF
--- a/tools/wrangle-attest/SPEC.md
+++ b/tools/wrangle-attest/SPEC.md
@@ -63,10 +63,16 @@ wrangle-attest --metadata-root <dir>... (--subject sha256:<hex> | --artifact <fi
 ```
 
 Honors the canonical top-level `<root>/wrangle_attestation_metadata.json` plus,
-for each immediate child dir of `<root>/scan/`, `<root>/scan/<tool>/wrangle_attestation_metadata.json`
-(a bounded one-level lookup, no recursion). Any other `wrangle_attestation_metadata.json`
-deeper in the tree or outside those two locations is ignored (a build-time
-dependency could plant one to forge a wrangle-signed attestation).
+for each allowlisted tool dir under `<root>/scan/` (`osv`, `zizmor`,
+`wrangle-lint`, `scorecard`, `dependency-review`),
+`<root>/scan/<tool>/wrangle_attestation_metadata.json` (a bounded one-level
+lookup, no recursion). Any other `wrangle_attestation_metadata.json` — deeper in
+the tree, outside those locations, or under a non-allowlisted `scan/<dir>/` — is
+ignored (a build-time dependency could plant one to forge a wrangle-signed
+attestation). The discovered set is deduplicated by directory and signed in a
+deterministic order. A `result-file` is read only after its symlink-resolved
+real path is asserted to stay within the manifest's own directory, so a symlink
+can't pull a sibling artifact or an arbitrary file into a signed predicate.
 Builds one Statement per honored manifest bound to the subject and writes them
 all to `--out` as JSONL. `--commit` is woven into the `scan/v1` envelope only;
 passthrough predicates ignore it.

--- a/tools/wrangle-attest/manifest.go
+++ b/tools/wrangle-attest/manifest.go
@@ -21,6 +21,17 @@ const (
 	predicateScanV1    = "https://github.com/TomHennen/wrangle/attestation/scan/v1"
 )
 
+// scanTools is the allowlist of honored <root>/scan/<tool>/ subdirectories. A
+// build-time dependency could plant scan/<faketool>/wrangle_attestation_metadata.json
+// at a canonical-shaped path; only the tools wrangle actually runs are signed.
+var scanTools = map[string]bool{
+	"osv":               true,
+	"zizmor":            true,
+	"wrangle-lint":      true,
+	"scorecard":         true,
+	"dependency-review": true,
+}
+
 // manifest is the tool↔engine contract written next to each native result.
 // `result-file` is resolved relative to the manifest's own directory so a
 // producer cannot escape its metadata dir or reach an absolute path.
@@ -67,9 +78,25 @@ func (m *manifest) validate() error {
 	return nil
 }
 
-// resultPath is the absolute path to the manifest's native result file.
-func (m *manifest) resultPath() string {
-	return filepath.Join(m.dir, m.ResultFile)
+// resultPath is the absolute path to the manifest's native result file, with
+// symlinks resolved and asserted to stay within the manifest's own directory.
+// filepath.IsLocal in validate blocks lexical `..`/absolute paths but follows
+// symlinks; a result-file symlinked out of its dir would otherwise read a
+// sibling artifact or an arbitrary file into a wrangle-signed predicate.
+func (m *manifest) resultPath() (string, error) {
+	realDir, err := filepath.EvalSymlinks(m.dir)
+	if err != nil {
+		return "", fmt.Errorf("result-file dir: %w", err)
+	}
+	realPath, err := filepath.EvalSymlinks(filepath.Join(m.dir, m.ResultFile))
+	if err != nil {
+		return "", fmt.Errorf("result-file: %w", err)
+	}
+	rel, err := filepath.Rel(realDir, realPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("result-file %q resolves outside the manifest directory", m.ResultFile)
+	}
+	return realPath, nil
 }
 
 const manifestFile = "wrangle_attestation_metadata.json"
@@ -110,11 +137,19 @@ func discoverManifests(roots []string) ([]manifest, error) {
 		}
 	}
 	sort.Slice(found, func(i, j int) bool { return found[i].dir < found[j].dir })
+	seen := make(map[string]bool, len(found))
+	for _, m := range found {
+		if seen[m.dir] {
+			return nil, fmt.Errorf("duplicate manifest directory %q", m.dir)
+		}
+		seen[m.dir] = true
+	}
 	return found, nil
 }
 
-// scanToolDirs returns the immediate child directories of <root>/scan/. A
-// missing scan/ dir is not an error. Non-directory entries are skipped; the
+// scanToolDirs returns the honored child directories of <root>/scan/: only the
+// allowlisted tool names (scanTools), never a bare scan/* glob. A missing scan/
+// dir is not an error. Non-directory entries and unknown names are skipped; the
 // lookup never recurses below scan/<tool>/.
 func scanToolDirs(root string) ([]string, error) {
 	scanRoot := filepath.Join(root, "scan")
@@ -127,7 +162,7 @@ func scanToolDirs(root string) ([]string, error) {
 	}
 	var dirs []string
 	for _, e := range entries {
-		if e.IsDir() {
+		if e.IsDir() && scanTools[e.Name()] {
 			dirs = append(dirs, filepath.Join(scanRoot, e.Name()))
 		}
 	}

--- a/tools/wrangle-attest/manifest_test.go
+++ b/tools/wrangle-attest/manifest_test.go
@@ -179,6 +179,64 @@ func TestDiscoverManifestsScanBounded(t *testing.T) {
 	}
 }
 
+// A scan/<faketool>/ dir outside the allowlist is ignored — not signed, not an
+// error — while an allowlisted sibling is still honored. Closes the "plant
+// scan/evil/wrangle_attestation_metadata.json at a canonical-shaped path" forge.
+func TestDiscoverManifestsScanAllowlist(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "scan/zizmor/wrangle_attestation_metadata.json", `{"predicate-type":"https://github.com/TomHennen/wrangle/attestation/scan/v1","result-file":"output.sarif","tool":{"name":"zizmor","version":"1.0"},"result":"clean"}`)
+	writeFile(t, root, "scan/evil/wrangle_attestation_metadata.json", `{"predicate-type":"https://evil.example/x","result-file":"r.json"}`)
+	got, err := discoverManifests([]string{root})
+	if err != nil {
+		t.Fatalf("a non-allowlisted scan dir must not cause an error: %v", err)
+	}
+	if len(got) != 1 || got[0].PredicateType != predicateScanV1 {
+		t.Fatalf("expected only the allowlisted zizmor manifest, got %d", len(got))
+	}
+}
+
+// A result-file symlinked out of its manifest dir is rejected at read time, even
+// though it is lexically local. Closes the "symlink result-file to a sibling
+// artifact / arbitrary file and get its content signed" forge.
+func TestResultPathSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.json")
+	if err := os.WriteFile(outside, []byte(`{"x":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mdir := filepath.Join(root, "md")
+	if err := os.MkdirAll(mdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(mdir, "sbom.spdx.json")); err != nil {
+		t.Fatal(err)
+	}
+	m := manifest{PredicateType: predicateSPDX, ResultFile: "sbom.spdx.json", dir: mdir}
+	if _, err := m.resultPath(); err == nil {
+		t.Fatal("expected symlinked result-file to be rejected")
+	}
+}
+
+// A result-file symlink that stays within the manifest dir resolves normally —
+// the containment check rejects escapes, not all symlinks.
+func TestResultPathSymlinkInDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "real.json"), []byte(`{"x":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real.json", filepath.Join(dir, "sbom.spdx.json")); err != nil {
+		t.Fatal(err)
+	}
+	m := manifest{PredicateType: predicateSPDX, ResultFile: "sbom.spdx.json", dir: dir}
+	got, err := m.resultPath()
+	if err != nil {
+		t.Fatalf("an in-dir symlink must resolve: %v", err)
+	}
+	if want, _ := filepath.EvalSymlinks(filepath.Join(dir, "real.json")); got != want {
+		t.Fatalf("resultPath = %q, want %q", got, want)
+	}
+}
+
 // A malformed manifest at an honored scan/<tool>/ location fails closed.
 func TestDiscoverManifestsScanFailClosed(t *testing.T) {
 	root := t.TempDir()

--- a/tools/wrangle-attest/statement.go
+++ b/tools/wrangle-attest/statement.go
@@ -35,7 +35,11 @@ func buildStatement(m manifest, subject *intoto.ResourceDescriptor, commit strin
 // statement. Passthrough types embed the JSON object as-is; the scan/v1 type
 // wraps SARIF in {tool, scannedCommit, result, sarif}.
 func buildPredicate(m manifest, commit string) (*structpb.Struct, error) {
-	raw, err := os.ReadFile(m.resultPath())
+	path, err := m.resultPath()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("result-file: %w", err)
 	}


### PR DESCRIPTION
## What

Deepens the #474 manifest-injection hardening for the `wrangle-attest` engine, which keyless-signs discovered producer manifests under wrangle's identity in the trusted verify job. A build-time dependency can write the metadata dir before it's signed; the residual exposure is **forging wrangle's security-verdict attestations** (a forged "OSV clean" / passing scorecard) to defeat consumer admission gates.

## Threats closed (one line each)

1. **Scan-tool allowlist.** A planted `scan/<faketool>/wrangle_attestation_metadata.json` at a canonical-shaped path getting an attacker-chosen predicate signed → `scanToolDirs` now honors only the allowlist (`osv`, `zizmor`, `wrangle-lint`, `scorecard`, `dependency-review`), not a bare `scan/*` glob.
2. **Symlink escape.** A `result-file` (lexically local) symlinked to a sibling artifact or an arbitrary file pulling that content into a signed predicate → `resultPath` now `EvalSymlinks`-resolves and asserts the real path stays under the manifest dir. `filepath.IsLocal` blocked `..`/absolute but followed symlinks.
3. **Non-deterministic set.** Ambiguity in the discovered set → dedup by directory (stable ordering already present).

## Files changed

- `tools/wrangle-attest/manifest.go` — `scanTools` allowlist; allowlist filter in `scanToolDirs`; symlink-resolving + containment `resultPath` (now returns an error); duplicate-dir guard in `discoverManifests`.
- `tools/wrangle-attest/statement.go` — thread the `resultPath` error.
- `tools/wrangle-attest/manifest_test.go` — `TestDiscoverManifestsScanAllowlist`, `TestResultPathSymlinkEscape`, `TestResultPathSymlinkInDir`.
- `tools/wrangle-attest/SPEC.md` — discovery contract (allowlist, dedup, symlink containment).

## Tests

`go test ./... && go vet ./...` clean; no existing SBOM/OSV/scan-v1/scorecard golden regressions. Each guard confirmed **load-bearing**: with the allowlist filter removed `TestDiscoverManifestsScanAllowlist` fails (signs `scan/evil/`); with the containment check removed `TestResultPathSymlinkEscape` fails (reads the out-of-dir symlink). `TestResultPathSymlinkInDir` confirms a legitimate in-dir symlink still resolves.

## Deferred for owner decision

- **#477 step 1 (content integrity at canonical paths).** The load-bearing step-ordering guard so adopter code running *after* metadata generation can't reopen SBOM tampering. This is a build-job restructuring (not an engine change) and the airtight version is step 4 — flagging rather than guessing the shape.
- **#477 step 4 (trusted-side reconstruction).** The issue says "Consider"/"Evaluate." Re-deriving the manifest set from known-trusted files changes the producer contract substantially; needs a design decision before implementing.

No composite/workflow files touched, so no bootstrap pin needed.

Part of #477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)