### PR TITLE
fix(pins): resolve self-ref pins transitively in check_pin_ancestry (#539)

### DIFF
--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -27,12 +27,12 @@ In that case, for the duration of the PR:
 3. Note the bootstrap pin in the PR description.
 
 ### Merge however you like — the check tells you when to bump
-A branch SHA can't become a main SHA until the code is on main, so a bootstrap pin is always bumped post-merge. You don't have to manage the merge method to make this safe — `tools/check_pin_ancestry.sh` (in the `integration` CI job, `fetch-depth: 0`) is the control. It asserts every wrangle self-ref pin is reachable from `HEAD`: green on the PR (the branch SHA is an ancestor of the branch), and after merge:
+A branch SHA can't become a main SHA until the code is on main, so a bootstrap pin is always bumped post-merge. You don't have to manage the merge method to make this safe — `tools/check_pin_ancestry.sh` (in the `integration` CI job, `fetch-depth: 0`) is the control. It resolves every wrangle self-ref pin at its pinned SHA — following the pins nested inside each composite at that SHA, not just the working-tree copy — and asserts each is reachable from `HEAD`: green on the PR (the branch SHA is an ancestor of the branch), and after merge:
 
 - **Red on main** → a pin is unreachable (you squashed a bootstrap pin, or forgot a bump). Run `tools/bump_action_pins.sh <main-sha>` and push. Until you do, main is red and the unattended showcase can't resolve that action.
 - **Green** → every pin resolves; bump at leisure (it just refreshes the SHA and the `# main` label).
 
-Merging a bootstrap-pin PR as a **merge commit** keeps the branch SHA reachable, so the check stays green and there's no red window — a convenience, not a requirement. Squash-and-bump-after works equally well. Either way the check can't be silently forgotten: a stale or orphaned pin fails CI on main rather than degrading quietly.
+A nested chain (`workflow → verify_release → verify`, `scan → tools/*`) takes one bump cycle per nesting level under squash: a commit can't pin itself, so editing an *inner* action needs the bump repeated until the check is green (#539). Because the check follows nested resolution, it stays red through the intermediate cycles rather than passing on a half-converged chain. Merging the bootstrap-pin PR as a **merge commit** keeps every branch SHA reachable, so a chain of any depth converges with no re-bump and no red window — a convenience, not a requirement.
 
 ### Recovery
 If `check_pin_ancestry` is red on main (or a showcase run failed to resolve a wrangle action):

--- a/test/test_check_pin_ancestry.bats
+++ b/test/test_check_pin_ancestry.bats
@@ -25,6 +25,17 @@ pin_workflow() {
         > "$REPO/.github/workflows/x.yml"
 }
 
+# write_composite <sha> — write+commit actions/comp pinning actions/inner at
+# <sha>, then print the commit it lives at.
+write_composite() {
+    mkdir -p "$REPO/actions/comp"
+    printf '      - uses: TomHennen/wrangle/actions/inner@%s # pin\n' "$1" \
+        > "$REPO/actions/comp/action.yml"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m comp
+    git -C "$REPO" rev-parse HEAD
+}
+
 @test "check_pin_ancestry: PASSES when the pin is an ancestor of HEAD" {
     local a; a="$(commit "$REPO" A)"
     commit "$REPO" B >/dev/null
@@ -74,6 +85,38 @@ pin_workflow() {
     run bash -c "cd '$REPO' && '$SCRIPT'"
     [ "$status" -eq 1 ]
     [[ "$output" == *UNREACHABLE* ]]
+}
+
+@test "check_pin_ancestry: FAILS on a false-green — the pinned composite resolves a stale nested pin even when the working-tree copy is current" {
+    # The window a literal-pin check misses: after one re-bump cycle the
+    # workflow's comp@<merge> still resolves a comp/action.yml that nests the
+    # orphaned inner@<branch>, while the working-tree comp nests the fixed
+    # inner@<ancestor>. Every literal sha is an ancestor (flat check green) yet
+    # the release path resolves stale inner code — the transitive walk must red.
+    local a; a="$(commit "$REPO" A)"
+    git -C "$REPO" checkout -q -b feature
+    local orphan; orphan="$(commit "$REPO" ORPHAN)"   # inner's branch sha
+    git -C "$REPO" checkout -q -
+    local s; s="$(write_composite "$orphan")"          # comp@s nests inner@orphan
+    # Working tree reflects a cycle-1 bump: comp now nests the reachable inner@a,
+    # but the workflow still pins comp@s (where comp nests inner@orphan).
+    printf '      - uses: TomHennen/wrangle/actions/inner@%s # pin\n' "$a" \
+        > "$REPO/actions/comp/action.yml"
+    printf '      - uses: TomHennen/wrangle/actions/comp@%s # pin\n' "$s" \
+        > "$REPO/.github/workflows/x.yml"
+    run bash -c "cd '$REPO' && '$SCRIPT'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *UNREACHABLE* ]]
+    [[ "$output" == *"$orphan"* ]]
+}
+
+@test "check_pin_ancestry: PASSES when a pinned composite resolves a nested pin that is an ancestor" {
+    local a; a="$(commit "$REPO" A)"
+    local s; s="$(write_composite "$a")"               # comp@s nests inner@a (ancestor)
+    printf '      - uses: TomHennen/wrangle/actions/comp@%s # pin\n' "$s" \
+        > "$REPO/.github/workflows/x.yml"
+    run bash -c "cd '$REPO' && '$SCRIPT'"
+    [ "$status" -eq 0 ]
 }
 
 @test "check_pin_ancestry: validates real YAML pins while ignoring placeholders in non-YAML and fixtures/" {

--- a/test/test_check_pin_ancestry.bats
+++ b/test/test_check_pin_ancestry.bats
@@ -25,13 +25,14 @@ pin_workflow() {
         > "$REPO/.github/workflows/x.yml"
 }
 
-# write_composite <sha> — write+commit actions/comp pinning actions/inner at
-# <sha>, then print the commit it lives at.
+# write_composite <sha> — commit actions/comp pinning actions/inner at <sha>
+# (committed, not just written, so the transitive walk can git-show it at the
+# returned sha), then print that commit.
 write_composite() {
     mkdir -p "$REPO/actions/comp"
     printf '      - uses: TomHennen/wrangle/actions/inner@%s # pin\n' "$1" \
         > "$REPO/actions/comp/action.yml"
-    git -C "$REPO" add -A
+    git -C "$REPO" add actions/comp/action.yml
     git -C "$REPO" commit -q -m comp
     git -C "$REPO" rev-parse HEAD
 }
@@ -88,11 +89,8 @@ write_composite() {
 }
 
 @test "check_pin_ancestry: FAILS on a false-green — the pinned composite resolves a stale nested pin even when the working-tree copy is current" {
-    # The window a literal-pin check misses: after one re-bump cycle the
-    # workflow's comp@<merge> still resolves a comp/action.yml that nests the
-    # orphaned inner@<branch>, while the working-tree comp nests the fixed
-    # inner@<ancestor>. Every literal sha is an ancestor (flat check green) yet
-    # the release path resolves stale inner code — the transitive walk must red.
+    # Every literal sha is an ancestor (a flat check passes), but comp@s resolves
+    # a comp/action.yml that still nests the orphaned inner@<branch>.
     local a; a="$(commit "$REPO" A)"
     git -C "$REPO" checkout -q -b feature
     local orphan; orphan="$(commit "$REPO" ORPHAN)"   # inner's branch sha

--- a/tools/check_pin_ancestry.sh
+++ b/tools/check_pin_ancestry.sh
@@ -2,34 +2,15 @@
 set -euo pipefail
 set -f
 
-# tools/check_pin_ancestry.sh — fail if any wrangle self-reference action pin
-# resolves to a sha that is not reachable from HEAD. The walk is transitive:
-# every declared pin is resolved AT its pinned sha (git show <sha>:<path>) and
-# the self-ref pins nested inside that resolved action.yml are walked too, so a
-# 2-level chain (workflow -> verify_release -> verify, or scan -> tools/*) is
-# held to the invariant at every hop.
+# Fail if any wrangle self-reference pin resolves to a sha not reachable from
+# HEAD. Transitive: each pin is resolved at its pinned sha (git show <sha>:<path>)
+# and the pins nested in that action.yml are walked too, so a chain like
+# workflow -> verify_release -> verify holds at every hop. A working-tree-only
+# check false-greens after one re-bump of such a chain; a nested sha whose commit
+# is absent fails closed. Needs full history (CI runs it with fetch-depth: 0).
+# Bootstrap-pin lifecycle and re-bump recovery: docs/e2e_testing.md.
 #
-# Why transitive: a literal-pin-only check reads the action.yml in the working
-# tree, but what actually runs on main is the action.yml AS OF the pinned sha.
-# After a single post-merge re-bump the two diverge — the workflow's
-# verify_release@<merge> still resolves a verify_release/action.yml that nests
-# the orphaned verify@<branch>, even though the working-tree copy already nests
-# the fixed verify@<merge>. A literal check goes green there (false green) while
-# the release path resolves stale code; the transitive walk catches it.
-#
-# Why reachable-from-HEAD: a "bootstrap pin" (see test/integration/SPEC.md
-# §Known limitations) points a self-reference at a BRANCH sha so the integration
-# test can exercise a not-yet-merged change. On a PR, HEAD includes the branch,
-# so the pin passes; a SQUASH merge orphans the branch sha, after which HEAD ==
-# main no longer reaches it and this check goes red, forcing the re-bump
-# (tools/bump_action_pins.sh <main-sha>). This needs full history — the CI job
-# checks out with fetch-depth: 0.
-#
-# A nested sha whose commit object is absent fails closed (UNREACHABLE), never
-# silently skipped.
-#
-# Exit: 0 if every resolved pin is reachable, 1 if any is missing/unreachable,
-# 2 on a usage/environment error.
+# Exit: 0 all reachable, 1 missing/unreachable, 2 usage/environment error.
 
 REPO_PREFIX="${WRANGLE_PINS_REPO:-TomHennen/wrangle}"
 
@@ -56,10 +37,8 @@ fi
 escaped_prefix="$(printf '%s' "$REPO_PREFIX" | sed 's/\./\\./g')"
 pin_re="${escaped_prefix}/[^@[:space:]]+@[0-9a-f]{40}"
 
-# Seed the walk with the pins declared in the working tree. Restricted to YAML
-# and skipping fixtures/ so action/workflow files are searched but shell
-# scripts, SPEC.md, and lint fixtures (which carry placeholder shas) can't
-# false-match.
+# Seed from pins declared in the working tree. YAML only, skipping fixtures/, so
+# shell scripts and lint placeholders can't false-match.
 mapfile -t root_refs < <(
     grep -rhoE --include='*.yml' --include='*.yaml' --exclude-dir=fixtures \
         "$pin_re" "${search_dirs[@]}" 2>/dev/null | sort -u
@@ -70,8 +49,7 @@ if [[ ${#root_refs[@]} -eq 0 ]]; then
     exit 0
 fi
 
-# BFS over "<via>|<ref>" entries; <via> is the human-readable resolution context
-# so an unreachable nested pin names the parent that pulled it in.
+# BFS; <via> carries the parent so an unreachable nested pin names its source.
 declare -A visited=()
 queue=()
 for ref in "${root_refs[@]}"; do
@@ -106,9 +84,8 @@ while [[ ${#queue[@]} -gt 0 ]]; do
         continue
     fi
 
-    # Resolve the action AT its pinned sha and enqueue the self-ref pins nested
-    # inside it. A subpath with no action.yml at that sha is a leaf (the ref may
-    # name a reusable workflow, not a composite) — nothing further to walk.
+    # Resolve the action at its pinned sha and walk the pins nested inside it.
+    # No action.yml at that sha = leaf (the ref may be a reusable workflow).
     content="$(git -C "$repo_root" show "$sha:$subpath/action.yml" 2>/dev/null)" \
         || content="$(git -C "$repo_root" show "$sha:$subpath/action.yaml" 2>/dev/null)" \
         || content=""

--- a/tools/check_pin_ancestry.sh
+++ b/tools/check_pin_ancestry.sh
@@ -3,27 +3,33 @@ set -euo pipefail
 set -f
 
 # tools/check_pin_ancestry.sh — fail if any wrangle self-reference action pin
-# is not reachable from HEAD. Walks every tree that may carry such pins (the
-# shared tools/self_ref_pin_paths.sh set), not just .github/workflows, so a
-# nested pin in a composite is held to the same reachability invariant.
+# resolves to a sha that is not reachable from HEAD. The walk is transitive:
+# every declared pin is resolved AT its pinned sha (git show <sha>:<path>) and
+# the self-ref pins nested inside that resolved action.yml are walked too, so a
+# 2-level chain (workflow -> verify_release -> verify, or scan -> tools/*) is
+# held to the invariant at every hop.
 #
-# Why this exists: a "bootstrap pin" (see test/integration/SPEC.md §Known
-# limitations) points a nested `TomHennen/wrangle/...@<sha>` self-reference at a
-# BRANCH sha so the integration test can exercise an action/policy change that
-# is not yet on main. That pin is reachable from HEAD on the PR branch (so this
-# check is green there), but a SQUASH merge orphans the branch sha — after which
-# release-showcase.yml (which tags every push to main) and any other main-side
-# caller can no longer resolve the action. This check turns that silent
-# post-merge breakage into a red CI check that forces the re-bump
-# (tools/bump_action_pins.sh <main-sha>).
+# Why transitive: a literal-pin-only check reads the action.yml in the working
+# tree, but what actually runs on main is the action.yml AS OF the pinned sha.
+# After a single post-merge re-bump the two diverge — the workflow's
+# verify_release@<merge> still resolves a verify_release/action.yml that nests
+# the orphaned verify@<branch>, even though the working-tree copy already nests
+# the fixed verify@<merge>. A literal check goes green there (false green) while
+# the release path resolves stale code; the transitive walk catches it.
 #
-# Reachable-from-HEAD is the correct invariant: on a PR, HEAD includes the
-# branch, so a bootstrap pin passes; on main after a squash, HEAD == main and
-# the orphaned sha is not an ancestor, so it fails. This needs full history —
-# the CI job that runs it checks out with fetch-depth: 0.
+# Why reachable-from-HEAD: a "bootstrap pin" (see test/integration/SPEC.md
+# §Known limitations) points a self-reference at a BRANCH sha so the integration
+# test can exercise a not-yet-merged change. On a PR, HEAD includes the branch,
+# so the pin passes; a SQUASH merge orphans the branch sha, after which HEAD ==
+# main no longer reaches it and this check goes red, forcing the re-bump
+# (tools/bump_action_pins.sh <main-sha>). This needs full history — the CI job
+# checks out with fetch-depth: 0.
 #
-# Exit: 0 if every pin is reachable, 1 if any is missing/unreachable, 2 on a
-# usage/environment error.
+# A nested sha whose commit object is absent fails closed (UNREACHABLE), never
+# silently skipped.
+#
+# Exit: 0 if every resolved pin is reachable, 1 if any is missing/unreachable,
+# 2 on a usage/environment error.
 
 REPO_PREFIX="${WRANGLE_PINS_REPO:-TomHennen/wrangle}"
 
@@ -46,37 +52,73 @@ if [[ ${#search_dirs[@]} -eq 0 ]]; then
     exit 2
 fi
 
-# Collect the unique 40-hex shas pinned on a TomHennen/wrangle/...@<sha> ref.
-# Restricted to YAML and skipping fixtures/ so action/workflow files are
-# searched but shell scripts, SPEC.md, and lint fixtures (which carry
-# placeholder shas) can't false-match.
 # The prefix's '.' is escaped so an org/repo name can't act as a regex wildcard.
 escaped_prefix="$(printf '%s' "$REPO_PREFIX" | sed 's/\./\\./g')"
-mapfile -t shas < <(
+pin_re="${escaped_prefix}/[^@[:space:]]+@[0-9a-f]{40}"
+
+# Seed the walk with the pins declared in the working tree. Restricted to YAML
+# and skipping fixtures/ so action/workflow files are searched but shell
+# scripts, SPEC.md, and lint fixtures (which carry placeholder shas) can't
+# false-match.
+mapfile -t root_refs < <(
     grep -rhoE --include='*.yml' --include='*.yaml' --exclude-dir=fixtures \
-        "${escaped_prefix}/[^@[:space:]]+@[0-9a-f]{40}" "${search_dirs[@]}" 2>/dev/null \
-        | grep -oE '[0-9a-f]{40}$' | sort -u
+        "$pin_re" "${search_dirs[@]}" 2>/dev/null | sort -u
 )
 
-if [[ ${#shas[@]} -eq 0 ]]; then
+if [[ ${#root_refs[@]} -eq 0 ]]; then
     printf 'check_pin_ancestry: no %s pins found in the pin paths\n' "$REPO_PREFIX"
     exit 0
 fi
 
+# BFS over "<via>|<ref>" entries; <via> is the human-readable resolution context
+# so an unreachable nested pin names the parent that pulled it in.
+declare -A visited=()
+queue=()
+for ref in "${root_refs[@]}"; do
+    queue+=("declared|$ref")
+done
+
 rc=0
-for sha in "${shas[@]}"; do
+checked=0
+while [[ ${#queue[@]} -gt 0 ]]; do
+    via="${queue[0]%%|*}"
+    ref="${queue[0]#*|}"
+    queue=("${queue[@]:1}")
+
+    rest="${ref#"$REPO_PREFIX"/}"
+    subpath="${rest%@*}"
+    sha="${rest##*@}"
+    key="$subpath@$sha"
+    [[ -n "${visited[$key]:-}" ]] && continue
+    visited[$key]=1
+    checked=$((checked + 1))
+
     if ! git -C "$repo_root" cat-file -e "${sha}^{commit}" 2>/dev/null; then
-        printf 'UNREACHABLE: %s — commit not present (shallow clone? the job needs fetch-depth: 0)\n' "$sha" >&2
+        printf 'UNREACHABLE: %s@%s — commit not present (shallow clone? the job needs fetch-depth: 0) [via %s]\n' \
+            "$subpath" "$sha" "$via" >&2
         rc=1
         continue
     fi
     if ! git -C "$repo_root" merge-base --is-ancestor "$sha" HEAD 2>/dev/null; then
-        printf 'UNREACHABLE: %s — not an ancestor of HEAD (orphaned by a squash merge? re-bump with tools/bump_action_pins.sh <main-sha>)\n' "$sha" >&2
+        printf 'UNREACHABLE: %s@%s — not an ancestor of HEAD (orphaned by a squash merge? re-bump with tools/bump_action_pins.sh <main-sha>) [via %s]\n' \
+            "$subpath" "$sha" "$via" >&2
         rc=1
+        continue
     fi
+
+    # Resolve the action AT its pinned sha and enqueue the self-ref pins nested
+    # inside it. A subpath with no action.yml at that sha is a leaf (the ref may
+    # name a reusable workflow, not a composite) — nothing further to walk.
+    content="$(git -C "$repo_root" show "$sha:$subpath/action.yml" 2>/dev/null)" \
+        || content="$(git -C "$repo_root" show "$sha:$subpath/action.yaml" 2>/dev/null)" \
+        || content=""
+    [[ -z "$content" ]] && continue
+    while IFS= read -r nested; do
+        [[ -n "$nested" ]] && queue+=("${subpath}@${sha:0:9}|$nested")
+    done < <(printf '%s\n' "$content" | grep -hoE "$pin_re" | sort -u)
 done
 
 if [[ "$rc" -eq 0 ]]; then
-    printf 'check_pin_ancestry: all %d wrangle self-ref pin(s) reachable from HEAD\n' "${#shas[@]}"
+    printf 'check_pin_ancestry: all %d wrangle self-ref pin(s) reachable from HEAD\n' "$checked"
 fi
 exit "$rc"


### PR DESCRIPTION
## What

Make `check_pin_ancestry` resolve wrangle self-ref pins **transitively** — following the pins nested inside each composite *at its pinned sha* — so the false-green window described in #539 becomes a hard red.

This is **step 1 of 3** from the #539 plan ([recommendation comment](https://github.com/TomHennen/wrangle/issues/539#issuecomment-4759994489)). Steps 2 (fixpoint bump driver) and 3 (allow merge commits for bootstrap-pin PRs) follow as separate PRs.

## Why

The check only validated the literal pin shas in the **working tree**, but what runs on main is the `action.yml` *as of the pinned sha*. After a single post-merge re-bump of a 2-level chain (`workflow → verify_release → verify`, or `scan → tools/*`), the two diverge:

- working-tree `verify_release/action.yml` nests the fixed `verify@<merge>` ✅
- but `verify_release@<merge>` resolves a `verify_release/action.yml` that still nests the orphaned `verify@<branch>` ❌

Every literal sha is an ancestor of HEAD, so the old check went **green** — while the release path verified/signed wrangle's own releases with stale `verify` code. Same class as the #381 incident (a nested `scan→zizmor` pin silently resolved pre-fix code for days, CI green). For a supply-chain tool, a control reporting a property it doesn't hold is the real bug; the 2-cycle churn is just the symptom.

## How

Transitive BFS over the pins: resolve each pin's `action.yml` at its pinned sha (`git show <sha>:<path>`), extract the self-ref pins nested inside *that* version, and hold each to the same reachable-from-HEAD invariant, recursively. A nested sha whose commit object is absent **fails closed** (UNREACHABLE), never skipped. Unreachable findings name the parent that pulled the pin in (`[via verify_release@<sha>]`).

The check now stays red through the intermediate re-bump cycles a nested chain needs under squash, instead of passing on a half-converged chain.

## Verification

- New regression test reproduces the exact false-green (working-tree copy current, pinned composite resolves a stale nested pin) → check goes red. Plus a transitive-pass companion.
- All `test_check_pin_ancestry.bats` (8), `test_bump_action_pins.bats`, `test_self_ref_pin_paths.bats`, `test_pin_consistency.bats` green.
- `shellcheck` (as `run_shellcheck.sh` runs it) and `wrangle-shell-lint` clean.
- Run against current main: `all 18 wrangle self-ref pin(s) reachable from HEAD` — main is fully converged, no spurious red.

## Notes

- `docs/e2e_testing.md` updated: the control now follows nested resolution, and the cycle-count rule (one bump cycle per nesting level under squash; merge-commit converges any depth with zero re-bump) is stated.
- No change to the script's interface (no args, exit 0/1/2) or the CI invocation in `local_build_shell.yml`.

Relates to #539, #382, #381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
