### PR TITLE
docs: note build pipelines don't work on user-owned private repos (#597)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ jobs:
 Once they've done this they'll get tests executed, vuln scanning, attestations, etc.
 
 > [!NOTE]
-> The build pipelines (Go, Python, npm, Container) don't work on a **user-owned private repo** yet — they persist provenance to GitHub's attestation store, which isn't available there, so no release is published. Use a public repo or an org-owned private repo on a plan with private attestations. See [the FAQ](docs/FAQ.md#can-i-use-wrangle-on-a-private-repo).
+> The build pipelines (Go, Python, npm, Container) don't work on user-owned private repos yet — see [the FAQ](docs/FAQ.md#can-i-use-wrangle-on-a-private-repo).
 
 Wrangle requires Dependabot so your dependencies and action pins keep updating automatically. It can't turn Dependabot on
 for you, but it does check you've set it up: a missing config fails the source scan until you fix it (or suppress the

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ jobs:
 
 Once they've done this they'll get tests executed, vuln scanning, attestations, etc.
 
+> [!NOTE]
+> The build pipelines (Go, Python, npm, Container) don't work on a **user-owned private repo** yet — they persist provenance to GitHub's attestation store, which isn't available there, so no release is published. Use a public repo or an org-owned private repo on a plan with private attestations. See [the FAQ](docs/FAQ.md#can-i-use-wrangle-on-a-private-repo).
+
 Wrangle requires Dependabot so your dependencies and action pins keep updating automatically. It can't turn Dependabot on
 for you, but it does check you've set it up: a missing config fails the source scan until you fix it (or suppress the
 finding). Copy gh_workflow_examples/dependabot.yml to .github/dependabot.yml and tailor it to your ecosystem.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -84,6 +84,20 @@ Leave immutable releases off on repos using wrangle's Go/Python/npm build types
 until [#407](https://github.com/TomHennen/wrangle/issues/407) moves the attach
 to a draft → attach → publish flow.
 
+## Can I use wrangle on a private repo?
+
+The **source-only** and **shell** workflows run anywhere. The build pipelines
+(Go, Python, npm, Container) don't work on a **user-owned private repo** yet:
+each one persists SLSA provenance to
+[GitHub's attestation store](https://docs.github.com/rest/repos/attestations#create-an-attestation),
+which GitHub doesn't offer for user-owned private repos. The `attest` job fails,
+`verify` is skipped, and no release is published.
+
+Run a build pipeline on a **public repo**, or on a **private repo owned by an
+org** with a plan that includes private attestations. Scan-tool specifics for
+private repos without Advanced Security are [below](#im-on-a-private-repo-without-advanced-security--which-scan-tools-work).
+Tracking: [#597](https://github.com/TomHennen/wrangle/issues/597).
+
 ## I'm on a private repo without Advanced Security — which scan tools work?
 
 Most of the default `scan-tools` work as-is. The SARIF upload to the Security

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -90,8 +90,9 @@ The **source-only** and **shell** workflows run anywhere. The build pipelines
 (Go, Python, npm, Container) don't work on a **user-owned private repo** yet:
 each one persists SLSA provenance to
 [GitHub's attestation store](https://docs.github.com/rest/repos/attestations#create-an-attestation),
-which GitHub doesn't offer for user-owned private repos. The `attest` job fails,
-`verify` is skipped, and no release is published.
+which GitHub doesn't offer for user-owned private repos. The release fails with
+`Failed to persist attestation: Feature not available for user-owned private
+repositories`, and nothing is published.
 
 Run a build pipeline on a **public repo**, or on a **private repo owned by an
 org** with a plan that includes private attestations. Scan-tool specifics for


### PR DESCRIPTION
## What

Documents that wrangle's build pipelines (Go, Python, npm, Container) cannot complete a release on a **user-owned private repo**: every build type persists SLSA provenance to GitHub's attestation store, which GitHub doesn't offer for user-owned private repos, so `attest` fails, `verify` is skipped, and nothing is published.

This is the doc-only response to part 1 of #597, ahead of today's announcement where this will otherwise bite adopters. The code fix (an opt-out input + decoupling `verify` from a failed `attest`) is deliberately left to a follow-up.

## Changes

- **`docs/FAQ.md`** — new "Can I use wrangle on a private repo?" entry, beside the existing private-repo scan-tools entry, mirroring the immutable-releases entry's altitude (state the fact, link the issue, don't reproduce mechanism).
- **`README.md`** — a `> [!NOTE]` callout under the Quick Start example linking to the FAQ entry.

## Scope notes

- Verified all four build pipelines actually persist (`attestations: write` + `attest-build-provenance`); source-only/shell don't attest and are called out as working anywhere.
- Part 2 of #597 (spurious SARIF `##[error]` lines) is already partly covered by the existing private-repo FAQ entry; the remaining sub-items (silently-tightened default `policy:`, the `:info`-vs-policy contradiction) are out of scope here and better split into their own issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)