### PR TITLE
docs(faq): how to waive an unfixable OSV finding (osv-scanner.toml)

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -76,6 +76,15 @@ scan-tools: "osv zizmor scorecard:info wrangle-lint"
 
 `osv`, `zizmor`, and `wrangle-lint` stay blocking on real findings.
 
+## An OSV finding I can't fix yet is blocking the release — what do I do?
+
+The default policy gates on a clean OSV scan, so an unfixed advisory blocks the
+release. To waive one you can't fix yet, suppress it in
+[`osv-scanner.toml`](https://google.github.io/osv-scanner/configuration/) with a
+`reason` — osv-scanner applies that config natively, so the advisory is excluded
+from the scan result. Keep the reason honest and drop the suppression once a fix
+ships.
+
 ## Why these tools and not others?
 
 They seemed good for the job. wrangle isn't a ranking of every scanner or


### PR DESCRIPTION
Closes the (2) doc item from #527 review: the default policy requires a clean OSV scan, so document the `osv-scanner.toml` suppression as the adopter escape hatch for an advisory they can't fix yet (osv-scanner applies it natively → excluded from the result). Adopter altitude, links the upstream config doc. The richer per-finding OpenVEX waiver is tracked in #532.