### PR TITLE
Cache Go tool binaries to skip relinking on stable go.sum

### DIFF
--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -55,6 +55,18 @@ on:
         required: false
         type: string
         default: ""
+      cache-setup-tools:
+        description: >
+          Set to "enabled" to cache the Go tool binaries the setup-script
+          installs into wrangle's standard bin dir ($RUNNER_TEMP/.wrangle/bin,
+          lib/env.sh), keyed on go-tools-dir's go.sum, so they aren't relinked
+          every run. Requires go-tools-dir. Test/scan only: a cache hit
+          restores prebuilt binaries instead of rebuilding, so go.sum is not
+          re-verified on the hit — never enable on a release build. Empty
+          (default) disables it.
+        required: false
+        type: string
+        default: ""
 
 jobs:
   # MUST stay first under `jobs:`: prep's guard refuses unsafe triggers
@@ -105,6 +117,16 @@ jobs:
         with:
           go-version-file: ${{ inputs.go-tools-dir }}/go.mod
           cache-dependency-path: ${{ inputs.go-tools-dir }}/go.sum
+
+      # Restores prebuilt tool binaries on a go.sum-stable run so they aren't
+      # relinked; a hit skips the go.sum re-verify, so this is test/scan only
+      # and never gates a release (this workflow attests nothing).
+      - name: Cache setup-script tool binaries
+        if: ${{ inputs.cache-setup-tools == 'enabled' && inputs.go-tools-dir != '' }}
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.temp }}/.wrangle/bin
+          key: setup-tools-${{ runner.os }}-${{ hashFiles(format('{0}/go.sum', inputs.go-tools-dir)) }}
 
       - name: Run shell build
         # TODO: replace with $/build/actions/shell when GitHub ships $/ syntax (#136)

--- a/.github/workflows/local_build_shell.yml
+++ b/.github/workflows/local_build_shell.yml
@@ -29,9 +29,11 @@ jobs:
       setup-script: test/setup_integration.sh
       # Cache the Go tools built from source: go-tools-dir for the
       # setup-script's tools in the shell-build job, go-cache for the
-      # scan job's osv-scanner et al.
+      # scan job's osv-scanner et al. cache-setup-tools also caches the
+      # linked tool binaries so they aren't relinked when go.sum is stable.
       go-cache: enabled
       go-tools-dir: tools
+      cache-setup-tools: enabled
 
   # Wrangle-internal (self-ref pins are not an adopter concern, so this
   # lives in the dogfood caller, not the reusable build_shell.yml). Fails

--- a/docs/SLSA_L3_AUDIT.md
+++ b/docs/SLSA_L3_AUDIT.md
@@ -36,7 +36,7 @@ adopter consuming wrangle through one of wrangle's **reusable workflows**:
 | python path (uv sub-path) | **Build L2** | Build L3 (Finding 1) |
 | container path | **Build L2** | Build L3 (Finding 2) |
 | Go path | **Build L3** [^go] | — |
-| shell path | **N/A** — no provenance produced | — |
+| shell path | **N/A** — no provenance produced [^shellcache] | — |
 
 [^npmci]: Conditional on the install command being `npm ci`, which re-verifies
     each cached tarball's SHA against `package-lock.json` on every install.
@@ -53,6 +53,15 @@ adopter consuming wrangle through one of wrangle's **reusable workflows**:
     — neither is automatically `npm ci`-like). Per-builder analysis lives in
     [`build/actions/go/SPEC.md`](../build/actions/go/SPEC.md) "Cache isolation",
     not in this historical document.
+
+[^shellcache]: The shell path signs nothing (source scan + shellcheck + bats),
+    so none of its caches can poison an attestation. `cache-setup-tools`
+    (`build_shell.yml`) is the strongest trust-on-hit of them: a
+    `tools/go.sum`-keyed hit restores prebuilt tool binaries without re-running
+    `go install`, so `go.sum` is not re-verified that run (the module/build
+    cache re-verifies it on rebuild). Acceptable only because no attested
+    artifact exists here — it must never be wired into a `build_and_publish_*`
+    release path.
 
 > **Update — 2026-05-17.** Findings 1 and 2 are now **resolved** by
 > [PR #226](https://github.com/TomHennen/wrangle/pull/226) (issue

--- a/test/setup_integration.sh
+++ b/test/setup_integration.sh
@@ -31,7 +31,18 @@ done
 # tools/go.mod's tool directives; env.sh pins GOPROXY/GOSUMDB so the sum
 # database can't be disabled. go requires an absolute GOBIN, and env.sh's
 # local default for WRANGLE_BIN_DIR is CWD-relative.
-GOBIN="$(cd "$WRANGLE_BIN_DIR" && pwd)" go -C "$REPO_ROOT/tools" install tool
+#
+# The stamp records the go.sum the binaries were built for: a warm bin dir
+# (a restored CI cache) with a matching stamp skips the rebuild, and a go.sum
+# change forces a fresh install so a stale cache can't serve mismatched tools.
+TOOLS_STAMP="$WRANGLE_BIN_DIR/.go-tools.stamp"
+GOSUM_DIGEST="$(sha256sum "$REPO_ROOT/tools/go.sum" | cut -d' ' -f1)"
+if [[ -f "$TOOLS_STAMP" && "$(<"$TOOLS_STAMP")" == "$GOSUM_DIGEST" ]]; then
+    printf 'setup_integration: Go tools present for current go.sum, skipping install\n'
+else
+    GOBIN="$(cd "$WRANGLE_BIN_DIR" && pwd)" go -C "$REPO_ROOT/tools" install tool
+    printf '%s\n' "$GOSUM_DIGEST" > "$TOOLS_STAMP"
+fi
 
 # The lint-tool venvs the unit bats exercise (wrangle-shell-lint needs
 # ast-grep; wrangle-workflow-lint runs lint.py under a python that can

--- a/test/test_setup_integration.bats
+++ b/test/test_setup_integration.bats
@@ -29,6 +29,20 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "setup_integration: guards the Go tool install with a go.sum-digest stamp" {
+    # A restored CI binary cache (build_shell.yml cache-setup-tools) must skip
+    # the rebuild: the install runs only when the stamp is absent or stale.
+    run grep -F '.go-tools.stamp' "$SETUP"
+    [ "$status" -eq 0 ]
+}
+
+@test "setup_integration: the dogfood workflow caches the installed Go tools" {
+    # local_build_shell.yml opts into the binary cache so go.sum-stable runs
+    # don't relink ampel/bnd/cosign/osv-scanner.
+    run grep -E 'cache-setup-tools:[[:space:]]*enabled' "$REPO_ROOT/.github/workflows/local_build_shell.yml"
+    [ "$status" -eq 0 ]
+}
+
 @test "setup_integration: the dogfood workflow auto-detects bats (no explicit list)" {
     # CI coverage must not depend on a hand-maintained file list: with
     # bats-path unset, build_shell auto-detects every .bats in the tree.


### PR DESCRIPTION
## What does this PR do?

Adds a `cache-setup-tools` workflow input to `build_shell.yml` that caches prebuilt Go tool binaries (ampel, bnd, cosign, osv-scanner) in CI, keyed on `go.sum`. This avoids relinking tools on every run when `go.sum` hasn't changed.

The implementation:
- Adds a new optional workflow input `cache-setup-tools` (disabled by default)
- Introduces a `.go-tools.stamp` file that records the SHA256 digest of `tools/go.sum`
- Modifies `setup_integration.sh` to skip the `go install` step if the stamp matches the current `go.sum`, allowing a restored cache to serve prebuilt binaries
- Adds a cache action step in `build_shell.yml` that restores/saves the `$RUNNER_TEMP/.wrangle/bin` directory
- Enables the feature in the dogfood workflow (`local_build_shell.yml`) with `cache-setup-tools: enabled`
- Adds integration tests to verify the stamp mechanism and dogfood opt-in

**Important:** This is test/scan-only. A cache hit skips `go.sum` re-verification, so it must never gate a release build (this workflow attests nothing per the comment).

## Checklist

- [x] Spec updated if contracts changed — no contract changes; this is an internal CI optimization
- [x] `make test` passes locally — new integration tests added to `test/test_setup_integration.bats`
- [x] CI passes on this PR
- [x] No new `continue-on-error` without justification
- [x] No `@main` refs in `uses:` lines (uses pinned `actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5`)
- [x] Tool `SPEC.md` — N/A, no tool changes

https://claude.ai/code/session_014dSkJ5fa5QYw58fnjVJ4jb