### PR TITLE
perf(test): parallelize the local suite + cache gotest (#530)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,14 @@ gotest:
 shellcheck:
 	@./build/actions/shell/run_shellcheck.sh .
 
-# Run bats tests
+# Run bats tests. Fan out across files with GNU parallel (#530); within-file
+# order is preserved so a file's setup assumptions hold. Falls back to serial
+# when parallel is absent, so a host without it still runs the suite.
+BATS_JOBS ?= $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+BATS_PARALLEL ?= $(if $(filter-out 0 1,$(BATS_JOBS)),$(if $(shell command -v parallel 2>/dev/null),--jobs $(BATS_JOBS) --no-parallelize-within-files))
 bats:
 	@echo "=== bats ==="
-	@bats test/ test/lib/ test/consumer/ test/integration/ tools/*/test.bats actions/*/*.bats build/actions/*/test.bats
+	@bats $(BATS_PARALLEL) test/ test/lib/ test/consumer/ test/integration/ tools/*/test.bats actions/*/*.bats build/actions/*/test.bats
 
 # Non-hermetic: installs real tools (network, registries, Sigstore) via
 # test/setup_integration.sh, then runs the integration bats suites. NOT in
@@ -55,7 +59,7 @@ bats:
 integration:
 	@echo "=== integration ==="
 	@if [[ -n "$$GOTMPDIR" ]]; then mkdir -p "$$GOTMPDIR"; fi
-	@source lib/env.sh && ./test/setup_integration.sh && bats $(INTEGRATION_BATS)
+	@source lib/env.sh && ./test/setup_integration.sh && bats $(BATS_PARALLEL) $(INTEGRATION_BATS)
 
 # Workflow security linting (matches tools/zizmor/action.yml's CI invocation).
 # --no-online-audits keeps the test container offline-friendly; the audits

--- a/test.sh
+++ b/test.sh
@@ -45,10 +45,16 @@ docker build -t "$IMAGE_NAME" -f "$SCRIPT_DIR/test/Dockerfile" "$SCRIPT_DIR"
 # Map the script-level alias to the Makefile target list. Array form so
 # `quick` can pass multiple targets to one `make` invocation without
 # leaning on word-splitting (and the SC2086 disable that used to require).
+#
+# The full suites' layers are independent, so `-j` runs them concurrently and
+# `-Otarget` keeps each layer's output grouped (#530). Single-target runs skip
+# the flags: there's nothing to parallelize, and integration wants live output
+# rather than the buffering `-Otarget` imposes.
+MAKE_FLAGS=()
 case "$TEST_TARGET" in
-    ci)    MAKE_TARGETS=(all) ;;
-    quick) MAKE_TARGETS=(lint shellcheck shellstyle workflowstyle gotest bats) ;;
-    *)     MAKE_TARGETS=("$TEST_TARGET") ;;
+    ci|all|test) MAKE_TARGETS=(all); MAKE_FLAGS=(-Otarget -j) ;;
+    quick)       MAKE_TARGETS=(lint shellcheck shellstyle workflowstyle gotest bats); MAKE_FLAGS=(-Otarget -j) ;;
+    *)           MAKE_TARGETS=("$TEST_TARGET") ;;
 esac
 
 # The repo mount is read-only, so the integration installs need a writable
@@ -61,11 +67,21 @@ esac
 # container would re-download and re-build everything per run — slow, and
 # big enough to exhaust the container layer. setup_integration.sh creates
 # $GOTMPDIR (go refuses a nonexistent one).
-DOCKER_ENV=()
+#
+# Unit suites reuse the same volume for the gotest layer's build + module
+# caches — wrangle-attest's module graph is ~700MB to fetch and compile, so a
+# cold container pays ~30s every run (#530). GOPATH stays at the image default
+# so the go build-type's govulncheck install-cache in $GOPATH/bin is untouched.
+# This warms only repeat local runs; CI runners are ephemeral, so the volume is
+# empty there and gotest still builds cold — the test suite never consumes a
+# cross-build cache, keeping it off release builds' cache-isolation surface
+# (SPEC.md §"Cache isolation is part of the L3 claim").
+DOCKER_ENV=(-v wrangle-test-gocache:/godata)
 if [[ "$TEST_TARGET" == "integration" ]]; then
     DOCKER_ENV+=(-e WRANGLE_BIN_DIR=/tmp/wrangle/bin -e WRANGLE_METADATA_DIR=/tmp/wrangle/metadata)
-    DOCKER_ENV+=(-v wrangle-test-gocache:/godata)
     DOCKER_ENV+=(-e GOPATH=/godata/gopath -e GOCACHE=/godata/gocache -e GOTMPDIR=/godata/tmp)
+else
+    DOCKER_ENV+=(-e GOCACHE=/godata/gocache -e GOMODCACHE=/godata/gomodcache)
 fi
 
 # Run the requested test suite
@@ -76,4 +92,4 @@ docker run --rm \
     -w /wrangle \
     ${DOCKER_ENV[@]+"${DOCKER_ENV[@]}"} \
     "$IMAGE_NAME" \
-    make "${MAKE_TARGETS[@]}"
+    make ${MAKE_FLAGS[@]+"${MAKE_FLAGS[@]}"} "${MAKE_TARGETS[@]}"

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -11,10 +11,15 @@ RUN apt-get update -q && \
         make \
         gcc \
         libc6-dev \
+        parallel \
         python3 \
         python3-venv \
         zip \
     && rm -rf /var/lib/apt/lists/*
+
+# GNU parallel backs `bats --jobs`; its first-run citation notice is silenced
+# once per HOME so it never pollutes test output.
+RUN mkdir -p /root/.parallel && touch /root/.parallel/will-cite
 
 # python3 + python3-venv host the isolated, hash-pinned venvs that zizmor,
 # ast-grep, and wrangle-workflow-lint's PyYAML each install into (each tool


### PR DESCRIPTION
## What

Speeds up the local test suite (`make test` / `./test.sh`), which left parallelism on the table and recompiled the first-party Go tools from scratch every run.

**Measured on 4 cores (container, `./test.sh`):**

| | Serial | Parallel | + warm gotest cache |
|---|---|---|---|
| Full unit suite | ~89s | ~71s | **~32s** |
| `bats` layer | ~51s | ~38s | — |
| `gotest` layer | ~30s | ~30s | **~0.4s** |

All green: 1174 ok / 0 failures, cold and warm.

## How

- **`bats --jobs`** — fan out across files (GNU `parallel`, added to `test/Dockerfile`), `--no-parallelize-within-files` so a file's `setup` assumptions hold. Falls back to serial when `parallel` is absent or `<2` cores. Applied to **both** the unit `bats` and `integration` targets — the integration bats isolate per-test (`mktemp`/`$BATS_TEST_TMPDIR`) and only *read* from Sigstore, so they parallelize cleanly (verified twice: 154 ok against live Fulcio/Rekor).
- **`make -Otarget -j`** — run the independent layers concurrently with grouped per-layer output. `bats` was ~85% of wall-clock, so this overlaps shellcheck/gotest into its window.
- **gotest cache** — persist `GOCACHE` + `GOMODCACHE` in the existing test volume. `wrangle-attest`'s ~700MB module graph cost ~30s of cold download+compile per run; warm runs are now <1s. `GOPATH` stays at the image default so the go build-type's `govulncheck` install-cache is untouched.

## SLSA L3 / cache safety

The gotest cache is confined to the **test harness**, never a release build:
- It produces no attested artifact — SPEC.md sanctions exactly this (*"PR builds keep caching for fast iteration, since they produce no attested artifact"*).
- CI runners are ephemeral, so the volume is empty there and gotest still builds **cold** — the suite never consumes a cross-build cache.
- The release/attestation builds keep their own cache-isolation controls (`should-release`-gated `cache: false` / empty `go-cache`), untouched here.

## Measurement notes

The win is core-bound (4-core numbers above; a 2-core CI runner sees less, more cores see more). The dominant lever was bats; `-Otarget -j` and the cache are second-order but real.

## Follow-ups (not in this PR)

- **Enable Go caching in CI** (`actions/cache` keyed on `tools/go.sum`, or restructuring the gotest layer to use `actions/setup-go`'s cache) — supported and L3-safe for the test suite, but a distinct cache-key design.
- The Dockerfile's `yaml.v3`-only module pre-fetch is now effectively dead (the unit suite redirects `GOMODCACHE`); left alone to keep scope tight.

Fixes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)