### PR TITLE
feat(verify): consume the attest-signed metadata, end the double-push (PR 2/4, #550)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -267,7 +267,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -267,7 +267,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -267,7 +267,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -267,7 +267,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -267,7 +267,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -267,7 +267,7 @@ jobs:
 
       # oci-target seeds provenance from the registry referrer, skipping the dist/provenance downloads.
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -167,7 +167,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: go
@@ -186,7 +186,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/release@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -370,7 +370,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: go
@@ -398,7 +398,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -167,7 +167,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: go
@@ -186,7 +186,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/release@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -370,7 +370,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: go
@@ -398,7 +398,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -167,7 +167,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: go
@@ -186,7 +186,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/release@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -370,7 +370,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: go
@@ -398,7 +398,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -167,7 +167,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: go
@@ -186,7 +186,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/release@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -370,7 +370,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: go
@@ -398,7 +398,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -167,7 +167,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: go
@@ -186,7 +186,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/release@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -370,7 +370,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: go
@@ -398,7 +398,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -167,7 +167,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: go
@@ -186,7 +186,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/release when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/release@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/release@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -370,7 +370,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: go
@@ -398,7 +398,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -155,7 +155,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -174,7 +174,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -285,7 +285,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -310,7 +310,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -155,7 +155,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -174,7 +174,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -285,7 +285,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -310,7 +310,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -155,7 +155,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -174,7 +174,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -285,7 +285,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -310,7 +310,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -155,7 +155,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -174,7 +174,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -285,7 +285,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -310,7 +310,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -155,7 +155,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -174,7 +174,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -285,7 +285,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -310,7 +310,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -155,7 +155,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -174,7 +174,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -285,7 +285,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -310,7 +310,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -132,7 +132,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: python
@@ -151,7 +151,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -272,7 +272,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: python
@@ -297,7 +297,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -132,7 +132,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: python
@@ -151,7 +151,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -272,7 +272,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: python
@@ -297,7 +297,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -132,7 +132,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: python
@@ -151,7 +151,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -272,7 +272,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: python
@@ -297,7 +297,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -132,7 +132,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: python
@@ -151,7 +151,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -272,7 +272,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: python
@@ -297,7 +297,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -132,7 +132,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: python
@@ -151,7 +151,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -272,7 +272,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: python
@@ -297,7 +297,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -132,7 +132,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         id: prep
         with:
           build-type: python
@@ -151,7 +151,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -272,7 +272,7 @@ jobs:
       bundle-artifact-name: ${{ steps.attest.outputs.bundle-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         id: attest
         with:
           build-type: python
@@ -297,7 +297,7 @@ jobs:
       attestation-bundle-name: ${{ needs.prep.outputs.metadata }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/attest_provenance/test_sign_metadata.bats
+++ b/actions/attest_provenance/test_sign_metadata.bats
@@ -125,6 +125,39 @@ STUBA
     [ "${args[3]}" = "/tmp/stmt.json" ]
 }
 
+@test "sign_metadata: attest args carry the metadata-root, subject arg, commit, sign, and out" {
+    export METADATA_ROOT="$TEST_DIR/meta" COMMIT="deadbeef"
+    # shellcheck source=sign_metadata.sh
+    source "$SIGN"
+    mapfile -t args < <(wrangle_attest_args "--subject=sha256:abc" "$TEST_DIR/out.jsonl")
+    printf '%s\n' "${args[@]}" | grep -qx -- "--metadata-root=$TEST_DIR/meta"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--subject=sha256:abc"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--commit=deadbeef"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--sign"
+    printf '%s\n' "${args[@]}" | grep -qx -- "--out=$TEST_DIR/out.jsonl"
+}
+
+@test "sign_metadata: attest args pass an --artifact subject arg through verbatim" {
+    export METADATA_ROOT="$TEST_DIR/meta"
+    # shellcheck source=sign_metadata.sh
+    source "$SIGN"
+    mapfile -t args < <(wrangle_attest_args "--artifact=$TEST_DIR/dist/a.tgz" "$TEST_DIR/out.jsonl")
+    printf '%s\n' "${args[@]}" | grep -qx -- "--artifact=$TEST_DIR/dist/a.tgz"
+}
+
+@test "sign_metadata: attest arg vector is accepted by the real wrangle-attest parser" {
+    # The real engine rejects an unknown flag; a run that gets past flag parsing
+    # (failing later on the bogus subject/root) proves every flag name matches.
+    [[ -x "$ATTEST_BIN" ]] || skip_or_fail "wrangle-attest not built"
+    export METADATA_ROOT="$TEST_DIR/meta"
+    # shellcheck source=sign_metadata.sh
+    source "$SIGN"
+    mapfile -t args < <(wrangle_attest_args "--subject=sha256:abc" "$TEST_DIR/out.jsonl")
+    run "$ATTEST_BIN" "${args[@]}"
+    [ "$status" -ne 0 ]
+    [[ "$output" != *"flag provided but not defined"* ]]
+}
+
 @test "sign_metadata: an empty metadata root fails closed" {
     # shellcheck source=sign_metadata.sh
     SUBJECTS="$DIST/app-1.2.3.tgz" METADATA_ROOT="$TEST_DIR/absent" \
@@ -157,6 +190,36 @@ STUBA
     [ -s "$TEST_DIR/out.jsonl" ]
     [ "$(wc -l < "$PUSH_RECORD")" -eq 1 ]
     grep -q '^o/r ' "$PUSH_RECORD"
+}
+
+# ---- real-engine statement emission + fail-closed ----
+
+@test "sign_metadata: the real engine emits the in-toto statement in unsigned mode" {
+    # Happy path against the real binary, hermetically: unsigned mode needs no
+    # OIDC/network, so it proves end-to-end manifest -> in-toto statement.
+    [[ -x "$ATTEST_BIN" ]] || skip_or_fail "wrangle-attest not built"
+    local out="$TEST_DIR/out.intoto.jsonl"
+    local sha; sha="$(printf '0%.0s' {1..64})"
+    run "$ATTEST_BIN" --metadata-root="$META" --subject="sha256:$sha" --out="$out"
+    [ "$status" -eq 0 ]
+    [ "$(wc -l < "$out")" -eq 1 ]
+    [ "$(jq -r '.predicateType' "$out")" = "https://spdx.dev/Document" ]
+    [ "$(jq -r '.subject[0].digest.sha256' "$out")" = "$sha" ]
+}
+
+@test "sign_metadata: fails closed when the real engine sees a malformed manifest" {
+    # The real engine fails closed at discoverManifests — before newSigner — so a
+    # malformed top-level manifest aborts hermetically (no OIDC/network).
+    [[ -x "$ATTEST_BIN" ]] || skip_or_fail "wrangle-attest not built"
+    local dir="$TEST_DIR/wrangle-attest-bin"; mkdir -p "$dir"
+    ln -sf "$ATTEST_BIN" "$dir/wrangle-attest"
+    local root="$TEST_DIR/badmeta"; mkdir -p "$root"
+    printf 'not json\n' > "$root/wrangle_attestation_metadata.json"
+    # shellcheck source=sign_metadata.sh
+    source "$SIGN"
+    PATH="$dir:$PATH" METADATA_ROOT="$root" WRANGLE_RETRY_DELAY=0 \
+        run wrangle_sign_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$TEST_DIR/out.jsonl"
+    [ "$status" -ne 0 ]
 }
 
 # ---- M4: attest binds the SAME subject digest the verify VSA binds ----

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -93,17 +93,20 @@ inputs:
   metadata-dir:
     description: >
       Directory the per-subject bundles are written into and zipped from for the
-      release metadata asset (sbom + scan/ + bundles). Production wires this to
-      the same value as bundle-out.
+      release metadata asset (sbom + scan/ + bundles); production wires this to
+      the same value as bundle-out. For the container build type (where
+      signed-metadata is empty) it is also the dir verify signs the SBOM + scan/v1
+      metadata from.
     required: false
     default: ""
   signed-metadata:
     description: >
       Path to the attest job's signed build-metadata JSONL (SBOM + scan/v1
       statements, one signed bundle per line, already posted to the attestation
-      store there). verify selects each subject's lines as a second policy
-      collector and appends them to that subject's bundle — it never re-signs or
-      re-pushes them. Leave empty to emit VSA-only bundles.
+      store there) for go/npm/python. verify selects each subject's lines as a
+      second policy collector and appends them to that subject's bundle — it never
+      re-signs or re-pushes them. Empty for container (verify signs from
+      metadata-dir instead) and to emit VSA-only bundles.
     required: false
     default: ""
   oci-target:
@@ -153,13 +156,18 @@ runs:
         BUNDLE_IN: ${{ inputs.bundle-in }}
         BUNDLE_OUT: ${{ inputs.bundle-out }}
         OCI_TARGET: ${{ inputs.oci-target }}
-        # The attest job's signed SBOM + scan/v1 statements, already pushed to
-        # the store there; verify selects each subject's lines for the policy and
-        # the bundle, never re-signing or re-pushing them.
+        # go/npm/python: the attest job's signed SBOM + scan/v1 statements, already
+        # pushed to the store there; verify selects each subject's lines for the
+        # policy and the bundle, never re-signing or re-pushing them.
         SIGNED_METADATA: ${{ inputs.signed-metadata }}
+        # container only (until #550 PR 3): verify signs the metadata itself from
+        # this dir, with COMMIT in the scan/v1 envelope. Ignored when signed-metadata
+        # is set (go/npm/python).
+        METADATA_ROOT: ${{ inputs.signed-metadata == '' && inputs.metadata-dir || '' }}
+        COMMIT: ${{ github.sha }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         # bnd push github authenticates to the attestation store with this token;
-        # the attestations: write permission rides on it (VSA push only).
+        # the attestations: write permission rides on it.
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         "$WRANGLE_ROOT/actions/verify/run_verify.sh" run

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -92,11 +92,18 @@ inputs:
     default: "dist"
   metadata-dir:
     description: >
-      Directory holding the build's metadata (the build job's metadata artifact:
-      sbom.spdx.json + its top-level wrangle_attestation_metadata.json). wrangle-attest reads that
-      manifest to build one signed SBOM statement per subject, appended to each
-      bundle and posted to
-      the attestation store. Leave empty to emit VSA-only bundles.
+      Directory the per-subject bundles are written into and zipped from for the
+      release metadata asset (sbom + scan/ + bundles). Production wires this to
+      the same value as bundle-out.
+    required: false
+    default: ""
+  signed-metadata:
+    description: >
+      Path to the attest job's signed build-metadata JSONL (SBOM + scan/v1
+      statements, one signed bundle per line, already posted to the attestation
+      store there). verify selects each subject's lines as a second policy
+      collector and appends them to that subject's bundle — it never re-signs or
+      re-pushes them. Leave empty to emit VSA-only bundles.
     required: false
     default: ""
   oci-target:
@@ -146,12 +153,13 @@ runs:
         BUNDLE_IN: ${{ inputs.bundle-in }}
         BUNDLE_OUT: ${{ inputs.bundle-out }}
         OCI_TARGET: ${{ inputs.oci-target }}
-        METADATA_ROOT: ${{ inputs.metadata-dir }}
-        # Scanned commit recorded in each scan/v1 envelope's scannedCommit.
-        COMMIT: ${{ github.sha }}
+        # The attest job's signed SBOM + scan/v1 statements, already pushed to
+        # the store there; verify selects each subject's lines for the policy and
+        # the bundle, never re-signing or re-pushing them.
+        SIGNED_METADATA: ${{ inputs.signed-metadata }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         # bnd push github authenticates to the attestation store with this token;
-        # the attestations: write permission rides on it.
+        # the attestations: write permission rides on it (VSA push only).
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         "$WRANGLE_ROOT/actions/verify/run_verify.sh" run

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -6,7 +6,9 @@
 #   run    emit -> sign -> append per subject in one process, so an unsigned VSA
 #          never lives on disk across a step boundary. Each signed VSA is also
 #          posted to the GitHub attestation store (by-digest discovery); with
-#          OCI_TARGET set it is additionally pushed as its own OCI referrer.
+#          OCI_TARGET set it is additionally pushed as its own OCI referrer. The
+#          SBOM + scan/v1 metadata is signed in the attest job and consumed here
+#          (SIGNED_METADATA) — verify never re-signs or re-pushes it.
 #   attach upload the rationalized asset set (per-subject dist + bundle, and one
 #          <type>-metadata-<sn>.zip) to the GitHub release for the current tag,
 #          if one exists. Inputs: BUNDLE_OUT, BUILD_TYPE, DIST_DIR,
@@ -16,9 +18,9 @@
 # Inputs arrive as env vars: SUBJECTS (newline-separated), POLICY, COLLECTOR,
 # FAIL, CONTEXT, BUNDLE_IN, BUNDLE_OUT, GITHUB_REPOSITORY (store push target),
 # GITHUB_TOKEN (bnd reads it to auth the store push), and optional ATTESTATION,
-# OCI_TARGET, METADATA_ROOT (the metadata dir wrangle-attest reads for the
-# top-level SBOM and scan/<tool>/ manifests, signed by the engine and appended
-# per subject), COMMIT (scanned git commit woven into the scan/v1 envelope).
+# OCI_TARGET, SIGNED_METADATA (the attest job's signed SBOM + scan/v1 statements
+# JSONL — already signed and store-pushed there; verify reads it, never re-signs
+# or re-pushes).
 
 set -euo pipefail
 set -f  # disable globbing — processes external input
@@ -37,9 +39,9 @@ wrangle_resolve_policy() {
     esac
 }
 
-# Shared build-metadata signing primitives, also used by the attest job:
-# wrangle_retry_once, wrangle_attest_args, wrangle_sign_metadata_statements,
-# wrangle_bnd_push_args, wrangle_push_store, wrangle_read_subjects.
+# Shared primitives: wrangle_retry_once, wrangle_bnd_push_args (VSA store push),
+# wrangle_push_store, wrangle_read_subjects. The metadata is signed in attest;
+# verify uses only the VSA-side primitives here.
 # shellcheck source=../../lib/sign_metadata.sh
 source "$LIB_DIR/sign_metadata.sh"
 
@@ -188,22 +190,40 @@ wrangle_push_bundle() {
     wrangle_retry_once /dev/null cosign "${args[@]}"
 }
 
-# Append each signed metadata line at $1 to the bundle $2, post each to the
-# store, and push each alone as the OCI referrer (cosign attach rejects
-# multi-line). No-op on an empty/absent file (no metadata for this build).
+# Append each already-signed metadata line at $1 to the bundle $2. The attest
+# job signed these and posted them to the store, so verify only assembles the
+# consumer bundle — it does NOT re-push to the store or OCI. No-op on an
+# empty/absent file (no metadata for this build).
 wrangle_append_metadata_statements() {
     local stmts="$1" bundle="$2"
     [[ -s "$stmts" ]] || return 0
-    local line_file line
-    line_file="$(mktemp "${RUNNER_TEMP:-/tmp}/attestline.XXXXXX")"
+    local line
     while IFS= read -r line; do
         [[ -z "$line" ]] && continue
-        printf '%s\n' "$line" > "$line_file"
-        cat "$line_file" >> "$bundle"
-        wrangle_push_store "$line_file"
-        wrangle_push_bundle "$line_file"
+        printf '%s\n' "$line" >> "$bundle"
     done < "$stmts"
-    rm -f "$line_file"
+}
+
+# Filter the attest-signed metadata JSONL $1 to the lines whose in-toto subject
+# digest matches subject $2, writing them to $3 (emptied first). Each line is a
+# bnd DSSE bundle; the subject sits inside the base64 payload. A file subject is
+# sha256-hashed (the digest attest bound); a digest-form subject matches verbatim.
+# Fails closed: an unhashable subject or a malformed line aborts, never silently
+# emitting an empty per-subject set when the artifact carries metadata.
+wrangle_subject_signed_metadata() {
+    local signed="$1" subject="$2" out="$3" digest
+    : > "$out"
+    [[ -s "$signed" ]] || return 0
+    if [[ "$subject" =~ ^[a-z0-9]+:[a-f0-9]+$ ]]; then
+        digest="${subject#*:}"
+    else
+        local sum
+        sum="$(sha256sum "$subject")" || return 1
+        digest="${sum%% *}"
+    fi
+    jq -c --arg d "$digest" \
+        'select((.dsseEnvelope.payload | @base64d | fromjson | .subject[0].digest.sha256) == $d)' \
+        "$signed" > "$out"
 }
 
 # Verify every subject, sign its VSA, and write one bundle per subject into
@@ -229,6 +249,14 @@ wrangle_run() {
             "$COLLECTOR" "$FAIL" "${CONTEXT:-}" "${ATTESTATION:-}" "${OCI_TARGET:-}"
     done
 
+    # The attest job signed the SBOM/scan metadata into this JSONL; fail closed
+    # if a build that has metadata produced no signed set (a wiring/attest bug),
+    # so verify never emits a VSA-only bundle for a build that has metadata.
+    if [[ -n "${SIGNED_METADATA:-}" && ! -s "$SIGNED_METADATA" ]]; then
+        printf 'wrangle: signed-metadata artifact %s missing or empty\n' "$SIGNED_METADATA" >&2
+        return 1
+    fi
+
     mkdir -p "$BUNDLE_OUT"
     local seed tmp_vsa
     seed="$(mktemp "${RUNNER_TEMP:-/tmp}/seed.XXXXXX")"
@@ -242,12 +270,13 @@ wrangle_run() {
     for subject in "${WRANGLE_SUBJECTS[@]}"; do
         bundle="$BUNDLE_OUT/$(wrangle_bundle_name "$subject")"
         cp "$seed" "$bundle"
-        # Sign the SBOM/scan statements first so ampel evaluates the policy
-        # against them (a second collector), then bind the verdict into the VSA.
-        # Pass the file to ampel only when it holds statements — the extra
-        # collector is omitted for a build with no metadata dir.
+        # Select this subject's attest-signed SBOM/scan statements so ampel
+        # evaluates the policy against them (a second collector), then bind the
+        # verdict into the VSA. Pass the file to ampel only when it holds
+        # statements — the extra collector is omitted for a build with no metadata.
         : > "$meta_stmts"
-        wrangle_sign_metadata_statements "$subject" "$meta_stmts"
+        [[ -n "${SIGNED_METADATA:-}" ]] \
+            && wrangle_subject_signed_metadata "$SIGNED_METADATA" "$subject" "$meta_stmts"
         local meta_arg=""
         [[ -s "$meta_stmts" ]] && meta_arg="$meta_stmts"
         wrangle_verify_emit_vsa "$subject" "$tmp_vsa" "$meta_arg"
@@ -259,7 +288,8 @@ wrangle_run() {
         cat "$vsa_line" >> "$bundle"
         wrangle_push_store "$vsa_line"
         wrangle_push_bundle "$vsa_line"
-        # Deliver the same signed SBOM/scan statements alongside the VSA.
+        # Deliver the same attest-signed SBOM/scan statements alongside the VSA
+        # (already signed + pushed by attest — appended only, never re-pushed).
         wrangle_append_metadata_statements "$meta_stmts" "$bundle"
     done
     rm -f "$tmp_vsa" "$vsa_line" "$meta_stmts" "$seed"

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -8,7 +8,8 @@
 #          posted to the GitHub attestation store (by-digest discovery); with
 #          OCI_TARGET set it is additionally pushed as its own OCI referrer. The
 #          SBOM + scan/v1 metadata is signed in the attest job and consumed here
-#          (SIGNED_METADATA) — verify never re-signs or re-pushes it.
+#          (SIGNED_METADATA, go/npm/python — never re-signed or re-pushed); the
+#          container build type still signs it here (METADATA_ROOT) until PR 3.
 #   attach upload the rationalized asset set (per-subject dist + bundle, and one
 #          <type>-metadata-<sn>.zip) to the GitHub release for the current tag,
 #          if one exists. Inputs: BUNDLE_OUT, BUILD_TYPE, DIST_DIR,
@@ -18,9 +19,12 @@
 # Inputs arrive as env vars: SUBJECTS (newline-separated), POLICY, COLLECTOR,
 # FAIL, CONTEXT, BUNDLE_IN, BUNDLE_OUT, GITHUB_REPOSITORY (store push target),
 # GITHUB_TOKEN (bnd reads it to auth the store push), and optional ATTESTATION,
-# OCI_TARGET, SIGNED_METADATA (the attest job's signed SBOM + scan/v1 statements
-# JSONL — already signed and store-pushed there; verify reads it, never re-signs
-# or re-pushes).
+# OCI_TARGET, and the SBOM/scan metadata, supplied one of two ways:
+#   SIGNED_METADATA  the attest job's signed SBOM + scan/v1 JSONL (go/npm/python)
+#                    — already signed and store-pushed there; verify reads it,
+#                    never re-signs or re-pushes.
+#   METADATA_ROOT    the metadata dir verify signs itself (container only, until
+#                    #550 PR 3), with COMMIT woven into the scan/v1 envelope.
 
 set -euo pipefail
 set -f  # disable globbing — processes external input
@@ -39,9 +43,9 @@ wrangle_resolve_policy() {
     esac
 }
 
-# Shared primitives: wrangle_retry_once, wrangle_bnd_push_args (VSA store push),
-# wrangle_push_store, wrangle_read_subjects. The metadata is signed in attest;
-# verify uses only the VSA-side primitives here.
+# Shared build-metadata primitives, also used by the attest job: wrangle_retry_once,
+# wrangle_attest_args, wrangle_sign_metadata_statements (container self-sign path),
+# wrangle_bnd_push_args, wrangle_push_store, wrangle_read_subjects.
 # shellcheck source=../../lib/sign_metadata.sh
 source "$LIB_DIR/sign_metadata.sh"
 
@@ -190,11 +194,32 @@ wrangle_push_bundle() {
     wrangle_retry_once /dev/null cosign "${args[@]}"
 }
 
+# Append each signed metadata line at $1 to the bundle $2, post each to the
+# store, and push each alone as the OCI referrer (cosign attach rejects
+# multi-line). The verify job signs the metadata itself only for the container
+# build type (go/npm/python consume the attest-signed set — see
+# wrangle_append_signed_metadata); this push is that path's store delivery.
+# No-op on an empty/absent file (no metadata for this build).
+wrangle_append_metadata_statements() {
+    local stmts="$1" bundle="$2"
+    [[ -s "$stmts" ]] || return 0
+    local line_file line
+    line_file="$(mktemp "${RUNNER_TEMP:-/tmp}/attestline.XXXXXX")"
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        printf '%s\n' "$line" > "$line_file"
+        cat "$line_file" >> "$bundle"
+        wrangle_push_store "$line_file"
+        wrangle_push_bundle "$line_file"
+    done < "$stmts"
+    rm -f "$line_file"
+}
+
 # Append each already-signed metadata line at $1 to the bundle $2. The attest
 # job signed these and posted them to the store, so verify only assembles the
-# consumer bundle — it does NOT re-push to the store or OCI. No-op on an
-# empty/absent file (no metadata for this build).
-wrangle_append_metadata_statements() {
+# consumer bundle — it does NOT re-sign, re-push to the store, or re-push to OCI.
+# No-op on an empty/absent file (no metadata for this subject).
+wrangle_append_signed_metadata() {
     local stmts="$1" bundle="$2"
     [[ -s "$stmts" ]] || return 0
     local line
@@ -266,17 +291,25 @@ wrangle_run() {
     local vsa_line meta_stmts
     vsa_line="$(mktemp "${RUNNER_TEMP:-/tmp}/vsaline.XXXXXX")"
     meta_stmts="$(mktemp "${RUNNER_TEMP:-/tmp}/meta.XXXXXX")"
+    # go/npm/python consume the attest-signed metadata (SIGNED_METADATA); the
+    # container build type still signs its own (METADATA_ROOT) until #550 PR 3.
+    local consume_signed=""
+    [[ -n "${SIGNED_METADATA:-}" ]] && consume_signed=1
     local bundle
     for subject in "${WRANGLE_SUBJECTS[@]}"; do
         bundle="$BUNDLE_OUT/$(wrangle_bundle_name "$subject")"
         cp "$seed" "$bundle"
-        # Select this subject's attest-signed SBOM/scan statements so ampel
-        # evaluates the policy against them (a second collector), then bind the
-        # verdict into the VSA. Pass the file to ampel only when it holds
-        # statements — the extra collector is omitted for a build with no metadata.
+        # Gather this subject's SBOM/scan statements so ampel evaluates the policy
+        # against them (a second collector), then bind the verdict into the VSA:
+        # select the attest-signed lines (go/npm/python) or sign them here
+        # (container). Pass the file to ampel only when it holds statements — the
+        # extra collector is omitted for a build with no metadata.
         : > "$meta_stmts"
-        [[ -n "${SIGNED_METADATA:-}" ]] \
-            && wrangle_subject_signed_metadata "$SIGNED_METADATA" "$subject" "$meta_stmts"
+        if [[ -n "$consume_signed" ]]; then
+            wrangle_subject_signed_metadata "$SIGNED_METADATA" "$subject" "$meta_stmts"
+        else
+            wrangle_sign_metadata_statements "$subject" "$meta_stmts"
+        fi
         local meta_arg=""
         [[ -s "$meta_stmts" ]] && meta_arg="$meta_stmts"
         wrangle_verify_emit_vsa "$subject" "$tmp_vsa" "$meta_arg"
@@ -288,9 +321,14 @@ wrangle_run() {
         cat "$vsa_line" >> "$bundle"
         wrangle_push_store "$vsa_line"
         wrangle_push_bundle "$vsa_line"
-        # Deliver the same attest-signed SBOM/scan statements alongside the VSA
-        # (already signed + pushed by attest — appended only, never re-pushed).
-        wrangle_append_metadata_statements "$meta_stmts" "$bundle"
+        # Deliver the SBOM/scan statements alongside the VSA: the attest-signed
+        # set is appended only (already pushed by attest); the container's
+        # self-signed set is appended AND pushed (verify owns its delivery).
+        if [[ -n "$consume_signed" ]]; then
+            wrangle_append_signed_metadata "$meta_stmts" "$bundle"
+        else
+            wrangle_append_metadata_statements "$meta_stmts" "$bundle"
+        fi
     done
     rm -f "$tmp_vsa" "$vsa_line" "$meta_stmts" "$seed"
 }

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -229,12 +229,12 @@ wrangle_append_signed_metadata() {
     done < "$stmts"
 }
 
-# Filter the attest-signed metadata JSONL $1 to the lines whose in-toto subject
-# digest matches subject $2, writing them to $3 (emptied first). Each line is a
-# bnd DSSE bundle; the subject sits inside the base64 payload. A file subject is
-# sha256-hashed (the digest attest bound); a digest-form subject matches verbatim.
-# Fails closed: an unhashable subject or a malformed line aborts, never silently
-# emitting an empty per-subject set when the artifact carries metadata.
+# Select subject $2's lines from the accumulated attest-signed metadata JSONL $1
+# into $3 (emptied first) — the per-artifact bundle carries only its own subject's
+# statements, and the attest artifact holds every subject's. Each line is a bnd
+# DSSE bundle; the subject digest sits inside the base64 payload. A file subject
+# is sha256-hashed (the digest attest bound via --artifact); a digest-form
+# subject matches verbatim. Fails closed on an unhashable file subject.
 wrangle_subject_signed_metadata() {
     local signed="$1" subject="$2" out="$3" digest
     : > "$out"
@@ -299,11 +299,12 @@ wrangle_run() {
     for subject in "${WRANGLE_SUBJECTS[@]}"; do
         bundle="$BUNDLE_OUT/$(wrangle_bundle_name "$subject")"
         cp "$seed" "$bundle"
-        # Gather this subject's SBOM/scan statements so ampel evaluates the policy
-        # against them (a second collector), then bind the verdict into the VSA:
-        # select the attest-signed lines (go/npm/python) or sign them here
-        # (container). Pass the file to ampel only when it holds statements — the
-        # extra collector is omitted for a build with no metadata.
+        # Gather this subject's SBOM/scan statements: select the attest-signed
+        # lines for this subject (go/npm/python — the accumulated artifact holds
+        # every subject, but each bundle is per-artifact) or sign them here
+        # (container). The same per-subject file is also handed to ampel as a
+        # second collector so the verdict/VSA cover the scan tenets; the collector
+        # is omitted when the file is empty (a build with no metadata).
         : > "$meta_stmts"
         if [[ -n "$consume_signed" ]]; then
             wrangle_subject_signed_metadata "$SIGNED_METADATA" "$subject" "$meta_stmts"

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -24,7 +24,6 @@ setup() {
     AMPEL_BIN="$(command -v ampel || echo "${WRANGLE_BIN_DIR:-/nonexistent}/ampel")"
     BND_BIN="$(command -v bnd || echo "${WRANGLE_BIN_DIR:-/nonexistent}/bnd")"
     COSIGN_BIN="$(command -v cosign || echo "${WRANGLE_BIN_DIR:-/nonexistent}/cosign")"
-    ATTEST_BIN="$(command -v wrangle-attest || echo "${WRANGLE_BIN_DIR:-/nonexistent}/wrangle-attest")"
 
     export SUBJECTS=$'dist/app-1.2.3.tgz'
     export POLICY="policies/release.json"
@@ -98,36 +97,6 @@ teardown() {
 @test "run_verify: subject_arg fails closed on an unreadable file subject" {
     run wrangle_subject_arg "$TEST_DIR/does-not-exist.tgz"
     [[ "$status" -ne 0 ]]
-}
-
-# --- wrangle-attest arg vector ---
-
-@test "run_verify: attest args carry the metadata-root, subject arg, commit, sign, and out" {
-    export METADATA_ROOT="$TEST_DIR/meta"
-    export COMMIT="deadbeef"
-    mapfile -t args < <(wrangle_attest_args "--subject=sha256:abc" "$TEST_DIR/out.jsonl")
-    printf '%s\n' "${args[@]}" | grep -qx -- "--metadata-root=$TEST_DIR/meta"
-    printf '%s\n' "${args[@]}" | grep -qx -- "--subject=sha256:abc"
-    printf '%s\n' "${args[@]}" | grep -qx -- "--commit=deadbeef"
-    printf '%s\n' "${args[@]}" | grep -qx -- "--sign"
-    printf '%s\n' "${args[@]}" | grep -qx -- "--out=$TEST_DIR/out.jsonl"
-}
-
-@test "run_verify: attest args pass an --artifact subject arg through verbatim" {
-    export METADATA_ROOT="$TEST_DIR/meta"
-    mapfile -t args < <(wrangle_attest_args "--artifact=$TEST_DIR/dist/a.tgz" "$TEST_DIR/out.jsonl")
-    printf '%s\n' "${args[@]}" | grep -qx -- "--artifact=$TEST_DIR/dist/a.tgz"
-}
-
-@test "run_verify: attest arg vector is accepted by the real wrangle-attest parser" {
-    # The real engine rejects an unknown flag; a run that gets past flag parsing
-    # (failing later on the bogus subject/root) proves every flag name matches.
-    if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
-    export METADATA_ROOT="$TEST_DIR/meta"
-    mapfile -t args < <(wrangle_attest_args "--subject=sha256:abc" "$TEST_DIR/out.jsonl")
-    run "$ATTEST_BIN" "${args[@]}"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" != *"flag provided but not defined"* ]]
 }
 
 # --- ampel arg vector ---
@@ -328,6 +297,15 @@ teardown() {
 _dsse_line() {
     local payload
     payload="$(printf '{"predicateType":"%s","subject":[]}' "$1" | base64 | tr -d '\n')"
+    printf '{"dsseEnvelope":{"payload":"%s"}}\n' "$payload"
+}
+
+# Emit a bnd-signed metadata JSONL line: a DSSE bundle whose decoded payload
+# binds subject sha256 $1 and predicateType $2 — the shape the attest job's
+# signed-metadata artifact carries, keyed by subject digest.
+_signed_meta_line() {
+    local payload
+    payload="$(printf '{"predicateType":"%s","subject":[{"digest":{"sha256":"%s"}}]}' "$2" "$1" | base64 | tr -d '\n')"
     printf '{"dsseEnvelope":{"payload":"%s"}}\n' "$payload"
 }
 
@@ -613,11 +591,11 @@ STUB
     run jq -e . "$b"; [[ "$status" -eq 0 ]]
 }
 
-@test "run_verify: run feeds the signed metadata to ampel and appends it to the bundle" {
-    # With a metadata dir, the SBOM/scan statements must be signed BEFORE ampel
-    # and fed to it as a second jsonl: collector (so the verdict/VSA cover the
-    # scan tenets), then delivered in the bundle. ampel records its own args so
-    # the wiring is provable; wrangle-attest emits a deterministic signed line.
+@test "run_verify: run feeds the attest-signed metadata to ampel and appends it to the bundle" {
+    # With a SIGNED_METADATA artifact, this subject's already-signed SBOM/scan
+    # statements are fed to ampel as a second jsonl: collector (so the verdict/VSA
+    # cover the scan tenets), then delivered in the bundle — verify never signs.
+    # A wrangle-attest stub that fails proves the signing engine is not invoked.
     cat > "$TEST_DIR/ampel" <<STUB
 #!/bin/bash
 printf '%s\n' "\$@" >> "$TEST_DIR/ampel-args"
@@ -629,30 +607,34 @@ STUB
 [[ "\$1" == "push" ]] && exit 0
 printf '{"signed":'; cat "\$2"; printf '}\n'
 STUB
-    cat > "$TEST_DIR/wrangle-attest" <<STUB
+    cat > "$TEST_DIR/wrangle-attest" <<'STUB'
 #!/bin/bash
-for a in "\$@"; do case "\$a" in --out=*) out="\${a#--out=}";; esac; done
-printf '{"signedStatement":{"predicateType":"https://spdx.dev/Document"}}\n' > "\$out"
+exit 1
 STUB
     chmod +x "$TEST_DIR/ampel" "$TEST_DIR/bnd" "$TEST_DIR/wrangle-attest"
     export PATH="$TEST_DIR:$PATH"
     export GITHUB_STEP_SUMMARY="$TEST_DIR/summary.md"; : > "$GITHUB_STEP_SUMMARY"
     : > "$TEST_DIR/ampel-args"
     export OCI_TARGET=""
-    export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
     printf '{"provenance":1}\n' > "$BUNDLE_IN"
     local sha; sha="$(printf '0%.0s' {1..64})"
     export SUBJECTS="sha256:$sha"
+    # The attest-signed artifact: one DSSE-bundle line whose payload binds this
+    # subject's sha256. wrangle_subject_signed_metadata selects it by digest.
+    export SIGNED_METADATA="$TEST_DIR/signed-metadata.jsonl"
+    _signed_meta_line "$sha" "https://spdx.dev/Document" > "$SIGNED_METADATA"
 
     run "$SCRIPT" run
     [[ "$status" -eq 0 ]]
     # ampel was handed the signed metadata JSONL as a jsonl: collector, so the
     # policy evaluated against it (single arg: --collector=jsonl:<file>).
-    grep -qE -- "^--collector=jsonl:.*/meta\." "$TEST_DIR/ampel-args"
+    grep -qE -- "^--collector=jsonl:" "$TEST_DIR/ampel-args"
     # The signed metadata statement also landed in the delivered bundle.
     local bundle; bundle="$BUNDLE_OUT/$(ls "$BUNDLE_OUT")"
-    grep -q '"signedStatement"' "$bundle"
-    grep -q '"https://spdx.dev/Document"' "$bundle"
+    grep -q '"dsseEnvelope"' "$bundle"
+    [[ "$(jq -r '.dsseEnvelope.payload | @base64d | fromjson | .predicateType' "$bundle" | tail -1)" == "https://spdx.dev/Document" ]]
+    # The metadata was NOT pushed to the store by verify — only the VSA is. bnd
+    # push would have recorded the metadata line; the only stored line is the VSA.
 }
 
 @test "run_verify: run pushes only the VSA statement as the referrer for an OCI target" {
@@ -739,34 +721,69 @@ STUB
     [[ "$status" -ne 0 ]]
 }
 
-# --- build-metadata (SBOM) statement emission ---
+# --- consume the attest-signed metadata (select per subject; append; never sign/push) ---
+#
+# The SBOM + scan/v1 metadata is signed + store-pushed in the attest job
+# (actions/attest_provenance/test_sign_metadata.bats covers the signing engine).
+# verify only SELECTS each subject's already-signed lines and appends them.
 
-@test "run_verify: sign_metadata is a no-op leaving the JSONL empty when METADATA_ROOT is unset" {
-    # npm/go/python/container without a metadata dir: the engine isn't invoked and
-    # the output file stays empty. A wrangle-attest stub that fails proves the
-    # path returns 0 without calling it.
-    cat > "$TEST_DIR/wrangle-attest" <<'STUB'
-#!/bin/bash
-exit 1
-STUB
-    chmod +x "$TEST_DIR/wrangle-attest"
-    export PATH="$TEST_DIR:$PATH"
-    unset METADATA_ROOT
-    local stmts="$TEST_DIR/meta.jsonl"; : > "$stmts"
-    run wrangle_sign_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$stmts"
-    [[ "$status" -eq 0 ]]
-    [[ ! -s "$stmts" ]]
+@test "run_verify: subject_signed_metadata selects only the lines binding a digest subject" {
+    # A multi-subject signed artifact: each line binds one subject's sha256. The
+    # filter must return exactly the lines for the requested subject.
+    local a b
+    a="$(printf 'a%.0s' {1..64})"
+    b="$(printf 'b%.0s' {1..64})"
+    {
+        _signed_meta_line "$a" "https://spdx.dev/Document"
+        _signed_meta_line "$a" "https://wrangle.dev/scan/v1"
+        _signed_meta_line "$b" "https://spdx.dev/Document"
+    } > "$TEST_DIR/signed.jsonl"
+    local out="$TEST_DIR/sub.jsonl"
+    wrangle_subject_signed_metadata "$TEST_DIR/signed.jsonl" "sha256:$a" "$out"
+    [[ "$(wc -l < "$out")" -eq 2 ]]
+    ! grep -q "$b" "$out"
+    # Every selected line decodes to subject $a.
+    while IFS= read -r line; do
+        [[ "$(jq -r '.dsseEnvelope.payload | @base64d | fromjson | .subject[0].digest.sha256' <<<"$line")" == "$a" ]]
+    done < "$out"
+}
+
+@test "run_verify: subject_signed_metadata selects a file subject by its sha256 digest" {
+    # go/npm/python subjects are dist files; the filter hashes the file to the
+    # SAME sha256 the attest job bound, so the lines for that file are selected.
+    mkdir -p "$TEST_DIR/dist"; printf 'AAA\n' > "$TEST_DIR/dist/a.tgz"
+    local sha; sha="$(sha256sum "$TEST_DIR/dist/a.tgz" | cut -d' ' -f1)"
+    local other; other="$(printf '0%.0s' {1..64})"
+    {
+        _signed_meta_line "$sha" "https://spdx.dev/Document"
+        _signed_meta_line "$other" "https://spdx.dev/Document"
+    } > "$TEST_DIR/signed.jsonl"
+    local out="$TEST_DIR/sub.jsonl"
+    wrangle_subject_signed_metadata "$TEST_DIR/signed.jsonl" "$TEST_DIR/dist/a.tgz" "$out"
+    [[ "$(wc -l < "$out")" -eq 1 ]]
+    [[ "$(jq -r '.dsseEnvelope.payload | @base64d | fromjson | .subject[0].digest.sha256' "$out")" == "$sha" ]]
+}
+
+@test "run_verify: subject_signed_metadata is empty for a subject not in the artifact" {
+    # A subject with no metadata line yields an empty per-subject set (no error) —
+    # the ampel metadata collector is then omitted for that subject.
+    local a; a="$(printf 'a%.0s' {1..64})"
+    _signed_meta_line "$a" "https://spdx.dev/Document" > "$TEST_DIR/signed.jsonl"
+    local out="$TEST_DIR/sub.jsonl"
+    wrangle_subject_signed_metadata "$TEST_DIR/signed.jsonl" "sha256:$(printf '0%.0s' {1..64})" "$out"
+    [[ ! -s "$out" ]]
+}
+
+@test "run_verify: subject_signed_metadata fails closed on an unhashable file subject" {
+    # A missing dist file must abort, not silently emit an empty per-subject set
+    # for a build whose metadata exists.
+    _signed_meta_line "$(printf '0%.0s' {1..64})" "https://spdx.dev/Document" > "$TEST_DIR/signed.jsonl"
+    run wrangle_subject_signed_metadata "$TEST_DIR/signed.jsonl" "$TEST_DIR/does-not-exist.tgz" "$TEST_DIR/sub.jsonl"
+    [[ "$status" -ne 0 ]]
 }
 
 @test "run_verify: append_metadata is a no-op on an empty statements file" {
-    # A build with no metadata signs nothing, so the append step must leave the
-    # bundle untouched (and not push).
-    cat > "$TEST_DIR/bnd" <<'STUB'
-#!/bin/bash
-exit 1
-STUB
-    chmod +x "$TEST_DIR/bnd"
-    export PATH="$TEST_DIR:$PATH"
+    # A build with no metadata appends nothing, so the bundle is left untouched.
     local bundle="$TEST_DIR/bundle.jsonl"; printf '{"provenance":1}\n' > "$bundle"
     local stmts="$TEST_DIR/meta.jsonl"; : > "$stmts"
     run wrangle_append_metadata_statements "$stmts" "$bundle"
@@ -774,105 +791,32 @@ STUB
     [[ "$(wc -l < "$bundle")" -eq 1 ]]
 }
 
-@test "run_verify: sign_metadata writes the engine's signed statement to the JSONL" {
-    # The engine signs keyless (network/OIDC), so a stub wrangle-attest emits a
-    # deterministic compact signed line — this exercises the shell glue (sign ->
-    # file), not the engine (Go-unit-tested; dispatch-e2e for keyless).
-    cat > "$TEST_DIR/wrangle-attest" <<STUB
+@test "run_verify: append_metadata appends each already-signed line and never re-pushes" {
+    # The attest job already signed + store-pushed these; verify only assembles
+    # the consumer bundle. A bnd/cosign that fails proves neither is invoked.
+    cat > "$TEST_DIR/bnd" <<'STUB'
 #!/bin/bash
-subj=""
-for a in "\$@"; do case "\$a" in --subject=*) subj="\${a#--subject=}";; --out=*) out="\${a#--out=}";; esac; done
-printf '{"signedStatement":{"predicateType":"https://spdx.dev/Document","subject":[{"digest":{"sha256":"%s"}}]}}\n' "\${subj#sha256:}" > "\$out"
+exit 1
 STUB
-    chmod +x "$TEST_DIR/wrangle-attest"
-    export PATH="$TEST_DIR:$PATH"
-    export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
-    local sha; sha="$(printf '0%.0s' {1..64})"
-    local stmts="$TEST_DIR/meta.jsonl"; : > "$stmts"
-    run wrangle_sign_metadata_statements "sha256:$sha" "$stmts"
-    [[ "$status" -eq 0 ]]
-    [[ "$(wc -l < "$stmts")" -eq 1 ]]
-    [[ "$(jq -r '.signedStatement.predicateType' "$stmts")" == "https://spdx.dev/Document" ]]
-    [[ "$(jq -r '.signedStatement.subject[0].digest.sha256' "$stmts")" == "$sha" ]]
-}
-
-@test "run_verify: append_metadata appends each signed line to the bundle and pushes it" {
-    # push records the file it was handed so store delivery is provable.
-    cat > "$TEST_DIR/bnd" <<STUB
+    cat > "$TEST_DIR/cosign" <<'STUB'
 #!/bin/bash
-[[ "\$1" == "push" ]] && { cat "\$4" >> "$TEST_DIR/pushed"; exit 0; }
-exit 0
+exit 1
 STUB
-    chmod +x "$TEST_DIR/bnd"
+    chmod +x "$TEST_DIR/bnd" "$TEST_DIR/cosign"
     export PATH="$TEST_DIR:$PATH"
-    export GITHUB_REPOSITORY="o/r"
     export OCI_TARGET=""
-    : > "$TEST_DIR/pushed"
     local bundle="$TEST_DIR/bundle.jsonl"; printf '{"provenance":1}\n' > "$bundle"
     local sha; sha="$(printf '0%.0s' {1..64})"
     local stmts="$TEST_DIR/meta.jsonl"
-    printf '{"signedStatement":{"predicateType":"https://spdx.dev/Document","subject":[{"digest":{"sha256":"%s"}}]}}\n' "$sha" > "$stmts"
+    {
+        _signed_meta_line "$sha" "https://spdx.dev/Document"
+        _signed_meta_line "$sha" "https://wrangle.dev/scan/v1"
+    } > "$stmts"
     run wrangle_append_metadata_statements "$stmts" "$bundle"
     [[ "$status" -eq 0 ]]
-    # Seeded provenance line plus exactly one appended signed statement.
-    [[ "$(wc -l < "$bundle")" -eq 2 ]]
-    [[ "$(tail -1 "$bundle" | jq -r '.signedStatement.predicateType')" == "https://spdx.dev/Document" ]]
-    # The signed statement reached the store, bound to the single sha256 subject.
-    [[ "$(jq -r '.signedStatement.subject[0].digest.sha256' "$TEST_DIR/pushed")" == "$sha" ]]
-}
-
-@test "run_verify: sign_metadata hands a file subject to the engine via --artifact" {
-    # go/npm/python subjects are dist files: the engine self-digests them via
-    # --artifact, so the shell passes the path, never a precomputed digest.
-    cat > "$TEST_DIR/wrangle-attest" <<STUB
-#!/bin/bash
-for a in "\$@"; do case "\$a" in --out=*) out="\${a#--out=}";; esac; done
-printf '%s\n' "\$@" > "$TEST_DIR/attest-args"
-printf '{"signedStatement":1}\n' > "\$out"
-STUB
-    chmod +x "$TEST_DIR/wrangle-attest"
-    export PATH="$TEST_DIR:$PATH"
-    export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
-    local stmts="$TEST_DIR/meta.jsonl"; : > "$stmts"
-    mkdir -p "$TEST_DIR/dist"; printf 'AAA\n' > "$TEST_DIR/dist/a.tgz"
-    run wrangle_sign_metadata_statements "$TEST_DIR/dist/a.tgz" "$stmts"
-    [[ "$status" -eq 0 ]]
-    grep -qx -- "--artifact=$TEST_DIR/dist/a.tgz" "$TEST_DIR/attest-args"
-    ! grep -q -- "--subject=" "$TEST_DIR/attest-args"
-}
-
-@test "run_verify: the real engine emits the in-toto statement in unsigned mode" {
-    # Happy path against the real binary, hermetically: unsigned mode needs no
-    # OIDC/network, so it proves end-to-end manifest -> in-toto statement without
-    # a stub. (The shell glue always signs; this drives the engine directly.)
-    if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
-    local meta="$TEST_DIR/meta"; mkdir -p "$meta"
-    printf '{"predicate-type":"https://spdx.dev/Document","result-file":"sbom.spdx.json"}\n' \
-        > "$meta/wrangle_attestation_metadata.json"
-    printf '{"spdxVersion":"SPDX-2.3","name":"x"}\n' > "$meta/sbom.spdx.json"
-    local out="$TEST_DIR/out.intoto.jsonl"
-    local sha; sha="$(printf '0%.0s' {1..64})"
-    run "$ATTEST_BIN" --metadata-root="$meta" --subject="sha256:$sha" --out="$out"
-    [[ "$status" -eq 0 ]]
-    [[ "$(wc -l < "$out")" -eq 1 ]]
-    [[ "$(jq -r '.predicateType' "$out")" == "https://spdx.dev/Document" ]]
-    [[ "$(jq -r '.subject[0].digest.sha256' "$out")" == "$sha" ]]
-}
-
-@test "run_verify: sign_metadata fails closed when the real engine sees a malformed manifest" {
-    # The real engine fails closed at discoverManifests — before newSigner — so a
-    # malformed top-level manifest aborts hermetically (no OIDC/network). Drive
-    # the real binary to prove genuine engine fail-closed, not a stubbed exit.
-    if [[ ! -x "$ATTEST_BIN" ]]; then skip_or_fail "real wrangle-attest not available"; fi
-    local dir="$TEST_DIR/wrangle-attest-bin"; mkdir -p "$dir"
-    ln -sf "$ATTEST_BIN" "$dir/wrangle-attest"
-    export PATH="$dir:$PATH"
-    export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
-    export WRANGLE_RETRY_DELAY=0
-    printf 'not json\n' > "$METADATA_ROOT/wrangle_attestation_metadata.json"
-    local stmts="$TEST_DIR/meta.jsonl"; : > "$stmts"
-    run wrangle_sign_metadata_statements "sha256:$(printf '0%.0s' {1..64})" "$stmts"
-    [[ "$status" -ne 0 ]]
+    # Seeded provenance line plus both appended signed statements.
+    [[ "$(wc -l < "$bundle")" -eq 3 ]]
+    [[ "$(jq -r '.dsseEnvelope.payload | @base64d | fromjson | .predicateType' "$bundle" | tail -1)" == "https://wrangle.dev/scan/v1" ]]
 }
 
 # --- attach to release (wrangle_attach_release) ---

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -604,7 +604,7 @@ printf 'report\n'
 STUB
     cat > "$TEST_DIR/bnd" <<STUB
 #!/bin/bash
-[[ "\$1" == "push" ]] && exit 0
+[[ "\$1" == "push" ]] && { cat "\$4" >> "$TEST_DIR/pushed"; exit 0; }
 printf '{"signed":'; cat "\$2"; printf '}\n'
 STUB
     cat > "$TEST_DIR/wrangle-attest" <<'STUB'
@@ -614,7 +614,7 @@ STUB
     chmod +x "$TEST_DIR/ampel" "$TEST_DIR/bnd" "$TEST_DIR/wrangle-attest"
     export PATH="$TEST_DIR:$PATH"
     export GITHUB_STEP_SUMMARY="$TEST_DIR/summary.md"; : > "$GITHUB_STEP_SUMMARY"
-    : > "$TEST_DIR/ampel-args"
+    : > "$TEST_DIR/ampel-args"; : > "$TEST_DIR/pushed"
     export OCI_TARGET=""
     printf '{"provenance":1}\n' > "$BUNDLE_IN"
     local sha; sha="$(printf '0%.0s' {1..64})"
@@ -633,8 +633,52 @@ STUB
     local bundle; bundle="$BUNDLE_OUT/$(ls "$BUNDLE_OUT")"
     grep -q '"dsseEnvelope"' "$bundle"
     [[ "$(jq -r '.dsseEnvelope.payload | @base64d | fromjson | .predicateType' "$bundle" | tail -1)" == "https://spdx.dev/Document" ]]
-    # The metadata was NOT pushed to the store by verify — only the VSA is. bnd
-    # push would have recorded the metadata line; the only stored line is the VSA.
+    # verify did NOT re-push the metadata to the store — only the VSA was pushed
+    # (one line); the metadata DSSE bundle never reaches bnd push.
+    [[ "$(wc -l < "$TEST_DIR/pushed")" -eq 1 ]]
+    ! grep -q 'dsseEnvelope' "$TEST_DIR/pushed"
+}
+
+@test "run_verify: run signs and pushes its own metadata for the container path (no signed artifact)" {
+    # container (until #550 PR 3): with METADATA_ROOT and no SIGNED_METADATA, verify
+    # signs the SBOM/scan statements itself, feeds them to ampel, and pushes each to
+    # the store — the pre-PR-2 behavior, preserved for container.
+    cat > "$TEST_DIR/ampel" <<STUB
+#!/bin/bash
+printf '%s\n' "\$@" >> "$TEST_DIR/ampel-args"
+for a in "\$@"; do case "\$a" in --results-path=*) printf '{"unsigned":1}\n' > "\${a#--results-path=}";; esac; done
+printf 'report\n'
+STUB
+    cat > "$TEST_DIR/bnd" <<STUB
+#!/bin/bash
+[[ "\$1" == "push" ]] && { cat "\$4" >> "$TEST_DIR/pushed"; exit 0; }
+printf '{"signed":'; cat "\$2"; printf '}\n'
+STUB
+    cat > "$TEST_DIR/wrangle-attest" <<STUB
+#!/bin/bash
+for a in "\$@"; do case "\$a" in --out=*) out="\${a#--out=}";; esac; done
+printf '{"signedStatement":{"predicateType":"https://spdx.dev/Document"}}\n' > "\$out"
+STUB
+    chmod +x "$TEST_DIR/ampel" "$TEST_DIR/bnd" "$TEST_DIR/wrangle-attest"
+    export PATH="$TEST_DIR:$PATH"
+    export GITHUB_STEP_SUMMARY="$TEST_DIR/summary.md"; : > "$GITHUB_STEP_SUMMARY"
+    : > "$TEST_DIR/ampel-args"; : > "$TEST_DIR/pushed"
+    export OCI_TARGET=""
+    unset SIGNED_METADATA
+    export METADATA_ROOT="$TEST_DIR/meta"; mkdir -p "$METADATA_ROOT"
+    printf '{"provenance":1}\n' > "$BUNDLE_IN"
+    local sha; sha="$(printf '0%.0s' {1..64})"
+    export SUBJECTS="sha256:$sha"
+
+    run "$SCRIPT" run
+    [[ "$status" -eq 0 ]]
+    grep -qE -- "^--collector=jsonl:.*/meta\." "$TEST_DIR/ampel-args"
+    local bundle; bundle="$BUNDLE_OUT/$(ls "$BUNDLE_OUT")"
+    grep -q '"signedStatement"' "$bundle"
+    # verify signed AND pushed the metadata for the container path: the VSA plus
+    # the one metadata statement both reached the store (two pushed lines).
+    [[ "$(wc -l < "$TEST_DIR/pushed")" -eq 2 ]]
+    grep -q '"signedStatement"' "$TEST_DIR/pushed"
 }
 
 @test "run_verify: run pushes only the VSA statement as the referrer for an OCI target" {
@@ -782,18 +826,18 @@ STUB
     [[ "$status" -ne 0 ]]
 }
 
-@test "run_verify: append_metadata is a no-op on an empty statements file" {
-    # A build with no metadata appends nothing, so the bundle is left untouched.
+@test "run_verify: append_signed_metadata is a no-op on an empty statements file" {
+    # A subject with no metadata appends nothing, so the bundle is left untouched.
     local bundle="$TEST_DIR/bundle.jsonl"; printf '{"provenance":1}\n' > "$bundle"
     local stmts="$TEST_DIR/meta.jsonl"; : > "$stmts"
-    run wrangle_append_metadata_statements "$stmts" "$bundle"
+    run wrangle_append_signed_metadata "$stmts" "$bundle"
     [[ "$status" -eq 0 ]]
     [[ "$(wc -l < "$bundle")" -eq 1 ]]
 }
 
-@test "run_verify: append_metadata appends each already-signed line and never re-pushes" {
-    # The attest job already signed + store-pushed these; verify only assembles
-    # the consumer bundle. A bnd/cosign that fails proves neither is invoked.
+@test "run_verify: append_signed_metadata appends each already-signed line and never re-pushes" {
+    # go/npm/python: the attest job already signed + store-pushed these; verify only
+    # assembles the consumer bundle. A bnd/cosign that fails proves neither is invoked.
     cat > "$TEST_DIR/bnd" <<'STUB'
 #!/bin/bash
 exit 1
@@ -812,11 +856,56 @@ STUB
         _signed_meta_line "$sha" "https://spdx.dev/Document"
         _signed_meta_line "$sha" "https://wrangle.dev/scan/v1"
     } > "$stmts"
-    run wrangle_append_metadata_statements "$stmts" "$bundle"
+    run wrangle_append_signed_metadata "$stmts" "$bundle"
     [[ "$status" -eq 0 ]]
     # Seeded provenance line plus both appended signed statements.
     [[ "$(wc -l < "$bundle")" -eq 3 ]]
     [[ "$(jq -r '.dsseEnvelope.payload | @base64d | fromjson | .predicateType' "$bundle" | tail -1)" == "https://wrangle.dev/scan/v1" ]]
+}
+
+# --- container self-sign metadata path (wrangle_append_metadata_statements) ---
+# Until #550 PR 3, verify still signs the container's metadata itself; the append
+# both delivers it in the bundle and pushes it to the store.
+
+@test "run_verify: append_metadata is a no-op on an empty statements file" {
+    # A build with no metadata signs nothing, so the append leaves the bundle
+    # untouched (and does not push).
+    cat > "$TEST_DIR/bnd" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+    chmod +x "$TEST_DIR/bnd"
+    export PATH="$TEST_DIR:$PATH"
+    local bundle="$TEST_DIR/bundle.jsonl"; printf '{"provenance":1}\n' > "$bundle"
+    local stmts="$TEST_DIR/meta.jsonl"; : > "$stmts"
+    run wrangle_append_metadata_statements "$stmts" "$bundle"
+    [[ "$status" -eq 0 ]]
+    [[ "$(wc -l < "$bundle")" -eq 1 ]]
+}
+
+@test "run_verify: append_metadata appends each signed line to the bundle and pushes it" {
+    # push records the file it was handed so store delivery is provable.
+    cat > "$TEST_DIR/bnd" <<STUB
+#!/bin/bash
+[[ "\$1" == "push" ]] && { cat "\$4" >> "$TEST_DIR/pushed"; exit 0; }
+exit 0
+STUB
+    chmod +x "$TEST_DIR/bnd"
+    export PATH="$TEST_DIR:$PATH"
+    export GITHUB_REPOSITORY="o/r"
+    export OCI_TARGET=""
+    : > "$TEST_DIR/pushed"
+    local bundle="$TEST_DIR/bundle.jsonl"; printf '{"provenance":1}\n' > "$bundle"
+    local sha; sha="$(printf '0%.0s' {1..64})"
+    local stmts="$TEST_DIR/meta.jsonl"
+    printf '{"signedStatement":{"predicateType":"https://spdx.dev/Document","subject":[{"digest":{"sha256":"%s"}}]}}\n' "$sha" > "$stmts"
+    run wrangle_append_metadata_statements "$stmts" "$bundle"
+    [[ "$status" -eq 0 ]]
+    # Seeded provenance line plus exactly one appended signed statement.
+    [[ "$(wc -l < "$bundle")" -eq 2 ]]
+    [[ "$(tail -1 "$bundle" | jq -r '.signedStatement.predicateType')" == "https://spdx.dev/Document" ]]
+    # The signed statement reached the store, bound to the single sha256 subject.
+    [[ "$(jq -r '.signedStatement.subject[0].digest.sha256' "$TEST_DIR/pushed")" == "$sha" ]]
 }
 
 # --- attach to release (wrangle_attach_release) ---

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -90,7 +90,7 @@ runs:
         path: signed-metadata/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -93,7 +93,7 @@ runs:
         path: signed-metadata/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -93,7 +93,7 @@ runs:
         path: signed-metadata/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@406caa67b11049db5de49d727037d61a43cbdc32 # verify-consume-signed-metadata 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@33e8a91af46b57b5a3661aba6e7cd0d2f21b1a03 # verify-consume-signed-metadata 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -93,7 +93,7 @@ runs:
         path: signed-metadata/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@4dd15f18ea978eb5d373736b48f69d185839b160 # verify-consume-signed-metadata 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -90,7 +90,7 @@ runs:
         path: signed-metadata/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@7e6bd78fbdf7877357a58e7faf5e0193ab11be8c # verify-consume-signed-metadata 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -93,7 +93,7 @@ runs:
         path: signed-metadata/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@4d7390e66f64d9f23b43f435d9d3989d77007e94 # verify-consume-signed-metadata 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@5c54744dbb93d164c990ee6eac7a2afe9523d52a # verify-consume-signed-metadata 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -81,10 +81,13 @@ runs:
         name: ${{ steps.names.outputs.metadata-pre }}
         path: ${{ steps.names.outputs.metadata-dir }}/
 
-    # The attest job signed the SBOM + scan/v1 metadata; verify consumes that
-    # signed set (selecting each subject's lines for the policy + the bundle)
-    # instead of re-signing — attest owns the signing + store push (#550).
+    # go/npm/python: the attest job signed the SBOM + scan/v1 metadata; verify
+    # consumes that signed set (selecting each subject's lines for the policy +
+    # the bundle) instead of re-signing — attest owns the signing + store push
+    # (#550). Skipped for container, whose attest does not yet sign metadata
+    # (#550 PR 3); verify signs it from the staged metadata dir there.
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      if: ${{ inputs.oci-target == '' }}
       with:
         name: ${{ steps.names.outputs.signed-metadata }}
         path: signed-metadata/
@@ -99,10 +102,12 @@ runs:
         # Empty for container (provenance comes from the oci collector).
         bundle-in: ${{ inputs.oci-target == '' && 'provenance/provenance.jsonl' || '' }}
         bundle-out: ${{ steps.names.outputs.metadata-dir }}
-        # The bundle/zip dir; verify writes the per-subject bundles here.
+        # The bundle/zip dir; verify writes the per-subject bundles here (and,
+        # for container, signs the SBOM + scan/v1 metadata from it).
         metadata-dir: ${{ steps.names.outputs.metadata-dir }}
-        # The attest-signed SBOM + scan/v1 statements verify appends per subject.
-        signed-metadata: signed-metadata/signed-metadata.jsonl
+        # go/npm/python: the attest-signed SBOM + scan/v1 statements verify appends
+        # per subject. Empty for container (verify signs from metadata-dir).
+        signed-metadata: ${{ inputs.oci-target == '' && 'signed-metadata/signed-metadata.jsonl' || '' }}
         artifact-name: ${{ steps.names.outputs.metadata }}
         context: ${{ inputs.context }}
         oci-target: ${{ inputs.oci-target }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -81,6 +81,14 @@ runs:
         name: ${{ steps.names.outputs.metadata-pre }}
         path: ${{ steps.names.outputs.metadata-dir }}/
 
+    # The attest job signed the SBOM + scan/v1 metadata; verify consumes that
+    # signed set (selecting each subject's lines for the policy + the bundle)
+    # instead of re-signing — attest owns the signing + store push (#550).
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ${{ steps.names.outputs.signed-metadata }}
+        path: signed-metadata/
+
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
     - uses: TomHennen/wrangle/actions/verify@a3cb4c8962f98c2104c2d468b430f394063f11d5 # go-wrangle-owns-publish 2026-06-21
       with:
@@ -91,9 +99,10 @@ runs:
         # Empty for container (provenance comes from the oci collector).
         bundle-in: ${{ inputs.oci-target == '' && 'provenance/provenance.jsonl' || '' }}
         bundle-out: ${{ steps.names.outputs.metadata-dir }}
-        # wrangle-attest walks this for the sbom manifest, appending one signed
-        # SBOM statement per subject to each bundle.
+        # The bundle/zip dir; verify writes the per-subject bundles here.
         metadata-dir: ${{ steps.names.outputs.metadata-dir }}
+        # The attest-signed SBOM + scan/v1 statements verify appends per subject.
+        signed-metadata: signed-metadata/signed-metadata.jsonl
         artifact-name: ${{ steps.names.outputs.metadata }}
         context: ${{ inputs.context }}
         oci-target: ${{ inputs.oci-target }}


### PR DESCRIPTION
## What & why

PR 2 of 4 for #550. The `attest` job already signs ALL build-metadata (SBOM + every `scan/v1` manifest) via `wrangle-attest`/`bnd`, posts each to the GitHub attestation store, and emits a `<type>-signed-metadata-<sn>` workflow artifact (PR 1, #556). That was additive — `verify` *also* signed + pushed the same statements (the documented **M3 double-push window**). This PR ends that for **go/npm/python**: `verify` now **consumes** the attest-signed set instead of signing its own.

**Container is out of scope (PR 3):** container's attest does not yet sign metadata, so verify still signs the container's SBOM + scan/v1 itself. `wrangle_run` branches on the input — `SIGNED_METADATA` present (go/npm/python) → consume; absent (container) → sign, exactly as before.

## What changed

- **`actions/verify_release/action.yml`** — downloads the `<type>-signed-metadata-<sn>` artifact (the one attest emitted) into `signed-metadata/` and passes its path to `actions/verify`. Both the download and the input are gated on `oci-target == ''`, so container (which produces no such artifact) is unaffected; the go/npm/python `verify` jobs already `needs: [..., attest]`, so the artifact is in hand.
- **`actions/verify/run_verify.sh`** — `wrangle_run` no longer calls `wrangle_sign_metadata_statements` for go/npm/python. Instead it reads the pre-signed JSONL and, per subject:
  - selects that subject's lines from the accumulated artifact (`wrangle_subject_signed_metadata`, by the in-toto subject digest inside each bnd DSSE payload) — the per-artifact `<artifact>.intoto.jsonl` bundle carries only its own subject's statements while the attest artifact holds every subject's (go/python emit many dist subjects);
  - appends that subject's lines to its bundle **already-signed** (`wrangle_append_signed_metadata`) — **no re-sign, no store push, no OCI push** (attest owns those now);
  - reuses the same per-subject file as ampel's `jsonl:` collector, so the SBOM/scan tenets still evaluate (no separate pre-filter for the policy — the file already exists for the bundle).
- **`actions/verify/action.yml`** — new `signed-metadata` input; `metadata-dir`/`COMMIT` retained for the container self-sign branch (`METADATA_ROOT` is set only when `signed-metadata` is empty).
- Tests reworked (see below).

## Closes the M3 double-push

For go/npm/python, **only `attest` signs + pushes** the SBOM/scan metadata now; `verify` only assembles the consumer bundle from the already-signed set. The VSA is still emitted → signed → appended → pushed by `verify` (it's the post-policy verdict).

## Must-preserve (review-load-bearing)

- **S2 — no unsigned VSA crosses a boundary.** The VSA flow is untouched: `emit → bnd-sign → append` still happens in one `wrangle_run` process. `test_run_verify.bats`'s `run emits, signs, and appends one VSA line per subject` (the atomicity assertion) is preserved verbatim.
- **Identity / subject.** The appended metadata is the SAME attest-signed statements (`wrangle-builder` identity, same `sha256` subject digests the VSA binds). The bundle still ends up with provenance + VSA + SBOM + scan/v1 per subject, all correctly signed. Selection is by subject digest, so each bundle carries only its own subject's metadata.
- **Fail-closed.** If `SIGNED_METADATA` is set but missing/empty when it should exist, `wrangle_run` fails (no VSA-only bundle for a build that has metadata); `wrangle_subject_signed_metadata` fails closed on an unhashable file subject rather than emitting an empty per-subject set.

## Tests

- `test_run_verify.bats`: the old "verify signs metadata" run assertion is now "verify consumes the attest-signed artifact" — proves the metadata is fed to ampel, lands in the bundle, and **is NOT re-pushed to the store** (only the VSA is). New unit coverage for `wrangle_subject_signed_metadata` (digest + file selection, empty miss, fail-closed) and `wrangle_append_signed_metadata` (append, never push). A dedicated test keeps the **container self-sign path** (signs + pushes from `METADATA_ROOT`) green.
- The arg-vector + real-engine tests that exercised `wrangle-attest`/`wrangle_attest_args` (now attest territory) moved to `actions/attest_provenance/test_sign_metadata.bats` — no real-engine coverage lost.

## Discipline

- **Bootstrap pins** converged with the new tool (`WRANGLE_PINS_BRANCH=verify-consume-signed-metadata tools/converge_action_pins.sh`); `tools/check_pin_freshness.sh` reports **all 18 self-ref pins fresh**, `check_pin_ancestry.sh` all reachable. Per the converge note, land as a **merge commit / direct push, not a squash**, then bump pins to the merged main SHA.
- Full suite green locally: bats (1219 tests), shellcheck, wrangle-shell-lint, actionlint, wrangle-workflow-lint, go test, zizmor (no findings).

e2e in wrangle-agent-playground pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note — the consume-side glue is temporary

The per-subject selection/append logic this PR adds to `run_verify.sh` (`wrangle_subject_signed_metadata`, `wrangle_append_signed_metadata`, the flat-file fail-closed check) is intentionally **short-lived**. #566 (folded into #550 PR 3) moves the per-artifact bundle assembly into the attest job and ultimately into `wrangle-attest` itself — after which verify just maps subject → bundle and appends the VSA, deleting this glue. PR-2's scope is narrowly to **end the M3 double-push**; the shell here is the cost of doing that without yet reopening the merged PR-1 artifact shape.