### PR TITLE
Cancel superseded PR runs for Test and Build Shell

### DIFF
--- a/.github/workflows/local_build_shell.yml
+++ b/.github/workflows/local_build_shell.yml
@@ -13,6 +13,11 @@ on:
     branches: ["**"]
   workflow_dispatch:
 
+# Cancel superseded PR runs; the run_id fallback keeps each main/tag push in its own group (never cancelled).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-shell:
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: ["**"]
 
+# Cancel superseded PR runs; the run_id fallback keeps each main push in its own group (never cancelled).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a `concurrency` group to the two PR-iteration workflows that lacked one — `test.yml` (Test) and `local_build_shell.yml` (Build Shell):

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
  cancel-in-progress: true
```

A newer commit on the same PR now cancels the superseded in-progress run. The `run_id` fallback puts each `main`/tag **push** in its own group, so release/`main` CI is never cancelled — only PR runs cancel each other. This mirrors the `cancel-in-progress: true` pattern `integration-test.yml` already uses.

## Why

These two workflows ran every superseded PR commit to completion. The payoff is mostly faster feedback and not paying for runs nobody reads — the compute saved is modest (superseded runs were low-single-digit % in a sampled burst window, and the expensive cross-repo e2e in `integration-test.yml` already cancels superseds). This just brings the remaining two PR workflows in line.

## Safety

- `cancel-in-progress` only ever fires for `pull_request` events; `main`/tag pushes get a unique `run_id` group and run to completion.
- No job logic changes.

Validated locally: `actionlint`, `wrangle-workflow-lint`, and YAML parse all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014dSkJ5fa5QYw58fnjVJ4jb)_