### PR TITLE
chore(pins): converge verify chain to the #549 ampel --workers fix

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -267,7 +267,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      uses: TomHennen/wrangle/build/actions/container@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -267,7 +267,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -178,7 +178,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         id: prep
         with:
           build-type: go
@@ -197,7 +197,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -231,7 +231,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -292,7 +292,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/release@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -383,7 +383,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         id: attest
         with:
           build-type: go
@@ -412,7 +412,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -178,7 +178,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         id: prep
         with:
           build-type: go
@@ -197,7 +197,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -231,7 +231,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/go/checks@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -292,7 +292,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/go/release@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -383,7 +383,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         id: attest
         with:
           build-type: go
@@ -412,7 +412,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -155,7 +155,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -174,7 +174,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/npm@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -284,7 +284,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -310,7 +310,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -155,7 +155,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -174,7 +174,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -284,7 +284,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -310,7 +310,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -132,7 +132,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         id: prep
         with:
           build-type: python
@@ -151,7 +151,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/build/actions/python@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -271,7 +271,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/attest_provenance@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         id: attest
         with:
           build-type: python
@@ -297,7 +297,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/verify_release@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -132,7 +132,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         id: prep
         with:
           build-type: python
@@ -151,7 +151,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -271,7 +271,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         id: attest
         with:
           build-type: python
@@ -297,7 +297,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/scan@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+        uses: TomHennen/wrangle/build/actions/shell@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      - uses: TomHennen/wrangle/actions/prep@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+        uses: TomHennen/wrangle/actions/scan@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      uses: TomHennen/wrangle/tools/zizmor@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      uses: TomHennen/wrangle/tools/scorecard@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+      uses: TomHennen/wrangle/tools/dependency-review@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -82,7 +82,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@6b91eb68e6373fd75ee49bc4107974cbd67155c0 # main 2026-06-20
+    - uses: TomHennen/wrangle/actions/verify@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -82,7 +82,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@75a6a2b43df1cc90c4832be31ceb1710a184ffbe # main 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}


### PR DESCRIPTION
Mechanical pin convergence completing the LGTM'd #549 merge. #549 changed `actions/verify/run_verify.sh` (the `--workers=32` stopgap) but not the nested pins, so the showcase/integration still resolved the pre-fix `verify@a5afc97`. Re-points the chain over two cycles to land on the workers-fixed verify: `build_and_publish → verify_release@6b86c0f → verify@75a6a2b` (`workers=32` present). Transitive `check_pin_ancestry` green.

Note: `converge_action_pins.sh` no-op'd here because the stale pins were still *reachable* ancestors — it only fires on unreachable pins, not stale-but-reachable ones after a code change. Done manually.