### PR TITLE
feat(pins): converge_action_pins — loop bump+commit to a green check (#539)

### DIFF
--- a/DEP_MGMT.md
+++ b/DEP_MGMT.md
@@ -106,7 +106,9 @@ whatever is already set.
 - **`make bump-action-pins`** rewrites wrangle's own self-references after a
   composite changes, across `.github/workflows/`, `actions/`, `build/`, and
   `tools/` (the shared `tools/self_ref_pin_paths.sh` set, which
-  `check_pin_ancestry` reuses).
+  `check_pin_ancestry` reuses). **`make converge-action-pins`** repeats the bump
+  across commits when a nested chain needs more than one cycle — land its commits
+  as a merge commit (see [docs/e2e_testing.md](docs/e2e_testing.md)).
 - **Manual today:** the binary+provenance installs (branch 2) and the base-image
   digest. Automating that surface — ideally one mechanism that also covers
   wrangle's own self-references — is #264.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test lint shellcheck shellstyle workflowstyle gotest bats zizmor integration bump-action-pins
+.PHONY: all test lint shellcheck shellstyle workflowstyle gotest bats zizmor integration bump-action-pins converge-action-pins
 
 # bash, not the default sh: the integration recipe sources lib/env.sh,
 # whose `set -o pipefail` dash doesn't reliably support.
@@ -76,6 +76,12 @@ zizmor:
 #        make bump-action-pins SHA=<sha>   # bump to a specific SHA
 bump-action-pins:
 	@./tools/bump_action_pins.sh $(SHA)
+
+# Loop bump + commit until check_pin_ancestry is green (a nested chain needs one
+# commit per level). Land the result as a merge commit, not a squash.
+# See tools/converge_action_pins.sh and #539.
+converge-action-pins:
+	@./tools/converge_action_pins.sh
 
 # Update a binary-download tool's version and hardcoded checksum. Go-module
 # tools (osv-scanner, cosign, ampel, bnd) are pinned in tools/go.mod and

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -37,6 +37,5 @@ A nested chain (`workflow → verify_release → verify`, `scan → tools/*`) ta
 ### Recovery
 If `check_pin_ancestry` is red on main (or a showcase run failed to resolve a wrangle action):
 
-1. `tools/bump_action_pins.sh <main-sha>` — repoints every wrangle self-ref pin to a SHA reachable from main.
-2. Push it (a dedicated one-line bump PR, or fold it into the next PR).
-3. The check goes green and the next showcase resolves the action.
+1. `tools/bump_action_pins.sh <main-sha>` — repoints every wrangle self-ref pin to a SHA reachable from main. Push it (a dedicated one-line bump PR, or fold it into the next PR); the check goes green and the next showcase resolves the action.
+2. For a nested chain that needs more than one bump cycle, `tools/converge_action_pins.sh` loops bump + commit until the check is green. Land its commits as a **merge commit** (not a squash), or the intermediate pins re-orphan.

--- a/test/test_converge_action_pins.bats
+++ b/test/test_converge_action_pins.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+
+# Unit tests for tools/converge_action_pins.sh. Hermetic: each test builds a
+# throwaway git repo, so the loop drives real bump_action_pins.sh +
+# check_pin_ancestry.sh without touching wrangle's own history.
+
+setup() {
+    TOOLS="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/tools"
+    SCRIPT="$TOOLS/converge_action_pins.sh"
+    REPO="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$REPO/.github/workflows" "$REPO/actions/comp"
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email t@example.com
+    git -C "$REPO" config user.name test
+    git -C "$REPO" config commit.gpgsign false
+}
+
+commit() {
+    git -C "$1" commit -q --allow-empty -m "$2"
+    git -C "$1" rev-parse HEAD
+}
+
+# pin <workflow-sha> <nested-sha> — point the workflow at comp@<workflow-sha>
+# and comp's nested inner at inner@<nested-sha>, in the working tree.
+pin() {
+    printf '      - uses: TomHennen/wrangle/actions/comp@%s # pin\n' "$1" \
+        > "$REPO/.github/workflows/x.yml"
+    printf '      - uses: TomHennen/wrangle/actions/inner@%s # pin\n' "$2" \
+        > "$REPO/actions/comp/action.yml"
+}
+
+count_commits() { git -C "$REPO" rev-list --count HEAD; }
+
+run_converge() { run bash -c "cd '$REPO' && '$SCRIPT'"; }
+run_check() { run bash -c "cd '$REPO' && '$TOOLS/check_pin_ancestry.sh'"; }
+
+@test "converge: no-op (0 commits) when already green" {
+    local a; a="$(commit "$REPO" A)"
+    pin "$a" "$a"
+    git -C "$REPO" add -A && git -C "$REPO" commit -q -m pins
+    local before; before="$(count_commits)"
+    run_converge
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already converged (0 commits)"* ]]
+    [ "$(count_commits)" -eq "$before" ]
+}
+
+@test "converge: an orphaned 2-level chain converges in two commits" {
+    commit "$REPO" A >/dev/null
+    git -C "$REPO" checkout -q -b feature
+    local orphan; orphan="$(commit "$REPO" ORPHAN)"
+    git -C "$REPO" checkout -q -
+    # Simulate the squash merge: both pins point at the now-orphaned branch sha.
+    pin "$orphan" "$orphan"
+    git -C "$REPO" add -A && git -C "$REPO" commit -q -m "squash merge"
+    local before; before="$(count_commits)"
+    run_converge
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"converged in 2 commit"* ]]
+    [[ "$output" == *NOTE* ]]
+    [ "$(count_commits)" -eq "$((before + 2))" ]
+    run_check
+    [ "$status" -eq 0 ]
+}
+
+@test "converge: stops at WRANGLE_CONVERGE_MAX_ITERS when the chain needs more" {
+    commit "$REPO" A >/dev/null
+    git -C "$REPO" checkout -q -b feature
+    local orphan; orphan="$(commit "$REPO" ORPHAN)"
+    git -C "$REPO" checkout -q -
+    pin "$orphan" "$orphan"
+    git -C "$REPO" add -A && git -C "$REPO" commit -q -m "squash merge"
+    WRANGLE_CONVERGE_MAX_ITERS=1 run bash -c "cd '$REPO' && '$SCRIPT'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not converged after 1 commit"* ]]
+}
+
+@test "converge: refuses to run with a dirty working tree" {
+    local a; a="$(commit "$REPO" A)"
+    pin "$a" "$a"
+    git -C "$REPO" add -A && git -C "$REPO" commit -q -m pins
+    printf 'dirty\n' > "$REPO/actions/comp/action.yml"
+    run_converge
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"working tree not clean"* ]]
+}

--- a/tools/converge_action_pins.sh
+++ b/tools/converge_action_pins.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# Drive wrangle self-ref pins to convergence: if check_pin_ancestry is red,
+# bump every pin to HEAD, commit, and repeat until it's green. A nested chain
+# needs one commit per level (a commit can't pin itself), so this can emit >1
+# commit — land them as a MERGE COMMIT or a direct push to main, never a squash,
+# or the intermediate pins re-orphan. No-op (0 commits) when already green.
+# Requires a clean working tree; commits on the current branch; does not push.
+#
+# Usage: tools/converge_action_pins.sh
+# Env: WRANGLE_CONVERGE_MAX_ITERS (default 10); bump_action_pins.sh's
+#      WRANGLE_PINS_* pass through.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bump="$SCRIPT_DIR/bump_action_pins.sh"
+check="$SCRIPT_DIR/check_pin_ancestry.sh"
+
+repo_root="$(git rev-parse --show-toplevel)" || {
+    printf 'converge_action_pins: not inside a git work tree\n' >&2
+    exit 2
+}
+
+if ! git -C "$repo_root" diff --quiet || ! git -C "$repo_root" diff --cached --quiet; then
+    printf 'converge_action_pins: working tree not clean; commit or stash first\n' >&2
+    exit 2
+fi
+
+if "$check" >/dev/null 2>&1; then
+    printf 'converge_action_pins: already converged (0 commits).\n'
+    exit 0
+fi
+
+max_iters="${WRANGLE_CONVERGE_MAX_ITERS:-10}"
+commits=0
+converged=false
+for ((i = 1; i <= max_iters; i++)); do
+    "$bump" "$(git -C "$repo_root" rev-parse HEAD)" >/dev/null
+    if git -C "$repo_root" diff --quiet; then
+        # Bumping to HEAD changed nothing yet the check is still red: no prior
+        # commit carries a reachable nested pin, so no bump can resolve it.
+        printf 'converge_action_pins: cannot converge — bump is a no-op but the check is still red\n' >&2
+        break
+    fi
+    git -C "$repo_root" commit -qam "chore: converge self-ref pins (cycle $i)"
+    commits=$((commits + 1))
+    if "$check" >/dev/null 2>&1; then
+        converged=true
+        break
+    fi
+done
+
+if [[ "$converged" != true ]]; then
+    printf 'converge_action_pins: not converged after %d commit(s); check_pin_ancestry:\n' "$commits" >&2
+    "$check" >&2 || true
+    exit 1
+fi
+
+printf 'converge_action_pins: converged in %d commit(s).\n' "$commits"
+if [[ "$commits" -gt 1 ]]; then
+    printf 'NOTE: %d commits — land as a merge commit or a direct push to main, NOT a squash, or the intermediate pins re-orphan.\n' "$commits"
+fi


### PR DESCRIPTION
## What

`tools/converge_action_pins.sh` — a maintainer driver that loops `bump_action_pins` + commit until `check_pin_ancestry` is green. **Step 2 of the #539 plan** (step 1 = #544, transitive check; merge commits for bootstrap PRs are now enabled).

## Why

A nested self-ref chain (`workflow → verify_release → verify`, `scan → tools/*`) needs **one commit per nesting level** to converge under squash — a commit can't pin itself, so the outer pin can only resolve a fixed inner action once a commit carrying that fix already exists. A single post-merge `bump_action_pins.sh` therefore leaves `check_pin_ancestry` red on a 2-level chain (the false-green #544 now correctly reports). Today that means hand-counting cycles across separate PRs (#522→#523, #536→#537). This makes the cycle count invisible: run one command, get the converged commit sequence.

## Behavior

- **Already green → no-op** (0 commits). Convergence only, not a freshness bump — rolling pins forward when nothing's orphaned stays `bump_action_pins.sh`'s job.
- **Red → loop**: bump every pin to HEAD, commit, re-check; repeat until green, bounded by `WRANGLE_CONVERGE_MAX_ITERS` (default 10).
- Requires a **clean working tree** (so the commits capture only pin edits); commits on the current branch; **does not push**.
- **Warns when it emits >1 commit**: those must land as a **merge commit** or a direct push to main, never a squash, or the intermediate commits re-orphan and you're back where you started. (This is why merge commits were enabled.)

## Verification

- New hermetic bats (`test/test_converge_action_pins.bats`): already-green no-op (0 commits), orphaned 2-level chain → converges in 2 commits + the merge-commit NOTE, `WRANGLE_CONVERGE_MAX_ITERS` guard, dirty-tree refusal. All green; full `check`/`bump`/`converge` set = 40 passing.
- `shellcheck` (as `run_shellcheck.sh` runs it) and `wrangle-shell-lint` clean.
- Against the real repo: correctly refuses on a dirty tree; main is already converged so a clean run is a 0-commit no-op.

## Notes

- Mirrors `bump_action_pins.sh`'s layout (top-level `tools/` script, tests in `test/`) and adds `make converge-action-pins`.
- `docs/e2e_testing.md` recovery section points to it for multi-cycle convergence.

Relates to #539. Follows #544.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
