### PR TITLE
release: bump adopter-facing pins v0.2.2 -> v0.3.0

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -120,7 +120,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/prep@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         id: prep
         with:
           build-type: container
@@ -139,7 +139,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/scan@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -168,7 +168,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      uses: TomHennen/wrangle/build/actions/container@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
       with:
         path: ${{ inputs.path }}
         imagename: ${{ inputs.imagename }}
@@ -245,7 +245,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -286,7 +286,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/verify_release@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/prep@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/scan@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/build/actions/go/checks@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/build/actions/go/build@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/attest_provenance@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/verify_release@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/prep@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/scan@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/build/actions/npm@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/attest_provenance@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/verify_release@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/prep@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/scan@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/build/actions/python@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/attest_provenance@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/verify_release@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -77,7 +77,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/prep@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -90,7 +90,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/scan@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -134,7 +134,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+        uses: TomHennen/wrangle/build/actions/shell@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/prep@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+        uses: TomHennen/wrangle/actions/scan@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
 ```

--- a/actions/scan/README.md
+++ b/actions/scan/README.md
@@ -23,7 +23,7 @@ jobs:
       actions: read
       contents: read
       security-events: write   # SARIF upload to the Security tab
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
 ```
 
 Findings appear in the Security tab; the run's step summary shows an overview.
@@ -49,7 +49,7 @@ The May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical exam
 The `tools` input is a space-separated list. Default: `"osv zizmor scorecard:info dependency-review wrangle-lint"`. Suffix with `:info` to make a tool's findings non-blocking.
 
 ```yaml
-uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
 with:
   tools: "osv zizmor"   # skip Scorecard and dependency-review
 ```

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -133,7 +133,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      uses: TomHennen/wrangle/tools/zizmor@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -141,7 +141,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      uses: TomHennen/wrangle/tools/scorecard@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -153,7 +153,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+      uses: TomHennen/wrangle/tools/dependency-review@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
 
     - name: Generate step summary
       if: always()

--- a/actions/verify-vsa/README.md
+++ b/actions/verify-vsa/README.md
@@ -19,7 +19,7 @@ Drop it into your publish job between `download-artifact` and the publish step:
     path: dist/
 
 # Pin by release tag; a SHA-pinned build's VSA fails this gate (see below).
-- uses: TomHennen/wrangle/actions/verify-vsa@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+- uses: TomHennen/wrangle/actions/verify-vsa@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
   with:
     path: dist/
     resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@de14f755ac78854bdcbd16ac94974eb8c5599b57 # main 2026-06-22
+    - uses: TomHennen/wrangle/actions/verify@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -35,7 +35,7 @@ Consumers verify the image with one command — ampel fetches the VSA straight f
 
 ```bash
 ampel verify --subject sha256:<digest> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.3.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector oci:<imagename>@sha256:<digest> \
   --context expectedResourceUri:<imagename>@sha256:<digest> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/build/actions/go/README.md
+++ b/build/actions/go/README.md
@@ -19,7 +19,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
 ```
@@ -76,7 +76,7 @@ Downstream users verify a release archive with one command. Download the archive
 
 ```bash
 ampel verify --subject <archive> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.3.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector jsonl:<archive>.intoto.jsonl \
   --context expectedResourceUri:pkg:golang/<module-path>@<version> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -17,7 +17,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       release-events: tag-only   # only tag pushes publish
@@ -58,7 +58,7 @@ Publishing happens in your workflow, so two things there are load-bearing — bo
 2. **Verify before you publish** — run wrangle's [`verify-vsa`](../../../actions/verify-vsa/README.md) action between `download-artifact` and `npm publish`, piping the build's `resource-uri` output, so the exact bytes leaving the runner are the bytes that passed wrangle's policy:
 
    ```yaml
-   - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+   - uses: TomHennen/wrangle/actions/verify-vsa@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
      with:
        path: dist/
        resource-uri: ${{ needs.build.outputs.resource-uri }}
@@ -83,7 +83,7 @@ Downstream users verify the released tarball with one command. Download the tarb
 
 ```bash
 ampel verify --subject <tarball> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.3.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector jsonl:<tarball>.intoto.jsonl \
   --context expectedResourceUri:pkg:npm/<name>@<version> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -17,7 +17,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       release-events: tag-only   # only tag pushes publish
@@ -58,7 +58,7 @@ Publishing happens in your workflow, so two things there are load-bearing — bo
 2. **Verify before you publish** — run wrangle's [`verify-vsa`](../../../actions/verify-vsa/README.md) action between `download-artifact` and the publish step, piping the build's `resource-uri` output, so the exact bytes leaving the runner are the bytes that passed wrangle's policy:
 
    ```yaml
-   - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+   - uses: TomHennen/wrangle/actions/verify-vsa@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
      with:
        path: dist/
        resource-uri: ${{ needs.build.outputs.resource-uri }}
@@ -79,7 +79,7 @@ Downstream users verify a dist file with one command. Download the wheel (or sdi
 
 ```bash
 ampel verify --subject <dist-file> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.3.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector jsonl:<dist-file>.intoto.jsonl \
   --context expectedResourceUri:pkg:pypi/<name>@<version> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/build/actions/shell/README.md
+++ b/build/actions/shell/README.md
@@ -13,7 +13,7 @@ jobs:
       contents: read
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
 ```
 
 PRs, pushes, and manual dispatches all run the same checks — there's no release step to gate.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -18,7 +18,7 @@ Pin by release **tag** (`@vX.Y.Z`), with an inline zizmor exception on that one
 line:
 
 ```yaml
-uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
 ```
 
 wrangle's release tags are

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -691,7 +691,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
 ```
 
 This is the entire file an adopter needs. No secrets, no configuration, no dependencies to manage.

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -73,7 +73,7 @@ by design. Use the `nonstrict` policy, which accepts any ref:
 
 ```bash
 ampel verify --subject wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-nonstrict-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.3.0#policies/wrangle-vsa-consumer-nonstrict-v1.hjson \
   --collector jsonl:wrangle-test-fixture-go_20260621-fa5bd7f_linux_amd64.tar.gz.intoto.jsonl \
   --context expectedResourceUri:pkg:golang/github.com/tomhennen/wrangle-test/go@v20260621-fa5bd7f \
   --context sourceRepo:https://github.com/TomHennen/wrangle-test
@@ -99,7 +99,7 @@ bundle and self-selects the VSA matching `--subject`:
 
 ```bash
 ampel verify --subject <artifact> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.3.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector jsonl:<artifact>.intoto.jsonl \
   --context expectedResourceUri:<resourceUri from the table above> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>
@@ -110,7 +110,7 @@ download step:
 
 ```bash
 ampel verify --subject sha256:<digest> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.3.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector oci:<imagename>@sha256:<digest> \
   --context expectedResourceUri:<imagename>@sha256:<digest> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>
@@ -129,7 +129,7 @@ build type, including a container image by its OCI digest:
 
 ```bash
 ampel verify --subject sha256:<digest> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.2.2#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.3.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector github:<your-org>/<your-repo> \
   --context expectedResourceUri:<resourceUri from the table above> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/gh_workflow_examples/build_and_publish_containers.yml
+++ b/gh_workflow_examples/build_and_publish_containers.yml
@@ -24,7 +24,7 @@ jobs:
       attestations: write  # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: PATH/TO/FOLDER/WITH/Dockerfile
       imagename: ghcr.io/${{ github.repository }}/YOUR_IMAGE_NAME

--- a/gh_workflow_examples/build_go.yml
+++ b/gh_workflow_examples/build_go.yml
@@ -37,7 +37,7 @@ jobs:
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       # release-events: tag-only         # default; uncomment + change to "non-pull-request" or "main-and-tags" for early failure detection on non-tag events

--- a/gh_workflow_examples/build_npm.yml
+++ b/gh_workflow_examples/build_npm.yml
@@ -52,7 +52,7 @@ jobs:
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       release-events: tag-only          # only tag pushes publish (recommended default)
@@ -96,7 +96,7 @@ jobs:
 
       # Verify the downloaded tarball against wrangle's signed VSA — the
       # full policy verdict — before any bytes leave this runner.
-      - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+      - uses: TomHennen/wrangle/actions/verify-vsa@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
         with:
           path: dist/
           resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/gh_workflow_examples/build_python.yml
+++ b/gh_workflow_examples/build_python.yml
@@ -49,7 +49,7 @@ jobs:
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       release-events: tag-only          # only tag pushes publish (recommended default)
@@ -74,7 +74,7 @@ jobs:
 
       # Verify the downloaded dist against wrangle's signed VSA — the
       # full policy verdict — before any bytes leave this runner.
-      - uses: TomHennen/wrangle/actions/verify-vsa@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+      - uses: TomHennen/wrangle/actions/verify-vsa@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
         with:
           path: dist/
           resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/gh_workflow_examples/build_shell.yml
+++ b/gh_workflow_examples/build_shell.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable
     # with:
     #   scan-path: "."       # optional: subdirectory to scan (default: repo root)
     #   bats-path: ""        # optional: path to bats tests (default: auto-detect)

--- a/gh_workflow_examples/check_source_change.yml
+++ b/gh_workflow_examples/check_source_change.yml
@@ -14,4 +14,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.2.2 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.3.0 # zizmor: ignore[unpinned-uses] - immutable


### PR DESCRIPTION
**The v0.3.0 release commit.** Bumps all 27 adopter-facing `@v0.2.2` → `@v0.3.0` refs (the `gh_workflow_examples/*.yml`, every `build/actions/*/README.md` + `actions/*/README.md`, top-level README, `docs/{FAQ,SPEC,verifying_artifacts}.md` — including the policy-locator URLs in the verify commands). None are executed by CI (docs/examples only). The pinned-path READMEs re-staled their action pins, so pins were re-converged to `# main` (19/19 fresh).

## Merge + tag
**Land as a MERGE commit, NOT squash** — the converged pins point at the bump commit, which a squash would orphan. Then **tag the merge commit `v0.3.0`** so `@v0.3.0` self-resolves to the commit that references it.

All three release gates are green: showcase run `v20260621-6a18321` succeeded (Gate 1), inventory signed off (Gate 2), verify commands validated (Gate 3).