### PR TITLE
feat(verify): create the GitHub release if a tag has none (#557)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -241,7 +241,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -282,7 +282,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -241,7 +241,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -282,7 +282,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -241,7 +241,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -282,7 +282,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -241,7 +241,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -282,7 +282,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -167,7 +167,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      uses: TomHennen/wrangle/build/actions/container@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -241,7 +241,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -282,7 +282,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -214,7 +214,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/build@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -364,7 +364,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: go
@@ -390,7 +390,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -214,7 +214,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/build@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -364,7 +364,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: go
@@ -390,7 +390,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -214,7 +214,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/build@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -364,7 +364,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: go
@@ -390,7 +390,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -214,7 +214,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/build@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -364,7 +364,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: go
@@ -390,7 +390,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -214,7 +214,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/checks@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/go/build@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         id: release
         with:
           path: ${{ inputs.path }}
@@ -364,7 +364,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: go
@@ -390,7 +390,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -387,7 +387,7 @@ jobs:
     permissions:
       id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
       attestations: write   # post each VSA to the GitHub attestation store
-      contents: write       # upload the attested archives + checksums + bundles to the pre-existing release
+      contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify_release@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -4,8 +4,8 @@ name: "Build, test, and release a Go project with best practices."
 #
 # Builds your Go project with goreleaser, attests it (SLSA provenance +
 # SBOM + scans, plus a signed VSA), and uploads the attested archives +
-# checksums.txt + .intoto.jsonl bundles to your GitHub Release for the tag.
-# You create the release; wrangle never creates one.
+# checksums.txt + .intoto.jsonl bundles to the GitHub Release for the tag.
+# wrangle creates the release if one doesn't exist yet.
 #
 # goreleaser runs with --skip=publish, so its own publishers (GitHub
 # release, Docker, Homebrew, deb/rpm/snap, announce) are skipped — wrangle
@@ -64,7 +64,7 @@ on:
               actions/prep/release_gate.sh for full vocabulary.
 
           wrangle uploads attested artifacts only on TAG PUSHES (it
-          attaches to the pre-existing release for the tag). The default
+          attaches to the tag's release, creating it if absent). The default
           `tag-only` is therefore also the cheapest setting — the
           pipeline runs only when it would do something meaningful. Use
           `non-pull-request` or `main-and-tags` for early failure
@@ -378,7 +378,7 @@ jobs:
   #
   # This job owns the publish: goreleaser ran --skip=publish, so nothing is live
   # until verify uploads the attested archives + checksums.txt + bundles to the
-  # pre-existing release. fail: true therefore DOES block the publish — a failed
+  # tag's release (created if absent). fail: true therefore DOES block the publish — a failed
   # policy means the bytes are never uploaded — and fails the workflow conclusion.
   verify:
     if: ${{ needs.prep.outputs.should-release == 'true' }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -204,7 +204,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -279,7 +279,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -302,7 +302,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -204,7 +204,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -279,7 +279,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -302,7 +302,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -204,7 +204,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -279,7 +279,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -302,7 +302,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -204,7 +204,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -279,7 +279,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -302,7 +302,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -299,7 +299,7 @@ jobs:
     permissions:
       id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
       attestations: write   # post each VSA to the GitHub attestation store
-      contents: write       # attach the bundle to the release on tag pushes
+      contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify_release@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -204,7 +204,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/npm@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -279,7 +279,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: npm
@@ -302,7 +302,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -179,7 +179,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -266,7 +266,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: python
@@ -289,7 +289,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -179,7 +179,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -266,7 +266,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: python
@@ -289,7 +289,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -179,7 +179,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -266,7 +266,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: python
@@ -289,7 +289,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -179,7 +179,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -266,7 +266,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: python
@@ -289,7 +289,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -179,7 +179,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/build/actions/python@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         id: build
         with:
           path: ${{ inputs.path }}
@@ -266,7 +266,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/attest_provenance@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         id: attest
         with:
           build-type: python
@@ -289,7 +289,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/verify_release@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -286,7 +286,7 @@ jobs:
     permissions:
       id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
       attestations: write   # post each VSA to the GitHub attestation store
-      contents: write       # attach the bundle to the release on tag pushes
+      contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify_release@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -65,7 +65,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/scan@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -112,7 +112,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+        uses: TomHennen/wrangle/build/actions/shell@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      - uses: TomHennen/wrangle/actions/prep@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+        uses: TomHennen/wrangle/actions/scan@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/tools/zizmor@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -132,7 +132,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/tools/scorecard@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -144,7 +144,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+      uses: TomHennen/wrangle/tools/dependency-review@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
 
     - name: Generate step summary
       if: always()

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -163,8 +163,8 @@ runs:
         path: ${{ inputs.bundle-out }}/
         if-no-files-found: error
 
-    # On a tag push, attach the rationalized asset set to the GitHub release if
-    # one exists (wrangle does not create releases).
+    # On a tag push, attach the rationalized asset set to the tag's GitHub
+    # release, creating it if none exists.
     - name: Attach assets to release
       if: github.ref_type == 'tag' && inputs.attach-to-release == 'true' && inputs.attach-release-assets == 'true'
       shell: bash

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -197,8 +197,8 @@ wrangle_run() {
     rm -f "$tmp_vsa" "$vsa_line"
 }
 
-# Attach the rationalized asset set to the current tag's GitHub release, if one
-# exists (wrangle never creates releases). Per subject: the <artifact> dist file
+# Attach the rationalized asset set to the current tag's GitHub release, creating
+# a published release for the tag if none exists. Per subject: the <artifact> dist file
 # and its <artifact>.intoto.jsonl bundle (flat); once per build: a
 # <type>-metadata-<sn>.zip of the metadata dir (sbom + scan/ + bundles). The
 # dist is attached alongside its bundle so no bundle is orphaned without its
@@ -207,9 +207,13 @@ wrangle_run() {
 # process substitution, so a find that dies mid-traversal fails closed.
 wrangle_attach_release() {
     local ref="$GITHUB_REF_NAME"
+    # No release for the tag: create an empty published release to fill with only
+    # attested assets. Fail closed if creation fails — never fall through to upload.
     if ! gh release view "$ref" >/dev/null 2>&1; then
-        printf 'wrangle: no GitHub release for %s; the bundles are the workflow artifact only.\n' "$ref" >&2
-        return 0
+        if ! gh release create "$ref" --generate-notes --title "$ref"; then
+            printf 'wrangle: failed to create GitHub release for %s\n' "$ref" >&2
+            return 1
+        fi
     fi
     local listing bundle base dist rc=0
     listing="$(mktemp "${RUNNER_TEMP:-/tmp}/bundles.XXXXXX")"

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -720,7 +720,7 @@ _require_zip() {
     grep -qx "release upload v1.2.3 $DIST_DIR/a.tgz --clobber" "$GH_LOG"
     grep -qx "release upload v1.2.3 $DIST_DIR/b.whl --clobber" "$GH_LOG"
     grep -q "release upload v1.2.3 .*python-metadata.zip --clobber" "$GH_LOG"
-    ! grep -q "release create" "$GH_LOG"   # wrangle never creates the release
+    ! grep -q "release create" "$GH_LOG"   # release exists, so no create call
 }
 
 @test "run_verify attach: go uploads the dist archives, their bundles, and checksums.txt (wrangle owns the publish)" {

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -658,8 +658,8 @@ STUB
 
 # --- attach to release (wrangle_attach_release) ---
 #
-# wrangle attaches the bundle only when a release already exists; it never
-# creates one. These tests drive a `gh` shim whose `release view` exit code
+# wrangle attaches the bundle to the tag's release, creating a published release
+# if none exists. These tests drive a `gh` shim whose `release view` exit code
 # follows GH_VIEW_SEQ so both branches (release present / absent) are exercised.
 
 # Install a gh shim on PATH that logs calls and returns scripted exit codes.
@@ -814,15 +814,27 @@ _require_zip() {
     [[ "$output" == *"duplicate release-asset basename"* ]]
 }
 
-@test "run_verify attach: missing release skips create and upload, exits 0" {
+@test "run_verify attach: missing release is created, then assets upload" {
+    _require_zip
     _install_gh_shim
     _stage_release_assets
     export BUILD_TYPE="python"
     export GH_VIEW_SEQ="1"            # view fails (no release)
     run "$SCRIPT" attach
-    [[ "$status" -eq 0 ]]            # no release is not an error — bundle stays the artifact
-    [[ "$output" == *"workflow artifact only"* ]]
-    if grep -q "release create" "$GH_LOG"; then return 1; fi
+    [[ "$status" -eq 0 ]]
+    grep -qx "release create v1.2.3 --generate-notes --title v1.2.3" "$GH_LOG"
+    grep -qx "release upload v1.2.3 $BUNDLE_OUT/a.tgz.intoto.jsonl --clobber" "$GH_LOG"
+}
+
+@test "run_verify attach: a failed release create fails closed, uploads nothing" {
+    _install_gh_shim
+    _stage_release_assets
+    export BUILD_TYPE="python"
+    export GH_VIEW_SEQ="1"            # view fails (no release)
+    export GH_CREATE_CODE="1"        # create fails
+    run "$SCRIPT" attach
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"failed to create GitHub release"* ]]
     if grep -q "release upload" "$GH_LOG"; then return 1; fi
 }
 

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@82020c060864596bc2c1c6e685c47aad29aabc5f # auto-create-release 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@96500f57808d01c8361c903bfdc68f5a33430f45 # bundle-assembly-attest 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@0ac42297e03c2c3c9986972c9502db28b7c1145f # auto-create-release 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@15590bfd02a76f62202eb27c62dde671507b7067 # auto-create-release 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@41c6d79490ecf81a4ce6be70fb77ad3718de9809 # auto-create-release 2026-06-21
+    - uses: TomHennen/wrangle/actions/verify@c8ed50ab9593b451b9685e54adce67f44aa14b07 # auto-create-release 2026-06-21
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/go/README.md
+++ b/build/actions/go/README.md
@@ -1,6 +1,6 @@
 # Wrangle Build Go
 
-Wrangle uses your `.goreleaser.yml` to build your binaries, then takes over the publish: it runs goreleaser with `--skip=publish` and uploads only what it can attest — the archives, `checksums.txt`, and a signed bundle per archive — to a GitHub Release you create. On top of the build, wrangle adds the security drudgery: gofmt/vet/test/govulncheck, an SPDX SBOM, SLSA Build L3 provenance, and a signed VSA your users verify with one command.
+Wrangle uses your `.goreleaser.yml` to build your binaries, then takes over the publish: it runs goreleaser with `--skip=publish` and uploads only what it can attest — the archives, `checksums.txt`, and a signed bundle per archive — to the tag's GitHub Release (which wrangle creates if you haven't). On top of the build, wrangle adds the security drudgery: gofmt/vet/test/govulncheck, an SPDX SBOM, SLSA Build L3 provenance, and a signed VSA your users verify with one command.
 
 This build type is for Go projects that ship binaries. Ship a CLI people `go install` today? Adopting wrangle additionally gets your users attested, downloadable binaries — and `go install` keeps working unchanged. Library-only modules (no binary to build) aren't supported ([#239](https://github.com/TomHennen/wrangle/issues/239)).
 
@@ -8,7 +8,7 @@ Because wrangle publishes only the attested archives + `checksums.txt`, goreleas
 
 ## Quick start
 
-Copy [`build_go.yml`](../../../gh_workflow_examples/build_go.yml) into `.github/workflows/` and set `path`. The example includes a tag-gated `create-release` job — wrangle attaches assets to a pre-existing release and never creates one, so that job (or your own release-creation step) is a precondition:
+Copy [`build_go.yml`](../../../gh_workflow_examples/build_go.yml) into `.github/workflows/` and set `path`. wrangle creates the tag's GitHub Release if one doesn't exist yet, so there's no release-creation step to wire up:
 
 ```yaml
 jobs:
@@ -46,12 +46,12 @@ Push a `v`-prefixed semver tag (e.g. `v1.2.3`) and wrangle runs the full pipelin
 - **Checks before bytes ship** — gofmt, `go vet`, `go test`, govulncheck run in a read-only job; a failure blocks the release job.
 - **An SPDX SBOM, scan findings (incl. govulncheck), and the signed bundle** in one `go-metadata-<sn>` workflow artifact ([what's in it](../../../docs/metadata_layout.md)).
 - **SLSA Build L3 provenance** tying each artifact to the workflow that built it ([the requirements it meets](../../../docs/REQUIREMENTS_MAPPING.md)).
-- **Release assets on tag pushes** — wrangle uploads the dist archives, `checksums.txt`, each `<archive>.intoto.jsonl` bundle (signed VSA + provenance), and a `go-metadata-<sn>.zip` with the SBOM + scan results to the release you created. Only attested bytes are published. Downstream users verify with one command.
+- **Release assets on tag pushes** — wrangle uploads the dist archives, `checksums.txt`, each `<archive>.intoto.jsonl` bundle (signed VSA + provenance), and a `go-metadata-<sn>.zip` with the SBOM + scan results to the tag's release (created if absent). Only attested bytes are published. Downstream users verify with one command.
 
 ## Good to know
 
 - **Tags must be `v`-prefixed semver** (`v1.2.3`) — goreleaser derives the version from the nearest `v*` tag. No `v*` tags yet? Use the [example config](../../../gh_workflow_examples/build_go.goreleaser.yml)'s snapshot template, which doesn't depend on tag history.
-- **You must create the release.** wrangle attaches to a pre-existing GitHub Release for the tag and never creates one; the example's `create-release` job handles this, or add your own `gh release create` step. No release for the tag? The assets stay workflow artifacts only.
+- **wrangle creates the release.** If the tag has no GitHub Release yet, wrangle creates a published one (auto-generated notes) and attaches the attested assets. Pre-create the release yourself only if you want custom notes or a draft.
 - **Provenance covers everything in `checksums.txt`** — the archives wrangle publishes. goreleaser's Docker/Homebrew/deb/rpm/announce verbs don't run under wrangle (it publishes only what it can attest); pair with the [container build type](../container/README.md) for attested images.
 - **`pull_request_target` can't trigger this workflow** — that trigger (and `workflow_run` chained from it) is a common exploit vector, so wrangle blocks both at startup.
 - **`release-events`** (default: `tag-only`) controls which events run the full pipeline — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating".

--- a/build/actions/go/SPEC.md
+++ b/build/actions/go/SPEC.md
@@ -34,7 +34,7 @@ The stale `cyclonedx-gomod` reference in [`docs/docker_best_practices.md`](../..
 
 ### Publish target — GitHub Releases
 
-**Pick:** GitHub Releases. wrangle owns the upload (see "Build-only goreleaser, wrangle owns the publish" below); the adopter creates the release.
+**Pick:** GitHub Releases. wrangle owns the upload and creates the release if absent (see "Build-only goreleaser, wrangle owns the publish" below).
 
 **Why:** This is what `slsa-verifier`, `cosign`, `oras`, the goreleaser-example project, and goreleaser itself all target. There is no separate Go binary registry. `pkg.go.dev` is a documentation index that auto-discovers tagged versions from `proxy.golang.org` — no publish action, no token required for module consumers.
 
@@ -60,16 +60,15 @@ Goreleaser's own release pipeline runs `cosign sign-blob` against each artifact 
 Wrangle runs goreleaser with `--skip=publish` on every event, and publishes nothing through it. Two principles force this:
 
 1. **Wrangle must not publish what it can't attest.** Goreleaser's native publish ships Docker images, Homebrew taps, deb/rpm/snap, AUR, and Slack/Discord announcements — none of which wrangle's provenance + VSA cover. Letting goreleaser publish would make wrangle a party to shipping un-attested artifacts.
-2. **Wrangle never *creates* releases.** It attaches to a pre-existing release (the adopter creates it, exactly as the python/npm flows require a pre-configured publish target). `wrangle_attach_release` no-ops when no release exists.
+2. **Wrangle owns the release lifecycle.** The publish path is wrangle's, not goreleaser's: `wrangle_attach_release` creates the tag's GitHub Release if none exists (published, auto-generated notes), then uploads only the attested set. The adopter can pre-create the release for custom notes or a draft.
 
 The sequence is therefore:
 
 1. **Goreleaser builds** (`release --clean --skip=publish`; `--snapshot` added on non-tag events because `release` refuses to run off a tag). It writes the archives + `checksums.txt` into `dist/` and uploads nothing. The build job runs at `contents: read`. `dist/` is handed to the verify job as a workflow artifact.
-2. **The adopter creates the GitHub Release** for the tag (a precondition; the example workflow ships a tag-gated `create-release` job).
-3. **Wrangle attests** by handing `dist/checksums.txt` to `actions/attest-build-provenance` (`subject-checksums: dist/checksums.txt`) in the `attest:` job, producing a signed Sigstore bundle.
-4. **Wrangle verifies and publishes** in the `verify:` job: ampel verifies the provenance against the wrangle PolicySet (fail-closed against `common.identities` + the SLSA tenets), emits the signed per-binary VSA, and uploads ONLY the attested set — the archives, `checksums.txt`, and the per-archive `<archive>.intoto.jsonl` bundles — to the pre-existing release on tag pushes. `contents: write` is held only by this job, which runs no adopter code.
+2. **Wrangle attests** by handing `dist/checksums.txt` to `actions/attest-build-provenance` (`subject-checksums: dist/checksums.txt`) in the `attest:` job, producing a signed Sigstore bundle.
+3. **Wrangle verifies and publishes** in the `verify:` job: ampel verifies the provenance against the wrangle PolicySet (fail-closed against `common.identities` + the SLSA tenets), emits the signed per-binary VSA, creates the tag's GitHub Release if none exists, and uploads ONLY the attested set — the archives, `checksums.txt`, and the per-archive `<archive>.intoto.jsonl` bundles — to it on tag pushes. `contents: write` is held only by this job, which runs no adopter code.
 
-Net properties: wrangle never creates releases; only attested bytes are published; the two adopter-code jobs (`checks`, `release`) run at `contents: read`; and the model matches python/npm (build → attest → verify → wrangle uploads to a pre-existing target). PR builds exercise the goreleaser pipeline (snapshot) without publishing.
+Net properties: only attested bytes are published; wrangle creates the tag's release if none exists; the two adopter-code jobs (`checks`, `release`) run at `contents: read`; and the model matches python/npm (build → attest → verify → wrangle uploads the attested set). PR builds exercise the goreleaser pipeline (snapshot) without publishing.
 
 **Predicate version (v1).** `actions/attest-build-provenance` emits `slsa.dev/provenance/v1` with buildType `https://actions.github.io/buildtypes/workflow/v1`. The Go build type uses the same producer as wrangle's container, python, and npm types (all moved to it in #316), so all four emit v1 predicates with a wrangle-workflow `builder.id`. The old generic generator emitted `v0.2` and named itself as `builder.id`; #316 closed both gaps at once.
 
@@ -107,7 +106,7 @@ The reusable workflow splits the build into two jobs, **both at `contents: read`
 - `checks` (`contents: read`) — `gofmt`, `go vet`, `go test`, `govulncheck`.
 - `release` (`contents: read`) — `goreleaser --skip=publish` (builds only, uploads nothing), `syft`, hash computation.
 
-Both adopter-code jobs run read-only because goreleaser publishes nothing — `dist/` leaves the `release` job only as a workflow artifact. `contents: write` is held by exactly one job, `verify`, which runs no adopter code; it uploads the attested set to the pre-existing release. This is stronger than the prior split: `go test` and goreleaser can't reach `$GITHUB_TOKEN` write at all, not merely in a separate job from the publish.
+Both adopter-code jobs run read-only because goreleaser publishes nothing — `dist/` leaves the `release` job only as a workflow artifact. `contents: write` is held by exactly one job, `verify`, which runs no adopter code; it creates the tag's release if absent and uploads the attested set. This is stronger than the prior split: `go test` and goreleaser can't reach `$GITHUB_TOKEN` write at all, not merely in a separate job from the publish.
 
 The split costs ~30s of extra latency (a second checkout + setup-go). The L3 audit pattern from #226 (release-vs-PR cache asymmetry) is preserved on both sides: both composites accept the `cache` input and disable caching on release builds.
 
@@ -128,9 +127,9 @@ This adds Go alongside python-uv and container as the third release-cache-disabl
 
 ### Authentication — `GITHUB_TOKEN` only
 
-Publishing to GitHub Releases requires `contents: write`, held only by the `verify:` job (it uploads the attested archives + `checksums.txt` + VSA bundles to the pre-existing release). The goreleaser/`release` job needs no token — `--skip=publish` uploads nothing. The adopter's release-creation step needs `contents: write` too. No external registry credentials, no Trusted Publisher to configure, no API tokens. This is the simplest auth model of any artifact-producing build type.
+Publishing to GitHub Releases requires `contents: write`, held only by the `verify:` job (it creates the tag's release if absent and uploads the attested archives + `checksums.txt` + VSA bundles to it). The goreleaser/`release` job needs no token — `--skip=publish` uploads nothing. No external registry credentials, no Trusted Publisher to configure, no API tokens. This is the simplest auth model of any artifact-producing build type.
 
-The permission cascade lesson from python ([HOW_TO_ADD_A_BUILD_TYPE.md "Permission cascade through nested reusable workflows"](../../../docs/HOW_TO_ADD_A_BUILD_TYPE.md)) applies: callers must grant the union of every job's declared permissions. For the picked path the union is `id-token: write` (Sigstore signing in the `attest`/`verify` jobs), `contents: write` (the `verify` upload — and the adopter's own release-creation job), and `attestations: write` (the `attest` job writes to GitHub's attestation store). Note the absence of `actions: read` — that was the former generator's requirement; `actions/attest-build-provenance` does not need it.
+The permission cascade lesson from python ([HOW_TO_ADD_A_BUILD_TYPE.md "Permission cascade through nested reusable workflows"](../../../docs/HOW_TO_ADD_A_BUILD_TYPE.md)) applies: callers must grant the union of every job's declared permissions. For the picked path the union is `id-token: write` (Sigstore signing in the `attest`/`verify` jobs), `contents: write` (the `verify` upload, which also creates the release if absent), and `attestations: write` (the `attest` job writes to GitHub's attestation store). Note the absence of `actions: read` — that was the former generator's requirement; `actions/attest-build-provenance` does not need it.
 
 `pkg.go.dev` indexing is automatic — `proxy.golang.org` discovers tags within minutes of `git push --tags`. No publish step, no auth.
 

--- a/build/actions/go/build/action.yml
+++ b/build/actions/go/build/action.yml
@@ -10,8 +10,8 @@ description: |
   Goreleaser builds the archives + checksums into dist/ but uploads
   nothing: wrangle owns the publish. The reusable workflow hands
   dist/ to the verify job, which attests it and uploads only the
-  attested archives + checksums.txt + bundles to a pre-existing
-  GitHub Release. wrangle never creates the release, and never
+  attested archives + checksums.txt + bundles to the tag's
+  GitHub Release, creating it if absent. wrangle never
   publishes the un-attestable downstream verbs (Docker pushes,
   Homebrew taps, deb/rpm/snap, announce) goreleaser's native publish
   would.

--- a/build/actions/go/test.bats
+++ b/build/actions/go/test.bats
@@ -764,14 +764,9 @@ func main() {}
     [[ "$status" -ne 0 ]]
 }
 
-@test "go: example workflow creates the release on tag push (wrangle attaches, never creates)" {
-    # wrangle attaches to a pre-existing release; the adopter must create it.
-    # The example ships a tag-gated create-release job so the assets land.
+@test "go: example workflow does NOT pre-create the release (wrangle creates it if absent)" {
     run grep -E '^  create-release:' "$EXAMPLE"
-    [[ "$status" -eq 0 ]]
-    section="$(awk '/^  [a-z][a-z_-]*:$/ { in_section = ($0 == "  create-release:") } in_section' "$EXAMPLE")"
-    grep -qF "gh release create" <<<"$section"
-    grep -qE "if:.*startsWith\\(github\\.ref, 'refs/tags/'\\)" <<<"$section"
+    [[ "$status" -ne 0 ]]
 }
 
 @test "go: example workflow grants contents: write to build job" {

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -41,7 +41,7 @@ These steps set up [npm Trusted Publishing](https://docs.npmjs.com/trusted-publi
 - **Source scan** built in — vulnerable dependencies (OSV), unsafe workflow patterns (Zizmor), and more ([details](../../../actions/scan/README.md)); a load-bearing finding blocks publish.
 - **An SPDX SBOM, scan findings, and the signed bundle** in one `npm-metadata-<sn>` workflow artifact ([what's in it](../../../docs/metadata_layout.md)).
 - **SLSA Build L3 provenance** ([the requirements it meets](../../../docs/REQUIREMENTS_MAPPING.md)), in addition to the L2 attestation `npm publish --provenance` writes to the registry.
-- **Release assets on tag pushes** — the tarball and its `<tarball>.intoto.jsonl` bundle (signed VSA + provenance) as a flat verify-pair, plus an `npm-metadata-<sn>.zip` with the SBOM + scan results. Downstream users verify with one command. wrangle attaches to an existing Release and never creates one, so create a published GitHub Release for the tag (a draft won't be found) before the workflow runs — otherwise these assets stay workflow artifacts.
+- **Release assets on tag pushes** — the tarball and its `<tarball>.intoto.jsonl` bundle (signed VSA + provenance) as a flat verify-pair, plus an `npm-metadata-<sn>.zip` with the SBOM + scan results. Downstream users verify with one command. wrangle creates the tag's GitHub Release if one doesn't exist yet (published, auto-generated notes); pre-create it yourself only for custom notes or a draft.
 
 ## Your publish job
 

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -41,7 +41,7 @@ These steps set up [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publi
 - **Source scan** built in — vulnerable dependencies (OSV), unsafe workflow patterns (Zizmor), and more ([details](../../../actions/scan/README.md)); a load-bearing finding blocks publish.
 - **An SPDX SBOM, scan findings, and the signed bundle** in one `python-metadata-<sn>` workflow artifact ([what's in it](../../../docs/metadata_layout.md)).
 - **SLSA Build L3 provenance** ([the requirements it meets](../../../docs/REQUIREMENTS_MAPPING.md)), plus PEP 740 attestations on PyPI from the publish step.
-- **Release assets on tag pushes** — each dist file and its `<dist-file>.intoto.jsonl` bundle (signed VSA + provenance) as a flat verify-pair, plus a `python-metadata-<sn>.zip` with the SBOM + scan results. Downstream users verify with one command. wrangle attaches to an existing Release and never creates one, so create a published GitHub Release for the tag (a draft won't be found) before the workflow runs — otherwise these assets stay workflow artifacts.
+- **Release assets on tag pushes** — each dist file and its `<dist-file>.intoto.jsonl` bundle (signed VSA + provenance) as a flat verify-pair, plus a `python-metadata-<sn>.zip` with the SBOM + scan results. Downstream users verify with one command. wrangle creates the tag's GitHub Release if one doesn't exist yet (published, auto-generated notes); pre-create it yourself only for custom notes or a draft.
 
 ## Your publish job
 

--- a/docs/REQUIREMENTS_MAPPING.md
+++ b/docs/REQUIREMENTS_MAPPING.md
@@ -249,11 +249,10 @@ These fall on the adopter (the *producer*); wrangle exists to satisfy them.
 - **Distribute provenance (MAY delegate to the ecosystem)** — MEETS for the build
   **provenance**: it lands in the GitHub attestation store (`attestations: write`),
   and for containers also as an OCI referrer on the image digest. The signed
-  **VSA** is delivered as: a GitHub release asset for **Go** (goreleaser creates
-  the release inline); a release asset for **Python/npm** *only if the adopter's
-  tooling created a release for the tag*, otherwise the run-scoped workflow
-  artifact; for **container** the VSA pushed as its own OCI referrer on the
-  image digest, plus the combined bundle as a run-scoped workflow artifact.
+  **VSA** is delivered as: a GitHub release asset for **Go/Python/npm** (wrangle
+  creates the tag's release if one doesn't exist yet); for **container** the VSA
+  pushed as its own OCI referrer on the image digest, plus the combined bundle as
+  a run-scoped workflow artifact.
   **Enabled, not executed:** for
   Python/npm wrangle stops before publish (publishing is the adopter's caller via
   Trusted Publishing), so whether the *registry* redistributes provenance is the

--- a/docs/REQUIREMENTS_MAPPING.md
+++ b/docs/REQUIREMENTS_MAPPING.md
@@ -249,10 +249,9 @@ These fall on the adopter (the *producer*); wrangle exists to satisfy them.
 - **Distribute provenance (MAY delegate to the ecosystem)** — MEETS for the build
   **provenance**: it lands in the GitHub attestation store (`attestations: write`),
   and for containers also as an OCI referrer on the image digest. The signed
-  **VSA** is delivered as: a GitHub release asset for **Go/Python/npm** (wrangle
-  creates the tag's release if one doesn't exist yet); for **container** the VSA
-  pushed as its own OCI referrer on the image digest, plus the combined bundle as
-  a run-scoped workflow artifact.
+  **VSA** is delivered as: a GitHub release asset for **Go/Python/npm**; for
+  **container** the VSA pushed as its own OCI referrer on the image digest, plus
+  the combined bundle as a run-scoped workflow artifact.
   **Enabled, not executed:** for
   Python/npm wrangle stops before publish (publishing is the adopter's caller via
   Trusted Publishing), so whether the *registry* redistributes provenance is the

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -45,10 +45,8 @@ Container builds publish no release — the VSA is an OCI referrer on the image
 digest (see below). Adopters can suppress the attach with the verify action's
 `attach-release-assets: false`.
 
-For Python and npm, wrangle attaches to an existing Release and never creates
-one, so create a published Release for the tag (a draft won't be found) before
-the workflow runs, or the assets stay workflow artifacts — see the per-language
-build READMEs.
+wrangle creates the Release for the tag automatically if none exists; pre-create
+one yourself only for custom notes or a draft — see the per-language build READMEs.
 
 ### A real example (the showcase Go release)
 

--- a/gh_workflow_examples/build_go.goreleaser.yml
+++ b/gh_workflow_examples/build_go.goreleaser.yml
@@ -4,7 +4,7 @@
 # requires. wrangle runs goreleaser with --skip=publish: it builds the
 # archives + checksums into dist/ but publishes nothing. wrangle then
 # uploads only the attested archives + checksums.txt (plus signed-VSA
-# bundles) to your pre-existing GitHub Release. Do NOT add goreleaser
+# bundles) to the tag's GitHub Release, creating it if absent. Do NOT add goreleaser
 # publisher config — release.draft, brews, dockers, nfpms, announce —
 # here: those verbs never run under --skip=publish, and wrangle only
 # publishes what it can attest. Full reference:

--- a/gh_workflow_examples/build_go.yml
+++ b/gh_workflow_examples/build_go.yml
@@ -12,10 +12,8 @@
 #
 # wrangle owns the publish: goreleaser only builds. wrangle's verify
 # job attaches the attested archives + checksums.txt + signed-VSA
-# bundles to a PRE-EXISTING GitHub Release — wrangle never creates
-# the release. The `create-release` job below creates it on tag push
-# so the assets have somewhere to land (mirrors how the python example
-# requires a configured publish target as a precondition).
+# bundles to the tag's GitHub Release, creating a published release if
+# one doesn't exist yet — so there's no release-creation step to wire up.
 #
 # Trigger note: `release-events: tag-only` means only tag pushes
 # publish. PR builds run the full pipeline (build → tests → SBOM) but
@@ -31,28 +29,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Create the GitHub Release wrangle's verify job attaches assets to.
-  # wrangle never creates releases; it attaches to a pre-existing one.
-  # Tag pushes only — there is no release to create otherwise.
-  create-release:
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write   # gh release create
-    steps:
-      - env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1 ||
-            gh release create "$TAG" --repo "$REPO" --title "$TAG" --generate-notes
-
   build:
-    needs: [create-release]
-    # create-release is skipped on non-tag events; allow that so PR / main
-    # builds still run (a skipped need otherwise cascades to a skip).
-    if: ${{ always() && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped') }}
     # Maximum the caller grants; wrangle's internal jobs each drop to the subset they actually need.
     permissions:
       contents: write   # wrangle's verify job attaches the attested assets to the release

--- a/gh_workflow_examples/build_npm.yml
+++ b/gh_workflow_examples/build_npm.yml
@@ -46,7 +46,7 @@ jobs:
   build:
     # Maximum the caller grants; wrangle's internal jobs each drop to the subset they actually need.
     permissions:
-      # The attach targets a published GitHub Release; create one for the tag before this runs, or the assets stay workflow artifacts.
+      # The attach targets the GitHub Release for the tag, which wrangle creates if none exists.
       contents: write   # wrangle's verify job attaches the VSA to the release on tags; GitHub validates at startup even on non-tag runs
       id-token: write   # OIDC for Sigstore signing
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance

--- a/gh_workflow_examples/build_python.yml
+++ b/gh_workflow_examples/build_python.yml
@@ -43,7 +43,7 @@ jobs:
   build:
     # Maximum the caller grants; wrangle's internal jobs each drop to the subset they actually need.
     permissions:
-      # The attach targets a published GitHub Release; create one for the tag before this runs, or the assets stay workflow artifacts.
+      # The attach targets the GitHub Release for the tag, which wrangle creates if none exists.
       contents: write   # wrangle's verify job attaches the VSA to the release on tags; GitHub validates at startup even on non-tag runs
       id-token: write   # OIDC for Sigstore signing
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance


### PR DESCRIPTION
Closes the "ease" half of release publishing: today `wrangle_attach_release` no-ops when a tag has no GitHub release, so the attested assets stay workflow-artifact-only. Now wrangle **creates a published release for the tag if none exists**, then fills it with only attested assets.

## What changed
- `actions/verify/run_verify.sh` — `wrangle_attach_release`: when `gh release view` finds no release, run `gh release create "$ref" --generate-notes --title "$ref"` (fail-closed: if creation fails, return non-zero and upload nothing), then the existing upload. When a release already exists, behavior is unchanged.
- Scope: go / npm / python (the GitHub-release build types). Container is unaffected (OCI delivery).
- Docs: the pre-create guidance in `verifying_artifacts.md` softens to "wrangle creates the release automatically if none exists; pre-create only for custom notes or a draft."

## Locked design
Default-on · published (not draft) · `--generate-notes`.

## Why it's safe
- **No new permission** — the verify job already holds `contents: write` to upload assets; creating the release uses the same grant (comments updated on all three workflows). The threat model doesn't move — the tag push already triggers build→attest→upload.
- **Preserves the #464 invariant** — wrangle creates an *empty* release and fills it with *only* attested assets.

## Tests
New bats: create-if-missing → assets upload; failed `release create` → fail-closed, uploads nothing. Existing "release exists" path unchanged.

## Notes
- Carries bootstrap pins (2-cycle converge) — **land as a MERGE commit, not squash.**
- Playground e2e of the create-if-missing path is pending (orchestrator will run it — release creation needs only `contents: write`).

Fixes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)