### PR TITLE
docs: note stacked-PR base-branch deletion hazard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ For throwaway end-to-end experiments before promoting to the integration compani
 ## Contributing process
 
 - Branch from `main` with descriptive names; PRs must pass CI (`make test`), shellcheck, and actionlint cleanly.
+- **Don't delete a branch that's the base of an open stacked PR** — GitHub auto-closes the dependent; rebase dependents onto `main` first (and `--delete-branch` fails from inside a worktree, where `main` is checked out elsewhere).
 - **No merge without an `LGTM` from the repository owner** — green CI alone is never authorization to merge.
 - If a PR fully fixes a tracked issue, close it from the description with a closing keyword (`Fixes #NNN`); if unsure it fully resolves the issue, ask the owner.
 - Update the README and `gh_workflow_examples/` if the adoption interface changes.


### PR DESCRIPTION
Adds one bullet to CLAUDE.md § Contributing process capturing a scar from the v0.3.0 saga: deleting a branch that is the **base of an open stacked PR** makes GitHub auto-close the dependent PR (hit during #570→#572), and `--delete-branch` fails from inside a worktree where `main` is checked out elsewhere.

Not lintable, so it's a one-line prose rule rather than a check. Kept to a single bullet per the file's one-sentence-per-rule convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)