### PR TITLE
docs: point CLAUDE.md at the wrangle-agent-playground scratch repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,8 @@ Wrangle uses its own workflows. If a wrangle feature does not work on the wrangl
 
 A PR that changes a composite action (or a file it reads, like a `policies/*.hjson` PolicySet) and wires it into a reusable workflow needs a **bootstrap pin**: the nested `uses: TomHennen/wrangle/actions/<name>@<sha>` self-reference is fetched from its pinned (main) SHA, not the PR head, so the integration test otherwise runs the old action. The pin → merge → bump lifecycle and the `check_pin_ancestry` control are in [docs/e2e_testing.md](docs/e2e_testing.md).
 
+For throwaway end-to-end experiments before promoting to the integration companion or `wrangle-test`, use the scratch repo [`TomHennen/wrangle-agent-playground`](https://github.com/TomHennen/wrangle-agent-playground) — commit/push/PR there freely; nothing in it is permanent.
+
 ## Security
 
 - **Least privilege.** Workflows request minimum permissions — never blanket `permissions: write-all`; the standard set for source scanning is `actions: read`, `contents: read`, `security-events: write`. Add more only as needed, with a comment explaining why.


### PR DESCRIPTION
Adds a one-line note under Dogfooding pointing to `TomHennen/wrangle-agent-playground` for throwaway e2e experiments before promoting to the integration companion or wrangle-test. Per owner request. Awaiting LGTM (doc-only).