### PR TITLE
fix(pins): detect & converge stale-but-reachable self-ref pins (#552)

### DIFF
--- a/.github/workflows/local_build_shell.yml
+++ b/.github/workflows/local_build_shell.yml
@@ -51,3 +51,13 @@ jobs:
 
       - name: Check action pin ancestry
         run: ./tools/check_pin_ancestry.sh
+
+      # Stale-but-reachable detection (#552): a pin can be an ancestor yet
+      # resolve OLD action code. Advisory until main is converged fresh — main
+      # may carry a stale pin in the window between an action-change merge and
+      # its post-merge bump, so blocking here would red main. An action-change
+      # PR converges its own pins in-PR (the merge commit keeps them reachable),
+      # so the freshness annotation is actionable pre-merge.
+      - name: Check action pin freshness (advisory)
+        continue-on-error: true
+        run: ./tools/check_pin_freshness.sh

--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,10 @@ zizmor:
 bump-action-pins:
 	@./tools/bump_action_pins.sh $(SHA)
 
-# Loop bump + commit until check_pin_ancestry is green (a nested chain needs one
+# Loop bump + commit until the nested pin chain is both reachable and fresh
+# (check_pin_ancestry + check_pin_freshness green; a nested chain needs one
 # commit per level). Land the result as a merge commit, not a squash.
-# See tools/converge_action_pins.sh and #539.
+# See tools/converge_action_pins.sh, #539, and #552.
 converge-action-pins:
 	@./tools/converge_action_pins.sh
 

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -32,10 +32,12 @@ A branch SHA can't become a main SHA until the code is on main, so a bootstrap p
 - **Red on main** → a pin is unreachable (you squashed a bootstrap pin, or forgot a bump). Run `tools/bump_action_pins.sh <main-sha>` and push. Until you do, main is red and the unattended showcase can't resolve that action.
 - **Green** → every pin resolves; bump at leisure (it just refreshes the SHA and the `# main` label).
 
+Reachability isn't sufficient on its own: a pin can be an ancestor yet still resolve **stale** action code when the path changed after the pin's last bump (#552 — e.g. an inner script edit while the pinned `action.yml` stays byte-identical). `tools/check_pin_freshness.sh` follows the same nested chain and flags any pin whose resolved content (ignoring nested pin-SHA-only differences) differs from `HEAD`. It runs advisory in CI today — main may be momentarily stale between an action-change merge and its post-merge bump — but an action-change PR should converge its own pins in-PR (merge commit) so the chain is fresh at merge.
+
 A nested chain (`workflow → verify_release → verify`, `scan → tools/*`) takes one bump cycle per nesting level under squash: a commit can't pin itself, so editing an *inner* action needs the bump repeated until the check is green (#539). Because the check follows nested resolution, it stays red through the intermediate cycles rather than passing on a half-converged chain. Merging the bootstrap-pin PR as a **merge commit** keeps every branch SHA reachable, so a chain of any depth converges with no re-bump and no red window — a convenience, not a requirement.
 
 ### Recovery
 If `check_pin_ancestry` is red on main (or a showcase run failed to resolve a wrangle action):
 
 1. `tools/bump_action_pins.sh <main-sha>` — repoints every wrangle self-ref pin to a SHA reachable from main. Push it (a dedicated one-line bump PR, or fold it into the next PR); the check goes green and the next showcase resolves the action.
-2. For a nested chain that needs more than one bump cycle, `tools/converge_action_pins.sh` loops bump + commit until the check is green. Land its commits as a **merge commit** (not a squash), or the intermediate pins re-orphan.
+2. For a nested chain that needs more than one bump cycle, `tools/converge_action_pins.sh` loops bump + commit until the chain is both reachable **and fresh** (`check_pin_ancestry` + `check_pin_freshness` both green). Land its commits as a **merge commit** (not a squash), or the intermediate pins re-orphan.

--- a/test/test_check_pin_freshness.bats
+++ b/test/test_check_pin_freshness.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+
+# Unit tests for tools/check_pin_freshness.sh. Hermetic: each test builds a
+# throwaway git repo so the assertions never depend on wrangle's real history.
+
+setup() {
+    SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/tools/check_pin_freshness.sh"
+    REPO="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$REPO/.github/workflows"
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email t@example.com
+    git -C "$REPO" config user.name test
+    git -C "$REPO" config commit.gpgsign false
+}
+
+commit() {
+    git -C "$1" commit -q --allow-empty -m "$2"
+    git -C "$1" rev-parse HEAD
+}
+
+# write_verify <body> — commit actions/verify with the given script body, print sha
+write_verify() {
+    mkdir -p "$REPO/actions/verify"
+    printf 'name: verify\n' > "$REPO/actions/verify/action.yml"
+    printf '%s\n' "$1" > "$REPO/actions/verify/run.sh"
+    git -C "$REPO" add actions/verify
+    git -C "$REPO" commit -q -m verify
+    git -C "$REPO" rev-parse HEAD
+}
+
+run_fresh() { run bash -c "cd '$REPO' && '$SCRIPT'"; }
+
+@test "check_pin_freshness: PASSES when a single-level pin resolves to HEAD content" {
+    local v; v="$(write_verify 'echo hi')"
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # pin\n' "$v" \
+        > "$REPO/.github/workflows/x.yml"
+    run_fresh
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"resolve to HEAD content"* ]]
+}
+
+@test "check_pin_freshness: FAILS on a stale-but-reachable pin (path content changed after the pin)" {
+    # The #558 shape: verify/run.sh changes after the pin; verify@old is still an
+    # ancestor (ancestry would pass) but resolves OLD code.
+    local old; old="$(write_verify 'echo OLD')"
+    write_verify 'echo NEW' >/dev/null   # HEAD advances; pin still names old
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # pin\n' "$old" \
+        > "$REPO/.github/workflows/x.yml"
+    # Ancestry holds: old is an ancestor of HEAD.
+    run bash -c "cd '$REPO' && '$(dirname "$SCRIPT")/check_pin_ancestry.sh'"
+    [ "$status" -eq 0 ]
+    run_fresh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *STALE* ]]
+    [[ "$output" == *"actions/verify"* ]]
+}
+
+@test "check_pin_freshness: catches a script change even when action.yml is byte-identical" {
+    # #558 precisely: verify/action.yml never moved, but run.sh did. An
+    # action.yml-only check would false-green here; the whole-tree diff catches it.
+    mkdir -p "$REPO/actions/verify"
+    printf 'name: verify\n' > "$REPO/actions/verify/action.yml"
+    printf 'echo OLD\n' > "$REPO/actions/verify/run.sh"
+    git -C "$REPO" add actions/verify && git -C "$REPO" commit -q -m v1
+    local old; old="$(git -C "$REPO" rev-parse HEAD)"
+    printf 'echo NEW\n' > "$REPO/actions/verify/run.sh"  # action.yml untouched
+    git -C "$REPO" commit -qam v2
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # pin\n' "$old" \
+        > "$REPO/.github/workflows/x.yml"
+    [ "$(git -C "$REPO" show "$old:actions/verify/action.yml")" = "$(git -C "$REPO" show HEAD:actions/verify/action.yml)" ]
+    run_fresh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *STALE* ]]
+}
+
+@test "check_pin_freshness: walks a 2-level chain and flags the stale nested pin" {
+    # workflow -> release@r (fresh) -> verify@old (stale): verify changed after
+    # the nested pin, so the chain is reachable but resolves OLD verify code. The
+    # transitive walk must descend release@r and flag the nested verify pin.
+    local old; old="$(write_verify 'echo OLD')"
+    write_verify 'echo NEW' >/dev/null
+    mkdir -p "$REPO/actions/release"
+    printf 'name: release\n' > "$REPO/actions/release/action.yml"
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # pin\n' "$old" \
+        >> "$REPO/actions/release/action.yml"
+    git -C "$REPO" add actions/release && git -C "$REPO" commit -q -m release
+    local r; r="$(git -C "$REPO" rev-parse HEAD)"
+    printf '      - uses: TomHennen/wrangle/actions/release@%s # pin\n' "$r" \
+        > "$REPO/.github/workflows/x.yml"
+    # release@r is fresh (its dir is unchanged at HEAD); only nested verify is stale.
+    run_fresh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"STALE: actions/verify"* ]]
+    [[ "$output" != *"STALE: actions/release"* ]]
+}
+
+@test "check_pin_freshness: PASSES (no-op) on an older pin whose path never changed" {
+    # A pin at an older sha is FRESH if its path is byte-identical to HEAD's —
+    # don't false-positive just because the sha is old.
+    local v; v="$(write_verify 'echo hi')"
+    commit "$REPO" "unrelated later commit" >/dev/null  # touches nothing under verify/
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # pin\n' "$v" \
+        > "$REPO/.github/workflows/x.yml"
+    run_fresh
+    [ "$status" -eq 0 ]
+}
+
+@test "check_pin_freshness: ignores third-party pins" {
+    # Only TomHennen/wrangle self-refs are checked; a stale-looking third-party
+    # ref must not be resolved or flagged.
+    local v; v="$(write_verify 'echo hi')"
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # pin\n' "$v" \
+        > "$REPO/.github/workflows/x.yml"
+    printf '      - uses: actions/checkout@%s # third party\n' \
+        "0000000000000000000000000000000000000000" >> "$REPO/.github/workflows/x.yml"
+    run_fresh
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"1 wrangle self-ref pin"* ]]
+}
+
+@test "check_pin_freshness: FAILS when the pinned sha is missing (shallow clone)" {
+    write_verify 'echo hi' >/dev/null
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # pin\n' \
+        "0000000000000000000000000000000000000000" > "$REPO/.github/workflows/x.yml"
+    run_fresh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *MISSING* ]]
+}
+
+@test "check_pin_freshness: PASSES (no-op) when there are no wrangle pins" {
+    commit "$REPO" A >/dev/null
+    printf 'jobs: {}\n' > "$REPO/.github/workflows/x.yml"
+    run_fresh
+    [ "$status" -eq 0 ]
+}

--- a/test/test_converge_action_pins.bats
+++ b/test/test_converge_action_pins.bats
@@ -21,23 +21,34 @@ commit() {
 }
 
 # pin <workflow-sha> <nested-sha> — point the workflow at comp@<workflow-sha>
-# and comp's nested inner at inner@<nested-sha>, in the working tree.
+# and comp's nested inner at inner@<nested-sha>, in the working tree. Both action
+# dirs carry a body file so freshness has real tree content to compare (an action
+# dir absent at the pinned sha would itself read as stale).
 pin() {
+    mkdir -p "$REPO/actions/comp" "$REPO/actions/inner"
+    printf 'name: inner\n' > "$REPO/actions/inner/action.yml"
     printf '      - uses: TomHennen/wrangle/actions/comp@%s # pin\n' "$1" \
         > "$REPO/.github/workflows/x.yml"
+    printf 'name: comp\n' > "$REPO/actions/comp/action.yml"
     printf '      - uses: TomHennen/wrangle/actions/inner@%s # pin\n' "$2" \
-        > "$REPO/actions/comp/action.yml"
+        >> "$REPO/actions/comp/action.yml"
 }
 
 count_commits() { git -C "$REPO" rev-list --count HEAD; }
 
 run_converge() { run bash -c "cd '$REPO' && '$SCRIPT'"; }
 run_check() { run bash -c "cd '$REPO' && '$TOOLS/check_pin_ancestry.sh'"; }
+run_fresh() { run bash -c "cd '$REPO' && '$TOOLS/check_pin_freshness.sh'"; }
 
-@test "converge: no-op (0 commits) when already green" {
-    local a; a="$(commit "$REPO" A)"
-    pin "$a" "$a"
+@test "converge: no-op (0 commits) when already converged (reachable + fresh)" {
+    # Seed the action dirs, then drive to a converged baseline so the chain is
+    # both reachable and fresh; a second run must then do nothing.
+    pin DUMMY DUMMY
+    git -C "$REPO" add -A && git -C "$REPO" commit -q -m "seed dirs"
+    local old; old="$(git -C "$REPO" rev-parse HEAD)"
+    pin "$old" "$old"
     git -C "$REPO" add -A && git -C "$REPO" commit -q -m pins
+    bash -c "cd '$REPO' && '$SCRIPT'" >/dev/null 2>&1   # reach a converged state
     local before; before="$(count_commits)"
     run_converge
     [ "$status" -eq 0 ]
@@ -45,13 +56,43 @@ run_check() { run bash -c "cd '$REPO' && '$TOOLS/check_pin_ancestry.sh'"; }
     [ "$(count_commits)" -eq "$before" ]
 }
 
-@test "converge: an orphaned 2-level chain converges in two commits" {
-    commit "$REPO" A >/dev/null
+@test "converge: a stale-but-reachable nested chain converges to fresh" {
+    # comp and inner both exist; the workflow and comp pin an OLD sha whose tree
+    # predates a later edit to inner — reachable (ancestry green) but resolving
+    # OLD inner content (freshness red). The fresh content is already on HEAD, so
+    # one bump cycle re-pins the chain to it.
+    pin DUMMY DUMMY
+    git -C "$REPO" add -A && git -C "$REPO" commit -q -m "seed dirs"
+    local old; old="$(git -C "$REPO" rev-parse HEAD)"
+    printf 'changed body\n' >> "$REPO/actions/inner/action.yml"  # inner moves after old
+    git -C "$REPO" commit -qam "edit inner"
+    pin "$old" "$old"
+    git -C "$REPO" add -A && git -C "$REPO" commit -q -m "pin stale chain"
+    run_check
+    [ "$status" -eq 0 ]   # ancestry green: old is an ancestor (false-green)
+    run_fresh
+    [ "$status" -eq 1 ]   # freshness red: old resolves stale inner content
+    run_converge
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"converged in 1 commit"* ]]
+    run_check
+    [ "$status" -eq 0 ]
+    run_fresh
+    [ "$status" -eq 0 ]
+}
+
+@test "converge: a fully-orphaned 2-level chain still needs two commits (squash recovery)" {
+    # Both pins point at a now-orphaned branch sha whose tree is absent from main:
+    # not reachable AND not fresh. Recovery needs one commit per nesting level —
+    # the freshness-aware loop must not regress the ancestry-recovery path.
+    pin DUMMY DUMMY
+    git -C "$REPO" add -A && git -C "$REPO" commit -q -m "seed dirs"
     git -C "$REPO" checkout -q -b feature
-    local orphan; orphan="$(commit "$REPO" ORPHAN)"
+    printf 'feature-only\n' >> "$REPO/actions/inner/action.yml"
+    git -C "$REPO" commit -qam "feature edit"
+    local orphan; orphan="$(git -C "$REPO" rev-parse HEAD)"
     git -C "$REPO" checkout -q -
-    # Simulate the squash merge: both pins point at the now-orphaned branch sha.
-    pin "$orphan" "$orphan"
+    pin "$orphan" "$orphan"   # squash-merge shape: pins name the orphaned sha
     git -C "$REPO" add -A && git -C "$REPO" commit -q -m "squash merge"
     local before; before="$(count_commits)"
     run_converge
@@ -60,6 +101,8 @@ run_check() { run bash -c "cd '$REPO' && '$TOOLS/check_pin_ancestry.sh'"; }
     [[ "$output" == *NOTE* ]]
     [ "$(count_commits)" -eq "$((before + 2))" ]
     run_check
+    [ "$status" -eq 0 ]
+    run_fresh
     [ "$status" -eq 0 ]
 }
 
@@ -73,6 +116,34 @@ run_check() { run bash -c "cd '$REPO' && '$TOOLS/check_pin_ancestry.sh'"; }
     WRANGLE_CONVERGE_MAX_ITERS=1 run bash -c "cd '$REPO' && '$SCRIPT'"
     [ "$status" -eq 1 ]
     [[ "$output" == *"not converged after 1 commit"* ]]
+}
+
+@test "converge: resolves a stale-but-reachable pin that ancestry alone calls green (#552)" {
+    # actions/verify changes after the workflow pins it; the pin stays an
+    # ancestor (check_pin_ancestry green) but resolves OLD code. Convergence is
+    # content-based, so it must bump the pin to the fresh HEAD and stop.
+    mkdir -p "$REPO/actions/verify"
+    printf 'name: verify\n' > "$REPO/actions/verify/action.yml"
+    printf 'echo OLD\n' > "$REPO/actions/verify/run.sh"
+    git -C "$REPO" add -A && git -C "$REPO" commit -q -m v1
+    local old; old="$(git -C "$REPO" rev-parse HEAD)"
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # pin\n' "$old" \
+        > "$REPO/.github/workflows/x.yml"
+    git -C "$REPO" add -A && git -C "$REPO" commit -q -m "pin verify@old"
+    printf 'echo NEW\n' > "$REPO/actions/verify/run.sh"   # HEAD advances; pin now stale
+    git -C "$REPO" commit -qam v2
+    # Ancestry passes (false-green), freshness fails — the exact #558 gap.
+    run bash -c "cd '$REPO' && '$TOOLS/check_pin_ancestry.sh'"
+    [ "$status" -eq 0 ]
+    run bash -c "cd '$REPO' && '$TOOLS/check_pin_freshness.sh'"
+    [ "$status" -eq 1 ]
+    local before; before="$(count_commits)"
+    run_converge
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"converged in 1 commit"* ]]
+    [ "$(count_commits)" -eq "$((before + 1))" ]
+    run bash -c "cd '$REPO' && '$TOOLS/check_pin_freshness.sh'"
+    [ "$status" -eq 0 ]
 }
 
 @test "converge: refuses to run with a dirty working tree" {

--- a/tools/check_pin_freshness.sh
+++ b/tools/check_pin_freshness.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# Fail if any wrangle self-reference pin resolves to STALE action code — i.e. the
+# pinned sha's tree for that path differs from HEAD's tree in something other than
+# the SHAs of the self-ref pins nested inside it. A pin can be reachable (an
+# ancestor of HEAD, so check_pin_ancestry is green) yet still resolve OLD code if
+# the path's scripts/logic changed after the pin was last bumped; the
+# showcase/integration then silently runs the stale action.
+#
+# Freshness is RESOLVED-content, not byte-identity of the tree: a converged
+# nested chain pins each composite at an OLDER sha whose own nested-pin SHAs
+# differ from HEAD's (each converge cycle re-bumps them), so a raw tree diff
+# would false-positive forever. So a path is fresh when its tree differs from
+# HEAD ONLY on self-ref `uses:` pin lines, AND every nested pin is itself fresh
+# (checked transitively by the BFS). Any non-pin change — e.g. #558's
+# run_verify.sh, while verify/action.yml stayed byte-identical — is STALE.
+#
+# Needs full history (CI runs it with fetch-depth: 0). Reachability is
+# check_pin_ancestry's job; both are required.
+#
+# Exit: 0 all fresh, 1 a pin is stale/missing, 2 usage/environment error.
+
+REPO_PREFIX="${WRANGLE_PINS_REPO:-TomHennen/wrangle}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=self_ref_pin_paths.sh
+source "$SCRIPT_DIR/self_ref_pin_paths.sh"
+
+repo_root="$(git rev-parse --show-toplevel)" || {
+    printf 'check_pin_freshness: not inside a git work tree\n' >&2
+    exit 2
+}
+
+mapfile -t pin_paths < <(wrangle_self_ref_pin_paths)
+search_dirs=()
+for rel in "${pin_paths[@]}"; do
+    [[ -d "$repo_root/$rel" ]] && search_dirs+=("$repo_root/$rel")
+done
+if [[ ${#search_dirs[@]} -eq 0 ]]; then
+    printf 'check_pin_freshness: none of the pin paths exist under %s\n' "$repo_root" >&2
+    exit 2
+fi
+
+# The prefix's '.' is escaped so an org/repo name can't act as a regex wildcard.
+escaped_prefix="$(printf '%s' "$REPO_PREFIX" | sed 's/\./\\./g')"
+pin_re="${escaped_prefix}/[^@[:space:]]+@[0-9a-f]{40}"
+
+# path_content_stale <sha> <subpath> — true (0) iff <subpath>'s tree at <sha>
+# differs from HEAD's in a line that is NOT a self-ref pin reference. Pin-SHA-only
+# differences are ignored here; each nested pin's own freshness is checked as the
+# BFS descends. -G/-S can't express "only these lines changed", so we diff with
+# no context and scan the +/- body lines.
+path_content_stale() {
+    local sha="$1" subpath="$2" line
+    while IFS= read -r line; do
+        # Skip diff headers (+++/---) and hunk markers; inspect only body changes.
+        case "$line" in
+            '+++ '* | '--- '* | '@@'*) continue ;;
+            '+'* | '-'*) ;;
+            *) continue ;;
+        esac
+        # A changed line that isn't a self-ref pin reference = real content drift.
+        if ! printf '%s' "${line:1}" | grep -qE "$pin_re"; then
+            return 0
+        fi
+    done < <(git -C "$repo_root" diff --unified=0 "$sha" HEAD -- "$subpath" 2>/dev/null)
+    return 1
+}
+
+# Seed from pins declared in the working tree. YAML only, skipping fixtures/, so
+# shell scripts and lint placeholders can't false-match.
+mapfile -t root_refs < <(
+    grep -rhoE --include='*.yml' --include='*.yaml' --exclude-dir=fixtures \
+        "$pin_re" "${search_dirs[@]}" 2>/dev/null | sort -u
+)
+
+if [[ ${#root_refs[@]} -eq 0 ]]; then
+    printf 'check_pin_freshness: no %s pins found in the pin paths\n' "$REPO_PREFIX"
+    exit 0
+fi
+
+# BFS; <via> carries the parent so a stale nested pin names its source.
+declare -A visited=()
+queue=()
+for ref in "${root_refs[@]}"; do
+    queue+=("declared|$ref")
+done
+
+rc=0
+checked=0
+while [[ ${#queue[@]} -gt 0 ]]; do
+    via="${queue[0]%%|*}"
+    ref="${queue[0]#*|}"
+    queue=("${queue[@]:1}")
+
+    rest="${ref#"$REPO_PREFIX"/}"
+    subpath="${rest%@*}"
+    sha="${rest##*@}"
+    key="$subpath@$sha"
+    [[ -n "${visited[$key]:-}" ]] && continue
+    visited[$key]=1
+    checked=$((checked + 1))
+
+    if ! git -C "$repo_root" cat-file -e "${sha}^{commit}" 2>/dev/null; then
+        printf 'MISSING: %s@%s — commit not present (shallow clone? the job needs fetch-depth: 0) [via %s]\n' \
+            "$subpath" "$sha" "$via" >&2
+        rc=1
+        continue
+    fi
+
+    # Stale = the pinned tree for this path differs from HEAD in any line that is
+    # NOT a self-ref pin SHA. Self-ref pin lines are excluded because a converged
+    # chain legitimately pins composites at older shas whose nested pin SHAs
+    # differ; those nested pins' freshness is verified separately as the BFS
+    # descends into them. Whole-path diff so a change to any script under the
+    # action dir is caught, not just action.yml.
+    if path_content_stale "$sha" "$subpath"; then
+        printf 'STALE: %s@%s — resolves non-pin content that differs from HEAD (re-bump with tools/converge_action_pins.sh) [via %s]\n' \
+            "$subpath" "${sha:0:9}" "$via" >&2
+        rc=1
+        # Still walk it: surfacing every stale hop in one run beats one-at-a-time.
+    fi
+
+    # Resolve the action at its pinned sha and walk the pins nested inside it.
+    # No action.yml at that sha = leaf (the ref may be a reusable workflow).
+    content="$(git -C "$repo_root" show "$sha:$subpath/action.yml" 2>/dev/null)" \
+        || content="$(git -C "$repo_root" show "$sha:$subpath/action.yaml" 2>/dev/null)" \
+        || content=""
+    [[ -z "$content" ]] && continue
+    while IFS= read -r nested; do
+        [[ -n "$nested" ]] && queue+=("${subpath}@${sha:0:9}|$nested")
+    done < <(printf '%s\n' "$content" | grep -hoE "$pin_re" | sort -u)
+done
+
+if [[ "$rc" -eq 0 ]]; then
+    printf 'check_pin_freshness: all %d wrangle self-ref pin(s) resolve to HEAD content\n' "$checked"
+fi
+exit "$rc"

--- a/tools/converge_action_pins.sh
+++ b/tools/converge_action_pins.sh
@@ -2,12 +2,15 @@
 set -euo pipefail
 set -f
 
-# Drive wrangle self-ref pins to convergence: if check_pin_ancestry is red,
-# bump every pin to HEAD, commit, and repeat until it's green. A nested chain
-# needs one commit per level (a commit can't pin itself), so this can emit >1
-# commit — land them as a MERGE COMMIT or a direct push to main, never a squash,
-# or the intermediate pins re-orphan. No-op (0 commits) when already green.
-# Requires a clean working tree; commits on the current branch; does not push.
+# Drive wrangle self-ref pins to convergence: while the nested chain isn't both
+# reachable (check_pin_ancestry) AND fresh (check_pin_freshness — every pin
+# resolves to HEAD's content), bump every pin to HEAD, commit, and repeat. A
+# nested chain needs one commit per level (a commit can't pin itself, and a
+# composite's nested pin only resolves to fresh content once that content is on
+# HEAD), so this can emit >1 commit — land them as a MERGE COMMIT or a direct
+# push to main, never a squash, or the intermediate pins re-orphan. No-op (0
+# commits) when already converged. Requires a clean working tree; commits on the
+# current branch; does not push.
 #
 # Usage: tools/converge_action_pins.sh
 # Env: WRANGLE_CONVERGE_MAX_ITERS (default 10); bump_action_pins.sh's
@@ -15,7 +18,12 @@ set -f
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 bump="$SCRIPT_DIR/bump_action_pins.sh"
-check="$SCRIPT_DIR/check_pin_ancestry.sh"
+ancestry="$SCRIPT_DIR/check_pin_ancestry.sh"
+freshness="$SCRIPT_DIR/check_pin_freshness.sh"
+
+# Converged = reachable AND fresh. Ancestry-only termination false-greens on a
+# stale-but-reachable chain (#552): the pins are ancestors yet resolve old code.
+converged_check() { "$ancestry" >/dev/null 2>&1 && "$freshness" >/dev/null 2>&1; }
 
 repo_root="$(git rev-parse --show-toplevel)" || {
     printf 'converge_action_pins: not inside a git work tree\n' >&2
@@ -27,7 +35,7 @@ if ! git -C "$repo_root" diff --quiet || ! git -C "$repo_root" diff --cached --q
     exit 2
 fi
 
-if "$check" >/dev/null 2>&1; then
+if converged_check; then
     printf 'converge_action_pins: already converged (0 commits).\n'
     exit 0
 fi
@@ -39,21 +47,22 @@ for ((i = 1; i <= max_iters; i++)); do
     "$bump" "$(git -C "$repo_root" rev-parse HEAD)" >/dev/null
     if git -C "$repo_root" diff --quiet; then
         # Bumping to HEAD changed nothing yet the check is still red: no prior
-        # commit carries a reachable nested pin, so no bump can resolve it.
+        # commit carries a reachable, fresh nested pin, so no bump can resolve it.
         printf 'converge_action_pins: cannot converge — bump is a no-op but the check is still red\n' >&2
         break
     fi
     git -C "$repo_root" commit -qam "chore: converge self-ref pins (cycle $i)"
     commits=$((commits + 1))
-    if "$check" >/dev/null 2>&1; then
+    if converged_check; then
         converged=true
         break
     fi
 done
 
 if [[ "$converged" != true ]]; then
-    printf 'converge_action_pins: not converged after %d commit(s); check_pin_ancestry:\n' "$commits" >&2
-    "$check" >&2 || true
+    printf 'converge_action_pins: not converged after %d commit(s); checks:\n' "$commits" >&2
+    "$ancestry" >&2 || true
+    "$freshness" >&2 || true
     exit 1
 fi
 


### PR DESCRIPTION
Fixes #552.

## Problem
`check_pin_ancestry` and `converge_action_pins` only react to *unreachable* self-ref pins. After an action's code changes and merges, a nested pin chain (e.g. `build_and_publish_go.yml → verify_release@A → verify@B`) can be **reachable but STALE** — every SHA is an ancestor, so ancestry passes, yet the chain resolves OLD action code. Verified 3× this session (#543→#546, #549→#551, #558); in #558 wrangle silently skipped uploading the go archive/checksums despite green CI — only a behavioral e2e caught it.

## Design

**1. Detection — `tools/check_pin_freshness.sh` (new).** For every wrangle self-ref pin (path set from `self_ref_pin_paths.sh`, third-party refs ignored), it follows the nested chain (`git show <sha>:<path>/action.yml`, walk nested pins — same BFS as ancestry) and flags any pin whose **resolved content differs from HEAD**.

Freshness is **resolved-content**, not raw tree identity. A converged nested chain legitimately pins each composite at an *older* SHA whose embedded nested-pin SHAs differ from HEAD's (each converge cycle re-bumps them), so a raw `git diff <sha> HEAD -- <path>` would false-positive forever. So a path is fresh when its tree differs from HEAD **only on self-ref `uses:` pin lines**, and every nested pin is itself fresh (checked transitively as the BFS descends). Any non-pin change is STALE. This is exactly #558: `verify_release@5d0d3553`'s only diff was the nested `verify` SHA, but the resolved `verify/run_verify.sh` had changed — a whole-tree-vs-action.yml-only check would each get it wrong; the resolved-content walk gets it right. Reachability and freshness are both required.

**2. Auto-fix — `converge_action_pins.sh` is now content-based.** It loops bump→commit until the chain is reachable **AND** fresh (both checks green), not until ancestry alone is green. Still one commit per nesting level; still a no-op when already converged.

**3. Tests.** New `test/test_check_pin_freshness.bats` (single-level, stale-but-reachable, action.yml-byte-identical-but-script-changed, nested 2-level, older-but-unchanged no-op, third-party ignored, missing-SHA, no-pins). `test/test_converge_action_pins.bats` gains the stale-but-reachable converge case (ancestry green + freshness red → converge → fresh) and keeps the orphan/squash 2-commit recovery.

## CI wiring + the merge-commit rationale
With merge-commits enabled, an action-change PR can converge its own pins **in-PR** (the merge commit keeps them reachable), so the chain is fresh at merge and freshness can gate the PR without redding main in the post-merge window. **But current `origin/main` is stale right now** (see below), so I wired freshness as an **advisory** (`continue-on-error: true`) step in the existing `pin-ancestry` job rather than blocking — blocking would have redded main on landing. Flip it to blocking once main is converged.

## Current-main freshness result
`origin/main` (`da3f6cb`) is **STALE**: `actions/verify@6b86c0f` resolves non-pin content (`run_verify.sh`, `emit_subjects.sh`, `install_tools.sh`) that differs from HEAD. Introduced by PR #556 (`da3f6cb`), which refactored `actions/verify` and bumped only the `attest_provenance` pin, leaving the `verify`/`verify_release`/`scan` chain pinned at the pre-refactor SHA. `scan` and `verify_release` themselves are **fresh** (their only diffs are nested pin SHAs). **Recommend a separate convergence bump** (`tools/converge_action_pins.sh`) to make main fresh, after which freshness can go blocking.

## #558 dogfood
At `edbb2d7a` (branch `go-wrangle-owns-publish`), chain `build_and_publish_go.yml → verify_release@5d0d3553 → verify@6b86c0f`:
- `check_pin_ancestry`: **PASS** — "all 18 wrangle self-ref pin(s) reachable from HEAD"
- `check_pin_freshness`: **FAIL** — "STALE: actions/verify@6b86c0ffc … [via actions/verify_release@5d0d3553b]"

Confirms the freshness check would have turned #558's silent false-green into a red CI check.

## Alternatives weighed
- *Compare `action.yml` only* — rejected: #558 changed `run_verify.sh` with a byte-identical `action.yml`; missed entirely.
- *Compare the whole tree byte-for-byte* — rejected: false-positives forever on converged chains (nested pin SHAs differ each cycle), and would have flagged `scan`/`verify_release` on main where only pin SHAs moved.
- *Block freshness in CI now* — rejected: main is currently stale, so it would red on landing.

All test layers green locally (`make test`: 1211 bats + shellcheck + shellstyle + workflowstyle + gotest + zizmor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)