### PR TITLE
perf(ci): cache the gotest Go module + build caches across runs (#542)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,21 @@ jobs:
         with:
           persist-credentials: false
 
+      # The suite runs in a container whose GOCACHE/GOMODCACHE live under this
+      # dir, so persisting it across runs spares the gotest layer from
+      # rebuilding wrangle-attest's ~700MB module graph cold every run (#542).
+      # Keyed on the test image's Go version (test/Dockerfile) + tools/go.sum.
+      # Test-only: the suite produces no attested artifact, so this stays off
+      # release builds' L3 cache-isolation surface (SPEC.md).
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.temp }}/gocache
+          key: gotest-${{ runner.os }}-${{ hashFiles('test/Dockerfile', 'tools/go.sum') }}
+          restore-keys: gotest-${{ runner.os }}-
+
       - name: Run tests
+        env:
+          WRANGLE_GOCACHE_DIR: ${{ runner.temp }}/gocache
         run: ./test.sh
 
   # Real keyless signing through the engine: the unit suite is hermetic

--- a/test.sh
+++ b/test.sh
@@ -62,21 +62,23 @@ esac
 # own defaults and must not see an override. ${arr[@]+...} keeps the empty
 # array safe under set -u on bash 3.2 (macOS).
 #
-# The named volume holds the Go module/build caches: the integration target
-# compiles large tool graphs (cosign, osv-scanner), and an ephemeral
-# container would re-download and re-build everything per run — slow, and
-# big enough to exhaust the container layer. setup_integration.sh creates
-# $GOTMPDIR (go refuses a nonexistent one).
-#
-# Unit suites reuse the same volume for the gotest layer's build + module
-# caches — wrangle-attest's module graph is ~700MB to fetch and compile, so a
-# cold container pays ~30s every run (#530). GOPATH stays at the image default
+# /godata holds the Go module/build caches: the integration target compiles
+# large tool graphs (cosign, osv-scanner) and the unit gotest layer fetches +
+# compiles wrangle-attest's ~700MB module graph, so a cold container pays ~30s
+# every run (#530). Locally a named volume warms repeat runs; in CI
+# WRANGLE_GOCACHE_DIR points it at an actions/cache-managed host dir so the
+# caches survive the ephemeral runner (#542). GOPATH stays at the image default
 # so the go build-type's govulncheck install-cache in $GOPATH/bin is untouched.
-# This warms only repeat local runs; CI runners are ephemeral, so the volume is
-# empty there and gotest still builds cold — the test suite never consumes a
-# cross-build cache, keeping it off release builds' cache-isolation surface
-# (SPEC.md §"Cache isolation is part of the L3 claim").
-DOCKER_ENV=(-v wrangle-test-gocache:/godata)
+# The suite is a test (no attested artifact), so this cross-run cache stays off
+# release builds' cache-isolation surface (SPEC.md §"Cache isolation is part of
+# the L3 claim"). setup_integration.sh creates $GOTMPDIR (go refuses a
+# nonexistent one).
+GOCACHE_MOUNT=wrangle-test-gocache
+if [[ -n "${WRANGLE_GOCACHE_DIR:-}" ]]; then
+    mkdir -p "$WRANGLE_GOCACHE_DIR"
+    GOCACHE_MOUNT="$WRANGLE_GOCACHE_DIR"
+fi
+DOCKER_ENV=(-v "$GOCACHE_MOUNT":/godata)
 if [[ "$TEST_TARGET" == "integration" ]]; then
     DOCKER_ENV+=(-e WRANGLE_BIN_DIR=/tmp/wrangle/bin -e WRANGLE_METADATA_DIR=/tmp/wrangle/metadata)
     DOCKER_ENV+=(-e GOPATH=/godata/gopath -e GOCACHE=/godata/gocache -e GOTMPDIR=/godata/tmp)

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -117,12 +117,4 @@ RUN set -euo pipefail && \
         --require-hashes -r /tmp/wwl-requirements.txt && \
     rm /tmp/wwl-requirements.txt
 
-# wrangle-lint is a first-party Go tool (a tool directive in tools/go.mod).
-# Pre-fetch its module dependency so the unit suite builds and tests it without
-# network access at test time.
-COPY tools/go.mod tools/go.sum /tmp/wl-tools/
-RUN set -euo pipefail && \
-    go -C /tmp/wl-tools mod download gopkg.in/yaml.v3 && \
-    rm -rf /tmp/wl-tools
-
 WORKDIR /wrangle


### PR DESCRIPTION
## What

The `test` job in `.github/workflows/test.yml` runs the suite in a container whose `GOCACHE`/`GOMODCACHE` live in a Docker volume that is **empty on every ephemeral CI runner**. So the `gotest` layer (`go -C tools test ./wrangle-lint/... ./wrangle-attest/...`) rebuilds `wrangle-attest`'s ~700MB module graph cold on every run (~30–40s).

This persists those caches across CI runs with `actions/cache`, cutting the layer to a few seconds on a cache hit.

## How

- **`.github/workflows/test.yml`** — adds an `actions/cache@…# v5.0.5` step and wires `WRANGLE_GOCACHE_DIR` into the test run. Keyed on the test image's Go version (`test/Dockerfile`) + `tools/go.sum`, with a `restore-keys` fallback for graceful partial restore.
- **`test.sh`** — the container's `/godata` Go-cache mount is now overridable: when `WRANGLE_GOCACHE_DIR` is set (CI) it bind-mounts that `actions/cache`-managed host dir; otherwise it keeps the local named volume.
- **`test/Dockerfile`** — removes the now-dead `yaml.v3` module pre-fetch. The suite redirects `GOMODCACHE` away from the image default, so it was never consulted.

## SLSA L3 cache isolation

This is a **test** cache only. `gotest` produces no attested artifact, so per `SPEC.md` §"Cache isolation is part of the L3 claim" it stays on the sanctioned side of the isolation rule. The change is confined to the `test` job and does **not** touch the release/attestation builds' `should-release`-gated cache-free isolation.

## Verification

- `actionlint`, `shellcheck`, `wrangle-workflow-lint`, `wrangle-shell-lint`, `zizmor` all pass.
- Ran `./test.sh quick` with `WRANGLE_GOCACHE_DIR` set → suite exit 0, image rebuilt cleanly without the prefetch, host dir populated (`gocache` 432M, `gomodcache` 427M), and every cache file readable by the non-root runner user (so `actions/cache`'s tar save succeeds).
- Independent security review (cache isolation, pin/cooldown, injection, permissions, ownership, Dockerfile change): **safe to merge**, no blockers.

Fixes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)