### PR TITLE
docs: add a real release-asset verification example (#505)

### DIFF
--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -76,7 +76,8 @@ ampel verify --subject wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.
 ```
 
 For your own releases — built by pinning wrangle's reusable workflows to a
-release tag — drop the `-nonstrict` and use `wrangle-vsa-consumer-v1`.
+release tag — swap `wrangle-vsa-consumer-nonstrict-v1` for the strict
+`wrangle-vsa-consumer-v1`.
 
 ## Recommended: `ampel verify` (one command)
 

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -52,20 +52,26 @@ build READMEs.
 
 ### A real example (the showcase Go release)
 
-The [`wrangle-test`](https://github.com/TomHennen/wrangle-test) showcase tag
-`v20260621-fa5bd7f` carries, for its Go build, the verify-pair plus the metadata
-zip and goreleaser's `checksums.txt`:
+The [`wrangle-test`](https://github.com/TomHennen/wrangle-test) showcase
+publishes a Go release you can verify yourself. Tag `v20260621-fa5bd7f`
+includes, for its Go build:
 
-- `wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz` — the dist archive
+- `wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz` — the archive
 - `wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz.intoto.jsonl` — its bundle (provenance + VSA)
 - `go-metadata-go.zip` — the [unified metadata](metadata_layout.md) (SBOM + scan results)
 - `checksums.txt` — goreleaser's archive checksums
 
-Download the archive and its `.intoto.jsonl`, then verify (the showcase builds
-from `main`, not a wrangle release tag, so its VSA carries a `@refs/heads/main`
-signer identity and the strict `v*` consumer policy rejects it by design — the
-`-nonstrict` variant accepts any ref, which is the right policy for a
-branch-built showcase):
+Download the archive and its bundle:
+
+```bash
+base=https://github.com/TomHennen/wrangle-test/releases/download/v20260621-fa5bd7f
+curl -sSLO "$base/wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz"
+curl -sSLO "$base/wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz.intoto.jsonl"
+```
+
+The showcase builds from `main`, not a release tag, so its VSA carries a
+`@refs/heads/main` signer identity — the strict `v*` consumer policy rejects it
+by design. Use the `nonstrict` policy, which accepts any ref:
 
 ```bash
 ampel verify --subject wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz \

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -50,6 +50,34 @@ one, so create a published Release for the tag (a draft won't be found) before
 the workflow runs, or the assets stay workflow artifacts — see the per-language
 build READMEs.
 
+### A real example (the showcase Go release)
+
+The [`wrangle-test`](https://github.com/TomHennen/wrangle-test) showcase tag
+`v20260621-fa5bd7f` carries, for its Go build, the verify-pair plus the metadata
+zip and goreleaser's `checksums.txt`:
+
+- `wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz` — the dist archive
+- `wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz.intoto.jsonl` — its bundle (provenance + VSA)
+- `go-metadata-go.zip` — the [unified metadata](metadata_layout.md) (SBOM + scan results)
+- `checksums.txt` — goreleaser's archive checksums
+
+Download the archive and its `.intoto.jsonl`, then verify (the showcase builds
+from `main`, not a wrangle release tag, so its VSA carries a `@refs/heads/main`
+signer identity and the strict `v*` consumer policy rejects it by design — the
+`-nonstrict` variant accepts any ref, which is the right policy for a
+branch-built showcase):
+
+```bash
+ampel verify --subject wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz \
+  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-nonstrict-v1.hjson \
+  --collector jsonl:wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz.intoto.jsonl \
+  --context expectedResourceUri:pkg:golang/github.com/tomhennen/wrangle-test/go@v20260621-fa5bd7f \
+  --context sourceRepo:https://github.com/TomHennen/wrangle-test
+```
+
+For your own releases — built by pinning wrangle's reusable workflows to a
+release tag — drop the `-nonstrict` and use `wrangle-vsa-consumer-v1`.
+
 ## Recommended: `ampel verify` (one command)
 
 [ampel](https://github.com/carabiner-dev/ampel) ≥ v1.3.0 (one Go binary)


### PR DESCRIPTION
## What

Adds a **real** release-asset verification example to `docs/verifying_artifacts.md`, per #505. The showcase (`TomHennen/wrangle-test`) now publishes the rationalized release-asset set after #501 merged, so the "What's on the GitHub release" section can carry concrete filenames plus a worked, validated verify command.

Touches **only** `docs/verifying_artifacts.md`.

## The exact release/asset and commands validated

**Release:** `TomHennen/wrangle-test` tag `v20260621-fa5bd7f` (first post-#501 tagged showcase; HEAD of wrangle main).

**Go asset set documented (real filenames):**
- `wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz` (dist archive)
- `wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz.intoto.jsonl` (provenance + VSA bundle)
- `go-metadata-go.zip` (unified metadata)
- `checksums.txt` (goreleaser)

**Commands run against the downloaded asset — all passed (exit 0):**

1. `checksums.txt` matches the archive sha256 (`393a4ead…f2cf3ce9`). ✅
2. ampel (documented command):
   ```
   ampel verify --subject wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz \
     --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-nonstrict-v1.hjson \
     --collector jsonl:wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz.intoto.jsonl \
     --context expectedResourceUri:pkg:golang/github.com/tomhennen/wrangle-test/go@v20260621-fa5bd7f \
     --context sourceRepo:https://github.com/TomHennen/wrangle-test
   ```
   → `Status: ● PASS`, control `vsa-passed` PASS, "VSA PASSED for the expected resource at SLSA Build L3". ✅
3. cosign `verify-blob-attestation` with the `@refs/heads/main` identity → `Verified OK`; decoded VSA confirms `verificationResult == PASSED`, `resourceUri == pkg:golang/github.com/tomhennen/wrangle-test/go@v20260621-fa5bd7f`, `verifiedLevels` includes `SLSA_BUILD_LEVEL_3`. ✅
4. `gh attestation verify … --signer-workflow …build_and_publish_go.yml` → exit 0. ✅

## v*-vs-main nuance

The VSA signing cert SAN is `…/build_and_publish_go.yml@refs/heads/main` (verified by decoding the cert), because the showcase builds from `main`, not a wrangle release tag. The strict `wrangle-vsa-consumer-v1` policy requires `@refs/tags/v[0-9.]+` and rejects this by design, so the documented command uses the `-nonstrict` variant (accepts any ref) — the correct policy for a branch-built showcase. The doc notes the distinction in one sentence and tells adopters to drop `-nonstrict` for their own tag-pinned releases.

The VSA-identity drift-guard (`test/test_vsa_identity_anchor.bats`) still passes — the added prose describes the `@refs/heads/main` case in words and does not introduce a loosened `yml@.+` regex into the guide.

## Validation

`make test` green locally (lint, shellcheck, shellstyle, workflowstyle, gotest, bats, zizmor). Draft — please review before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)