### PR TITLE
feat(attest): sign build-metadata attestations in attest (PR 1/4, #550)

### DIFF
--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -384,7 +384,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@bba08e56d3f4bfb9806d5ae5b69f9a49cec86082 # attest-sign-metadata-pr1 2026-06-21
         id: attest
         with:
           build-type: go

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -384,7 +384,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@bba08e56d3f4bfb9806d5ae5b69f9a49cec86082 # attest-sign-metadata-pr1 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@c00abcd513d72db7726ee84682904f5af8006699 # attest-sign-metadata-pr1 2026-06-21
         id: attest
         with:
           build-type: go

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -367,7 +367,8 @@ jobs:
 
   # Generate SLSA L3 build provenance via GitHub's attestation API, naming THIS
   # reusable workflow as builder.id (its job_workflow_ref) and the Sigstore
-  # signing identity
+  # signing identity, then sign the SBOM + scan/v1 metadata over the built dist
+  # and post it to the attestation store — persisted independent of the verdict
   attest:
     if: ${{ needs.prep.outputs.should-release == 'true' }}
     needs: [prep, release]

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -270,7 +270,8 @@ jobs:
 
   # Generate SLSA L3 build provenance via GitHub's attestation API, naming THIS
   # reusable workflow as builder.id (its job_workflow_ref) and the Sigstore
-  # signing identity
+  # signing identity, then sign the SBOM + scan/v1 metadata over the built dist
+  # and post it to the attestation store — persisted independent of the verdict
   attest:
     if: ${{ needs.prep.outputs.should-release == 'true' }}
     # needs `scan` so a load-bearing finding blocks attestation + the caller's publish.
@@ -295,9 +296,8 @@ jobs:
   # and append it to the SLSA provenance, producing one per-artifact
   # <artifact>.intoto.jsonl bundle. bnd signs each VSA keyless with this workflow's
   # OIDC identity; a FAILED policy fails the step (fail: true) and blocks the
-  # caller's publish via needs: propagation. Provenance-only for now — SBOM/OSV
-  # tenets follow once those are produced as signed attestations a registered
-  # identity covers.
+  # caller's publish via needs: propagation. The SBOM + scan/v1 metadata is
+  # signed in the attest job; verify evaluates it and binds the verdict.
   verify:
     if: ${{ needs.prep.outputs.should-release == 'true' }}
     needs: [prep, build, attest]

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -285,7 +285,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@bba08e56d3f4bfb9806d5ae5b69f9a49cec86082 # attest-sign-metadata-pr1 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@c00abcd513d72db7726ee84682904f5af8006699 # attest-sign-metadata-pr1 2026-06-21
         id: attest
         with:
           build-type: npm

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -285,7 +285,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@bba08e56d3f4bfb9806d5ae5b69f9a49cec86082 # attest-sign-metadata-pr1 2026-06-21
         id: attest
         with:
           build-type: npm

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -272,7 +272,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@bba08e56d3f4bfb9806d5ae5b69f9a49cec86082 # attest-sign-metadata-pr1 2026-06-21
         id: attest
         with:
           build-type: python

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -272,7 +272,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@bba08e56d3f4bfb9806d5ae5b69f9a49cec86082 # attest-sign-metadata-pr1 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@c00abcd513d72db7726ee84682904f5af8006699 # attest-sign-metadata-pr1 2026-06-21
         id: attest
         with:
           build-type: python

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -257,7 +257,8 @@ jobs:
 
   # Generate SLSA L3 build provenance via GitHub's attestation API, naming THIS
   # reusable workflow as builder.id (its job_workflow_ref) and the Sigstore
-  # signing identity
+  # signing identity, then sign the SBOM + scan/v1 metadata over the built dist
+  # and post it to the attestation store — persisted independent of the verdict
   attest:
     if: ${{ needs.prep.outputs.should-release == 'true' }}
     # needs `scan` so a load-bearing finding blocks attestation + the caller's publish.
@@ -282,9 +283,8 @@ jobs:
   # and append it to the SLSA provenance, producing one per-artifact
   # <artifact>.intoto.jsonl bundle. bnd signs each VSA keyless with this workflow's
   # OIDC identity; a FAILED policy fails the step (fail: true) and blocks the
-  # caller's publish via needs: propagation. Provenance-only for now — SBOM/OSV
-  # tenets follow once those are produced as signed attestations a registered
-  # identity covers.
+  # caller's publish via needs: propagation. The SBOM + scan/v1 metadata is
+  # signed in the attest job; verify evaluates it and binds the verdict.
   verify:
     if: ${{ needs.prep.outputs.should-release == 'true' }}
     needs: [prep, build, attest]

--- a/actions/attest_provenance/action.yml
+++ b/actions/attest_provenance/action.yml
@@ -4,9 +4,13 @@ description: >
   download the build's dist, generate SLSA L3 build provenance via GitHub's
   attestation API, stage the signed bundle as one-JSON-per-line jsonl, and
   upload it as the provenance-bundle workflow artifact the verify job reads.
-  The dist and provenance-bundle artifact names are computed here from
-  build-type + shortname (lib/shortname.sh via the action_path), so callers
-  don't pass them.
+  Then sign every build-metadata attestation (SBOM + scan/v1) over the same dist
+  subjects with wrangle-attest/bnd, post each to the GitHub attestation store,
+  and emit them as the signed-metadata workflow artifact — so the signed set is
+  persisted independent of the later policy verdict (#550). The dist,
+  provenance-bundle, metadata, and signed-metadata artifact names are computed
+  here from build-type + shortname (lib/shortname.sh via the action_path), so
+  callers don't pass them.
 
   Pass exactly one subject: subject-checksums (go: dist/checksums.txt, the
   canonical subject set the VSA binds to) or subject-path (npm/python:
@@ -33,6 +37,9 @@ outputs:
   bundle-artifact-name:
     description: "Name of the provenance-bundle workflow artifact the verify job downloads."
     value: ${{ steps.names.outputs.provenance-bundle }}
+  signed-metadata-artifact-name:
+    description: "Name of the signed build-metadata workflow artifact (SBOM + scan/v1 statements) for verify/consumers."
+    value: ${{ steps.names.outputs.signed-metadata }}
 
 runs:
   using: composite
@@ -84,4 +91,51 @@ runs:
       with:
         name: ${{ steps.names.outputs.provenance-bundle }}
         path: ${{ runner.temp }}/provenance.jsonl
+        if-no-files-found: error
+
+    # Sign every build-metadata attestation (SBOM + scan/v1) here, in attest, so
+    # the signed set is persisted independent of the later policy verdict (#550).
+    # The build job's pre-verify metadata is the input wrangle-attest walks.
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ${{ steps.names.outputs.metadata-pre }}
+        path: ${{ steps.names.outputs.metadata-dir }}/
+
+    # Build only bnd (sign) + wrangle-attest (build the statements); attest does
+    # not run ampel or cosign.
+    - name: Install attest tools
+      shell: bash
+      run: |
+        "${{ github.action_path }}/install_tools.sh"
+
+    # Resolve the dist files to self-digest — the SAME subjects verify binds the
+    # VSA to, so attest-signed metadata and the VSA share the sha256 digest.
+    - name: Resolve metadata subjects
+      id: subjects
+      shell: bash
+      env:
+        SUBJECT_CHECKSUMS: ${{ inputs.subject-checksums }}
+        SUBJECT_PATH: ${{ inputs.subject-path }}
+      run: |
+        "${{ github.action_path }}/resolve_subjects.sh"
+
+    - name: Sign and store the build-metadata attestations
+      shell: bash
+      env:
+        METADATA_ROOT: ${{ steps.names.outputs.metadata-dir }}
+        SUBJECTS: ${{ steps.subjects.outputs.subjects }}
+        OUT: ${{ runner.temp }}/signed-metadata.jsonl
+        # Scanned commit recorded in each scan/v1 envelope's scannedCommit.
+        COMMIT: ${{ github.sha }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        # bnd push github authenticates to the attestation store with this token;
+        # the attestations: write permission rides on it.
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        "${{ github.action_path }}/sign_metadata.sh"
+
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ steps.names.outputs.signed-metadata }}
+        path: ${{ runner.temp }}/signed-metadata.jsonl
         if-no-files-found: error

--- a/actions/attest_provenance/install_tools.sh
+++ b/actions/attest_provenance/install_tools.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# Build the attest-job signing tools into WRANGLE_BIN_DIR: wrangle-attest (build
+# the SBOM + scan/v1 statements) and bnd (keyless-sign + push to the GitHub
+# attestation store). attest runs neither ampel (no verdict here) nor cosign (no
+# OCI push), so it builds only this pair — not the verify or scan toolchains.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"${SCRIPT_DIR}/../../lib/install_go_tools.sh" \
+    github.com/TomHennen/wrangle/tools/wrangle-attest \
+    github.com/carabiner-dev/bnd

--- a/actions/attest_provenance/resolve_subjects.sh
+++ b/actions/attest_provenance/resolve_subjects.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
-# Resolve the dist files whose metadata the attest job signs, one path per line,
-# into GITHUB_OUTPUT's `subjects` key. These are the SAME subjects the verify
-# job self-digests its VSA against, so attest-signed metadata and the VSA bind
+set -euo pipefail
+set -f
+
+# Resolve the dist files whose metadata the attest job signs into GITHUB_OUTPUT's
+# `subjects` key (lib/resolve_subjects.sh). These are the SAME subjects the
+# verify job binds its VSA to, so attest-signed metadata and the VSA bind
 # identical sha256 digests (issue #550 M4).
 #
 # Exactly one of:
 #   SUBJECT_CHECKSUMS  a sha256sum-format file (go: dist/checksums.txt); each
-#                      '<sha256>  <filename>' line names a dist/<filename> subject.
+#                      '<sha256>  <filename>' line names a DIST_DIR/<filename>.
 #   SUBJECT_PATH       a glob of dist files (npm/python: dist/*).
-#
-# DIST_DIR (default dist) is the directory checksums-file basenames resolve under.
 
-set -euo pipefail
-set -f  # disable globbing — we expand SUBJECT_PATH explicitly, once
-
-dist_dir="${DIST_DIR:-dist}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../lib/resolve_subjects.sh
+source "$SCRIPT_DIR/../../lib/resolve_subjects.sh"
 
 if [[ -n "${SUBJECT_CHECKSUMS:-}" && -n "${SUBJECT_PATH:-}" ]] \
     || [[ -z "${SUBJECT_CHECKSUMS:-}" && -z "${SUBJECT_PATH:-}" ]]; then
@@ -22,35 +22,11 @@ if [[ -n "${SUBJECT_CHECKSUMS:-}" && -n "${SUBJECT_PATH:-}" ]] \
     exit 1
 fi
 
-subjects=()
+declare -a WRANGLE_RESOLVED=()
 if [[ -n "${SUBJECT_CHECKSUMS:-}" ]]; then
-    if [[ ! -f "$SUBJECT_CHECKSUMS" ]]; then
-        printf 'resolve_subjects: checksums file %s not found\n' "$SUBJECT_CHECKSUMS" >&2
-        exit 1
-    fi
-    # Each line is '<sha256>  <filename>'; the subject is the dist file itself,
-    # self-digested by wrangle-attest so attest and verify agree on the digest.
-    while read -r _ file; do
-        [[ -z "$file" ]] && continue
-        subjects+=("$dist_dir/$file")
-    done < "$SUBJECT_CHECKSUMS"
+    wrangle_resolve_checksums "$SUBJECT_CHECKSUMS"
 else
-    # Expand the glob in one guarded window; nullglob would silently drop a
-    # mistyped path, so a no-match is a hard error below.
-    set +f
-    for f in $SUBJECT_PATH; do
-        [[ -f "$f" ]] && subjects+=("$f")
-    done
-    set -f
+    wrangle_resolve_glob "$SUBJECT_PATH"
 fi
 
-if [[ "${#subjects[@]}" -eq 0 ]]; then
-    printf 'resolve_subjects: no subject files resolved\n' >&2
-    exit 1
-fi
-
-{
-    printf 'subjects<<WRANGLE_EOF\n'
-    printf '%s\n' "${subjects[@]}"
-    printf 'WRANGLE_EOF\n'
-} >> "$GITHUB_OUTPUT"
+wrangle_emit_subjects

--- a/actions/attest_provenance/resolve_subjects.sh
+++ b/actions/attest_provenance/resolve_subjects.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Resolve the dist files whose metadata the attest job signs, one path per line,
+# into GITHUB_OUTPUT's `subjects` key. These are the SAME subjects the verify
+# job self-digests its VSA against, so attest-signed metadata and the VSA bind
+# identical sha256 digests (issue #550 M4).
+#
+# Exactly one of:
+#   SUBJECT_CHECKSUMS  a sha256sum-format file (go: dist/checksums.txt); each
+#                      '<sha256>  <filename>' line names a dist/<filename> subject.
+#   SUBJECT_PATH       a glob of dist files (npm/python: dist/*).
+#
+# DIST_DIR (default dist) is the directory checksums-file basenames resolve under.
+
+set -euo pipefail
+set -f  # disable globbing — we expand SUBJECT_PATH explicitly, once
+
+dist_dir="${DIST_DIR:-dist}"
+
+if [[ -n "${SUBJECT_CHECKSUMS:-}" && -n "${SUBJECT_PATH:-}" ]] \
+    || [[ -z "${SUBJECT_CHECKSUMS:-}" && -z "${SUBJECT_PATH:-}" ]]; then
+    printf 'resolve_subjects: pass exactly one of SUBJECT_CHECKSUMS or SUBJECT_PATH\n' >&2
+    exit 1
+fi
+
+subjects=()
+if [[ -n "${SUBJECT_CHECKSUMS:-}" ]]; then
+    if [[ ! -f "$SUBJECT_CHECKSUMS" ]]; then
+        printf 'resolve_subjects: checksums file %s not found\n' "$SUBJECT_CHECKSUMS" >&2
+        exit 1
+    fi
+    # Each line is '<sha256>  <filename>'; the subject is the dist file itself,
+    # self-digested by wrangle-attest so attest and verify agree on the digest.
+    while read -r _ file; do
+        [[ -z "$file" ]] && continue
+        subjects+=("$dist_dir/$file")
+    done < "$SUBJECT_CHECKSUMS"
+else
+    # Expand the glob in one guarded window; nullglob would silently drop a
+    # mistyped path, so a no-match is a hard error below.
+    set +f
+    for f in $SUBJECT_PATH; do
+        [[ -f "$f" ]] && subjects+=("$f")
+    done
+    set -f
+fi
+
+if [[ "${#subjects[@]}" -eq 0 ]]; then
+    printf 'resolve_subjects: no subject files resolved\n' >&2
+    exit 1
+fi
+
+{
+    printf 'subjects<<WRANGLE_EOF\n'
+    printf '%s\n' "${subjects[@]}"
+    printf 'WRANGLE_EOF\n'
+} >> "$GITHUB_OUTPUT"

--- a/actions/attest_provenance/sign_metadata.sh
+++ b/actions/attest_provenance/sign_metadata.sh
@@ -1,86 +1,21 @@
 #!/bin/bash
+set -euo pipefail
+set -f
+
 # Sign every build-metadata attestation (SBOM + each scan/<tool>/ manifest
 # wrangle-attest discovers under METADATA_ROOT) for each dist subject and post
 # each signed statement to the GitHub attestation store. Runs in the attest job
 # so the signed metadata is persisted independent of the later policy verdict.
 # The VSA is NOT produced here — it is a verdict ampel mints in verify.
 #
-# Each subject is self-digested via wrangle-attest --artifact, binding the SAME
-# sha256 digest verify binds the VSA to. bnd keyless-signs via the calling
-# workflow's OIDC identity (id-token: write) and the store push authenticates
-# with GITHUB_TOKEN (attestations: write).
-#
-# Inputs (env): METADATA_ROOT (the metadata dir holding the manifests), SUBJECTS
-# (newline-separated dist file paths), GITHUB_REPOSITORY (store push target),
-# GITHUB_TOKEN (bnd store auth), OUT (signed-metadata JSONL to emit), and
-# optional COMMIT (scanned git commit woven into the scan/v1 envelope).
-
-set -euo pipefail
-set -f  # disable globbing — processes external input
+# The signing primitives are shared with the verify job (lib/sign_metadata.sh).
+# Inputs (env): METADATA_ROOT, SUBJECTS, GITHUB_REPOSITORY, GITHUB_TOKEN, COMMIT
+# (see lib/sign_metadata.sh), plus OUT (the signed-metadata JSONL to emit).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="$(cd "$SCRIPT_DIR/../../lib" && pwd)"
-
-# Re-evaluation is deterministic, so a retry can only flip a transient Sigstore
-# or store I/O failure. WRANGLE_RETRY_DELAY spaces attempts (tests set it to 0).
-wrangle_retry_once() {
-    local out="$1"; shift
-    "$@" > "$out" && return 0
-    local rc=$?
-    printf 'wrangle: %s failed (exit %s); retrying once for transient I/O\n' "$1" "$rc" >&2
-    sleep "${WRANGLE_RETRY_DELAY:-5}"
-    "$@" > "$out"
-}
-
-# Build the wrangle-attest arg vector (one arg per line for mapfile) that signs
-# the build metadata for one subject into a JSONL bundle. $1 = subject file
-# self-digested into the sha256 subject; $2 = output JSONL path.
-wrangle_attest_args() {
-    printf '%s\n' \
-        --metadata-root="$METADATA_ROOT" \
-        --artifact="$1" \
-        --commit="${COMMIT:-}" \
-        --sign \
-        --out="$2"
-}
-
-# Build the bnd arg vector that posts a signed statement to the GitHub
-# attestation store. $1 is <owner>/<repo>; $2 the signed statement file. The
-# store is keyed by subject digest, giving consumers by-digest discovery.
-wrangle_bnd_push_args() {
-    printf '%s\n' push github "$1" "$2"
-}
-
-# Sign subject $1's build-metadata statements into the JSONL at $2, one signed
-# bundle per line; leaves $2 empty when there is no metadata. Fails closed.
-wrangle_sign_metadata_statements() {
-    local subject="$1" stmts="$2"
-    local args
-    mapfile -t args < <(wrangle_attest_args "$subject" "$stmts")
-    wrangle_retry_once /dev/null wrangle-attest "${args[@]}"
-}
-
-# Post the signed statement at $1 to the GitHub attestation store. Fails closed.
-wrangle_push_store() {
-    local args
-    mapfile -t args < <(wrangle_bnd_push_args "$GITHUB_REPOSITORY" "$1")
-    wrangle_retry_once /dev/null bnd "${args[@]}"
-}
-
-# Read SUBJECTS into WRANGLE_SUBJECTS, dropping blank lines. Fail closed on an
-# empty set: a release subject is always present, so zero means a wiring bug.
-wrangle_read_subjects() {
-    mapfile -t WRANGLE_SUBJECTS <<< "$SUBJECTS"
-    local s kept=()
-    for s in "${WRANGLE_SUBJECTS[@]}"; do
-        [[ "$s" =~ ^[[:space:]]*$ ]] || kept+=("$s")
-    done
-    WRANGLE_SUBJECTS=("${kept[@]}")
-    if [[ "${#WRANGLE_SUBJECTS[@]}" -eq 0 ]]; then
-        printf 'wrangle: no subjects to sign metadata for\n' >&2
-        return 1
-    fi
-}
+# shellcheck source=../../lib/sign_metadata.sh
+source "$LIB_DIR/sign_metadata.sh"
 
 # Sign and push the metadata for every subject, accumulating every signed line
 # into OUT (the emitted signed-metadata artifact).
@@ -102,8 +37,7 @@ wrangle_sign_metadata() {
     for subject in "${WRANGLE_SUBJECTS[@]}"; do
         : > "$stmts"
         wrangle_sign_metadata_statements "$subject" "$stmts"
-        # A subject with no discovered manifests would yield an empty file; the
-        # release SBOM manifest is always present, so an empty file is a bug.
+        # The release SBOM manifest is always present, so an empty file is a bug.
         if [[ ! -s "$stmts" ]]; then
             printf 'wrangle: no signed metadata produced for %s\n' "$subject" >&2
             rm -f "$stmts"

--- a/actions/attest_provenance/sign_metadata.sh
+++ b/actions/attest_provenance/sign_metadata.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Sign every build-metadata attestation (SBOM + each scan/<tool>/ manifest
+# wrangle-attest discovers under METADATA_ROOT) for each dist subject and post
+# each signed statement to the GitHub attestation store. Runs in the attest job
+# so the signed metadata is persisted independent of the later policy verdict.
+# The VSA is NOT produced here — it is a verdict ampel mints in verify.
+#
+# Each subject is self-digested via wrangle-attest --artifact, binding the SAME
+# sha256 digest verify binds the VSA to. bnd keyless-signs via the calling
+# workflow's OIDC identity (id-token: write) and the store push authenticates
+# with GITHUB_TOKEN (attestations: write).
+#
+# Inputs (env): METADATA_ROOT (the metadata dir holding the manifests), SUBJECTS
+# (newline-separated dist file paths), GITHUB_REPOSITORY (store push target),
+# GITHUB_TOKEN (bnd store auth), OUT (signed-metadata JSONL to emit), and
+# optional COMMIT (scanned git commit woven into the scan/v1 envelope).
+
+set -euo pipefail
+set -f  # disable globbing — processes external input
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "$SCRIPT_DIR/../../lib" && pwd)"
+
+# Re-evaluation is deterministic, so a retry can only flip a transient Sigstore
+# or store I/O failure. WRANGLE_RETRY_DELAY spaces attempts (tests set it to 0).
+wrangle_retry_once() {
+    local out="$1"; shift
+    "$@" > "$out" && return 0
+    local rc=$?
+    printf 'wrangle: %s failed (exit %s); retrying once for transient I/O\n' "$1" "$rc" >&2
+    sleep "${WRANGLE_RETRY_DELAY:-5}"
+    "$@" > "$out"
+}
+
+# Build the wrangle-attest arg vector (one arg per line for mapfile) that signs
+# the build metadata for one subject into a JSONL bundle. $1 = subject file
+# self-digested into the sha256 subject; $2 = output JSONL path.
+wrangle_attest_args() {
+    printf '%s\n' \
+        --metadata-root="$METADATA_ROOT" \
+        --artifact="$1" \
+        --commit="${COMMIT:-}" \
+        --sign \
+        --out="$2"
+}
+
+# Build the bnd arg vector that posts a signed statement to the GitHub
+# attestation store. $1 is <owner>/<repo>; $2 the signed statement file. The
+# store is keyed by subject digest, giving consumers by-digest discovery.
+wrangle_bnd_push_args() {
+    printf '%s\n' push github "$1" "$2"
+}
+
+# Sign subject $1's build-metadata statements into the JSONL at $2, one signed
+# bundle per line; leaves $2 empty when there is no metadata. Fails closed.
+wrangle_sign_metadata_statements() {
+    local subject="$1" stmts="$2"
+    local args
+    mapfile -t args < <(wrangle_attest_args "$subject" "$stmts")
+    wrangle_retry_once /dev/null wrangle-attest "${args[@]}"
+}
+
+# Post the signed statement at $1 to the GitHub attestation store. Fails closed.
+wrangle_push_store() {
+    local args
+    mapfile -t args < <(wrangle_bnd_push_args "$GITHUB_REPOSITORY" "$1")
+    wrangle_retry_once /dev/null bnd "${args[@]}"
+}
+
+# Read SUBJECTS into WRANGLE_SUBJECTS, dropping blank lines. Fail closed on an
+# empty set: a release subject is always present, so zero means a wiring bug.
+wrangle_read_subjects() {
+    mapfile -t WRANGLE_SUBJECTS <<< "$SUBJECTS"
+    local s kept=()
+    for s in "${WRANGLE_SUBJECTS[@]}"; do
+        [[ "$s" =~ ^[[:space:]]*$ ]] || kept+=("$s")
+    done
+    WRANGLE_SUBJECTS=("${kept[@]}")
+    if [[ "${#WRANGLE_SUBJECTS[@]}" -eq 0 ]]; then
+        printf 'wrangle: no subjects to sign metadata for\n' >&2
+        return 1
+    fi
+}
+
+# Sign and push the metadata for every subject, accumulating every signed line
+# into OUT (the emitted signed-metadata artifact).
+wrangle_sign_metadata() {
+    # shellcheck source=../../lib/env.sh
+    source "$LIB_DIR/env.sh"
+
+    if [[ -z "${METADATA_ROOT:-}" || ! -d "${METADATA_ROOT}" ]]; then
+        printf 'wrangle: metadata dir %s missing — nothing to sign\n' "${METADATA_ROOT:-}" >&2
+        return 1
+    fi
+
+    local -a WRANGLE_SUBJECTS
+    wrangle_read_subjects
+
+    : > "$OUT"
+    local stmts subject line
+    stmts="$(mktemp "${RUNNER_TEMP:-/tmp}/attestmeta.XXXXXX")"
+    for subject in "${WRANGLE_SUBJECTS[@]}"; do
+        : > "$stmts"
+        wrangle_sign_metadata_statements "$subject" "$stmts"
+        # A subject with no discovered manifests would yield an empty file; the
+        # release SBOM manifest is always present, so an empty file is a bug.
+        if [[ ! -s "$stmts" ]]; then
+            printf 'wrangle: no signed metadata produced for %s\n' "$subject" >&2
+            rm -f "$stmts"
+            return 1
+        fi
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            printf '%s\n' "$line" >> "$OUT"
+            printf '%s\n' "$line" > "$stmts.line"
+            wrangle_push_store "$stmts.line"
+        done < "$stmts"
+        rm -f "$stmts.line"
+    done
+    rm -f "$stmts"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    wrangle_sign_metadata
+fi

--- a/actions/attest_provenance/test.bats
+++ b/actions/attest_provenance/test.bats
@@ -69,3 +69,42 @@ setup() {
     run grep -F 'value: ${{ steps.names.outputs.provenance-bundle }}' "$ACTION"
     [ "$status" -eq 0 ]
 }
+
+@test "attest_provenance: downloads the pre-verify metadata for signing" {
+    run grep -F 'name: ${{ steps.names.outputs.metadata-pre }}' "$ACTION"
+    [ "$status" -eq 0 ]
+}
+
+@test "attest_provenance: installs the attest tools and signs the metadata" {
+    run grep -F 'install_tools.sh' "$ACTION"
+    [ "$status" -eq 0 ]
+    run grep -F 'resolve_subjects.sh' "$ACTION"
+    [ "$status" -eq 0 ]
+    run grep -F 'sign_metadata.sh' "$ACTION"
+    [ "$status" -eq 0 ]
+}
+
+@test "attest_provenance: threads GITHUB_TOKEN and COMMIT into the sign step" {
+    # bnd needs the token to auth the store push; COMMIT lands in the scan/v1 envelope.
+    run grep -F 'GITHUB_TOKEN: ${{ github.token }}' "$ACTION"
+    [ "$status" -eq 0 ]
+    run grep -F 'COMMIT: ${{ github.sha }}' "$ACTION"
+    [ "$status" -eq 0 ]
+}
+
+@test "attest_provenance: uploads and outputs the signed-metadata artifact" {
+    run grep -F 'name: ${{ steps.names.outputs.signed-metadata }}' "$ACTION"
+    [ "$status" -eq 0 ]
+    run grep -F 'value: ${{ steps.names.outputs.signed-metadata }}' "$ACTION"
+    [ "$status" -eq 0 ]
+}
+
+# M1 — the attest job runs no adopter-controlled code: it only downloads the
+# already-built dist + metadata and runs attest-provenance + wrangle-attest over
+# them. Guard against a future executable step (run:/uses:) that invokes a
+# caller build/test hook. Scope to step bodies so an input description that
+# merely names a tool (e.g. "goreleaser's dist/checksums.txt") is not flagged.
+@test "attest_provenance: runs no adopter build/test hook (trust boundary)" {
+    run grep -Ei '^[[:space:]]*(run:|- uses:|uses:).*(goreleaser|docker build|npm (run |test|ci)|python -m build|pytest|setup-script)' "$ACTION"
+    [ "$status" -ne 0 ]
+}

--- a/actions/attest_provenance/test_install_tools.bats
+++ b/actions/attest_provenance/test_install_tools.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+# Behavioral test for actions/attest_provenance/install_tools.sh: the attest job
+# signs but does not verify, so it builds only wrangle-attest (statements) + bnd
+# (sign + store push) — never ampel or cosign. A fake `go` records the packages.
+
+setup() {
+    DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    TEST_DIR="$(mktemp -d)"
+    export DIR TEST_DIR
+
+    GO_RECORD="$TEST_DIR/go-install-record"
+    : > "$GO_RECORD"
+    FAKE_BIN="$TEST_DIR/fakebin"
+    mkdir -p "$FAKE_BIN"
+    export GO_RECORD FAKE_BIN
+    cat > "$FAKE_BIN/go" << 'FAKEGO'
+#!/usr/bin/env bash
+set -euo pipefail
+pkgs=()
+seen_install=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -C) shift 2; continue ;;
+        install) seen_install=1; shift; continue ;;
+        *) [ "$seen_install" -eq 1 ] && pkgs+=("$1"); shift ;;
+    esac
+done
+[ "${#pkgs[@]}" -gt 0 ] && printf '%s\n' "${pkgs[@]}" >> "$GO_RECORD"
+exit 0
+FAKEGO
+    chmod +x "$FAKE_BIN/go"
+    export WRANGLE_BIN_DIR="$TEST_DIR/bin"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "attest install_tools.sh: builds wrangle-attest + bnd, not ampel or cosign" {
+    PATH="$FAKE_BIN:$PATH" run "$DIR/install_tools.sh"
+    [ "$status" -eq 0 ]
+    grep -Fq 'github.com/TomHennen/wrangle/tools/wrangle-attest' "$GO_RECORD"
+    grep -Fq 'github.com/carabiner-dev/bnd' "$GO_RECORD"
+    ! grep -Fq 'ampel' "$GO_RECORD"
+    ! grep -Fq 'cosign' "$GO_RECORD"
+}

--- a/actions/attest_provenance/test_sign_metadata.bats
+++ b/actions/attest_provenance/test_sign_metadata.bats
@@ -97,14 +97,22 @@ STUB
 
 # ---- sign_metadata.sh (arg shape, no real tools) ----
 
-@test "sign_metadata: wrangle-attest args self-digest the subject and --sign" {
-    export METADATA_ROOT="$META" COMMIT="abc123"
+@test "sign_metadata: a file subject is self-digested via --artifact and signed" {
+    export METADATA_ROOT="$META" COMMIT="abc123" WRANGLE_RETRY_DELAY=0
+    # A stub wrangle-attest records its args so we can assert the derived flags.
+    STUB_BIN="$TEST_DIR/stubbin"; mkdir -p "$STUB_BIN"
+    cat > "$STUB_BIN/wrangle-attest" << STUBA
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$TEST_DIR/attest-args"
+for a in "\$@"; do case "\$a" in --out=*) printf '{}' > "\${a#--out=}";; esac; done
+STUBA
+    chmod +x "$STUB_BIN/wrangle-attest"
     # shellcheck source=sign_metadata.sh
     source "$SIGN"
-    mapfile -t args < <(wrangle_attest_args "dist/app-1.2.3.tgz" "/tmp/out.jsonl")
-    printf '%s\n' "${args[@]}" | grep -qx -- "--artifact=dist/app-1.2.3.tgz"
-    printf '%s\n' "${args[@]}" | grep -qx -- "--sign"
-    printf '%s\n' "${args[@]}" | grep -qx -- "--out=/tmp/out.jsonl"
+    PATH="$STUB_BIN:$PATH" wrangle_sign_metadata_statements "dist/app-1.2.3.tgz" "/tmp/out.jsonl"
+    grep -qx -- "--artifact=dist/app-1.2.3.tgz" "$TEST_DIR/attest-args"
+    grep -qx -- "--sign" "$TEST_DIR/attest-args"
+    grep -qx -- "--out=/tmp/out.jsonl" "$TEST_DIR/attest-args"
 }
 
 @test "sign_metadata: bnd push targets the GitHub store by repo" {

--- a/actions/attest_provenance/test_sign_metadata.bats
+++ b/actions/attest_provenance/test_sign_metadata.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+
+# Tests for the attest-job metadata signing (issue #550):
+#   resolve_subjects.sh — derive the dist subjects (go checksums / npm-python glob)
+#   sign_metadata.sh     — wrangle-attest --sign per subject + bnd store push
+#
+# wrangle-attest runs for real (it self-digests offline); bnd is stubbed because
+# the keyless --sign + store push need OIDC/network. The M4 invariant — attest
+# binds the SAME sha256 subject the verify job binds the VSA to — is asserted by
+# comparing the attest statement's subject digest to the sha256sum the verify
+# subject builder (run_verify.sh wrangle_subject_arg) computes from the same file.
+load "../../test/lib/bats_helpers"
+
+setup() {
+    DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+    SIGN="$DIR/sign_metadata.sh"
+    RESOLVE="$DIR/resolve_subjects.sh"
+    TEST_DIR="$(mktemp -d)"
+    export DIR REPO_ROOT SIGN RESOLVE TEST_DIR
+
+    # A real built dist file + a metadata dir with the SBOM manifest the engine
+    # discovers and signs.
+    DIST="$TEST_DIR/dist"
+    META="$TEST_DIR/meta"
+    mkdir -p "$DIST" "$META"
+    printf 'artifact-bytes-v1.2.3' > "$DIST/app-1.2.3.tgz"
+    printf '{"spdxVersion":"SPDX-2.3"}' > "$META/sbom.spdx.json"
+    printf '{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}' \
+        > "$META/wrangle_attestation_metadata.json"
+    export DIST META
+
+    GITHUB_OUTPUT="$TEST_DIR/gh_output"
+    : > "$GITHUB_OUTPUT"
+    export GITHUB_OUTPUT
+    export RUNNER_TEMP="$TEST_DIR"
+    export WRANGLE_BIN_DIR="$TEST_DIR/bin"
+    export WRANGLE_RETRY_DELAY=0
+
+    ATTEST_BIN="$(command -v wrangle-attest || echo "${WRANGLE_BIN_DIR}/wrangle-attest")"
+    export ATTEST_BIN
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# Build a fake bnd on PATH that records each `push github <repo> <file>` and
+# copies the pushed statement aside so a test can inspect what was posted.
+stub_bnd() {
+    STUB_BIN="$TEST_DIR/stubbin"
+    mkdir -p "$STUB_BIN"
+    PUSH_RECORD="$TEST_DIR/bnd-push-record"
+    PUSHED_DIR="$TEST_DIR/pushed"
+    mkdir -p "$PUSHED_DIR"
+    : > "$PUSH_RECORD"
+    export STUB_BIN PUSH_RECORD PUSHED_DIR
+    cat > "$STUB_BIN/bnd" << 'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "push" && "${2:-}" == "github" ]]; then
+    printf '%s %s\n' "$3" "$4" >> "$PUSH_RECORD"
+    cat "$4" >> "$PUSHED_DIR/all.jsonl"
+fi
+exit 0
+STUB
+    chmod +x "$STUB_BIN/bnd"
+}
+
+# ---- resolve_subjects.sh ----
+
+@test "resolve_subjects: npm/python glob lists each dist file" {
+    SUBJECT_PATH="$DIST/*" SUBJECT_CHECKSUMS="" run "$RESOLVE"
+    [ "$status" -eq 0 ]
+    grep -q "subjects<<" "$GITHUB_OUTPUT"
+    grep -Fq "$DIST/app-1.2.3.tgz" "$GITHUB_OUTPUT"
+}
+
+@test "resolve_subjects: go checksums file lists each named dist file" {
+    printf '%s  %s\n' deadbeef app-1.2.3.tgz > "$TEST_DIR/checksums.txt"
+    SUBJECT_CHECKSUMS="$TEST_DIR/checksums.txt" SUBJECT_PATH="" DIST_DIR="$DIST" run "$RESOLVE"
+    [ "$status" -eq 0 ]
+    grep -Fq "$DIST/app-1.2.3.tgz" "$GITHUB_OUTPUT"
+}
+
+@test "resolve_subjects: rejects zero or both subject inputs" {
+    SUBJECT_PATH="" SUBJECT_CHECKSUMS="" run "$RESOLVE"
+    [ "$status" -ne 0 ]
+    SUBJECT_PATH="$DIST/*" SUBJECT_CHECKSUMS="$TEST_DIR/c.txt" run "$RESOLVE"
+    [ "$status" -ne 0 ]
+}
+
+@test "resolve_subjects: a glob matching nothing fails closed" {
+    SUBJECT_PATH="$TEST_DIR/nope/*" SUBJECT_CHECKSUMS="" run "$RESOLVE"
+    [ "$status" -ne 0 ]
+}
+
+# ---- sign_metadata.sh (arg shape, no real tools) ----
+
+@test "sign_metadata: wrangle-attest args self-digest the subject and --sign" {
+    export METADATA_ROOT="$META" COMMIT="abc123"
+    # shellcheck source=sign_metadata.sh
+    source "$SIGN"
+    mapfile -t args < <(wrangle_attest_args "dist/app-1.2.3.tgz" "/tmp/out.jsonl")
+    printf '%s\n' "${args[@]}" | grep -qx -- "--artifact=dist/app-1.2.3.tgz"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--sign"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--out=/tmp/out.jsonl"
+}
+
+@test "sign_metadata: bnd push targets the GitHub store by repo" {
+    # shellcheck source=sign_metadata.sh
+    source "$SIGN"
+    mapfile -t args < <(wrangle_bnd_push_args "o/r" "/tmp/stmt.json")
+    [ "${args[0]}" = push ]
+    [ "${args[1]}" = github ]
+    [ "${args[2]}" = "o/r" ]
+    [ "${args[3]}" = "/tmp/stmt.json" ]
+}
+
+@test "sign_metadata: an empty metadata root fails closed" {
+    # shellcheck source=sign_metadata.sh
+    SUBJECTS="$DIST/app-1.2.3.tgz" METADATA_ROOT="$TEST_DIR/absent" \
+        OUT="$TEST_DIR/out.jsonl" GITHUB_REPOSITORY="o/r" run "$SIGN"
+    [ "$status" -ne 0 ]
+}
+
+# ---- end-to-end with real wrangle-attest (unsigned-statement variant via stub bnd) ----
+# wrangle-attest --sign needs OIDC; to exercise the per-subject statement +
+# push plumbing offline we drive the real engine without --sign by stubbing it
+# to emit the unsigned statement, and stub bnd to record the push.
+
+@test "sign_metadata: signs every subject's metadata and pushes each line" {
+    [[ -x "$ATTEST_BIN" ]] || skip_or_fail "wrangle-attest not built"
+    stub_bnd
+    # A wrapper that forwards to the real engine but drops --sign (offline).
+    cat > "$STUB_BIN/wrangle-attest" << STUBA
+#!/usr/bin/env bash
+set -euo pipefail
+args=()
+for a in "\$@"; do [[ "\$a" == "--sign" ]] || args+=("\$a"); done
+exec "$ATTEST_BIN" "\${args[@]}"
+STUBA
+    chmod +x "$STUB_BIN/wrangle-attest"
+
+    PATH="$STUB_BIN:$PATH" SUBJECTS="$DIST/app-1.2.3.tgz" METADATA_ROOT="$META" \
+        OUT="$TEST_DIR/out.jsonl" GITHUB_REPOSITORY="o/r" COMMIT="abc123" run "$SIGN"
+    [ "$status" -eq 0 ]
+    # One signed statement emitted to OUT and one push recorded.
+    [ -s "$TEST_DIR/out.jsonl" ]
+    [ "$(wc -l < "$PUSH_RECORD")" -eq 1 ]
+    grep -q '^o/r ' "$PUSH_RECORD"
+}
+
+# ---- M4: attest binds the SAME subject digest the verify VSA binds ----
+
+@test "sign_metadata: attest subject digest equals the verify subject digest (M4)" {
+    [[ -x "$ATTEST_BIN" ]] || skip_or_fail "wrangle-attest not built"
+    # Attest side: wrangle-attest self-digests the dist file into the statement.
+    "$ATTEST_BIN" --metadata-root="$META" --artifact="$DIST/app-1.2.3.tgz" \
+        --out="$TEST_DIR/stmt.jsonl"
+    attest_digest="$(jq -r '.subject[0].digest.sha256' "$TEST_DIR/stmt.jsonl" | head -1)"
+
+    # Verify side: run_verify.sh wrangle_subject_arg hashes the same file.
+    # shellcheck source=../verify/run_verify.sh
+    source "$REPO_ROOT/actions/verify/run_verify.sh"
+    verify_arg="$(wrangle_subject_arg "$DIST/app-1.2.3.tgz")"
+    verify_digest="${verify_arg#--subject-hash=sha256:}"
+
+    [ -n "$attest_digest" ]
+    [ "$attest_digest" = "$verify_digest" ]
+}

--- a/actions/verify/emit_subjects.sh
+++ b/actions/verify/emit_subjects.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
-# Resolve the verify action's subjects: pass through SUBJECTS_IN if set, else
-# expand the DIST_FILES JSON array to one dist/<file> subject per line. Writes a
-# heredoc to GITHUB_OUTPUT's `subjects` key.
 set -euo pipefail
 set -f
+
+# Resolve the verify action's subjects: pass through SUBJECTS_IN if set, else
+# expand the DIST_FILES JSON array to one dist/<file> subject per line. Writes a
+# heredoc to GITHUB_OUTPUT's `subjects` key (lib/resolve_subjects.sh).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../lib/resolve_subjects.sh
+source "$SCRIPT_DIR/../../lib/resolve_subjects.sh"
 
 if [[ -n "${SUBJECTS_IN:-}" ]]; then
     subjects="$SUBJECTS_IN"
 else
-    # Run jq before the group write: a `{ …; } >> file` group returns the last
-    # command's status, so a jq failure inside it would be masked.
+    # Run jq in a command substitution so a malformed array fails closed under
+    # set -e (a process-substitution loop would mask the jq exit status).
     subjects="$(printf '%s' "$DIST_FILES" | jq -r '.[] | "dist/" + .')"
 fi
-{
-    printf 'subjects<<WRANGLE_EOF\n'
-    printf '%s\n' "$subjects"
-    printf 'WRANGLE_EOF\n'
-} >> "$GITHUB_OUTPUT"
+
+declare -a WRANGLE_RESOLVED=()
+while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    WRANGLE_RESOLVED+=("$line")
+done <<< "$subjects"
+
+wrangle_emit_subjects

--- a/actions/verify/install_tools.sh
+++ b/actions/verify/install_tools.sh
@@ -5,13 +5,11 @@ set -f
 # Build the verify tools into WRANGLE_BIN_DIR: ampel (verify), bnd (sign), and
 # wrangle-attest (build the unsigned scan/build statements) always; cosign (push
 # the VSA as an OCI referrer) only when OCI_TARGET names a container image digest
-# — npm/go/python verify never pushes, so it never needs cosign. Installing the
-# rest of the tool manifest here would compile the scan toolchain (osv-scanner
-# et al.) that verify never runs.
+# — npm/go/python verify never pushes, so it never needs cosign. Selecting the
+# subset here avoids compiling the scan toolchain (osv-scanner et al.) verify
+# never runs.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../../lib/env.sh
-source "${SCRIPT_DIR}/../../lib/env.sh"
 
 pkgs=(
     github.com/carabiner-dev/ampel/cmd/ampel
@@ -22,4 +20,4 @@ if [[ -n "${OCI_TARGET:-}" ]]; then
     pkgs+=(github.com/sigstore/cosign/v3/cmd/cosign)
 fi
 
-GOBIN="$WRANGLE_BIN_DIR" go -C "${SCRIPT_DIR}/../../tools" install "${pkgs[@]}"
+"${SCRIPT_DIR}/../../lib/install_go_tools.sh" "${pkgs[@]}"

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -37,18 +37,11 @@ wrangle_resolve_policy() {
     esac
 }
 
-# Run a command, retrying once on failure to absorb transient Sigstore I/O.
-# Re-evaluation is deterministic, so a retry can only flip a transient failure.
-# $1 is the stdout capture, truncated per attempt. WRANGLE_RETRY_DELAY spaces
-# the attempts (tests set it to 0).
-wrangle_retry_once() {
-    local out="$1"; shift
-    "$@" > "$out" && return 0
-    local rc=$?
-    printf 'wrangle: %s failed (exit %s); retrying once for transient Sigstore I/O\n' "$1" "$rc" >&2
-    sleep "${WRANGLE_RETRY_DELAY:-5}"
-    "$@" > "$out"
-}
+# Shared build-metadata signing primitives, also used by the attest job:
+# wrangle_retry_once, wrangle_attest_args, wrangle_sign_metadata_statements,
+# wrangle_bnd_push_args, wrangle_push_store, wrangle_read_subjects.
+# shellcheck source=../../lib/sign_metadata.sh
+source "$LIB_DIR/sign_metadata.sh"
 
 # Emit the ampel subject flag for one subject, one arg per line. A digest-form
 # subject (algo:hex, e.g. a container) passes through; a file subject is hashed
@@ -111,29 +104,6 @@ wrangle_cosign_attach_args() {
     printf '%s\n' attach attestation \
         --attestation "$1" \
         "$2"
-}
-
-# Build the bnd arg vector that posts a signed VSA to the GitHub attestation
-# store. $1 is <owner>/<repo>; $2 the bnd-signed VSA file. The store is keyed
-# by subject digest, giving consumers by-digest discovery via ampel's github:
-# collector.
-wrangle_bnd_push_args() {
-    printf '%s\n' push github "$1" "$2"
-}
-
-# Split SUBJECTS into an array, dropping blank lines. Fail closed on an empty
-# set: zero subjects would emit a provenance-only bundle with no VSA.
-wrangle_read_subjects() {
-    mapfile -t WRANGLE_SUBJECTS <<< "$SUBJECTS"
-    local s kept=()
-    for s in "${WRANGLE_SUBJECTS[@]}"; do
-        [[ "$s" =~ ^[[:space:]]*$ ]] || kept+=("$s")
-    done
-    WRANGLE_SUBJECTS=("${kept[@]}")
-    if [[ "${#WRANGLE_SUBJECTS[@]}" -eq 0 ]]; then
-        printf 'wrangle: no subjects to verify — refusing to emit a VSA-less bundle\n' >&2
-        return 1
-    fi
 }
 
 # ampel verify one subject -> unsigned VSA at $2, streaming the report to the
@@ -218,34 +188,6 @@ wrangle_push_bundle() {
     wrangle_retry_once /dev/null cosign "${args[@]}"
 }
 
-# Build the wrangle-attest arg vector (one arg per line for mapfile) that signs the
-# build metadata into in-toto statements. $1 = subject arg (--subject=<digest> or
-# --artifact=<file>); $2 = output JSONL path.
-wrangle_attest_args() {
-    printf '%s\n' \
-        --metadata-root="$METADATA_ROOT" \
-        "$1" \
-        --commit="${COMMIT:-}" \
-        --sign \
-        --out="$2"
-}
-
-# Sign subject $1's build-metadata statements (SBOM + scan/v1) into the JSONL at $2,
-# one signed bundle per line; leaves $2 empty when there's no metadata. Signed
-# before ampel so the policy can evaluate them via a second collector. Fails closed.
-wrangle_sign_metadata_statements() {
-    [[ -z "${METADATA_ROOT:-}" || ! -d "${METADATA_ROOT:-}" ]] && return 0
-    local subject="$1" stmts="$2" subject_arg
-    if [[ "$subject" =~ ^[a-z0-9]+:[a-f0-9]+$ ]]; then
-        subject_arg="--subject=$subject"
-    else
-        subject_arg="--artifact=$subject"
-    fi
-    local args
-    mapfile -t args < <(wrangle_attest_args "$subject_arg" "$stmts")
-    wrangle_retry_once /dev/null wrangle-attest "${args[@]}"
-}
-
 # Append each signed metadata line at $1 to the bundle $2, post each to the
 # store, and push each alone as the OCI referrer (cosign attach rejects
 # multi-line). No-op on an empty/absent file (no metadata for this build).
@@ -262,15 +204,6 @@ wrangle_append_metadata_statements() {
         wrangle_push_bundle "$line_file"
     done < "$stmts"
     rm -f "$line_file"
-}
-
-# Post the signed VSA at $1 to the GitHub attestation store (all build types).
-# Provenance is already in the store from attest-build-provenance, so only the
-# VSA is pushed. Fails closed: a missing by-digest VSA is a real delivery gap.
-wrangle_push_store() {
-    local args
-    mapfile -t args < <(wrangle_bnd_push_args "$GITHUB_REPOSITORY" "$1")
-    wrangle_retry_once /dev/null bnd "${args[@]}"
 }
 
 # Verify every subject, sign its VSA, and write one bundle per subject into

--- a/lib/derive_names.sh
+++ b/lib/derive_names.sh
@@ -42,6 +42,7 @@ main() {
         printf 'metadata=%s\n' "$(artifact_name "${type}-metadata" "$shortname")"
         printf 'metadata-pre=%s\n' "$(artifact_name "${type}-premeta" "$shortname")"
         printf 'provenance-bundle=%s\n' "$(artifact_name "${type}-provenance-bundle" "$shortname")"
+        printf 'signed-metadata=%s\n' "$(artifact_name "${type}-signed-metadata" "$shortname")"
         printf 'metadata-dir=%s\n' "$(metadata_dir "$type" "$shortname")"
         printf 'shortname=%s\n' "$shortname"
     } >> "$GITHUB_OUTPUT"

--- a/lib/install_go_tools.sh
+++ b/lib/install_go_tools.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# Build the named Go tool packages into WRANGLE_BIN_DIR via a single `go install`.
+# Each argument is a full module package path (e.g. github.com/carabiner-dev/bnd);
+# every wrangle tool builds from tools/go.mod, so versions route through go.sum.
+# Callers select the subset they need so a job never compiles a toolchain it
+# won't run. Downstream steps re-source lib/env.sh to find the binaries on PATH.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=env.sh
+source "${SCRIPT_DIR}/env.sh"
+
+if [[ "$#" -eq 0 ]]; then
+    printf 'install_go_tools.sh: at least one package path is required\n' >&2
+    exit 1
+fi
+
+GOBIN="$WRANGLE_BIN_DIR" go -C "${SCRIPT_DIR}/../tools" install "$@"

--- a/lib/resolve_subjects.sh
+++ b/lib/resolve_subjects.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# lib/resolve_subjects.sh — Shared subject-list resolution for the attest and
+# verify jobs. Both derive the dist subjects a signature binds to from a build-
+# type-specific input, then emit them as the `subjects` heredoc on GITHUB_OUTPUT.
+# Sourced; the caller appends to WRANGLE_RESOLVED via the resolvers, then calls
+# wrangle_emit_subjects.
+
+# Expand each dist file named in a sha256sum-format checksums file ($1) into a
+# DIST_DIR/<filename> subject, appending to the WRANGLE_RESOLVED array. Each line
+# is '<sha256>  <filename>'; the subject is the dist file itself.
+wrangle_resolve_checksums() {
+    local checksums="$1" dist_dir="${DIST_DIR:-dist}" _ file
+    if [[ ! -f "$checksums" ]]; then
+        printf 'resolve_subjects: checksums file %s not found\n' "$checksums" >&2
+        return 1
+    fi
+    while read -r _ file; do
+        [[ -z "$file" ]] && continue
+        WRANGLE_RESOLVED+=("$dist_dir/$file")
+    done < "$checksums"
+}
+
+# Expand a glob ($1, e.g. dist/*) into each matching regular file, appending to
+# WRANGLE_RESOLVED. nullglob would silently drop a mistyped path, so a no-match
+# leaves WRANGLE_RESOLVED untouched and the caller fails closed. The glob runs in
+# a subshell so `set +f` cannot leak glob-enabled state to the rest of the script.
+wrangle_resolve_glob() {
+    local matched f
+    matched="$(
+        set +f
+        # shellcheck disable=SC2086 # intentional glob expansion of the pattern in $1
+        printf '%s\n' $1
+    )"
+    while IFS= read -r f; do
+        [[ -f "$f" ]] && WRANGLE_RESOLVED+=("$f")
+    done <<< "$matched"
+}
+
+# Write WRANGLE_RESOLVED as the `subjects` heredoc on GITHUB_OUTPUT, one path per
+# line. Fails closed on an empty set: a release subject is always present.
+wrangle_emit_subjects() {
+    if [[ "${#WRANGLE_RESOLVED[@]}" -eq 0 ]]; then
+        printf 'resolve_subjects: no subject files resolved\n' >&2
+        return 1
+    fi
+    {
+        printf 'subjects<<WRANGLE_EOF\n'
+        printf '%s\n' "${WRANGLE_RESOLVED[@]}"
+        printf 'WRANGLE_EOF\n'
+    } >> "$GITHUB_OUTPUT"
+}

--- a/lib/sign_metadata.sh
+++ b/lib/sign_metadata.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# lib/sign_metadata.sh — Shared build-metadata signing primitives.
+#
+# Source this to sign the build metadata (SBOM + each scan/<tool>/ manifest
+# wrangle-attest discovers under METADATA_ROOT) and post each signed statement
+# to the GitHub attestation store. Used by both the verify job (alongside the
+# VSA) and the attest job (independent of the policy verdict). Callers own the
+# per-subject orchestration; these are the shared building blocks.
+#
+# Inputs (env): METADATA_ROOT (the metadata dir wrangle-attest reads), SUBJECTS
+# (newline-separated dist file paths / sha256: digests, read by
+# wrangle_read_subjects), GITHUB_REPOSITORY (store push target), GITHUB_TOKEN
+# (bnd reads it to auth the store push), COMMIT (scanned git commit woven into
+# the scan/v1 envelope). bnd keyless-signs via the caller's OIDC identity.
+
+# Run a command, retrying once on failure to absorb transient Sigstore I/O.
+# Re-evaluation is deterministic, so a retry can only flip a transient failure.
+# $1 is the stdout capture, truncated per attempt. WRANGLE_RETRY_DELAY spaces
+# the attempts (tests set it to 0).
+wrangle_retry_once() {
+    local out="$1"; shift
+    "$@" > "$out" && return 0
+    local rc=$?
+    printf 'wrangle: %s failed (exit %s); retrying once for transient Sigstore I/O\n' "$1" "$rc" >&2
+    sleep "${WRANGLE_RETRY_DELAY:-5}"
+    "$@" > "$out"
+}
+
+# Build the wrangle-attest arg vector (one arg per line for mapfile) that signs
+# the build metadata into in-toto statements. $1 = subject arg
+# (--subject=<digest> or --artifact=<file>); $2 = output JSONL path.
+wrangle_attest_args() {
+    printf '%s\n' \
+        --metadata-root="$METADATA_ROOT" \
+        "$1" \
+        --commit="${COMMIT:-}" \
+        --sign \
+        --out="$2"
+}
+
+# Build the bnd arg vector that posts a signed statement to the GitHub
+# attestation store. $1 is <owner>/<repo>; $2 the signed statement file. The
+# store is keyed by subject digest, giving consumers by-digest discovery.
+wrangle_bnd_push_args() {
+    printf '%s\n' push github "$1" "$2"
+}
+
+# Sign subject $1's build-metadata statements (SBOM + scan/v1) into the JSONL at
+# $2, one signed bundle per line; leaves $2 empty when there's no metadata. A
+# digest-form subject (algo:hex) passes through as --subject; a file subject is
+# self-digested by the engine via --artifact. Fails closed.
+wrangle_sign_metadata_statements() {
+    [[ -z "${METADATA_ROOT:-}" || ! -d "${METADATA_ROOT:-}" ]] && return 0
+    local subject="$1" stmts="$2" subject_arg
+    if [[ "$subject" =~ ^[a-z0-9]+:[a-f0-9]+$ ]]; then
+        subject_arg="--subject=$subject"
+    else
+        subject_arg="--artifact=$subject"
+    fi
+    local args
+    mapfile -t args < <(wrangle_attest_args "$subject_arg" "$stmts")
+    wrangle_retry_once /dev/null wrangle-attest "${args[@]}"
+}
+
+# Post the signed statement at $1 to the GitHub attestation store. Fails closed:
+# a missing by-digest statement is a real delivery gap.
+wrangle_push_store() {
+    local args
+    mapfile -t args < <(wrangle_bnd_push_args "$GITHUB_REPOSITORY" "$1")
+    wrangle_retry_once /dev/null bnd "${args[@]}"
+}
+
+# Split SUBJECTS into WRANGLE_SUBJECTS, dropping blank lines. Fail closed on an
+# empty set: a release subject is always present, so zero means a wiring bug.
+wrangle_read_subjects() {
+    mapfile -t WRANGLE_SUBJECTS <<< "$SUBJECTS"
+    local s kept=()
+    for s in "${WRANGLE_SUBJECTS[@]}"; do
+        [[ "$s" =~ ^[[:space:]]*$ ]] || kept+=("$s")
+    done
+    WRANGLE_SUBJECTS=("${kept[@]}")
+    if [[ "${#WRANGLE_SUBJECTS[@]}" -eq 0 ]]; then
+        printf 'wrangle: no subjects to sign — refusing to proceed\n' >&2
+        return 1
+    fi
+}

--- a/test/test_derive_names.bats
+++ b/test/test_derive_names.bats
@@ -21,6 +21,7 @@ setup() {
     grep -qx 'metadata=go-metadata' "$GITHUB_OUTPUT"
     grep -qx 'metadata-pre=go-premeta' "$GITHUB_OUTPUT"
     grep -qx 'provenance-bundle=go-provenance-bundle' "$GITHUB_OUTPUT"
+    grep -qx 'signed-metadata=go-signed-metadata' "$GITHUB_OUTPUT"
 }
 
 @test "package_metadata: subdir build appends the shortname" {
@@ -30,6 +31,7 @@ setup() {
     grep -qx 'metadata=python-metadata-services_api' "$GITHUB_OUTPUT"
     grep -qx 'metadata-pre=python-premeta-services_api' "$GITHUB_OUTPUT"
     grep -qx 'provenance-bundle=python-provenance-bundle-services_api' "$GITHUB_OUTPUT"
+    grep -qx 'signed-metadata=python-signed-metadata-services_api' "$GITHUB_OUTPUT"
 }
 
 @test "package_metadata: each build type namespaces its names" {

--- a/test/test_install_go_tools.bats
+++ b/test/test_install_go_tools.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+# Behavioral test for lib/install_go_tools.sh — the shared `go install` helper
+# both the verify and attest jobs delegate to. A fake `go` records the package
+# paths it was asked to build; the helper must pass exactly its arguments and
+# build from tools/go.mod.
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    SCRIPT="$REPO_ROOT/lib/install_go_tools.sh"
+    TEST_DIR="$(mktemp -d)"
+    export REPO_ROOT SCRIPT TEST_DIR
+
+    GO_RECORD="$TEST_DIR/go-install-record"
+    : > "$GO_RECORD"
+    FAKE_BIN="$TEST_DIR/fakebin"
+    mkdir -p "$FAKE_BIN"
+    export GO_RECORD FAKE_BIN
+    cat > "$FAKE_BIN/go" << 'FAKEGO'
+#!/usr/bin/env bash
+set -euo pipefail
+pkgs=()
+seen_install=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -C) shift 2; continue ;;
+        install) seen_install=1; shift; continue ;;
+        *) [ "$seen_install" -eq 1 ] && pkgs+=("$1"); shift ;;
+    esac
+done
+[ "${#pkgs[@]}" -gt 0 ] && printf '%s\n' "${pkgs[@]}" >> "$GO_RECORD"
+exit 0
+FAKEGO
+    chmod +x "$FAKE_BIN/go"
+    export WRANGLE_BIN_DIR="$TEST_DIR/bin"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "install_go_tools.sh: builds exactly the requested packages" {
+    PATH="$FAKE_BIN:$PATH" run "$SCRIPT" \
+        github.com/TomHennen/wrangle/tools/wrangle-attest \
+        github.com/carabiner-dev/bnd
+    [ "$status" -eq 0 ]
+    grep -Fqx 'github.com/TomHennen/wrangle/tools/wrangle-attest' "$GO_RECORD"
+    grep -Fqx 'github.com/carabiner-dev/bnd' "$GO_RECORD"
+    # No ampel or cosign unless asked.
+    ! grep -Fq 'ampel' "$GO_RECORD"
+    ! grep -Fq 'cosign' "$GO_RECORD"
+}
+
+@test "install_go_tools.sh: rejects an empty package set" {
+    PATH="$FAKE_BIN:$PATH" run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## What & why

Move signing + store-push of the **build-metadata** attestations (SBOM + every `scan/v1` manifest) into the **`attest`** job, alongside the SLSA provenance, so the signed set is persisted **independent of the later policy verdict**. Today metadata is signed in `verify`, *after* ampel passes — so a failed `verify` discards the signed SBOM/scan statements (the bug #550 fixes). This is PR 1 of 4 for #550, scoped to **go/npm/python** (container is PR 3).

The VSA stays in `verify` — it's a verdict ampel mints, and can't exist before the policy runs.

## What changed

- `actions/attest_provenance/action.yml`: after the provenance step it now downloads the pre-verify metadata (`metadata-pre`), builds `wrangle-attest` + `bnd`, self-digests each dist subject, runs `wrangle-attest --sign` over the whole metadata dir, posts each signed statement to the GitHub attestation store, and emits a `<type>-signed-metadata-<sn>` workflow artifact. `GITHUB_TOKEN` (bnd store auth) and `COMMIT` (`github.sha`) are threaded into the signing step.
- New helpers beside the action: `resolve_subjects.sh` (derive the dist subjects from go's `checksums.txt` / npm-python `dist/*`), `sign_metadata.sh` (sign + push per subject), `install_tools.sh` (builds only `wrangle-attest` + `bnd` — no ampel/cosign).
- `lib/install_go_tools.sh`: shared `go install` helper; `actions/verify/install_tools.sh` now delegates to it (one source of truth for the `go install` mechanic).
- `lib/derive_names.sh`: adds the `signed-metadata` artifact name.
- Wired into the go/npm/python `attest` jobs (no new inputs — the action computes its names) and refreshed the now-stale "provenance-only for now" comments in their verify jobs.

## Must-fixes addressed

- **S1 — sign ALL metadata.** `wrangle-attest --sign` runs over the whole metadata dir, so it signs every discovered manifest (SBOM + osv/zizmor/wrangle-lint `scan/v1`, scorecard if present), not just SBOM+scan.
- **M1 — trust boundary.** The attest job runs **no adopter-controlled code** — only `attest-build-provenance` + `wrangle-attest` over the already-built `dist/`. A bats test (`runs no adopter build/test hook`) guards against a future step shelling a caller build/test hook. (SPEC prose move is PR 4.)
- **M2 — per-type activeness.** Confirmed via showcase run `27905469742` (wrangle-test) + the build workflows: go/npm/python each produce a `metadata-pre` with ≥1 signable manifest today (4 statements each: SBOM + osv + zizmor + wrangle-lint). The "provenance-only" workflow comments were stale and are corrected.
- **M3 — double-push window (additive).** This PR is **additive**: `attest` AND `verify` both sign+push the same statements until PR 2 removes verify's. The store accepts multiple attestations per subject and ampel de-dupes, so this is a **bounded, non-breaking transient** for one release cycle.
- **M4 — subject-binding invariant.** attest self-digests each dist file via `wrangle-attest --artifact`, binding the SAME `sha256` subject the verify VSA binds (verify's `wrangle_subject_arg` hashes the same file). A bats assertion proves the attest statement's subject digest equals the verify subject digest.
- **Identity.** attest and verify are sibling jobs in the same reusable workflow, so signing in attest mints the same `job_workflow_ref` Sigstore identity (`wrangle-builder`). **No PolicySet change.** Permissions unchanged (`id-token: write` + `attestations: write` already present); only `GITHUB_TOKEN` is wired into the new step.
- **S3 — bootstrap pin.** The go/npm/python `attest_provenance` self-refs are bootstrap-pinned to the PR head so the integration test runs the PR's attest code (`converge_action_pins` no-ops on stale-but-reachable, #552, so the pin is manual). Transitive `check_pin_ancestry` is green (all 18 pins reachable). Bumped to a main SHA post-merge per `docs/e2e_testing.md`.

## Validation

`shellcheck`, `actionlint`, `zizmor`, `wrangle-shell-lint`, `wrangle-workflow-lint` clean; full bats suite green (1238 passing, including new attest-side coverage); `go test ./wrangle-attest/...` green. **e2e validation in wrangle-agent-playground pending.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
