### PR TITLE
docs: de-drift build-type SPECs (inlined python workflow + stale gate-job refs)

### DIFF
--- a/build/actions/go/SPEC.md
+++ b/build/actions/go/SPEC.md
@@ -49,7 +49,7 @@ The stale `cyclonedx-gomod` reference in [`docs/docker_best_practices.md`](../..
 - **Same shape as python, npm, and container.** The composite owns build/test/SBOM/lint and emits `dist/`; the `attest:` job (a separate job inside wrangle's reusable workflow) calls `actions/attest-build-provenance` over the dist; the `verify:` job then verifies that provenance (ampel against the wrangle PolicySet, fail-closed) and emits the signed VSA. Consistency keeps the per-build-type cognitive load low.
 - **Preserves the test/SBOM/lint seam.** Wrangle's value-add steps slot between "build" and "provenance" the same way they do for python — the build action emits `dist/`, runs syft against it, runs gating, and then hands off. There's nowhere new to learn.
 - **Same L3 isolation as the ecosystem-specific Go builder.** L3 comes from the provenance being produced by an isolated, trusted builder; wrangle's reusable workflow *is* that builder, and the `attest:` step runs inside it, so its `job_workflow_ref` is both the Sigstore cert SAN and the provenance `builder.id`. Per the L3 audit, switching to `builder_go_slsa3.yml` would not close any conformance gap this approach leaves open.
-- **`lib/release_gate.sh` works either way.** Wrangle gates the `attest:` job with `if: ${{ needs.gate.outputs.should-release == 'true' }}`. That predicate-on-the-job pattern is build-type-agnostic.
+- **`actions/prep/release_gate.sh` works either way.** Wrangle gates the `attest:` job with `if: ${{ needs.prep.outputs.should-release == 'true' }}`. That predicate-on-the-job pattern is build-type-agnostic.
 
 #### Cosign `sign-blob` on top of SLSA — not picked
 
@@ -150,7 +150,7 @@ Across both binary releases and the validation-only sub-shape, wrangle adds the 
 - **Test gating** — tests must pass before SLSA provenance is generated (binary mode) or before the workflow declares success (validate-only mode).
 - **Vulnscan** via the existing source-scan infrastructure (OSV-Scanner against `go.sum`).
 - **Lint** via `gofmt` + `golangci-lint`.
-- **Release-events gating** — the `release_gate` job decides whether to run the `attest`/`verify` jobs at all (binary mode); the same predicate vocabulary as python.
+- **Release-events gating** — the `prep` job's release gate decides whether to run the `attest`/`verify` jobs at all (binary mode); the same predicate vocabulary as python.
 - **Checksum-pinned handoff** to `actions/attest-build-provenance` (binary mode) — the attest step reads `dist/checksums.txt` directly, no string interpolation across job boundaries, no surface for a hash-substitution attack.
 - **Consistent metadata layout, step summary, and artifact upload naming** — same shape as every other build type.
 - **One-line adoption** — a single `uses:` line replaces a multi-step workflow.
@@ -169,7 +169,7 @@ The build artifact differs across the two modes (release binaries vs. nothing), 
 
 Practical notes for whoever picks up the implementation PR.
 
-- **Match python's reusable-workflow shape.** `build_and_publish_go.yml` mirrors `build_and_publish_python.yml`: a `checks`/`release` build pair, a `gate` job (`lib/release_gate.sh`), an `attest` job (`actions/attest-build-provenance`, gated on `should-release`), and a `verify` job (`actions/verify` verifying the provenance against the wrangle PolicySet and emitting the signed VSA, gated on `should-release`). Outputs follow the unified naming: `metadata-artifact-name`, `dist-artifact-name`, `provenance-artifact-name`, `should-release`.
+- **Match python's reusable-workflow shape.** `build_and_publish_go.yml` mirrors `build_and_publish_python.yml`: a `prep` job (`actions/prep/release_gate.sh`) heading the pipeline, a `checks`/`release` build pair, an `attest` job (`actions/attest-build-provenance`, gated on `should-release`), and a `verify` job (`actions/verify` verifying the provenance against the wrangle PolicySet and emitting the signed VSA, gated on `should-release`). Outputs follow the unified naming: `metadata-artifact-name`, `dist-artifact-name`, `provenance-artifact-name`, `should-release`.
 - **Goreleaser invocation.** Use `goreleaser/goreleaser-action` SHA-pinned, with `args: release --clean`. Set `-trimpath` and `-buildvcs=false` defaults via `.goreleaser.yml` template the action ships, or document them as a hard requirement on the adopter's config.
 - **Subjects.** Pass `subject-checksums: dist/checksums.txt` to `actions/attest-build-provenance` — not a `dist/*` glob: goreleaser writes non-artifact bookkeeping (`artifacts.json`, `config.yaml`, `metadata.json`) and per-target build subdirs into `dist/` that are not released artifacts. The checksums file is the canonical released-artifact set, and the same set the VSA binds to.
 - **`::stop-commands::` guard around build/test invocations.** The ecosystem-specific Go builder wraps the compile step in a `::stop-commands::` directive so workflow-command injection via build-tool stdout is neutralized. Wrangle adopted this for its existing build types in #230 via the shared `lib/stop_commands_guard.sh` helper; the Go build action MUST use the same helper around `goreleaser` and `go test` invocations. See npm's `build/actions/npm/build_and_pack.sh` and python's `build/actions/python/run_tests.sh` for the invocation pattern.

--- a/build/actions/npm/SPEC.md
+++ b/build/actions/npm/SPEC.md
@@ -159,7 +159,7 @@ Practical things the implementer will hit. Not contract-design speculation; that
   9. Write `sbom.spdx.json` into the unified `metadata/npm/<shortname>/` directory; the scan job's `scan/` output and (on release) the verify job's `.intoto.jsonl` bundle are folded into the same directory.
 - **Reusable workflow shape mirrors python's:**
   1. `build` job runs the composite (steps above), uploads `npm-dist-<shortname>` and `npm-metadata-<shortname>` artifacts.
-  2. `gate` job runs `lib/release_gate.sh` and exposes `should-release`.
+  2. `prep` job runs `actions/prep/release_gate.sh` and exposes `should-release`.
   3. `attest` job (gated on `should-release`) runs `actions/attest-build-provenance` with `subject-path: dist/*` and uploads the signed bundle. Export the bundle's artifact name as `provenance-artifact-name` so it can be downloaded by name.
   4. `verify` job (gated on `should-release`) runs `actions/verify` per dist artifact: ampel verifies the provenance against the wrangle PolicySet (fail-closed against `common.identities` + the SLSA tenets), emits the signed SLSA VSA, and attaches it to the release on tag pushes. Verify failure fails the workflow; the adopter's publish (gated on `needs:`) is blocked.
 - **Reflection on `package.json`.** Steps 3 and 4 are conditional on `"scripts.build"` and `"scripts.test"` being defined. Use `jq` against `package.json` rather than running `npm run build` and catching the "missing script" exit code — clearer logs.

--- a/build/actions/python/SPEC.md
+++ b/build/actions/python/SPEC.md
@@ -125,7 +125,7 @@ The reusable workflow runs an `attest:` job that calls `actions/attest-build-pro
 
 The `attest:` job declares `id-token: write` (OIDC for Sigstore keyless signing), `attestations: write` (write the attestation to GitHub's store), and `contents: read` (`download-artifact` reads the same-run dist). It does **not** need `actions: read` (which the former generator required to detect the Actions environment).
 
-Provenance is gated on the `release-events` input (default `non-pull-request`). The reusable workflow runs a small `gate` job that calls `lib/release_gate.sh` and exposes a `should-release` output; the `attest:` job runs only when `should-release == 'true'`. On gated-out runs (e.g., PRs, or non-tag events when `release-events: tag-only`), only the build + test + SBOM steps run. See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full predicate vocabulary.
+Provenance is gated on the `release-events` input (default `non-pull-request`). The `prep` job runs `actions/prep/release_gate.sh` and exposes a `should-release` output; the `attest:` job runs only when `needs.prep.outputs.should-release == 'true'`. On gated-out runs (e.g., PRs, or non-tag events when `release-events: tag-only`), only the build + test + SBOM steps run. See [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating" for the full predicate vocabulary.
 
 The separate `verify:` job (which emits the signed SLSA VSA) declares `contents: write` so it can attach the VSA to the GitHub release on tag pushes. Callers of this reusable workflow must therefore grant `contents: write` themselves for that job.
 
@@ -133,7 +133,7 @@ The separate `verify:` job (which emits the signed SLSA VSA) declares `contents:
 
 The `verify:` job runs `actions/verify`, which drives ampel against the provenance the `attest:` job produced. ampel verifies the provenance's Sigstore signature against the `wrangle-provenance-python-v1` PolicySet's `common.identities` — fail-closed, so only wrangle's reusable-workflow signer (`TomHennen/wrangle/.github/workflows/build_and_publish_python.yml`, both the Sigstore cert SAN and the provenance `builder.id`) passes — and checks the SLSA tenets, then emits the signed SLSA VSA.
 
-The job is gated on `should-release` (the same `gate` job that gates `attest:`); it is not opt-out-able. If verification fails, the job fails — and via standard `needs:` propagation the reusable workflow fails. The caller's publish job, gated on `should-release == 'true'`, is therefore blocked. This catches the "dist tampered with between wrangle's build and the caller's publish" case as a wrangle-owned guarantee rather than per-adopter boilerplate.
+The job is gated on `should-release` (the same `prep` gate that gates `attest:`); it is not opt-out-able. If verification fails, the job fails — and via standard `needs:` propagation the reusable workflow fails. The caller's publish job, gated on `should-release == 'true'`, is therefore blocked. This catches the "dist tampered with between wrangle's build and the caller's publish" case as a wrangle-owned guarantee rather than per-adopter boilerplate.
 
 ### 10. Publish (adopter workflow, gated on should-release)
 
@@ -183,106 +183,7 @@ Callers of this reusable workflow must grant `contents: write` so the validator 
 
 ## Reusable workflow
 
-`.github/workflows/build_and_publish_python.yml` runs build-and-test in one job (`build`), generates SLSA provenance in a second job (`attest`), and verifies that provenance and emits the signed SLSA VSA in a third (`verify`). Provenance comes from `actions/attest-build-provenance` run as a step *inside* the reusable workflow, not from a nested generator reusable workflow. Publishing lives in the adopter's calling workflow — see step 10 for why.
-
-```yaml
-on:
-  workflow_call:
-    inputs:
-      path:
-        required: false
-        type: string
-        default: "."
-      python-version:
-        required: false
-        type: string
-        default: ""
-      run-tests:
-        required: false
-        type: boolean
-        default: true
-      release-events:
-        required: false
-        type: string
-        default: non-pull-request
-    outputs:
-      hashes:
-        value: ${{ jobs.build.outputs.hashes }}
-      version:
-        value: ${{ jobs.build.outputs.version }}
-      dist-artifact-name:
-        value: ${{ jobs.build.outputs.dist-artifact-name }}
-      provenance-artifact-name:
-        value: ${{ jobs.attest.outputs.bundle-artifact-name }}
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read    # minimal — no OIDC, no publish
-    outputs:
-      hashes: ${{ steps.build.outputs.hashes }}
-      version: ${{ steps.build.outputs.version }}
-      shortname: ${{ steps.build.outputs.shortname }}
-      dist-artifact-name: ${{ steps.names.outputs.dist }}
-    steps:
-      - uses: actions/checkout@<sha>
-      # TODO: replace with $/ when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@<sha>
-        id: build
-        with:
-          path: ${{ inputs.path }}
-          python-version: ${{ inputs.python-version }}
-          run-tests: ${{ inputs.run-tests }}
-      - id: names
-        env:
-          SHORTNAME: ${{ steps.build.outputs.shortname }}
-        run: |
-          printf 'dist=python-dist-%s\n' "$SHORTNAME" >> "$GITHUB_OUTPUT"
-          printf 'metadata=python-metadata-%s\n' "$SHORTNAME" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@<sha>
-        with:
-          name: ${{ steps.names.outputs.dist }}
-          path: ${{ inputs.path }}/dist/
-      - uses: actions/upload-artifact@<sha>
-        with:
-          name: ${{ steps.names.outputs.metadata }}
-          path: ${{ steps.build.outputs.metadata-dir }}/
-
-  gate:
-    runs-on: ubuntu-latest
-    outputs: { should-release: ${{ steps.gate.outputs.should-release }} }
-    steps:
-      - uses: actions/checkout@<sha>
-      - id: gate
-        env:
-          EVENTS_INPUT: ${{ inputs.release-events }}
-          EVENT_NAME: ${{ github.event_name }}
-          REF: ${{ github.ref }}
-        run: ./lib/release_gate.sh
-
-  attest:
-    if: ${{ needs.gate.outputs.should-release == 'true' }}
-    needs: [gate, build]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write       # OIDC for Sigstore keyless signing
-      attestations: write   # write the attestation to GitHub's store
-      contents: read        # download-artifact reads the same-run dist
-    outputs:
-      bundle-artifact-name: python-provenance-bundle-${{ needs.build.outputs.shortname }}
-    steps:
-      - uses: actions/download-artifact@<sha>
-        with:
-          name: ${{ needs.build.outputs.dist-artifact-name }}
-          path: dist/
-      - uses: actions/attest-build-provenance@<sha>
-        id: attest
-        with:
-          subject-path: dist/*
-```
-
-The `verify` job (omitted above for brevity) verifies the provenance against the wrangle PolicySet and emits the signed SLSA VSA via `actions/verify`, attaching it to the release on tag pushes; it needs `id-token: write` and `contents: write`. The publish job lives in the adopter's calling workflow (see `gh_workflow_examples/build_python.yml`), which depends on this reusable workflow's `dist-artifact-name`, `provenance-artifact-name`, `hashes`, and `should-release` outputs.
+[`build_and_publish_python.yml`](../../../.github/workflows/build_and_publish_python.yml) heads with the shared `prep` job (`actions/prep`) — the trigger guard, the release-events gate exposing `should-release`, and the derived artifact names — and every other job runs `needs: [prep]`. `build` builds, tests, scans, and uploads the `dist/` and metadata artifacts; `attest` generates SLSA provenance from `actions/attest-build-provenance` (`subject-path: dist/*`) run as a step *inside* the reusable workflow, not from a nested generator; `verify` verifies that provenance and emits the signed SLSA VSA. `attest` and `verify` are gated on `needs.prep.outputs.should-release == 'true'`, so gated-out runs build, test, and scan only. Inputs and outputs live in the workflow file; the outputs an adopter consumes are listed under "Outputs" above. Publishing lives in the adopter's calling workflow (see [`gh_workflow_examples/build_python.yml`](../../../gh_workflow_examples/build_python.yml)) — step 10 explains why — and depends on this workflow's `dist-artifact-name`, `provenance-artifact-name`, `hashes`, and `should-release` outputs.
 
 ## Security model
 


### PR DESCRIPTION
claude: Cleans up the build-type SPEC drift that surfaced on #526 (the "did we inline the whole reusable workflow here?" thread).

These SPECs predate the #504 `prep` consolidation:

- **`build/actions/python/SPEC.md`** — replaced the ~95-line inlined copy of the reusable workflow (a standalone `gate:` job running `./lib/release_gate.sh`, `needs.gate.outputs`, no `prep`/`scan`) with a link to [`build_and_publish_python.yml`](../../../.github/workflows/build_and_publish_python.yml) plus a concise job-shape narrative (`prep` → `scan`/`build` → `attest` → `verify`, gated on `needs.prep.outputs.should-release`). Per CLAUDE.md's adopter-doc rule — copies of a source of truth drift; point to it. Also fixed the two `gate`-job prose references in the provenance/verify sections.
- **`build/actions/go/SPEC.md`** — three references to a `gate` job / `lib/release_gate.sh` / `needs.gate.outputs` → the `prep` job / `actions/prep/release_gate.sh` / `needs.prep.outputs` (go's real workflow heads with `prep`).
- **`build/actions/npm/SPEC.md`** — the one `gate`-job/`lib/release_gate.sh` reference in the (still Phase-1-research) shape description, pointed at `prep` / `actions/prep/release_gate.sh` for consistency.

Docs-only; full `./test.sh` green in the pinned container.

## Deliberately out of scope

`build/actions/container/SPEC.md` describes a "**gate job**" ~8 times across its security model (the success barrier enforcing the build+sign+provenance hard-fail contract). The real `build_and_publish_container.yml` has **no** `gate` job — it's `prep` → `scan` → `build` → `attest` → `verify`, and the contract is now enforced by `needs:` propagation through the gated `verify` job. That's a deeper threat-model rewrite (not a mechanical rename), so I left it for a focused follow-up rather than bundle a security-model rewrite into a drift sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
