### PR TITLE
docs: fix the container VSA cosign recipe (verify-attestation can't resolve an OCI referrer)

### DIFF
--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -186,28 +186,40 @@ old (possibly vulnerable) release; it raises the floor from any commit to any
 release. `--type` must be the full URI — cosign rejects the
 `slsaverificationsummary` alias.
 
-For container images, a digest subject has no file blob, so the command is
-`cosign verify-attestation` (cosign v3) against the image — this reads the VSA
-from its by-digest registry referrer. If you'd rather verify from the file,
-pull the VSA line out of the combined `<sha256-digest>.intoto.jsonl` workflow
-artifact and use `cosign verify-blob-attestation --new-bundle-format`, exactly
-as the file-artifact path above does. `cosign verify-attestation` prints the
-verified envelope to stdout, so capture and decode that:
+For container images the VSA is an OCI referrer on the image digest, not a
+`sha256-<digest>.att` tag, so `cosign verify-attestation` cannot find it. Pull
+the VSA referrer bundle with `cosign download attestation` (which lists each
+referrer bundle on its own line), select the VSA line, then bind it to the image
+digest with `cosign verify-blob-attestation --new-bundle-format` — a digest
+subject has no file blob, so pass `--digest`/`--digestAlg` in place of a path:
 
 ```bash
-cosign verify-attestation \
-  --type https://slsa.dev/verification_summary/v1 \
+imagename=<imagename>; digest=<digest>   # the sha256 hex, no "sha256:" prefix
+
+cosign download attestation "$imagename@sha256:$digest" \
+  | jq -c "select(.dsseEnvelope.payload | @base64d | fromjson
+    | .predicateType == \"https://slsa.dev/verification_summary/v1\")" > vsa.intoto.jsonl
+
+cosign verify-blob-attestation --bundle vsa.intoto.jsonl --new-bundle-format \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp '^https://github\.com/TomHennen/wrangle/\.github/workflows/build_and_publish_container\.yml@refs/tags/v[0-9.]+$' \
   --certificate-github-workflow-repository <your-org>/<your-repo> \
-  <imagename>@sha256:<digest> > vsa.json
+  --type https://slsa.dev/verification_summary/v1 \
+  --digest "$digest" --digestAlg sha256
 
-payload="$(jq -r '.payload' vsa.json | base64 -d)"
-jq -e '.subject[0].digest.sha256 == "<digest>"' <<<"$payload"
+payload="$(jq -r '.dsseEnvelope.payload' vsa.intoto.jsonl | base64 -d)"
 jq -e '.predicate.verificationResult == "PASSED"' <<<"$payload"
-jq -e '.predicate.resourceUri == "<imagename>@sha256:<digest>"' <<<"$payload"
+jq -e ".predicate.resourceUri == \"$imagename@sha256:$digest\"" <<<"$payload"
 jq -e '.predicate.verifiedLevels | index("SLSA_BUILD_LEVEL_3")' <<<"$payload"
 ```
+
+If you'd rather verify from the file, the combined `<sha256-digest>.intoto.jsonl`
+workflow artifact carries the same VSA — swap the `cosign download attestation`
+step for a `jq` filter over that file, exactly as the file-artifact path above
+does. The `@refs/tags/v…` anchor is the strict release identity (see the
+file-artifact note above); the showcase staging image is built SHA-pinned, so
+its VSA carries a bare `@<sha>` identity and verifies only under a loosened
+anchor.
 
 > **`slsa-verifier verify-vsa` is not usable here.** It only verifies
 > *key-signed* VSAs (it requires `--public-key-path`); wrangle's VSAs are


### PR DESCRIPTION
## The bug

`docs/verifying_artifacts.md` documented `cosign verify-attestation` as the
cosign-side recipe for verifying a **container's** VSA. It does not work.

wrangle stores the container VSA as an OCI **referrer** on the image digest
(`artifactType: application/vnd.dev.sigstore.bundle.v0.3+json`), but
`cosign verify-attestation` discovers attestations only via the legacy
`sha256-<digest>.att` **tag** convention. No such tag exists, so it finds
nothing and hangs.

Confirmed empirically against the showcase staging image — `cosign tree`
shows the VSA as a `https://slsa.dev/verification_summary/v1` OCI referrer (no
`.att` tag), and `cosign verify-attestation` against the image times out:

```
$ cosign tree ghcr.io/tomhennen/wrangle-test-staging@sha256:8c17...b2067
└── 🔗 https://slsa.dev/verification_summary/v1 artifacts via OCI referrer: ...@sha256:ddfa...7089
$ timeout 60 cosign verify-attestation --type .../verification_summary/v1 ... <image>
Terminated   (exit 124)
```

The file-artifact `cosign verify-blob-attestation` recipe in the same doc was
fine; only the container `verify-attestation` path was broken.

## The fix

Replace it with the working path, mirroring the file-artifact recipe:
pull the referrer bundle with `cosign download attestation` (which lists each
referrer bundle on its own line), select the VSA line by predicate type, then
bind it to the image digest with
`cosign verify-blob-attestation --new-bundle-format` using `--digest`/`--digestAlg`
(a digest subject has no file blob). Keeps the strict `@refs/tags/v…` identity
anchor an adopter uses against a tagged release, and notes the showcase image is
SHA-pinned (so verifies only under a loosened anchor). ampel's `oci:` collector
remains the recommended one-command container path above this section.

## Validation (cosign v3.0.6, the tools/go.mod pin)

Ran the documented flow verbatim against the staging image
`ghcr.io/tomhennen/wrangle-test-staging@sha256:8c175175cff5720e00947d3b4ba3712813534ff464fb5a0ad7ed46a4336b2067`
(with the loosened `@<40hex>` anchor, since the showcase image is SHA-pinned):

```
Verified OK
verify-blob-attestation EXIT: 0
true      # .predicate.verificationResult == "PASSED"
true      # .predicate.resourceUri == "ghcr.io/tomhennen/wrangle-test-staging@sha256:8c17...b2067"
0         # .predicate.verifiedLevels | index("SLSA_BUILD_LEVEL_3")
```

Decoded predicate fields observed: `resourceUri` =
`ghcr.io/tomhennen/wrangle-test-staging@sha256:8c17...b2067`,
`verificationResult` = `PASSED`, `verifiedLevels` = `["SLSA_BUILD_LEVEL_3"]`.

Doc-only change. `tools/check_pin_freshness.sh` green (all 19 self-ref pins
resolve to HEAD content); no code or pin changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)