### PR TITLE
fix(verify): feed engine-signed SBOM/scan attestations to the policy (#541)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -267,7 +267,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@cd0e0042b4b04786f965af4e9563ba742e5a53cf # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@a5afc97a46de3989346ef7b390b634489c0ba73f # fix-541-scan-collector 2026-06-20
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -412,7 +412,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@cd0e0042b4b04786f965af4e9563ba742e5a53cf # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@a5afc97a46de3989346ef7b390b634489c0ba73f # fix-541-scan-collector 2026-06-20
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -310,7 +310,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@cd0e0042b4b04786f965af4e9563ba742e5a53cf # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@a5afc97a46de3989346ef7b390b634489c0ba73f # fix-541-scan-collector 2026-06-20
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -297,7 +297,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@cd0e0042b4b04786f965af4e9563ba742e5a53cf # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@a5afc97a46de3989346ef7b390b634489c0ba73f # fix-541-scan-collector 2026-06-20
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -66,13 +66,10 @@ wrangle_subject_arg() {
     printf -- '--subject-hash=sha256:%s\n' "${digest%% *}"
 }
 
-# Build the ampel verify arg vector for one subject, one arg per line for
-# mapfile. $1 is the subject; $2 the unsigned-VSA output path; $3 (optional) a
-# JSONL of engine-signed build-metadata statements (SBOM + scan/v1) added as a
-# second jsonl: collector so the policy verdict — and the emitted VSA — cover the
-# SBOM and scan tenets, not only the provenance the first collector seeds. It
-# must be a collector, not --attestation: --attestation parses a single
-# statement, but the metadata JSONL holds one line per signed statement.
+# Build the ampel verify arg vector (one arg per line for mapfile). $1 = subject;
+# $2 = unsigned-VSA output; $3 (optional) = signed-metadata JSONL, added as a second
+# jsonl: collector so the verdict (and VSA) cover the SBOM/scan tenets. Must be a
+# collector, not --attestation (which parses only one statement; metadata is multi-line).
 wrangle_ampel_verify_args() {
     local subject="$1" results_path="$2" metadata="${3:-}"
     # Capture (not process-substitute) so a subject-hashing failure aborts.
@@ -218,13 +215,9 @@ wrangle_push_bundle() {
     wrangle_retry_once /dev/null cosign "${args[@]}"
 }
 
-# Build the wrangle-attest arg vector that turns the build metadata into signed
-# in-toto statements (one signed Sigstore-bundle JSONL line per statement), one
-# arg per line for mapfile. $1 is the pre-formed subject arg (--subject=<digest>
-# or --artifact=<file>); $2 the JSONL output path. METADATA_ROOT holds the
-# build's wrangle_attestation_metadata.json files (the SBOM's, the scan tools'
-# scan/v1); COMMIT is the scanned git commit woven into the scan/v1 envelope
-# only, ignored by the SBOM passthrough.
+# Build the wrangle-attest arg vector (one arg per line for mapfile) that signs the
+# build metadata into in-toto statements. $1 = subject arg (--subject=<digest> or
+# --artifact=<file>); $2 = output JSONL path.
 wrangle_attest_args() {
     printf '%s\n' \
         --metadata-root="$METADATA_ROOT" \
@@ -234,17 +227,9 @@ wrangle_attest_args() {
         --out="$2"
 }
 
-# For one subject, build and sign the SBOM (and any other build-metadata)
-# statement(s) via the engine into the JSONL at $2 (one signed Sigstore bundle
-# per line). No-op leaving $2 empty when METADATA_ROOT is unset/empty (a build
-# that produced no metadata). $1 is the subject. A digest subject (container)
-# passes through as --subject; a file subject is handed to the engine via
-# --artifact, which self-digests it to the same sha256 the VSA binds to. The
-# engine signs in the same trusted process as the VSA and fails closed on a
-# malformed manifest, an unreadable artifact, or a signing failure, so an absent
-# statement is a real gap, not a silent skip. Signed here — before ampel — so
-# the policy evaluates against the SBOM/scan statements (fed as a second
-# collector), not only the provenance the first collector seeds.
+# Sign subject $1's build-metadata statements (SBOM + scan/v1) into the JSONL at $2,
+# one signed bundle per line; leaves $2 empty when there's no metadata. Signed
+# before ampel so the policy can evaluate them via a second collector. Fails closed.
 wrangle_sign_metadata_statements() {
     [[ -z "${METADATA_ROOT:-}" || ! -d "${METADATA_ROOT:-}" ]] && return 0
     local subject="$1" stmts="$2" subject_arg

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -67,15 +67,21 @@ wrangle_subject_arg() {
 }
 
 # Build the ampel verify arg vector for one subject, one arg per line for
-# mapfile. $1 is the subject; $2 the unsigned-VSA output path.
+# mapfile. $1 is the subject; $2 the unsigned-VSA output path; $3 (optional) a
+# JSONL of engine-signed build-metadata statements (SBOM + scan/v1) added as a
+# second jsonl: collector so the policy verdict — and the emitted VSA — cover the
+# SBOM and scan tenets, not only the provenance the first collector seeds. It
+# must be a collector, not --attestation: --attestation parses a single
+# statement, but the metadata JSONL holds one line per signed statement.
 wrangle_ampel_verify_args() {
-    local subject="$1" results_path="$2"
+    local subject="$1" results_path="$2" metadata="${3:-}"
     # Capture (not process-substitute) so a subject-hashing failure aborts.
     local subject_arg
     subject_arg="$(wrangle_subject_arg "$subject")"
     local args=(verify "$subject_arg"
-        --collector="$COLLECTOR"
-        --policy="$(wrangle_resolve_policy "$POLICY")"
+        --collector="$COLLECTOR")
+    [[ -n "$metadata" ]] && args+=(--collector="jsonl:$metadata")
+    args+=(--policy="$(wrangle_resolve_policy "$POLICY")"
         --exit-code="$FAIL"
         --attest-results
         --attest-format=vsa
@@ -131,11 +137,12 @@ wrangle_read_subjects() {
 }
 
 # ampel verify one subject -> unsigned VSA at $2, streaming the report to the
-# step summary. $1 is the subject.
+# step summary. $1 is the subject; $3 (optional) the engine-signed metadata
+# JSONL fed to the policy alongside the collector.
 wrangle_verify_emit_vsa() {
-    local subject="$1" results_path="$2"
+    local subject="$1" results_path="$2" metadata="${3:-}"
     local args report rc=0
-    mapfile -t args < <(wrangle_ampel_verify_args "$subject" "$results_path")
+    mapfile -t args < <(wrangle_ampel_verify_args "$subject" "$results_path" "$metadata")
     # Fail closed: an aborted arg builder (e.g. a subject file we couldn't hash)
     # yields a short/empty vector, never a silently mis-verified subject.
     if [[ "${args[0]:-}" != "verify" || "${args[1]:-}" != --subject* ]]; then
@@ -228,30 +235,36 @@ wrangle_attest_args() {
 }
 
 # For one subject, build and sign the SBOM (and any other build-metadata)
-# statement(s) via the engine, then append each signed line to the bundle and
-# post each to the store. No-op when METADATA_ROOT is unset/empty (a build that
-# produced no metadata). $1 is the subject, $2 the bundle file. A digest subject
-# (container) passes through as --subject; a file subject is handed to the
-# engine via --artifact, which self-digests it to the same sha256 the VSA binds
-# to. The engine signs in the same trusted process as the VSA and fails closed
-# on a malformed manifest, an unreadable artifact, or a signing failure (no
-# partial bundle), so an absent statement is a real gap, not a silent skip.
-wrangle_emit_metadata_statements() {
+# statement(s) via the engine into the JSONL at $2 (one signed Sigstore bundle
+# per line). No-op leaving $2 empty when METADATA_ROOT is unset/empty (a build
+# that produced no metadata). $1 is the subject. A digest subject (container)
+# passes through as --subject; a file subject is handed to the engine via
+# --artifact, which self-digests it to the same sha256 the VSA binds to. The
+# engine signs in the same trusted process as the VSA and fails closed on a
+# malformed manifest, an unreadable artifact, or a signing failure, so an absent
+# statement is a real gap, not a silent skip. Signed here — before ampel — so
+# the policy evaluates against the SBOM/scan statements (fed as a second
+# collector), not only the provenance the first collector seeds.
+wrangle_sign_metadata_statements() {
     [[ -z "${METADATA_ROOT:-}" || ! -d "${METADATA_ROOT:-}" ]] && return 0
-    local subject="$1" bundle="$2" subject_arg
+    local subject="$1" stmts="$2" subject_arg
     if [[ "$subject" =~ ^[a-z0-9]+:[a-f0-9]+$ ]]; then
         subject_arg="--subject=$subject"
     else
         subject_arg="--artifact=$subject"
     fi
-    local stmts args
-    stmts="$(mktemp "${RUNNER_TEMP:-/tmp}/attest.XXXXXX")"
+    local args
     mapfile -t args < <(wrangle_attest_args "$subject_arg" "$stmts")
-    wrangle_retry_once /dev/null wrangle-attest "${args[@]}" || { rm -f "$stmts"; return 1; }
-    # Each line is one signed Sigstore bundle (compact JSONL): appended to the
-    # bundle, posted to the store, and pushed alone as the OCI referrer (cosign
-    # attach rejects multi-line).
-    local line_file
+    wrangle_retry_once /dev/null wrangle-attest "${args[@]}"
+}
+
+# Append each signed metadata line at $1 to the bundle $2, post each to the
+# store, and push each alone as the OCI referrer (cosign attach rejects
+# multi-line). No-op on an empty/absent file (no metadata for this build).
+wrangle_append_metadata_statements() {
+    local stmts="$1" bundle="$2"
+    [[ -s "$stmts" ]] || return 0
+    local line_file line
     line_file="$(mktemp "${RUNNER_TEMP:-/tmp}/attestline.XXXXXX")"
     while IFS= read -r line; do
         [[ -z "$line" ]] && continue
@@ -260,7 +273,7 @@ wrangle_emit_metadata_statements() {
         wrangle_push_store "$line_file"
         wrangle_push_bundle "$line_file"
     done < "$stmts"
-    rm -f "$stmts" "$line_file"
+    rm -f "$line_file"
 }
 
 # Post the signed VSA at $1 to the GitHub attestation store (all build types).
@@ -301,13 +314,22 @@ wrangle_run() {
     wrangle_seed_bundle "$seed"
 
     tmp_vsa="$(mktemp "${RUNNER_TEMP:-/tmp}/vsa.XXXXXX")"
-    local vsa_line
+    local vsa_line meta_stmts
     vsa_line="$(mktemp "${RUNNER_TEMP:-/tmp}/vsaline.XXXXXX")"
+    meta_stmts="$(mktemp "${RUNNER_TEMP:-/tmp}/meta.XXXXXX")"
     local bundle
     for subject in "${WRANGLE_SUBJECTS[@]}"; do
         bundle="$BUNDLE_OUT/$(wrangle_bundle_name "$subject")"
         cp "$seed" "$bundle"
-        wrangle_verify_emit_vsa "$subject" "$tmp_vsa"
+        # Sign the SBOM/scan statements first so ampel evaluates the policy
+        # against them (a second collector), then bind the verdict into the VSA.
+        # Pass the file to ampel only when it holds statements — the extra
+        # collector is omitted for a build with no metadata dir.
+        : > "$meta_stmts"
+        wrangle_sign_metadata_statements "$subject" "$meta_stmts"
+        local meta_arg=""
+        [[ -s "$meta_stmts" ]] && meta_arg="$meta_stmts"
+        wrangle_verify_emit_vsa "$subject" "$tmp_vsa" "$meta_arg"
         wrangle_sign_vsa "$tmp_vsa"
         # Flatten bnd's pretty statement to one JSON line: appended to the bundle,
         # posted to the store, and pushed alone as the OCI referrer (cosign attach
@@ -316,11 +338,10 @@ wrangle_run() {
         cat "$vsa_line" >> "$bundle"
         wrangle_push_store "$vsa_line"
         wrangle_push_bundle "$vsa_line"
-        # Append the build-metadata statements (SBOM, …) bound to this same
-        # single-sha256 subject, signed and delivered alongside the VSA.
-        wrangle_emit_metadata_statements "$subject" "$bundle"
+        # Deliver the same signed SBOM/scan statements alongside the VSA.
+        wrangle_append_metadata_statements "$meta_stmts" "$bundle"
     done
-    rm -f "$tmp_vsa" "$vsa_line" "$seed"
+    rm -f "$tmp_vsa" "$vsa_line" "$meta_stmts" "$seed"
 }
 
 # Attach the rationalized asset set to the current tag's GitHub release, if one

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -170,6 +170,34 @@ teardown() {
     [[ "${found_att:-0}" -eq 1 ]]
 }
 
+@test "run_verify: ampel args feed the signed metadata JSONL to the policy as a second collector" {
+    # The SBOM/scan tenets fail closed unless ampel evaluates the policy against
+    # the engine-signed metadata, so the verdict (and VSA) must cover it. It must
+    # be a jsonl: collector, not --attestation: the metadata is multi-statement
+    # JSONL and --attestation parses only a single statement.
+    local meta="$TEST_DIR/meta.jsonl"
+    mapfile -t args < <(wrangle_ampel_verify_args "sha256:abc" "$VSA" "$meta")
+    printf '%s\n' "${args[@]}" | grep -qx -- "--collector=jsonl:$meta"
+    # The metadata is never routed through --attestation (single-statement only).
+    if printf '%s\n' "${args[@]}" | grep -qx -- "--attestation"; then return 1; fi
+}
+
+@test "run_verify: ampel args omit the metadata collector when none was signed" {
+    mapfile -t args < <(wrangle_ampel_verify_args "sha256:abc" "$VSA" "")
+    # Only the seed collector remains — no jsonl: collector for the metadata.
+    [[ "$(printf '%s\n' "${args[@]}" | grep -c -- "--collector=")" -eq 1 ]]
+}
+
+@test "run_verify: ampel args carry both the seed collector and the metadata collector" {
+    # The provenance seed collector and the metadata collector coexist (ampel
+    # --collector is repeatable), so neither shadows the other.
+    local meta="$TEST_DIR/meta.jsonl"
+    mapfile -t args < <(wrangle_ampel_verify_args "sha256:abc" "$VSA" "$meta")
+    [[ "$(printf '%s\n' "${args[@]}" | grep -c -- "--collector=")" -eq 2 ]]
+    printf '%s\n' "${args[@]}" | grep -qx -- "--collector=$COLLECTOR"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--collector=jsonl:$meta"
+}
+
 @test "run_verify: ampel arg vector is accepted by the real ampel parser" {
     # The real ampel rejects an unknown flag with a non-"subject" error; a bad
     # subject means every flag in our vector parsed. Confirms the flag names
@@ -582,6 +610,48 @@ STUB
     run jq -e . "$b"; [[ "$status" -eq 0 ]]
 }
 
+@test "run_verify: run feeds the signed metadata to ampel and appends it to the bundle" {
+    # With a metadata dir, the SBOM/scan statements must be signed BEFORE ampel
+    # and fed to it as a second jsonl: collector (so the verdict/VSA cover the
+    # scan tenets), then delivered in the bundle. ampel records its own args so
+    # the wiring is provable; wrangle-attest emits a deterministic signed line.
+    cat > "$TEST_DIR/ampel" <<STUB
+#!/bin/bash
+printf '%s\n' "\$@" >> "$TEST_DIR/ampel-args"
+for a in "\$@"; do case "\$a" in --results-path=*) printf '{"unsigned":1}\n' > "\${a#--results-path=}";; esac; done
+printf 'report\n'
+STUB
+    cat > "$TEST_DIR/bnd" <<STUB
+#!/bin/bash
+[[ "\$1" == "push" ]] && exit 0
+printf '{"signed":'; cat "\$2"; printf '}\n'
+STUB
+    cat > "$TEST_DIR/wrangle-attest" <<STUB
+#!/bin/bash
+for a in "\$@"; do case "\$a" in --out=*) out="\${a#--out=}";; esac; done
+printf '{"signedStatement":{"predicateType":"https://spdx.dev/Document"}}\n' > "\$out"
+STUB
+    chmod +x "$TEST_DIR/ampel" "$TEST_DIR/bnd" "$TEST_DIR/wrangle-attest"
+    export PATH="$TEST_DIR:$PATH"
+    export GITHUB_STEP_SUMMARY="$TEST_DIR/summary.md"; : > "$GITHUB_STEP_SUMMARY"
+    : > "$TEST_DIR/ampel-args"
+    export OCI_TARGET=""
+    export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
+    printf '{"provenance":1}\n' > "$BUNDLE_IN"
+    local sha; sha="$(printf '0%.0s' {1..64})"
+    export SUBJECTS="sha256:$sha"
+
+    run "$SCRIPT" run
+    [[ "$status" -eq 0 ]]
+    # ampel was handed the signed metadata JSONL as a jsonl: collector, so the
+    # policy evaluated against it (single arg: --collector=jsonl:<file>).
+    grep -qE -- "^--collector=jsonl:.*/meta\." "$TEST_DIR/ampel-args"
+    # The signed metadata statement also landed in the delivered bundle.
+    local bundle; bundle="$BUNDLE_OUT/$(ls "$BUNDLE_OUT")"
+    grep -q '"signedStatement"' "$bundle"
+    grep -q '"https://spdx.dev/Document"' "$bundle"
+}
+
 @test "run_verify: run pushes only the VSA statement as the referrer for an OCI target" {
     # Container path: provenance fetched via cosign download; the combined
     # provenance+VSA bundle is written for the workflow artifact, but only the
@@ -668,10 +738,10 @@ STUB
 
 # --- build-metadata (SBOM) statement emission ---
 
-@test "run_verify: emit_metadata is a no-op when METADATA_ROOT is unset" {
-    # npm/go/python/container without a metadata dir: nothing is appended and the
-    # engine isn't invoked. A wrangle-attest stub that fails proves the path
-    # returns 0 untouched.
+@test "run_verify: sign_metadata is a no-op leaving the JSONL empty when METADATA_ROOT is unset" {
+    # npm/go/python/container without a metadata dir: the engine isn't invoked and
+    # the output file stays empty. A wrangle-attest stub that fails proves the
+    # path returns 0 without calling it.
     cat > "$TEST_DIR/wrangle-attest" <<'STUB'
 #!/bin/bash
 exit 1
@@ -679,39 +749,67 @@ STUB
     chmod +x "$TEST_DIR/wrangle-attest"
     export PATH="$TEST_DIR:$PATH"
     unset METADATA_ROOT
-    local bundle="$TEST_DIR/bundle.jsonl"
-    printf '{"provenance":1}\n' > "$bundle"
-    run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
+    local stmts="$TEST_DIR/meta.jsonl"; : > "$stmts"
+    run wrangle_sign_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$stmts"
+    [[ "$status" -eq 0 ]]
+    [[ ! -s "$stmts" ]]
+}
+
+@test "run_verify: append_metadata is a no-op on an empty statements file" {
+    # A build with no metadata signs nothing, so the append step must leave the
+    # bundle untouched (and not push).
+    cat > "$TEST_DIR/bnd" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+    chmod +x "$TEST_DIR/bnd"
+    export PATH="$TEST_DIR:$PATH"
+    local bundle="$TEST_DIR/bundle.jsonl"; printf '{"provenance":1}\n' > "$bundle"
+    local stmts="$TEST_DIR/meta.jsonl"; : > "$stmts"
+    run wrangle_append_metadata_statements "$stmts" "$bundle"
     [[ "$status" -eq 0 ]]
     [[ "$(wc -l < "$bundle")" -eq 1 ]]
 }
 
-@test "run_verify: emit_metadata appends and pushes the engine's signed statement" {
+@test "run_verify: sign_metadata writes the engine's signed statement to the JSONL" {
     # The engine signs keyless (network/OIDC), so a stub wrangle-attest emits a
-    # deterministic compact signed line — this exercises the shell glue (append +
-    # store + referrer), not the engine (Go-unit-tested; dispatch-e2e for keyless).
+    # deterministic compact signed line — this exercises the shell glue (sign ->
+    # file), not the engine (Go-unit-tested; dispatch-e2e for keyless).
     cat > "$TEST_DIR/wrangle-attest" <<STUB
 #!/bin/bash
 subj=""
 for a in "\$@"; do case "\$a" in --subject=*) subj="\${a#--subject=}";; --out=*) out="\${a#--out=}";; esac; done
 printf '{"signedStatement":{"predicateType":"https://spdx.dev/Document","subject":[{"digest":{"sha256":"%s"}}]}}\n' "\${subj#sha256:}" > "\$out"
 STUB
+    chmod +x "$TEST_DIR/wrangle-attest"
+    export PATH="$TEST_DIR:$PATH"
+    export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
+    local sha; sha="$(printf '0%.0s' {1..64})"
+    local stmts="$TEST_DIR/meta.jsonl"; : > "$stmts"
+    run wrangle_sign_metadata_statements "sha256:$sha" "$stmts"
+    [[ "$status" -eq 0 ]]
+    [[ "$(wc -l < "$stmts")" -eq 1 ]]
+    [[ "$(jq -r '.signedStatement.predicateType' "$stmts")" == "https://spdx.dev/Document" ]]
+    [[ "$(jq -r '.signedStatement.subject[0].digest.sha256' "$stmts")" == "$sha" ]]
+}
+
+@test "run_verify: append_metadata appends each signed line to the bundle and pushes it" {
     # push records the file it was handed so store delivery is provable.
     cat > "$TEST_DIR/bnd" <<STUB
 #!/bin/bash
 [[ "\$1" == "push" ]] && { cat "\$4" >> "$TEST_DIR/pushed"; exit 0; }
 exit 0
 STUB
-    chmod +x "$TEST_DIR/wrangle-attest" "$TEST_DIR/bnd"
+    chmod +x "$TEST_DIR/bnd"
     export PATH="$TEST_DIR:$PATH"
-    export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
     export GITHUB_REPOSITORY="o/r"
     export OCI_TARGET=""
     : > "$TEST_DIR/pushed"
-    local bundle="$TEST_DIR/bundle.jsonl"
-    printf '{"provenance":1}\n' > "$bundle"
+    local bundle="$TEST_DIR/bundle.jsonl"; printf '{"provenance":1}\n' > "$bundle"
     local sha; sha="$(printf '0%.0s' {1..64})"
-    run wrangle_emit_metadata_statements "sha256:$sha" "$bundle"
+    local stmts="$TEST_DIR/meta.jsonl"
+    printf '{"signedStatement":{"predicateType":"https://spdx.dev/Document","subject":[{"digest":{"sha256":"%s"}}]}}\n' "$sha" > "$stmts"
+    run wrangle_append_metadata_statements "$stmts" "$bundle"
     [[ "$status" -eq 0 ]]
     # Seeded provenance line plus exactly one appended signed statement.
     [[ "$(wc -l < "$bundle")" -eq 2 ]]
@@ -720,7 +818,7 @@ STUB
     [[ "$(jq -r '.signedStatement.subject[0].digest.sha256' "$TEST_DIR/pushed")" == "$sha" ]]
 }
 
-@test "run_verify: emit_metadata hands a file subject to the engine via --artifact" {
+@test "run_verify: sign_metadata hands a file subject to the engine via --artifact" {
     # go/npm/python subjects are dist files: the engine self-digests them via
     # --artifact, so the shell passes the path, never a precomputed digest.
     cat > "$TEST_DIR/wrangle-attest" <<STUB
@@ -732,15 +830,9 @@ STUB
     chmod +x "$TEST_DIR/wrangle-attest"
     export PATH="$TEST_DIR:$PATH"
     export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
-    export OCI_TARGET=""
-    cat > "$TEST_DIR/bnd" <<'STUB'
-#!/bin/bash
-exit 0
-STUB
-    chmod +x "$TEST_DIR/bnd"
+    local stmts="$TEST_DIR/meta.jsonl"; : > "$stmts"
     mkdir -p "$TEST_DIR/dist"; printf 'AAA\n' > "$TEST_DIR/dist/a.tgz"
-    local bundle="$TEST_DIR/bundle.jsonl"; printf '{"provenance":1}\n' > "$bundle"
-    run wrangle_emit_metadata_statements "$TEST_DIR/dist/a.tgz" "$bundle"
+    run wrangle_sign_metadata_statements "$TEST_DIR/dist/a.tgz" "$stmts"
     [[ "$status" -eq 0 ]]
     grep -qx -- "--artifact=$TEST_DIR/dist/a.tgz" "$TEST_DIR/attest-args"
     ! grep -q -- "--subject=" "$TEST_DIR/attest-args"
@@ -764,7 +856,7 @@ STUB
     [[ "$(jq -r '.subject[0].digest.sha256' "$out")" == "$sha" ]]
 }
 
-@test "run_verify: emit_metadata fails closed when the real engine sees a malformed manifest" {
+@test "run_verify: sign_metadata fails closed when the real engine sees a malformed manifest" {
     # The real engine fails closed at discoverManifests — before newSigner — so a
     # malformed top-level manifest aborts hermetically (no OIDC/network). Drive
     # the real binary to prove genuine engine fail-closed, not a stubbed exit.
@@ -775,11 +867,9 @@ STUB
     export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
     export WRANGLE_RETRY_DELAY=0
     printf 'not json\n' > "$METADATA_ROOT/wrangle_attestation_metadata.json"
-    local bundle="$TEST_DIR/bundle.jsonl"; printf '{"provenance":1}\n' > "$bundle"
-    run wrangle_emit_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$bundle"
+    local stmts="$TEST_DIR/meta.jsonl"; : > "$stmts"
+    run wrangle_sign_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$stmts"
     [[ "$status" -ne 0 ]]
-    # Nothing appended: the seeded provenance line is untouched.
-    [[ "$(wc -l < "$bundle")" -eq 1 ]]
 }
 
 # --- attach to release (wrangle_attach_release) ---

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -82,7 +82,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@cd0e0042b4b04786f965af4e9563ba742e5a53cf # main 2026-06-20
+    - uses: TomHennen/wrangle/actions/verify@a5afc97a46de3989346ef7b390b634489c0ba73f # fix-541-scan-collector 2026-06-20
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/policies/test.bats
+++ b/policies/test.bats
@@ -299,6 +299,35 @@ expect_fail_closed() {
     [ "$output" = "SLSA_BUILD_LEVEL_3" ]
 }
 
+# The verify job (actions/verify) feeds ampel TWO collectors: the provenance
+# seed and a second jsonl: of the engine-signed SBOM/scan statements. This is
+# the #541 regression — evaluating against the provenance-only collector failed
+# every scan tenet. Reproduce the exact wiring: provenance in one collector, the
+# four metadata statements in a second, and assert the verdict matches the
+# single-collector PASS. The provenance-only half asserts the bug fails closed.
+@test "ampel policy: default-go-v1 PASSES via the verify-job's split collectors (provenance + metadata)" {
+    local prov="$BATS_TEST_TMPDIR/prov.jsonl" meta="$BATS_TEST_TMPDIR/meta.jsonl"
+    head -1 "$TD/good-default.bundle.jsonl" > "$prov"
+    tail -n +2 "$TD/good-default.bundle.jsonl" > "$meta"
+    run "$AMPEL" verify -p "$DEFAULT_GO_LOGIC" -s "$SUBJECT" \
+        -c "jsonl:$prov" -c "jsonl:$meta" -x "$CTX" -f tty
+    [ "$status" -eq 0 ]
+}
+
+@test "ampel policy: default-go-v1 FAILS on the provenance-only collector (the #541 bug)" {
+    local prov="$BATS_TEST_TMPDIR/prov.jsonl"
+    head -1 "$TD/good-default.bundle.jsonl" > "$prov"
+    local rs="$BATS_TEST_TMPDIR/resultset.json"
+    run "$AMPEL" verify -p "$DEFAULT_GO_LOGIC" -s "$SUBJECT" -c "jsonl:$prov" -x "$CTX" \
+        --attest-results --attest-format=ampel --results-path="$rs" -f tty
+    [ "$status" -ne 0 ]
+    [ -s "$rs" ]
+    run jq -r '.predicate.results[] | select(.policy.id == "sbom-exists") | .status' "$rs"
+    [ "$output" = "FAIL" ]
+    run jq -r '.predicate.results[] | select(.policy.id == "osv-scan-clean") | .status' "$rs"
+    [ "$output" = "FAIL" ]
+}
+
 @test "ampel policy: default-go-v1 FAILS (osv) on an OSV scan with findings" {
     expect_fail "$DEFAULT_GO_LOGIC" "$TD/bad-osv-findings.bundle.jsonl" "osv-scan-clean"
 }


### PR DESCRIPTION
## Problem (#541, blocks #420 acceptance)

`actions/verify/run_verify.sh` ran the per-subject `ampel verify` with only `--collector=jsonl:<provenance>`, so the policy verdict (and the emitted VSA) never saw the SBOM and scan/v1 statements `wrangle-attest` signs. The default/strict tiers' `sbom-exists` / `osv-scan-clean` / `zizmor-scan-clean` / `wrangle-lint-scan-clean` tenets therefore failed closed on every real release ("required attestations missing"), confirmed on showcase `v20260620-6bb5a05`. The attestations were valid — just never fed to the policy evaluation.

## The fix (verify-job wiring, not the policy)

Sign the SBOM/scan statements **before** ampel and feed them as a **second `jsonl:` collector**, so the policy evaluates against them and the VSA verdict legitimately covers the scan/SBOM tenets (the intended #420 behavior).

Implementation: `wrangle_emit_metadata_statements` is split into `wrangle_sign_metadata_statements` (sign-only, run before ampel) and `wrangle_append_metadata_statements` (deliver: append + store + OCI referrer, run after the VSA). The signed JSONL becomes `--collector=jsonl:<file>`.

**Why a collector, not `--attestation`:** `--attestation` parses a *single* statement; the signed metadata is multi-statement JSONL (SBOM + osv + zizmor + wrangle-lint). Feeding it via `--attestation` fails with `proto: syntax error (line 2:1): unexpected token {`. ampel's `jsonl:` collector ingests the multi-line signed Sigstore bundles correctly.

## Trust boundary

Unchanged. Scans run untrusted and emit inert SARIF; **all** signing stays in the trusted post-build verify context (`wrangle-attest --sign`, same OIDC identity as the VSA). Only engine-signed statements reach ampel; the policy's identity gate (`build_and_publish_<eco>.yml@<ref>`) admits them. No new permissions, no untrusted data into ampel, and the VSA is still signed within the same process before crossing a step boundary.

## Validation against the real ampel binary (v1.3.0)

- **`jsonl:` collector ingests real signed Sigstore bundles + validates identity:** ran the production `wrangle-provenance-go-v1` policy against the real signed `test/consumer/fixtures/go-provenance.intoto.jsonl` fed as a `jsonl:` collector — all 3 SLSA tenets PASS, identity gate satisfied. (Feeding the *multi-line* metadata via `--attestation` reproduces the proto parse error, confirming the collector is the correct mechanism.)
- **Exact verify-job wiring, default tier:** provenance in collector A + the four signed scan/SBOM statements in collector B → `default-go-v1` PASS (all 7 tenets green, exit 0). Drop collector B (the bug) → `sbom-exists`/`osv`/`zizmor`/`wrangle-lint` FAIL, exit 1 — the exact failure from the issue.

```
collector=provenance + collector=jsonl:metadata  → sbom/osv/zizmor/wrangle-lint PASS, exit 0
collector=provenance only (the bug)              → sbom/osv/zizmor/wrangle-lint FAIL, exit 1
```

## Tests

- `actions/verify/test_run_verify.bats`: assert the arg vector adds a second `--collector=jsonl:<metadata>` (never `--attestation`), omits it when no metadata, coexists with the seed collector; the run-flow test asserts ampel is handed the metadata collector and the bundle gets the signed statements.
- `policies/test.bats`: two new real-ampel tests reproducing the exact split-collector wiring — PASS with both collectors, FAIL on provenance-only (the #541 regression guard).
- `./test.sh` (full, incl. zizmor): 1180 ok / 0 failures. Full `policies/test.bats` and `actions/verify/test_run_verify.bats` green against the real ampel locally.

## Bootstrap pins

The verify chain self-refs (`build_and_publish_*.yml` → `verify_release`, `verify_release` → `verify`) are bootstrap-pinned to `a5afc97a46de3989346ef7b390b634489c0ba73f` so the dispatch/showcase run the fix, not the main-pinned old action. `tools/check_pin_ancestry.sh` is green. **Bump to the main sha after merge** (`tools/bump_action_pins.sh <main-sha>`).

The showcase policy tier is intentionally left on the default tier (not touched) so it validates this fix once merged.

Fixes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)