### PR TITLE
feat(go): wrangle owns the publish — goreleaser builds, adopter creates the release, wrangle uploads only attested artifacts (#464)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -267,7 +267,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -267,7 +267,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -267,7 +267,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -175,7 +175,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         id: prep
         with:
           build-type: go
@@ -194,7 +194,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -228,7 +228,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -290,7 +290,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/release@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -378,7 +378,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         id: attest
         with:
           build-type: go
@@ -406,7 +406,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -388,13 +388,12 @@ jobs:
   # Emit one signed SLSA Verification Summary Attestation (VSA) per dist archive
   # and append it to the SLSA provenance, producing one per-artifact
   # <archive>.intoto.jsonl bundle consumers fetch. bnd signs each VSA keyless with
-  # this workflow's OIDC identity; the bundle is attached to the release on tag.
+  # this workflow's OIDC identity.
   #
-  # goreleaser publishes INLINE in the `release` job, so by the time this runs
-  # the release is already live. fail: true therefore does NOT block goreleaser's
-  # publish; it (a) fails the overall workflow conclusion so any downstream caller
-  # job gated on this reusable workflow is blocked, and (b) surfaces a
-  # policy/tooling regression loudly. Keep fail: true for both effects.
+  # This job owns the publish: goreleaser ran --skip=publish, so nothing is live
+  # until verify uploads the attested archives + checksums.txt + bundles to the
+  # pre-existing release. fail: true therefore DOES block the publish — a failed
+  # policy means the bytes are never uploaded — and fails the workflow conclusion.
   verify:
     if: ${{ needs.prep.outputs.should-release == 'true' }}
     needs: [prep, release, attest]
@@ -402,7 +401,7 @@ jobs:
     permissions:
       id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
       attestations: write   # post each VSA to the GitHub attestation store
-      contents: write       # attach the bundle to the release on tag pushes
+      contents: write       # upload the attested archives + checksums + bundles to the pre-existing release
     outputs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -2,27 +2,24 @@ name: "Build, test, and release a Go project with best practices."
 
 # Build + SLSA provenance reusable workflow for Go.
 #
-# The build is split into two jobs with different permissions:
+# wrangle owns the publish; goreleaser only builds. The two adopter-code
+# jobs run at contents: read — neither can write to the repo:
 #
-#   - `checks` (contents: read) runs the quality gates that don't
-#     need write access: gofmt, go vet, go test, govulncheck. The
-#     `go test` step executes arbitrary adopter test code, so
-#     denying it `contents: write` is real defense-in-depth — a
-#     compromised dependency or hostile test cannot use $GITHUB_TOKEN
-#     to push to the repo.
+#   - `checks` (contents: read) runs the quality gates: gofmt, go vet,
+#     go test, govulncheck. `go test` executes arbitrary adopter test
+#     code; denying it write access is real defense-in-depth.
 #
-#   - `release` (contents: write) runs goreleaser, which publishes
-#     to GitHub Releases on tag pushes and needs write access. The
-#     `release` job depends on `checks` so quality gates must pass
-#     before any bytes ship.
+#   - `release` (contents: read) runs goreleaser with --skip=publish:
+#     it builds the archives + checksums into dist/ and uploads nothing.
+#     It depends on `checks` so quality gates pass before any bytes are
+#     attested.
 #
-# Goreleaser owns its native publish: on tag pushes it creates the
-# GitHub Release, attaches archives + checksums, and runs whatever
-# downstream verbs the adopter's .goreleaser.yml configures (Docker
-# pushes, Homebrew taps, deb/rpm/snap, announce). wrangle's attest job
-# produces the provenance shortly after — same
-# "publish first, attest second" shape as wrangle's container build
-# type.
+# Only the verify job holds contents: write, and it runs no adopter code:
+# it attests the dist and uploads only the attested archives +
+# checksums.txt + .intoto.jsonl bundles to a PRE-EXISTING GitHub Release
+# (the adopter creates the release; wrangle never does). Un-attestable
+# downstream goreleaser verbs (Docker pushes, Homebrew taps, deb/rpm/snap,
+# announce) are never run. Same shape as wrangle's python and npm types.
 
 on:
   workflow_call:
@@ -74,13 +71,13 @@ on:
               github.event_name is in the list. See
               actions/prep/release_gate.sh for full vocabulary.
 
-          Goreleaser publishes only on TAG PUSHES (`gh release create`
-          requires a tag). The default `tag-only` is therefore also
-          the cheapest setting — workflow runs only when it would do
-          something meaningful. Use `non-pull-request` or
-          `main-and-tags` for early failure detection on non-tag
-          events (at the cost of a snapshot goreleaser run on every
-          matching push).
+          wrangle uploads attested artifacts only on TAG PUSHES (it
+          attaches to the pre-existing release for the tag). The default
+          `tag-only` is therefore also the cheapest setting — the
+          pipeline runs only when it would do something meaningful. Use
+          `non-pull-request` or `main-and-tags` for early failure
+          detection on non-tag events (at the cost of a snapshot
+          goreleaser run on every matching push).
         required: false
         type: string
         default: tag-only
@@ -253,8 +250,9 @@ jobs:
           path: ${{ steps.checks.outputs.metadata-dir }}/
           if-no-files-found: warn   # govulncheck JSON is informational; not having it is OK
 
-  # Goreleaser invocation + SBOM + hash. contents: write because
-  # goreleaser publishes inline on tag pushes. Sequenced after
+  # Goreleaser invocation (--skip=publish) + SBOM + hash. contents: read
+  # because goreleaser publishes nothing — it only builds dist/, which is
+  # handed to the verify job as a workflow artifact. Sequenced after
   # `checks` so quality gates have already passed.
   #
   # The `if:` is load-bearing for the run-tests: false path. With
@@ -274,7 +272,7 @@ jobs:
       (needs.scan.result == 'success' || needs.prep.outputs.should-release != 'true')
     runs-on: ubuntu-latest
     permissions:
-      contents: write    # goreleaser creates the GitHub Release
+      contents: read     # goreleaser runs --skip=publish; it writes nothing to the repo
     outputs:
       hashes: ${{ steps.release.outputs.hashes }}
       version: ${{ steps.release.outputs.version }}
@@ -297,10 +295,6 @@ jobs:
         with:
           path: ${{ inputs.path }}
           go-version: ${{ inputs.go-version }}
-          # publish == AND of (release-events gate) AND (tag push).
-          # Both must hold for goreleaser to do a full publish; otherwise
-          # it builds in --snapshot mode without uploading anything.
-          publish: ${{ needs.prep.outputs.should-release == 'true' && startsWith(github.ref, 'refs/tags/') }}
           cache: ${{ needs.prep.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
           install-zig: ${{ inputs.install-zig }}
 

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -167,7 +167,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         id: prep
         with:
           build-type: go
@@ -186,7 +186,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/release@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -370,7 +370,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         id: attest
         with:
           build-type: go
@@ -398,7 +398,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -175,7 +175,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         id: prep
         with:
           build-type: go
@@ -194,7 +194,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -228,7 +228,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -290,7 +290,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/release@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -378,7 +378,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c00abcd513d72db7726ee84682904f5af8006699 # attest-sign-metadata-pr1 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         id: attest
         with:
           build-type: go
@@ -406,7 +406,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -1,25 +1,17 @@
 name: "Build, test, and release a Go project with best practices."
 
-# Build + SLSA provenance reusable workflow for Go.
+# Build, attest, and release a Go project — reusable workflow.
 #
-# wrangle owns the publish; goreleaser only builds. The two adopter-code
-# jobs run at contents: read — neither can write to the repo:
+# Builds your Go project with goreleaser, attests it (SLSA provenance +
+# SBOM + scans, plus a signed VSA), and uploads the attested archives +
+# checksums.txt + .intoto.jsonl bundles to your GitHub Release for the tag.
+# You create the release; wrangle never creates one.
 #
-#   - `checks` (contents: read) runs the quality gates: gofmt, go vet,
-#     go test, govulncheck. `go test` executes arbitrary adopter test
-#     code; denying it write access is real defense-in-depth.
-#
-#   - `release` (contents: read) runs goreleaser with --skip=publish:
-#     it builds the archives + checksums into dist/ and uploads nothing.
-#     It depends on `checks` so quality gates pass before any bytes are
-#     attested.
-#
-# Only the verify job holds contents: write, and it runs no adopter code:
-# it attests the dist and uploads only the attested archives +
-# checksums.txt + .intoto.jsonl bundles to a PRE-EXISTING GitHub Release
-# (the adopter creates the release; wrangle never does). Un-attestable
-# downstream goreleaser verbs (Docker pushes, Homebrew taps, deb/rpm/snap,
-# announce) are never run. Same shape as wrangle's python and npm types.
+# goreleaser runs with --skip=publish, so its own publishers (GitHub
+# release, Docker, Homebrew, deb/rpm/snap, announce) are skipped — wrangle
+# publishes only what it can attest. Run those from your own job if you
+# need them. The job/permission split (adopter code never holds
+# contents: write) is in build/actions/go/SPEC.md.
 
 on:
   workflow_call:

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -155,7 +155,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -174,7 +174,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -285,7 +285,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c00abcd513d72db7726ee84682904f5af8006699 # attest-sign-metadata-pr1 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -310,7 +310,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -155,7 +155,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -174,7 +174,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -285,7 +285,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -310,7 +310,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -155,7 +155,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -174,7 +174,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -285,7 +285,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -310,7 +310,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -132,7 +132,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         id: prep
         with:
           build-type: python
@@ -151,7 +151,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -272,7 +272,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         id: attest
         with:
           build-type: python
@@ -297,7 +297,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -132,7 +132,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         id: prep
         with:
           build-type: python
@@ -151,7 +151,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -272,7 +272,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c00abcd513d72db7726ee84682904f5af8006699 # attest-sign-metadata-pr1 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         id: attest
         with:
           build-type: python
@@ -297,7 +297,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -132,7 +132,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         id: prep
         with:
           build-type: python
@@ -151,7 +151,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -272,7 +272,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         id: attest
         with:
           build-type: python
@@ -297,7 +297,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -83,7 +83,7 @@ inputs:
     required: false
     default: "true"
   build-type:
-    description: "Build type (go/python/npm/container) — for go, goreleaser owns the dist on the release so wrangle attaches the bundle + metadata zip only."
+    description: "Build type (go/python/npm/container)."
     required: false
     default: ""
   dist-dir:

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -270,10 +270,9 @@ wrangle_run() {
 # and its <artifact>.intoto.jsonl bundle (flat); once per build: a
 # <type>-metadata-<sn>.zip of the metadata dir (sbom + scan/ + bundles). The
 # dist is attached alongside its bundle so no bundle is orphaned without its
-# artifact. For the go build type goreleaser owns the dist + checksums.txt on
-# the release (#463), so wrangle attaches the bundle + metadata zip only.
-# Enumerate via a temp file, not a process substitution, so a find that dies
-# mid-traversal fails closed.
+# artifact. For go, wrangle owns the publish: it also attaches checksums.txt
+# (goreleaser built but published nothing). Enumerate via a temp file, not a
+# process substitution, so a find that dies mid-traversal fails closed.
 wrangle_attach_release() {
     local ref="$GITHUB_REF_NAME"
     if ! gh release view "$ref" >/dev/null 2>&1; then
@@ -298,8 +297,7 @@ wrangle_attach_release() {
     fi
     while IFS= read -r -d '' bundle; do
         gh release upload "$ref" "$bundle" --clobber
-        # Attach the dist sibling alongside its bundle (skip go — goreleaser owns it).
-        [[ "${BUILD_TYPE:-}" == "go" ]] && continue
+        # Attach the dist sibling alongside its bundle so no bundle is orphaned.
         base="${bundle##*/}"
         dist="${DIST_DIR:-dist}/${base%.intoto.jsonl}"
         if [[ -f "$dist" ]]; then
@@ -312,6 +310,19 @@ wrangle_attach_release() {
     done < "$listing"
     rm -f "$listing"
     [[ "$rc" -ne 0 ]] && return "$rc"
+    # go: the attested-artifact set includes checksums.txt — it's not a VSA
+    # subject (it's the manifest the subjects derive from), so it has no bundle
+    # of its own. goreleaser built it but published nothing; wrangle owns the
+    # publish, so attach it too. Fail closed if it's missing.
+    if [[ "${BUILD_TYPE:-}" == "go" ]]; then
+        local checksums="${DIST_DIR:-dist}/checksums.txt"
+        if [[ -f "$checksums" ]]; then
+            gh release upload "$ref" "$checksums" --clobber
+        else
+            printf 'wrangle: go checksums.txt (%s) not found\n' "$checksums" >&2
+            return 1
+        fi
+    fi
     wrangle_attach_metadata_zip "$ref"
 }
 

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -942,19 +942,32 @@ _require_zip() {
     ! grep -q "release create" "$GH_LOG"   # wrangle never creates the release
 }
 
-@test "run_verify attach: go skips the dist (goreleaser owns it) but still attaches bundle + metadata zip" {
+@test "run_verify attach: go uploads the dist archives, their bundles, and checksums.txt (wrangle owns the publish)" {
     _require_zip
     _install_gh_shim
     _stage_release_assets
+    : > "$DIST_DIR/checksums.txt"
     export BUILD_TYPE="go"
     export GH_VIEW_SEQ="0"
     run "$SCRIPT" attach
     [[ "$status" -eq 0 ]]
     grep -qx "release upload v1.2.3 $BUNDLE_OUT/a.tgz.intoto.jsonl --clobber" "$GH_LOG"
+    grep -qx "release upload v1.2.3 $DIST_DIR/a.tgz --clobber" "$GH_LOG"
+    grep -qx "release upload v1.2.3 $DIST_DIR/b.whl --clobber" "$GH_LOG"
+    # checksums.txt has no bundle of its own but is part of the attested set.
+    grep -qx "release upload v1.2.3 $DIST_DIR/checksums.txt --clobber" "$GH_LOG"
     grep -q "release upload v1.2.3 .*python-metadata.zip --clobber" "$GH_LOG"
-    # The dist itself is goreleaser's to attach — wrangle must not double-attach.
-    ! grep -q "release upload v1.2.3 $DIST_DIR/a.tgz --clobber" "$GH_LOG"
-    ! grep -q "release upload v1.2.3 $DIST_DIR/b.whl --clobber" "$GH_LOG"
+}
+
+@test "run_verify attach: go fails closed when checksums.txt is missing" {
+    _require_zip
+    _install_gh_shim
+    _stage_release_assets
+    export BUILD_TYPE="go"        # no checksums.txt staged
+    export GH_VIEW_SEQ="0"
+    run "$SCRIPT" attach
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"checksums.txt"* ]]
 }
 
 @test "run_verify attach: a bundle whose dist is missing fails closed (no orphan bundle)" {

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -82,7 +82,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -82,7 +82,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@4077473ede90fd53da6a5e5cfb7f4ebacb1ec6ea # go-wrangle-owns-publish 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -82,7 +82,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@6b86c0ffc7f1c7443183be4afb95b4c9de040cab # main 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@a4d70b32aab2be5b5f77fd11b64ba367f821c1f3 # go-wrangle-owns-publish 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -99,7 +99,7 @@ runs:
         oci-target: ${{ inputs.oci-target }}
         attach-to-release: ${{ inputs.attach-to-release }}
         attach-release-assets: ${{ inputs.attach-release-assets }}
-        # go's dist is owned by goreleaser on the release; wrangle skips it.
+        # build-type selects the attach behavior; go adds checksums.txt.
         build-type: ${{ inputs.build-type }}
         dist-dir: dist
         fail: "true"

--- a/build/actions/go/README.md
+++ b/build/actions/go/README.md
@@ -1,18 +1,20 @@
 # Wrangle Build Go
 
-Wrangle wraps your existing `.goreleaser.yml` — it doesn't replace it. You keep your goreleaser config and everything it already does (Docker pushes, Homebrew taps, deb/rpm, announcements). Wrangle adds the security drudgery around it: gofmt/vet/test/govulncheck, an SPDX SBOM, SLSA Build L3 provenance, and a signed VSA your users can verify with one command.
+Wrangle uses your `.goreleaser.yml` to build your binaries, then takes over the publish: it runs goreleaser with `--skip=publish` and uploads only what it can attest — the archives, `checksums.txt`, and a signed bundle per archive — to a GitHub Release you create. On top of the build, wrangle adds the security drudgery: gofmt/vet/test/govulncheck, an SPDX SBOM, SLSA Build L3 provenance, and a signed VSA your users verify with one command.
 
-This build type is for Go projects that ship binaries: it builds them with goreleaser and publishes downloadable archives to a GitHub Release. Ship a CLI people `go install` today? Adopting wrangle additionally gets your users attested, downloadable binaries — and `go install` keeps working unchanged. Library-only modules (no binary to build) aren't supported ([#239](https://github.com/TomHennen/wrangle/issues/239)).
+This build type is for Go projects that ship binaries. Ship a CLI people `go install` today? Adopting wrangle additionally gets your users attested, downloadable binaries — and `go install` keeps working unchanged. Library-only modules (no binary to build) aren't supported ([#239](https://github.com/TomHennen/wrangle/issues/239)).
+
+Because wrangle publishes only the attested archives + `checksums.txt`, goreleaser's downstream publisher verbs (Docker pushes, Homebrew taps, deb/rpm, announcements) are **not** run — wrangle won't be party to publishing artifacts it can't attest. Need attested images? Pair with the [container build type](../container/README.md). Need a tap or deb/rpm? Run that from a separate job against the binaries wrangle published.
 
 ## Quick start
 
-Copy [`build_go.yml`](../../../gh_workflow_examples/build_go.yml) into `.github/workflows/` and set `path`:
+Copy [`build_go.yml`](../../../gh_workflow_examples/build_go.yml) into `.github/workflows/` and set `path`. The example includes a tag-gated `create-release` job — wrangle attaches assets to a pre-existing release and never creates one, so that job (or your own release-creation step) is a precondition:
 
 ```yaml
 jobs:
   build:
     permissions:
-      contents: write         # goreleaser creates the Release; verify attaches the VSA
+      contents: write         # verify attaches the attested assets to the release
       id-token: write         # Sigstore keyless signing
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan
@@ -36,7 +38,7 @@ checksum:
   name_template: "checksums.txt"   # keep this exact name — it's how wrangle knows what to attest
 ```
 
-Push a `v`-prefixed semver tag (e.g. `v1.2.3`) and wrangle runs the full pipeline and publishes the release. PRs build and test without publishing.
+Push a `v`-prefixed semver tag (e.g. `v1.2.3`) and wrangle runs the full pipeline, then uploads the attested archives + `checksums.txt` + signed bundles to the release for that tag. PRs build and test without publishing.
 
 ## What you get
 
@@ -44,12 +46,13 @@ Push a `v`-prefixed semver tag (e.g. `v1.2.3`) and wrangle runs the full pipelin
 - **Checks before bytes ship** — gofmt, `go vet`, `go test`, govulncheck run in a read-only job; a failure blocks the release job.
 - **An SPDX SBOM, scan findings (incl. govulncheck), and the signed bundle** in one `go-metadata-<sn>` workflow artifact ([what's in it](../../../docs/metadata_layout.md)).
 - **SLSA Build L3 provenance** tying each artifact to the workflow that built it ([the requirements it meets](../../../docs/REQUIREMENTS_MAPPING.md)).
-- **Release assets on tag pushes** — goreleaser attaches the dist archives + `checksums.txt`; wrangle adds each `<archive>.intoto.jsonl` bundle (signed VSA + provenance) and a `go-metadata-<sn>.zip` with the SBOM + scan results. Downstream users verify with one command.
+- **Release assets on tag pushes** — wrangle uploads the dist archives, `checksums.txt`, each `<archive>.intoto.jsonl` bundle (signed VSA + provenance), and a `go-metadata-<sn>.zip` with the SBOM + scan results to the release you created. Only attested bytes are published. Downstream users verify with one command.
 
 ## Good to know
 
 - **Tags must be `v`-prefixed semver** (`v1.2.3`) — goreleaser derives the version from the nearest `v*` tag. No `v*` tags yet? Use the [example config](../../../gh_workflow_examples/build_go.goreleaser.yml)'s snapshot template, which doesn't depend on tag history.
-- **Provenance covers everything in `checksums.txt`.** Docker images and Homebrew taps goreleaser pushes are *not* covered — pair with wrangle's [container build type](../container/README.md) for images.
+- **You must create the release.** wrangle attaches to a pre-existing GitHub Release for the tag and never creates one; the example's `create-release` job handles this, or add your own `gh release create` step. No release for the tag? The assets stay workflow artifacts only.
+- **Provenance covers everything in `checksums.txt`** — the archives wrangle publishes. goreleaser's Docker/Homebrew/deb/rpm/announce verbs don't run under wrangle (it publishes only what it can attest); pair with the [container build type](../container/README.md) for attested images.
 - **`pull_request_target` can't trigger this workflow** — that trigger (and `workflow_run` chained from it) is a common exploit vector, so wrangle blocks both at startup.
 - **`release-events`** (default: `tag-only`) controls which events run the full pipeline — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating".
 - **Workflow outputs** are documented in [`build_and_publish_go.yml`](../../../.github/workflows/build_and_publish_go.yml) itself.

--- a/build/actions/go/SPEC.md
+++ b/build/actions/go/SPEC.md
@@ -34,9 +34,9 @@ The stale `cyclonedx-gomod` reference in [`docs/docker_best_practices.md`](../..
 
 ### Publish target — GitHub Releases
 
-**Pick:** GitHub Releases. Goreleaser handles the upload natively given a `GITHUB_TOKEN` with `contents: write`.
+**Pick:** GitHub Releases. wrangle owns the upload (see "Build-only goreleaser, wrangle owns the publish" below); the adopter creates the release.
 
-**Why:** This is what `slsa-verifier`, `cosign`, `oras`, the goreleaser-example project, and goreleaser itself all do. There is no separate Go binary registry. `pkg.go.dev` is a documentation index that auto-discovers tagged versions from `proxy.golang.org` — no publish action, no token required for module consumers.
+**Why:** This is what `slsa-verifier`, `cosign`, `oras`, the goreleaser-example project, and goreleaser itself all target. There is no separate Go binary registry. `pkg.go.dev` is a documentation index that auto-discovers tagged versions from `proxy.golang.org` — no publish action, no token required for module consumers.
 
 ### Attestation — `actions/attest-build-provenance`
 
@@ -55,19 +55,21 @@ The stale `cyclonedx-gomod` reference in [`docs/docker_best_practices.md`](../..
 
 Goreleaser's own release pipeline runs `cosign sign-blob` against each artifact in addition to producing SLSA provenance, and an earlier draft of this doc recommended the same. On second look the case doesn't hold up: SLSA provenance already attests the artifact's SHA-256 as the in-toto subject, so `gh attestation verify` is the strictly stronger check — it confirms "the bytes I'm holding match what the provenance signed" *and* binds workflow identity, commit, and builder. `cosign verify-blob` would give a downstream verifier the bytes claim only, and would do so via a separate signature, separate verification command, and separate failure mode. The only argument for shipping it is verifier-tool familiarity — a sigstore-literate consumer who runs `cosign verify` on container images can `cosign verify-blob` a Go binary without reaching for `gh attestation verify`. That is a UX argument, not a security argument; it does not justify the extra signing step, the extra signature artifact, or the second verifier surface to document. If adopters request `cosign verify-blob` ergonomics later, expose it as an opt-in input on the Go build action — but don't make it the default. Same posture as wrangle's other build types: one strong signature path, not two.
 
-#### Publish-first, attest-second (the picked sequence)
+#### Build-only goreleaser, wrangle owns the publish (the picked sequence)
 
-Wrangle does NOT force goreleaser into `--skip=publish`. Doing so would neuter every downstream goreleaser verb — Docker pushes, Homebrew taps, deb/rpm/snap, AUR, Slack/Discord announcements, all the post-build distribution the adopter put in their `.goreleaser.yml`. For most adopters, those features are most of why they reach for goreleaser; wrangle taking over the publish would be a major UX regression.
+Wrangle runs goreleaser with `--skip=publish` on every event, and publishes nothing through it. Two principles force this:
+
+1. **Wrangle must not publish what it can't attest.** Goreleaser's native publish ships Docker images, Homebrew taps, deb/rpm/snap, AUR, and Slack/Discord announcements — none of which wrangle's provenance + VSA cover. Letting goreleaser publish would make wrangle a party to shipping un-attested artifacts.
+2. **Wrangle never *creates* releases.** It attaches to a pre-existing release (the adopter creates it, exactly as the python/npm flows require a pre-configured publish target). `wrangle_attach_release` no-ops when no release exists.
 
 The sequence is therefore:
 
-1. **Goreleaser publishes natively** on tag push (`release --clean`, no `--skip=publish`). It creates the GitHub Release, attaches archives + checksums, and runs every adopter-configured downstream verb.
-2. **Wrangle attests** by handing `dist/checksums.txt` to `actions/attest-build-provenance` (`subject-checksums: dist/checksums.txt`) in the `attest:` job, producing a signed Sigstore bundle.
-3. **Wrangle verifies and attaches** in the `verify:` job: ampel verifies the provenance against the wrangle PolicySet (fail-closed against `common.identities` + the SLSA tenets), emits the signed per-binary VSA, and attaches it to the same release on tag pushes — surfacing any mismatch loudly even though the bytes are already live. The provenance bundle itself is exposed as a workflow artifact.
+1. **Goreleaser builds** (`release --clean --skip=publish`; `--snapshot` added on non-tag events because `release` refuses to run off a tag). It writes the archives + `checksums.txt` into `dist/` and uploads nothing. The build job runs at `contents: read`. `dist/` is handed to the verify job as a workflow artifact.
+2. **The adopter creates the GitHub Release** for the tag (a precondition; the example workflow ships a tag-gated `create-release` job).
+3. **Wrangle attests** by handing `dist/checksums.txt` to `actions/attest-build-provenance` (`subject-checksums: dist/checksums.txt`) in the `attest:` job, producing a signed Sigstore bundle.
+4. **Wrangle verifies and publishes** in the `verify:` job: ampel verifies the provenance against the wrangle PolicySet (fail-closed against `common.identities` + the SLSA tenets), emits the signed per-binary VSA, and uploads ONLY the attested set — the archives, `checksums.txt`, and the per-archive `<archive>.intoto.jsonl` bundles — to the pre-existing release on tag pushes. `contents: write` is held only by this job, which runs no adopter code.
 
-This is the same shape wrangle's container build type uses (`docker push` then `actions/attest-build-provenance`). The small window between goreleaser's publish and the provenance arriving is acceptable: the provenance attests content-addressed hashes, so consumers who download in the window can verify once the attestation lands, and hashes don't change in transit. Adopters who want a stronger "no naked window" guarantee can opt out by setting up their own release pipeline; wrangle's posture matches the established container path.
-
-On non-tag events goreleaser runs `release --clean --snapshot --skip=publish` — `--snapshot` because `release` refuses to run off a tag, `--skip=publish` because there's no release to publish to. PR builds exercise the goreleaser pipeline without publishing.
+Net properties: wrangle never creates releases; only attested bytes are published; the two adopter-code jobs (`checks`, `release`) run at `contents: read`; and the model matches python/npm (build → attest → verify → wrangle uploads to a pre-existing target). PR builds exercise the goreleaser pipeline (snapshot) without publishing.
 
 **Predicate version (v1).** `actions/attest-build-provenance` emits `slsa.dev/provenance/v1` with buildType `https://actions.github.io/buildtypes/workflow/v1`. The Go build type uses the same producer as wrangle's container, python, and npm types (all moved to it in #316), so all four emit v1 predicates with a wrangle-workflow `builder.id`. The old generic generator emitted `v0.2` and named itself as `builder.id`; #316 closed both gaps at once.
 
@@ -100,16 +102,16 @@ Under the picked approach wrangle's test step and the attest step both run again
 
 ### Permissions architecture — checks and release as separate jobs
 
-The reusable workflow splits the build into two jobs with different permissions:
+The reusable workflow splits the build into two jobs, **both at `contents: read`**:
 
 - `checks` (`contents: read`) — `gofmt`, `go vet`, `go test`, `govulncheck`.
-- `release` (`contents: write`) — `goreleaser` (which publishes inline on tag pushes), `syft`, hash computation.
+- `release` (`contents: read`) — `goreleaser --skip=publish` (builds only, uploads nothing), `syft`, hash computation.
 
-The split exists because `go test` executes arbitrary adopter test code (and `govulncheck` walks the full callgraph). Composite actions inherit their calling job's permissions; if those two steps lived in the same composite as the `goreleaser` invocation, `go test` would run with `contents: write` — meaning a compromised dependency or hostile test could use `$GITHUB_TOKEN` to push to the repo. Splitting denies that capability.
+Both adopter-code jobs run read-only because goreleaser publishes nothing — `dist/` leaves the `release` job only as a workflow artifact. `contents: write` is held by exactly one job, `verify`, which runs no adopter code; it uploads the attested set to the pre-existing release. This is stronger than the prior split: `go test` and goreleaser can't reach `$GITHUB_TOKEN` write at all, not merely in a separate job from the publish.
 
 The split costs ~30s of extra latency (a second checkout + setup-go). The L3 audit pattern from #226 (release-vs-PR cache asymmetry) is preserved on both sides: both composites accept the `cache` input and disable caching on release builds.
 
-`release` depends on `checks` via `needs:`, so quality gates always run first and a failure blocks any bytes from shipping.
+`release` depends on `checks` via `needs:`, so quality gates always run first and a failure blocks any bytes from being attested.
 
 Adopters consuming via direct composite mode forfeit this isolation (everything runs in their own job under whatever permissions they grant). That's already documented as a non-L3 path.
 
@@ -126,9 +128,9 @@ This adds Go alongside python-uv and container as the third release-cache-disabl
 
 ### Authentication — `GITHUB_TOKEN` only
 
-Publishing to GitHub Releases requires `contents: write` (goreleaser creates the release; the `verify:` job also needs it to attach the per-binary VSA, and python's caller already grants it). No external registry credentials, no Trusted Publisher to configure, no API tokens. This is the simplest auth model of any artifact-producing build type.
+Publishing to GitHub Releases requires `contents: write`, held only by the `verify:` job (it uploads the attested archives + `checksums.txt` + VSA bundles to the pre-existing release). The goreleaser/`release` job needs no token — `--skip=publish` uploads nothing. The adopter's release-creation step needs `contents: write` too. No external registry credentials, no Trusted Publisher to configure, no API tokens. This is the simplest auth model of any artifact-producing build type.
 
-The permission cascade lesson from python ([HOW_TO_ADD_A_BUILD_TYPE.md "Permission cascade through nested reusable workflows"](../../../docs/HOW_TO_ADD_A_BUILD_TYPE.md)) applies: callers must grant the union of every job's declared permissions. For the picked path the union is `id-token: write` (Sigstore signing in the `attest`/`verify` jobs), `contents: write` (goreleaser publish + VSA attach), and `attestations: write` (the `attest` job writes to GitHub's attestation store). Note the absence of `actions: read` — that was the former generator's requirement; `actions/attest-build-provenance` does not need it.
+The permission cascade lesson from python ([HOW_TO_ADD_A_BUILD_TYPE.md "Permission cascade through nested reusable workflows"](../../../docs/HOW_TO_ADD_A_BUILD_TYPE.md)) applies: callers must grant the union of every job's declared permissions. For the picked path the union is `id-token: write` (Sigstore signing in the `attest`/`verify` jobs), `contents: write` (the `verify` upload — and the adopter's own release-creation job), and `attestations: write` (the `attest` job writes to GitHub's attestation store). Note the absence of `actions: read` — that was the former generator's requirement; `actions/attest-build-provenance` does not need it.
 
 `pkg.go.dev` indexing is automatic — `proxy.golang.org` discovers tags within minutes of `git push --tags`. No publish step, no auth.
 
@@ -170,7 +172,7 @@ The build artifact differs across the two modes (release binaries vs. nothing), 
 Practical notes for whoever picks up the implementation PR.
 
 - **Match python's reusable-workflow shape.** `build_and_publish_go.yml` mirrors `build_and_publish_python.yml`: a `prep` job (`actions/prep/release_gate.sh`) heading the pipeline, a `checks`/`release` build pair, an `attest` job (`actions/attest-build-provenance`, gated on `should-release`), and a `verify` job (`actions/verify` verifying the provenance against the wrangle PolicySet and emitting the signed VSA, gated on `should-release`). Outputs follow the unified naming: `metadata-artifact-name`, `dist-artifact-name`, `provenance-artifact-name`, `should-release`.
-- **Goreleaser invocation.** Use `goreleaser/goreleaser-action` SHA-pinned, with `args: release --clean`. Set `-trimpath` and `-buildvcs=false` defaults via `.goreleaser.yml` template the action ships, or document them as a hard requirement on the adopter's config.
+- **Goreleaser invocation.** Use `goreleaser/goreleaser-action` SHA-pinned, with `args: release --clean --skip=publish` (add `--snapshot` on non-tag events; `GORELEASER_CURRENT_TAG` pins the tag on tag pushes). No `GITHUB_TOKEN` — it publishes nothing. Set `-trimpath` and `-buildvcs=false` defaults via the adopter's `.goreleaser.yml`, or document them as a hard requirement on that config.
 - **Subjects.** Pass `subject-checksums: dist/checksums.txt` to `actions/attest-build-provenance` — not a `dist/*` glob: goreleaser writes non-artifact bookkeeping (`artifacts.json`, `config.yaml`, `metadata.json`) and per-target build subdirs into `dist/` that are not released artifacts. The checksums file is the canonical released-artifact set, and the same set the VSA binds to.
 - **`::stop-commands::` guard around build/test invocations.** The ecosystem-specific Go builder wraps the compile step in a `::stop-commands::` directive so workflow-command injection via build-tool stdout is neutralized. Wrangle adopted this for its existing build types in #230 via the shared `lib/stop_commands_guard.sh` helper; the Go build action MUST use the same helper around `goreleaser` and `go test` invocations. See npm's `build/actions/npm/build_and_pack.sh` and python's `build/actions/python/run_tests.sh` for the invocation pattern.
 - **Cache gating on release status.** Goreleaser caches the Go module cache and build cache by default. Per the release-vs-PR build asymmetry pattern established in #226 (see [`docs/SLSA_L3_AUDIT.md`](../../../docs/SLSA_L3_AUDIT.md) §"Release-vs-PR build asymmetry"), the Go build action should leave caches enabled for non-release events and disable them on release events — caches that are unsafe to use for an L3-attested build are safe for a PR build because no provenance is produced.

--- a/build/actions/go/release/action.yml
+++ b/build/actions/go/release/action.yml
@@ -145,15 +145,15 @@ runs:
         # binary version below is bumped by hand on the 7-day delay.
         version: "2.15.4"
         workdir: ${{ inputs.path }}
-        # Always --skip=publish: goreleaser builds the archives + checksums
-        # into dist/ but uploads nothing. wrangle's verify job publishes the
-        # attested subset. --snapshot on non-tag events because `release`
-        # refuses to run off a tag; on tags GORELEASER_CURRENT_TAG names it.
+        # goreleaser's `release` builds the binaries AND assembles the
+        # release artifacts (the .tar.gz archives + checksums.txt); `build`
+        # alone produces neither, and wrangle needs them to attest + upload.
+        # --skip=publish stops `release` from creating the GitHub release or
+        # pushing Docker/Homebrew/announce — wrangle's verify job publishes
+        # the attested subset. --snapshot on non-tag events (`release`
+        # refuses to run off a tag); on tags GORELEASER_CURRENT_TAG names it.
         args: ${{ startsWith(github.ref, 'refs/tags/') && 'release --clean --skip=publish' || 'release --clean --snapshot --skip=publish' }}
       env:
-        # No GITHUB_TOKEN: --skip=publish uploads nothing, so goreleaser
-        # needs no release credentials. The build job runs at contents: read.
-        #
         # Pin goreleaser to the tag that triggered this run so version
         # resolution is deterministic when several tags point at the same
         # commit. Empty on non-tag (snapshot) builds, which goreleaser

--- a/build/actions/go/release/action.yml
+++ b/build/actions/go/release/action.yml
@@ -1,19 +1,20 @@
 name: Wrangle Go Release
 description: |
-  Invoke goreleaser to build (and on tag pushes, publish) a Go
-  project; generate the SBOM via syft; compute artifact hashes for
-  SLSA provenance. Sister composite to `build/actions/go/checks` —
-  the calling reusable workflow runs checks first (with
-  `contents: read`), then this composite (with `contents: write`,
-  since goreleaser publishes inline). See build/actions/go/SPEC.md
+  Invoke goreleaser to build a Go project (always `--skip=publish`);
+  generate the SBOM via syft; compute artifact hashes for SLSA
+  provenance. Sister composite to `build/actions/go/checks` — the
+  calling reusable workflow runs both with `contents: read`, since
+  goreleaser publishes nothing. See build/actions/go/SPEC.md
   "Permissions architecture."
 
-  Goreleaser owns its native publish on tag pushes: it creates the
-  GitHub Release, attaches archives + checksums, and runs whatever
-  downstream verbs the adopter's .goreleaser.yml configures (Docker
-  pushes, Homebrew taps, deb/rpm/snap, announce, etc.). wrangle's
-  attest job in the reusable workflow produces the provenance
-  shortly after.
+  Goreleaser builds the archives + checksums into dist/ but uploads
+  nothing: wrangle owns the publish. The reusable workflow hands
+  dist/ to the verify job, which attests it and uploads only the
+  attested archives + checksums.txt + bundles to a pre-existing
+  GitHub Release. wrangle never creates the release, and never
+  publishes the un-attestable downstream verbs (Docker pushes,
+  Homebrew taps, deb/rpm/snap, announce) goreleaser's native publish
+  would.
 
 inputs:
   path:
@@ -37,24 +38,6 @@ inputs:
       the L3 reasoning.
     required: false
     default: "enabled"
-  publish:
-    description: |
-      Whether goreleaser publishes the release inline. The calling
-      reusable workflow sets this to the AND of `should-release`
-      (from the gate job) and `startsWith(github.ref, 'refs/tags/')`
-      — both conditions must hold for a publish to actually be
-      possible (gh release requires a tag, and the adopter's
-      release-events input controls whether wrangle's pipeline
-      treats this event as a release at all).
-
-      true  -> goreleaser runs `release --clean` (full publish,
-               creates the GitHub Release, runs Docker pushes,
-               Homebrew taps, etc. per the adopter's config).
-      false -> goreleaser runs `release --clean --snapshot --skip=publish`
-               (builds locally, no upload). PR builds use this so
-               the pipeline is exercised without publishing.
-    required: false
-    default: "false"
   install-zig:
     description: |
       When true, install zig (via mlugg/setup-zig) before goreleaser
@@ -90,11 +73,10 @@ runs:
       env:
         INPUT_PATH: ${{ inputs.path }}
         INPUT_CACHE: ${{ inputs.cache }}
-        INPUT_PUBLISH: ${{ inputs.publish }}
         INPUT_INSTALL_ZIG: ${{ inputs.install-zig }}
       run: |
         set -euo pipefail
-        "${{ github.action_path }}/validate_inputs.sh" "$INPUT_PATH" "$INPUT_CACHE" "$INPUT_PUBLISH" "$INPUT_INSTALL_ZIG"
+        "${{ github.action_path }}/validate_inputs.sh" "$INPUT_PATH" "$INPUT_CACHE" "$INPUT_INSTALL_ZIG"
 
     # cgo cross-compile warning — coarse grep over .goreleaser.yml.
     # Adopters with CGO_ENABLED=1 + a multi-arch / cross-OS matrix who
@@ -163,23 +145,19 @@ runs:
         # binary version below is bumped by hand on the 7-day delay.
         version: "2.15.4"
         workdir: ${{ inputs.path }}
-        # publish == 'true' → full release (native goreleaser publish).
-        # publish != 'true' → snapshot + skip-publish (build only).
-        # Caller sets publish from `should-release && startsWith(refs/tags/)`,
-        # so the false branch covers both PR builds and main-pushes
-        # under tag-only release-events.
-        args: ${{ inputs.publish == 'true' && 'release --clean' || 'release --clean --snapshot --skip=publish' }}
+        # Always --skip=publish: goreleaser builds the archives + checksums
+        # into dist/ but uploads nothing. wrangle's verify job publishes the
+        # attested subset. --snapshot on non-tag events because `release`
+        # refuses to run off a tag; on tags GORELEASER_CURRENT_TAG names it.
+        args: ${{ startsWith(github.ref, 'refs/tags/') && 'release --clean --skip=publish' || 'release --clean --snapshot --skip=publish' }}
       env:
-        # goreleaser's publish path needs GITHUB_TOKEN for the GitHub
-        # Release create + upload. The caller of the reusable workflow
-        # grants contents: write at startup. Harmless when not
-        # publishing.
-        GITHUB_TOKEN: ${{ github.token }}
-        # Pin goreleaser to the tag that triggered this run. When several
-        # tags point at the same commit, goreleaser's own resolution picks
-        # an arbitrary one and re-targets that tag's existing Release,
-        # failing the upload with 422 already_exists. Empty on non-tag
-        # (snapshot) builds, which goreleaser treats as unset.
+        # No GITHUB_TOKEN: --skip=publish uploads nothing, so goreleaser
+        # needs no release credentials. The build job runs at contents: read.
+        #
+        # Pin goreleaser to the tag that triggered this run so version
+        # resolution is deterministic when several tags point at the same
+        # commit. Empty on non-tag (snapshot) builds, which goreleaser
+        # treats as unset.
         GORELEASER_CURRENT_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
 
     - name: Resume workflow commands (end)
@@ -234,7 +212,6 @@ runs:
       env:
         INPUT_PATH: ${{ inputs.path }}
         VERSION: ${{ steps.metadata.outputs.version }}
-        PUBLISH: ${{ inputs.publish }}
       run: |
         set -euo pipefail
-        "${{ github.action_path }}/generate_summary.sh" "$INPUT_PATH" "$VERSION" "$PUBLISH"
+        "${{ github.action_path }}/generate_summary.sh" "$INPUT_PATH" "$VERSION"

--- a/build/actions/go/release/generate_summary.sh
+++ b/build/actions/go/release/generate_summary.sh
@@ -1,27 +1,24 @@
 #!/bin/bash
 # Writes the GitHub Actions step summary for the Go release composite.
-# Renders a markdown table with project / version / published flag,
-# plus a list of every file in <dist_dir>/.
+# Renders a markdown table with project / version, plus a list of
+# every file in <dist_dir>/.
 #
-# Usage: build/actions/go/release/generate_summary.sh <input_path> <version> <published>
+# Usage: build/actions/go/release/generate_summary.sh <input_path> <version>
 #
 #   input_path: project directory (used as the "Project" label and
 #               to locate dist/).
 #   version:    the release version (tag or "snapshot").
-#   published:  "true" or "false" — surfaces whether goreleaser
-#               actually published vs. ran in snapshot mode.
 
 set -euo pipefail
 set -f  # processes external arguments — disable globbing per CLAUDE.md
 
-if [[ $# -ne 3 ]]; then
-    printf 'Usage: %s <input_path> <version> <published>\n' "$0" >&2
+if [[ $# -ne 2 ]]; then
+    printf 'Usage: %s <input_path> <version>\n' "$0" >&2
     exit 1
 fi
 
 INPUT_PATH="$1"
 VERSION="$2"
-PUBLISHED="$3"
 
 if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
     printf 'Note: GITHUB_STEP_SUMMARY not set; printing to stdout instead.\n'
@@ -35,7 +32,6 @@ fi
     printf '| | |\n|---|---|\n'
     printf '| **Project** | %s |\n' "$INPUT_PATH"
     printf '| **Version** | %s |\n' "$VERSION"
-    printf '| **Published** | %s |\n' "$PUBLISHED"
     printf '| **Artifacts** | |\n'
     # Expand dist/* inside a subshell so globbing is restored on every
     # exit path — a bare `set +f` here would leak glob-enabled state to

--- a/build/actions/go/release/validate_inputs.sh
+++ b/build/actions/go/release/validate_inputs.sh
@@ -1,36 +1,29 @@
 #!/bin/bash
-# Validates inputs to the Go release composite: path, cache, publish,
+# Validates inputs to the Go release composite: path, cache,
 # install-zig, plus go.mod and .goreleaser.yml presence.
 #
-# Usage: build/actions/go/release/validate_inputs.sh <path> <cache> <publish> <install-zig>
+# Usage: build/actions/go/release/validate_inputs.sh <path> <cache> <install-zig>
 #
 #   path:        project directory (relative)
 #   cache:       "enabled" or "disabled"
-#   publish:     "true" or "false"
 #   install-zig: "true" or "false"
 
 set -euo pipefail
 set -f  # processes external arguments — disable globbing per CLAUDE.md
 
-if [[ $# -ne 4 ]]; then
-    printf 'Usage: %s <path> <cache> <publish> <install-zig>\n' "$0" >&2
+if [[ $# -ne 3 ]]; then
+    printf 'Usage: %s <path> <cache> <install-zig>\n' "$0" >&2
     exit 1
 fi
 
 INPUT_PATH="$1"
 INPUT_CACHE="$2"
-INPUT_PUBLISH="$3"
-INPUT_INSTALL_ZIG="$4"
+INPUT_INSTALL_ZIG="$3"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ "$INPUT_CACHE" != "enabled" && "$INPUT_CACHE" != "disabled" ]]; then
     printf 'Error: cache input must be one of enabled|disabled (got: %s)\n' "$INPUT_CACHE" >&2
-    exit 1
-fi
-
-if [[ "$INPUT_PUBLISH" != "true" && "$INPUT_PUBLISH" != "false" ]]; then
-    printf 'Error: publish input must be one of true|false (got: %s)\n' "$INPUT_PUBLISH" >&2
     exit 1
 fi
 

--- a/build/actions/go/test.bats
+++ b/build/actions/go/test.bats
@@ -258,7 +258,7 @@ func main() {}
     write_gomod "$proj"
     write_goreleaser "$proj"
     cd "$BATS_TEST_TMPDIR"
-    run "$RELEASE_DIR/validate_inputs.sh" "proj" "enabled" "false" "false"
+    run "$RELEASE_DIR/validate_inputs.sh" "proj" "enabled" "false"
     [[ "$status" -eq 0 ]]
 }
 
@@ -267,7 +267,7 @@ func main() {}
     write_gomod "$proj"
     printf 'version: 2\n' > "$proj/.goreleaser.yaml"
     cd "$BATS_TEST_TMPDIR"
-    run "$RELEASE_DIR/validate_inputs.sh" "proj" "enabled" "false" "false"
+    run "$RELEASE_DIR/validate_inputs.sh" "proj" "enabled" "false"
     [[ "$status" -eq 0 ]]
 }
 
@@ -275,7 +275,7 @@ func main() {}
     local proj="$BATS_TEST_TMPDIR/proj"
     write_gomod "$proj"
     cd "$BATS_TEST_TMPDIR"
-    run "$RELEASE_DIR/validate_inputs.sh" "proj" "enabled" "false" "false"
+    run "$RELEASE_DIR/validate_inputs.sh" "proj" "enabled" "false"
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"no .goreleaser.yml"* ]]
     [[ "$output" == *"build_go.goreleaser.yml"* ]]
@@ -286,7 +286,7 @@ func main() {}
     write_gomod "$proj"
     write_goreleaser "$proj"
     cd "$BATS_TEST_TMPDIR"
-    run "$RELEASE_DIR/validate_inputs.sh" "proj" "enabled" "false" "garbage"
+    run "$RELEASE_DIR/validate_inputs.sh" "proj" "enabled" "garbage"
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"install-zig input must be one of true|false"* ]]
 }
@@ -296,7 +296,7 @@ func main() {}
     write_gomod "$proj"
     write_goreleaser "$proj"
     cd "$BATS_TEST_TMPDIR"
-    run "$RELEASE_DIR/validate_inputs.sh" "proj" "enabled" "false" "true"
+    run "$RELEASE_DIR/validate_inputs.sh" "proj" "enabled" "true"
     [[ "$status" -eq 0 ]]
 }
 
@@ -326,7 +326,7 @@ func main() {}
 }
 
 @test "go.release: validate_inputs.sh rejects path traversal" {
-    run "$RELEASE_DIR/validate_inputs.sh" "../escape" "enabled" "false" "false"
+    run "$RELEASE_DIR/validate_inputs.sh" "../escape" "enabled" "false"
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"path traversal not allowed"* ]]
 }
@@ -365,11 +365,10 @@ func main() {}
     GITHUB_STEP_SUMMARY="$BATS_TEST_TMPDIR/summary.md"
     : > "$GITHUB_STEP_SUMMARY"
     export GITHUB_STEP_SUMMARY
-    run "$RELEASE_DIR/generate_summary.sh" "$proj" "v1.2.3" "true"
+    run "$RELEASE_DIR/generate_summary.sh" "$proj" "v1.2.3"
     [[ "$status" -eq 0 ]]
     grep -q "Go Release Results" "$GITHUB_STEP_SUMMARY"
     grep -q "\\*\\*Version\\*\\* | v1.2.3" "$GITHUB_STEP_SUMMARY"
-    grep -q "\\*\\*Published\\*\\* | true" "$GITHUB_STEP_SUMMARY"
     grep -q "app.tar.gz" "$GITHUB_STEP_SUMMARY"
     grep -q "checksums.txt" "$GITHUB_STEP_SUMMARY"
 }
@@ -380,7 +379,7 @@ func main() {}
     GITHUB_STEP_SUMMARY="$BATS_TEST_TMPDIR/summary.md"
     : > "$GITHUB_STEP_SUMMARY"
     export GITHUB_STEP_SUMMARY
-    run "$RELEASE_DIR/generate_summary.sh" "$proj" "snapshot" "false"
+    run "$RELEASE_DIR/generate_summary.sh" "$proj" "snapshot"
     [[ "$status" -eq 0 ]]
     grep -q "Go Release Results" "$GITHUB_STEP_SUMMARY"
     # No file rows. File rows look like `| | \`<filename>\` |`;
@@ -394,7 +393,7 @@ func main() {}
     local proj="$BATS_TEST_TMPDIR/proj"
     mkdir -p "$proj/dist"
     : > "$proj/dist/app.tar.gz"
-    run bash -c 'unset GITHUB_STEP_SUMMARY; "$1" "$2" "v1.0.0" "true"' -- "$RELEASE_DIR/generate_summary.sh" "$proj"
+    run bash -c 'unset GITHUB_STEP_SUMMARY; "$1" "$2" "v1.0.0"' -- "$RELEASE_DIR/generate_summary.sh" "$proj"
     [[ "$status" -eq 0 ]]
     [[ "$output" == *"Go Release Results"* ]]
     [[ "$output" == *"app.tar.gz"* ]]
@@ -451,16 +450,25 @@ func main() {}
     [[ "$status" -eq 0 ]]
 }
 
-@test "go.release: ternary structure picks bare 'release --clean' on publish==true" {
-    # Per Gemini review on #238: forcing --skip=publish kills every
-    # downstream goreleaser verb. The args ternary must read:
-    #   inputs.publish == 'true' && 'release --clean' || 'release --clean --snapshot --skip=publish'
-    # so publish==true gets the bare publish-enabled invocation.
-    run grep -E "inputs\\.publish == 'true' && 'release --clean' \\|\\|" "$RELEASE_ACTION"
+@test "go.release: goreleaser always runs --skip=publish (wrangle owns the publish)" {
+    # wrangle never lets goreleaser publish: it could ship un-attestable
+    # artifacts (Docker, Homebrew, deb/rpm, announce). Both ternary branches
+    # must carry --skip=publish; the non-tag branch adds --snapshot because
+    # `release` refuses to run off a tag.
+    run grep -E "'release --clean --skip=publish' \\|\\| 'release --clean --snapshot --skip=publish'" "$RELEASE_ACTION"
     [[ "$status" -eq 0 ]]
-    # publish==false branch must --skip=publish (no release exists).
-    run grep -E "release --clean --snapshot --skip=publish" "$RELEASE_ACTION"
-    [[ "$status" -eq 0 ]]
+    # No bare publish-enabled invocation anywhere.
+    run grep -E "'release --clean'( |')" "$RELEASE_ACTION"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "go.release: goreleaser step sets no GITHUB_TOKEN env (publishes nothing)" {
+    # --skip=publish uploads nothing, so the build job needs no release
+    # credentials and runs at contents: read. A GITHUB_TOKEN env entry here
+    # would be a least-privilege regression. Match an actual env key (6+
+    # spaces, `GITHUB_TOKEN:`), not the explanatory comment.
+    section="$(awk '/name: Run goreleaser/,/Resume workflow commands/' "$RELEASE_ACTION")"
+    ! grep -qE '^[[:space:]]+GITHUB_TOKEN:' <<<"$section"
 }
 
 @test "go.release: goreleaser is pinned to the triggering tag" {
@@ -636,8 +644,24 @@ func main() {}
     ! grep -qE '^      contents: write([[:space:]]|$)' <<<"$section"
 }
 
-@test "go: workflow release job has contents: write (goreleaser publishes inline)" {
+@test "go: workflow release job has contents: read (goreleaser publishes nothing)" {
+    # goreleaser runs --skip=publish; the build job uploads dist/ only as a
+    # workflow artifact. No adopter-code job holds contents: write — only the
+    # verify job (which runs no adopter code) does, for the release upload.
     section="$(awk '/^  [a-z][a-z_-]*:$/ { in_section = ($0 == "  release:") } in_section' "$WORKFLOW")"
+    grep -qE '^      contents: read([[:space:]]|$)' <<<"$section"
+    ! grep -qE '^      contents: write([[:space:]]|$)' <<<"$section"
+}
+
+@test "go: only the verify job holds contents: write (least privilege)" {
+    # Load-bearing: contents: write must appear on exactly one job — verify,
+    # which runs no adopter code. If it ever lands on checks/release/scan a
+    # hostile test or build could push to the repo with $GITHUB_TOKEN.
+    for job in scan checks release attest; do
+        section="$(awk -v j="  $job:" '/^  [a-z][a-z_-]*:$/ { in_section = ($0 == j) } in_section' "$WORKFLOW")"
+        ! grep -qE '^      contents: write([[:space:]]|$)' <<<"$section"
+    done
+    section="$(awk '/^  [a-z][a-z_-]*:$/ { in_section = ($0 == "  verify:") } in_section' "$WORKFLOW")"
     grep -qE '^      contents: write([[:space:]]|$)' <<<"$section"
 }
 
@@ -679,7 +703,7 @@ func main() {}
     grep -qE "needs\\.scan\\.result" <<<"$section"
 }
 
-@test "go: workflow does NOT have a publish job (goreleaser owns publish inline)" {
+@test "go: workflow does NOT have a separate publish job (verify owns the upload)" {
     run grep '^  publish:' "$WORKFLOW"
     [[ "$status" -ne 0 ]]
 }
@@ -735,9 +759,19 @@ func main() {}
     [[ "$status" -ne 0 ]]
 }
 
-@test "go: example workflow does NOT have a publish job (goreleaser owns publish)" {
+@test "go: example workflow does NOT have a publish job (wrangle's verify owns the upload)" {
     run grep -E '^  publish:' "$EXAMPLE"
     [[ "$status" -ne 0 ]]
+}
+
+@test "go: example workflow creates the release on tag push (wrangle attaches, never creates)" {
+    # wrangle attaches to a pre-existing release; the adopter must create it.
+    # The example ships a tag-gated create-release job so the assets land.
+    run grep -E '^  create-release:' "$EXAMPLE"
+    [[ "$status" -eq 0 ]]
+    section="$(awk '/^  [a-z][a-z_-]*:$/ { in_section = ($0 == "  create-release:") } in_section' "$EXAMPLE")"
+    grep -qF "gh release create" <<<"$section"
+    grep -qE "if:.*startsWith\\(github\\.ref, 'refs/tags/'\\)" <<<"$section"
 }
 
 @test "go: example workflow grants contents: write to build job" {

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -202,10 +202,10 @@ is emitted; consumers use the VSA path above.
 
 ## The timing model: publish first, attest second
 
-Go and container builds publish inline (goreleaser / `docker push`) and the
-attest + verify jobs complete shortly after — typically 30s–2min. This is
-fine because the SLSA contract is "consumer runs the verifier", not
-"consumer trusts that an attestation exists":
+The container build type publishes inline (`docker push`) and its attest +
+verify jobs complete shortly after — typically 30s–2min. This is fine because
+the SLSA contract is "consumer runs the verifier", not "consumer trusts that
+an attestation exists":
 
 - Download during the gap and verify → "no attestation found" → treat as
   untrusted, retry later.
@@ -213,6 +213,10 @@ fine because the SLSA contract is "consumer runs the verifier", not
   the artifact. Broken provenance reaching the store does no harm; the
   verify step is what's load-bearing.
 - Download without verifying → you've opted out of SLSA's guarantees.
+
+The go build type has no such gap: goreleaser only builds, and the verify
+job is what uploads the attested archives + `checksums.txt` to the release —
+so nothing is published before it is attested.
 
 ## Ecosystem-native checks (Python / npm)
 

--- a/gh_workflow_examples/build_go.goreleaser.yml
+++ b/gh_workflow_examples/build_go.goreleaser.yml
@@ -1,8 +1,14 @@
 # Copy this file to your repo at `.goreleaser.yml` (or `.goreleaser.yaml`).
 #
 # This is the minimum goreleaser config wrangle's Go build type
-# requires. Adjust to your project — common additions are listed in
-# the comments. Full reference: https://goreleaser.com/customization/.
+# requires. wrangle runs goreleaser with --skip=publish: it builds the
+# archives + checksums into dist/ but publishes nothing. wrangle then
+# uploads only the attested archives + checksums.txt (plus signed-VSA
+# bundles) to your pre-existing GitHub Release. Do NOT add goreleaser
+# publisher config — release.draft, brews, dockers, nfpms, announce —
+# here: those verbs never run under --skip=publish, and wrangle only
+# publishes what it can attest. Full reference:
+# https://goreleaser.com/customization/.
 
 version: 2
 
@@ -37,8 +43,9 @@ builds:
 checksum:
   name_template: "checksums.txt"
 
-# Tarball naming for the archives goreleaser uploads. Goreleaser's
-# defaults are reasonable; this is just the explicit form.
+# Tarball naming for the archives goreleaser builds (and wrangle
+# uploads). Goreleaser's defaults are reasonable; this is just the
+# explicit form.
 archives:
   - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
@@ -51,22 +58,10 @@ archives:
 snapshot:
   version_template: "{{ .ShortCommit }}-snapshot"
 
-# (Optional) Goreleaser's downstream verbs — wrangle preserves all of
-# these. Add what your project needs:
-#
-# brews:                    # update a Homebrew tap
-#   - repository:
-#       owner: your-org
-#       name: homebrew-tap
-#
-# dockers:                  # push images to ghcr.io etc.
-#   - image_templates:
-#       - "ghcr.io/your-org/your-app:{{ .Tag }}"
-#
-# nfpms:                    # build deb / rpm / apk packages
-#   - vendor: your-org
-#     formats: [deb, rpm]
-#
-# announce:                 # post to Slack / Discord / etc.
-#   slack:
-#     enabled: true
+# NOTE: goreleaser's downstream publisher verbs (brews, dockers, nfpms,
+# announce, …) do NOT run under wrangle — it invokes goreleaser with
+# --skip=publish and publishes only the attested archives + checksums.txt
+# itself, because it can't attest those other outputs. Need attested
+# container images? Pair with wrangle's container build type. Need a
+# Homebrew tap or deb/rpm? Run that from a separate, non-wrangle job
+# against the binaries wrangle published.

--- a/gh_workflow_examples/build_go.yml
+++ b/gh_workflow_examples/build_go.yml
@@ -3,21 +3,23 @@
 # Before first use:
 # 1. Copy `gh_workflow_examples/build_go.goreleaser.yml` to your
 #    repo root as `.goreleaser.yml` and adjust to your project
-#    (binary name, GOOS/GOARCH matrix, downstream verbs).
+#    (binary name, GOOS/GOARCH matrix). Do NOT add goreleaser
+#    publisher config (release.draft, brews, dockers, announce, …):
+#    wrangle runs goreleaser with --skip=publish and publishes only
+#    the attested archives + checksums.txt itself.
 # 2. Make sure your release tags match `v*` — goreleaser uses the
 #    tag name as the version.
 #
-# Wrangle's reusable workflow handles build, tests, SBOM, SLSA L3
-# provenance generation, its `verify` job's provenance verification (fail-
-# closed, via ampel against the wrangle PolicySet) plus signed-VSA
-# emission, and dispatch of every downstream goreleaser verb (Docker
-# pushes, Homebrew taps, deb/rpm/snap, announcements). Goreleaser
-# publishes natively on tag push; this caller workflow just gates which
-# events trigger that.
+# wrangle owns the publish: goreleaser only builds. wrangle's verify
+# job attaches the attested archives + checksums.txt + signed-VSA
+# bundles to a PRE-EXISTING GitHub Release — wrangle never creates
+# the release. The `create-release` job below creates it on tag push
+# so the assets have somewhere to land (mirrors how the python example
+# requires a configured publish target as a precondition).
 #
 # Trigger note: `release-events: tag-only` means only tag pushes
-# publish a release. PR builds run the full pipeline (build → tests
-# → SBOM) but do NOT mint provenance or publish.
+# publish. PR builds run the full pipeline (build → tests → SBOM) but
+# do NOT mint provenance or publish.
 name: Go Build
 
 on:
@@ -29,10 +31,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Create the GitHub Release wrangle's verify job attaches assets to.
+  # wrangle never creates releases; it attaches to a pre-existing one.
+  # Tag pushes only — there is no release to create otherwise.
+  create-release:
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # gh release create
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1 ||
+            gh release create "$TAG" --repo "$REPO" --title "$TAG" --generate-notes
+
   build:
+    needs: [create-release]
+    # create-release is skipped on non-tag events; allow that so PR / main
+    # builds still run (a skipped need otherwise cascades to a skip).
+    if: ${{ always() && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped') }}
     # Maximum the caller grants; wrangle's internal jobs each drop to the subset they actually need.
     permissions:
-      contents: write   # goreleaser creates the Release + wrangle's verify job attaches the VSA
+      contents: write   # wrangle's verify job attaches the attested assets to the release
       id-token: write   # OIDC for Sigstore signing
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API


### PR DESCRIPTION
## What
Reworks the go build type so wrangle owns the publish without ever creating releases (#464; supersedes the stale original #464 PR).

- **goreleaser runs `--skip=publish`** (snapshot on non-tag) — builds the archives + `checksums.txt`, publishes nothing (no GitHub release, no Docker/Homebrew/deb-rpm/announce).
- **The adopter creates the GitHub Release** (a precondition, like python/npm). Wrangle never creates one.
- **wrangle's `verify` uploads only the attested set** — archives + `checksums.txt` + `.intoto.jsonl` bundles — to that pre-existing release.

## Why
goreleaser's native publish can ship a lot wrangle can't attest (Docker images, Homebrew taps, deb/rpm/snap, announcements). Wrangle shouldn't publish un-attestable bytes, nor create releases on the adopter's behalf. This satisfies both, keeps least-privilege (both adopter-code jobs at `contents: read`; `contents: write` only on `verify`, which runs no adopter code), and makes go consistent with python/npm. Fixes #463, #464.

## Net properties
- ✅ wrangle never creates releases (adopter does)
- ✅ only attested bytes published (goreleaser publishes nothing; verify uploads only what it attested)
- ✅ least-privilege (write only on the no-adopter-code verify job)
- ✅ go consistent with python/npm

## Validation
- Independent adversarial review — security properties verified in code.
- go-e2e in `wrangle-agent-playground` (adopter pre-creates the release): green; release carries the attested archive + `checksums.txt` + bundle; goreleaser published nothing; digest spot-check (archive sha256 == bundle subject == checksums entry).
- Rebased on current main (#556 `lib/` refactor + #559 pin tooling); pins re-converged fresh.

## Follow-ups
- Adopter must pre-create the release — docs/easing tracked in #557.
- `build/actions/go/release` no longer publishes — rename tracked in #560.
