### PR TITLE
docs: tool containerization design exploration (#596)

### DIFF
--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -15,10 +15,10 @@ Wrangle's tool layer solves four problems at once, each only partially:
    ampel, bnd, cosign, wrangle-lint, …), a bespoke `install.sh` (syft), a pip `requirements.txt`
    (zizmor), and action wrappers. Coverage is uneven and drift is a recurring review finding
    (#264/#277/#286).
-2. **Speed.** Adapter tools are compiled from source on every run: `run.sh` `go install`s osv-scanner's
-   dependency tree cold, which is slow enough that the scan action raises `WRANGLE_INSTALL_TIMEOUT` from
-   its 300 s default to 900 s. The Go build cache that would help is off by default on attested paths
-   for SLSA-L3 reasons.
+2. **Speed.** Adapter tools are installed and compiled on every run: `run.sh` `go install`s
+   osv-scanner's dependency tree cold, which is slow enough that the scan action raises
+   `WRANGLE_INSTALL_TIMEOUT` from its 300 s default to 900 s. The Go build cache that would help is off
+   by default on attested paths for SLSA-L3 reasons.
 3. **Supply-chain isolation.** A tool today is contained by a stripped environment, the adapter
    contract, and a post-run filesystem snapshot — not a real sandbox. Stronger isolation was deferred
    (#267), and each bespoke `install.sh` adds audit surface.
@@ -26,7 +26,7 @@ Wrangle's tool layer solves four problems at once, each only partially:
    carrying GitHub-Actions-specific dispatch (#137).
 
 A single primitive — a pinned image behind a fixed contract — addresses all four: the digest is the
-version, the prebuilt layer removes the per-run compile, the container is the sandbox, and "add a tool"
+version, the prebuilt layer removes the per-run install, the container is the sandbox, and "add a tool"
 becomes "publish an image that honors the contract."
 
 ## 2. Goals and constraints
@@ -62,9 +62,9 @@ docker run --rm --network <policy> -u <runner_uid>:<gid> \
 - **Ownership** — the container runs as the runner UID/GID, or output files are written as `root` and
   the runner cannot consume them.
 - **Network** — `--network none` by default; egress is a **per-tool** opt-in (not per-kind). Some tools
-  need it: zizmor's online audits reach the GitHub API, osv refreshes its advisory DB. *Granularity:*
-  Docker offers deny-all vs allow-all cheaply; a true domain allowlist needs an egress proxy, so opt-in
-  initially means full egress for the tools that declare it.
+  need it: zizmor's online audits reach the GitHub API, osv refreshes its advisory DB. *Decision:*
+  accept full egress for the tools that declare it (they already have it today); a true per-domain
+  allowlist needs an egress proxy and is tracked as a later nice-to-have, not a launch requirement.
 - **Secrets** — `scan`/`sbom` tools receive none by default; a tool needing an authed call (zizmor → a
   GitHub token) declares it and receives it through the existing `WRANGLE_EXTRA_` channel.
 
@@ -85,14 +85,21 @@ SPEC's Adapter Script Interface (environment/security sections) is updated in th
 
 The contract is parameterized over tool kind:
 
-| Kind | Input | Output | Exit | Adopter-substitutable |
-|------|-------|--------|------|-----------------------|
+| Kind | Input | Primary output | Exit | Adopter-substitutable |
+|------|-------|----------------|------|-----------------------|
 | `scan` | `src_dir` (ro) | `output.sarif` (SARIF 2.1.0) | 0 clean / 1 findings / 2 error | yes |
 | `sbom` | `src_dir` or built artifact | `sbom.<format>.json` (SPDX or CycloneDX, declared) | 0 ok / 2 error | yes |
 | `attest`/`verify` | metadata + targets | signed attestations / verdict | tool-specific | no |
 
 `sbom` declares its format rather than assuming SPDX; its exit codes have no "findings" state; and its
-input may be a built artifact, not source. Everything else matches today's adapter interface.
+input may be a built artifact, not source.
+
+**Output handling.** A tool's *primary* output (above) drives gating. Beyond it, wrangle gives specific
+filenames special handling — `output.sarif` feeds the result/Security-tab upload, `output.md` feeds the
+GHA step summary — and **persists anything else the tool writes to `/output`** into the published
+metadata (and thus the signed attestation). So the contract is "write your primary output; write
+`output.md` if you have a human-readable summary; anything else under `/output` is carried along," not a
+fixed file list.
 
 ### 3.4 Packaging
 
@@ -104,11 +111,14 @@ A tool's build path follows from **who owns it**:
 | Third-party tool wrapped | osv, syft, zizmor | Dockerfile via `build_and_publish_container` |
 | Adopter's own tool | a BYO SBOM generator | adopter's choice; wrangle ships only the contract |
 
-For wrapped third-party tools, the image is **built from source** by default: a multi-stage Dockerfile
-compiles the tool from wrangle's `tools/go.mod` and copies the binary onto a distroless base. This keeps
-the `go.mod` in-repo, so Dependabot, osv, and govulncheck continue to see the tool's transitive
-dependencies and wrangle retains the ability to patch a dependency ahead of upstream. The compile moves
-from every run to image-publish time. (Building a single tool from the shared `tools/go.mod` and
+For wrapped third-party tools, the image is built by **installing the tool through its canonical package
+manager** — a Go module/tool directive (osv from `tools/go.mod`), a hash-pinned PyPI install (zizmor),
+cargo `--locked`, etc. — into a multi-stage Dockerfile, then copying the result onto a distroless base.
+This is deliberately *not* a git-clone-and-rebuild: using the canonical distribution keeps the
+dependency manifest (`go.sum`, `requirements.txt`, `Cargo.lock`) in-repo, which is exactly what lets
+Dependabot, osv, and govulncheck keep scanning the tool's transitive dependencies and lets wrangle patch
+a dependency ahead of upstream. It also matches DEP_MGMT.md's integrity ladder. The install/compile
+moves from every run to image-publish time. (Building a single tool from the shared `tools/go.mod` and
 extracting one binary is validated — see §4.)
 
 zizmor moves into this model too. It is action-pattern today only because Rust/pip install was awkward;
@@ -124,44 +134,41 @@ This is what lets wrangle own the surface — mounts, network, user, environment
 output layout — rather than ceding it to whatever an action's `action.yml` chooses to do. It also keeps
 the model CI-agnostic (#171) and flattens the nested `uses: ./tools/*` composition (#137).
 
-### 3.6 Reference model
+### 3.6 Reference model: a curated catalog
 
-The image digest is a **wrangle-curated default**, not something each adopter pins. Two compatible
-homes:
+The image digests are not pinned by each adopter; they live in a **wrangle-curated catalog** — a single
+`tool → {digest, capabilities}` manifest the orchestrator reads (subsuming the #264 `tools.lock` idea).
+The catalog, not a per-tool action input, is the home for tool *definition*, because capabilities
+(network, secret, format) don't fit cleanly as action inputs, and because one manifest is the cleanest
+thing for the pin tooling to track and for adopters to read.
 
-- a **defaulted input** on the scan action (`osv-image: ghcr.io/…@sha256:…`), and/or
-- a **`tools.lock`** — a single `tool → digest` manifest the orchestrator reads (subsuming the #264
-  lock idea), which is the cleaner central store for the pin tooling and gives adopters a transparent
-  view of what they run.
-
-Either way, **adopters inherit the image by pinning wrangle**, exactly as they already inherit every
-bundled tool version. Wrangle bumps its own default when it updates a tool. An adopter who *overrides*
-(brings their own image, or pins a different digest) owns that pin's freshness; wrangle can offer rails
-(a `docker` Dependabot entry, a lint warning on a stale override) but cannot vouch for an image it does
-not control.
+- **Adopters inherit the catalog by pinning wrangle**, exactly as they already inherit every bundled
+  tool version. Wrangle bumps a digest when it updates a tool.
+- **Selection stays short-name + policy** — the existing `tools: "osv zizmor:info …"` interface is
+  unchanged; a name resolves through the catalog to an image.
+- **Overrides** are an adopter-supplied catalog fragment (a different digest for a built-in, or a whole
+  new tool). Because selection is by short name, an adopter can swap in a *different* tool that does the
+  same job — not just a different image of the same tool. An override is a pin the adopter now owns the
+  freshness of; wrangle can offer rails (a `docker` Dependabot entry, a lint warning on a stale
+  override) but cannot vouch for an image it does not control.
 
 ### 3.7 Capability declaration
 
 Two distinct layers:
 
-- **Selection** (per run, adopter-facing): which tools to run and at what policy — today's
-  `tools: "osv zizmor:info …"` string.
-- **Definition** (static, per tool): a tool name resolves to `{image digest, kind, network, secret,
-  output}`. Capabilities live here, alongside the reference model, not in the selection string.
+- **Selection** (per run, adopter-facing): which tools to run and at what policy — the `tools:` string.
+- **Definition** (static, per tool): the catalog entry — `{image digest, kind, network, secret,
+  output}`.
 
 **A capability grant comes from the trusting party — wrangle, or the adopter for their own tool — never
 from the image itself.** An image may *request* a capability (e.g. an OCI label), but granting it is the
 orchestrator's decision; otherwise the sandboxed tool would define its own sandbox. Grants are therefore
-recorded in-repo as reviewable lines, default to `network=none, secret=none`, and are relaxed only
-explicitly — consistent with wrangle's least-privilege and input-validation rules.
+recorded in-repo as reviewable catalog lines, default to `network=none, secret=none`, and are relaxed
+only explicitly — consistent with wrangle's least-privilege and input-validation rules.
 
 ### 3.8 Configuration, illustrated
 
-The reference model (§3.6) and the capability definition (§3.7) live together in one wrangle-curated
-**catalog** (the `tools.lock` of §3.6). Capabilities — network, secret, output format — don't fit
-cleanly as action inputs, so the catalog file is the natural home for *definition*; the scan action's
-input stays *selection* plus an optional override pointer. Schema below is illustrative; the exact
-format is open (§8).
+Schema below is the proposed shape; exact field names and file locations are bikeshed-able (§9).
 
 **Internal — wrangle's curated catalog** (wrangle bumps it; adopters inherit by pinning wrangle):
 
@@ -170,7 +177,7 @@ format is open (§8).
 tools:
   osv:
     kind: scan
-    image: ghcr.io/tomhennen/wrangle/osv@sha256:1531…   # built from this repo's go.mod
+    image: ghcr.io/tomhennen/wrangle/osv@sha256:1531…   # installed from this repo's go.mod
     network: egress          # default is none; osv refreshes its advisory DB
   zizmor:
     kind: scan
@@ -184,13 +191,16 @@ tools:
     # network omitted → none; no secret
 ```
 
+(During migration a catalog entry may carry `delivery: adapter` to keep running the old in-process
+adapter for a tool not yet containerized; the default is `delivery: image`. See §10.)
+
 **Adopter — selecting tools** (pin wrangle, choose which to run, optionally point at an override file):
 
 ```yaml
 # adopter .github/workflows/scan.yml
 jobs:
   scan:
-    uses: TomHennen/wrangle/.github/workflows/scan.yml@v0.4.0   # pin → inherit the catalog above
+    uses: TomHennen/wrangle/.github/workflows/scan.yml@<wrangle-version>  # pin a wrangle release
     with:
       tools: "osv zizmor:info my-sbom"     # selection + policy (unchanged from today)
       tool-overrides: .wrangle/tools.yaml  # optional; overrides/extends the catalog
@@ -211,14 +221,12 @@ tools:
 ```
 
 What the three pieces demonstrate:
-- **Inheritance** — an adopter who only sets `tools:` runs wrangle's curated, cooldown-vetted images
-  and pins nothing of their own.
-- **Override ownership** — overriding `osv` means pinning a digest the adopter now owns the freshness
-  of; wrangle's pin tooling covers its own catalog, not this entry (wrangle can offer a Dependabot
-  entry / lint warning, §3.6, but not vouch for it).
+- **Inheritance** — an adopter who only sets `tools:` runs wrangle's curated, cooldown-vetted images and
+  pins nothing of their own.
+- **Override ownership** — overriding `osv` means pinning a digest the adopter now owns the freshness of;
+  wrangle's pin tooling covers its own catalog, not this entry.
 - **Trust direction** — `my-sbom`'s capabilities are declared by the *adopter*, in the adopter's file;
-  the image grants itself nothing, and an unspecified capability defaults closed (no network, no
-  secret).
+  the image grants itself nothing, and an unspecified capability defaults closed.
 
 ## 4. Evidence
 
@@ -232,7 +240,7 @@ fetching the pinned v2.4.0:
 
 | Delivery | Cold acquire | Warm acquire | Build (publish-time) |
 |----------|-------------:|-------------:|----------------------|
-| `go install` from source (today) | **85.1 s** | 0.29 s | — |
+| `go install` (today) | **85.1 s** | 0.29 s | — |
 | prebuilt binary (download + verify) | 0.65 s | — | — |
 | **container (`docker pull`)** | **1.73 s** | 0.09 s | 97 s build, 82 MB image |
 
@@ -244,72 +252,96 @@ not a meaningful per-delivery signal.)
 
 ## 5. Alternatives considered
 
-- **Prebuilt binary (download + verify).** Fastest acquire, but a raw binary carries no `go.mod`
-  manifest (no transitive-CVE notices), sits below build-from-source on the integrity ladder, and gets
-  no sandbox. Rejected as the delivery mechanism; useful only as the speed floor it establishes above.
-- **`FROM <upstream image>`.** Fastest of all (no compile), but the tool's dependencies leave wrangle's
-  `go.mod` so the source scan goes blind, and a registry digest is a checksum served by the same source
+- **Prebuilt binary (download + verify).** Fastest acquire, but a raw binary carries no dependency
+  manifest (no transitive-CVE notices), sits below a package-manager install on the integrity ladder,
+  and gets no sandbox. Rejected as the delivery mechanism; useful only as the speed floor it establishes
+  above.
+- **`FROM <upstream image>`.** Fastest of all (no install), but the tool's dependencies leave wrangle's
+  manifest so the source scan goes blind, and a registry digest is a checksum served by the same source
   as the bytes — straining the "checksums not from the binary's source" rule. Permitted only for tools
   where wrangle accepts delegating build and patch cadence to upstream, and only with the upstream
   image's provenance verified at pull time. Not the default.
-- **Tools as raw `uses:` action steps.** Cedes the execution surface to GitHub Actions and ties the
-  model to one CI. Rejected in favor of orchestrator-driven `docker run` (§3.5).
+- **Tools as raw `uses:` action steps.** Cedes the execution surface to GitHub Actions and ties the model
+  to one CI. Rejected in favor of orchestrator-driven `docker run` (§3.5).
 
 ## 6. Security model and prerequisites
 
 - **Tool output is an inert assertion.** SARIF/SBOM is schema-validated before wrangle embeds it in any
   signed predicate, and the pass/fail result is derived orchestrator-side. A wrangle signature attests
   *"tool X produced this,"* never *"this is correct"* — important for adopter-supplied tools.
-- **Adoption enforcement (the residual prerequisite).** Build-from-source keeps CVE *detection* working
-  via the in-repo `go.mod`. What remains is ensuring a published fix is actually *adopted*: the
-  consuming reference (image digest) must be freshness/ancestry/cooldown-checked so a stale pin cannot
-  pass CI green (the #539/#544 class). This means teaching the pin toolchain (WL005 cooldown,
-  `check_pin_ancestry`, `check_pin_freshness`, `bump_action_pins`, `self_ref_pin_paths`) to understand
-  OCI `@sha256:` digests, adding a `docker` Dependabot ecosystem, and a DEP_MGMT.md integrity rung for
-  images. Because the digest lives in one curated place (§3.6), this is a narrow, wrangle-internal task,
-  and it is required only before *production consumption*, not before prototyping.
+- **Adoption enforcement (the residual prerequisite).** Installing via the canonical package manager
+  keeps the dependency manifest in-repo, so CVE *detection* keeps working. What remains is ensuring a
+  published fix is actually *adopted*: the catalog's image digest must be freshness/ancestry/cooldown-
+  checked so a stale pin cannot pass CI green (the #539/#544 class). This means teaching the pin
+  toolchain (WL005 cooldown, `check_pin_ancestry`, `check_pin_freshness`, `bump_action_pins`,
+  `self_ref_pin_paths`) to understand OCI `@sha256:` digests, adding a `docker` Dependabot ecosystem, and
+  a DEP_MGMT.md integrity rung for images. Because the digest lives in one curated place (§3.6), this is a
+  narrow, wrangle-internal task, required only before *production consumption*, not before prototyping.
 - **Adopter-supplied images** are adopter-trusted, not wrangle-trusted: they run under the strictest
   contract by default (no network, no secrets), any relaxation is explicit, and wrangle's signature
   covers provenance of the run, not correctness of the tool.
 
 ## 7. Scope
 
-- **In scope:** wrapping third-party adapter tools as contract images, osv first.
+- **In scope:** wrapping third-party adapter tools as contract images, osv first, then all scan-kind
+  tools.
 - **Held, tracked separately:** the attest/verify toolchain (cosign, ampel, bnd, wrangle-attest). It
   shares a `go.mod` and runs together, so it would package as one image — but it *inverts* the sandbox
   (it needs network and the OIDC signing token) and would interpose an image-supply-chain link in front
-  of the signing key. That is a different, higher-stakes problem than the scan path and is not part of
-  this proposal.
+  of the signing key. That is a different, higher-stakes problem than the scan path. It is **deferred,
+  not abandoned** for two reasons: (a) those tools are a large share of the remaining cold-compile time,
+  so the full speed win needs them eventually; and (b) containerizing the verify path (an `ampel` image)
+  is what would unlock **VSA-verified caching** of all tool images — verifying each image's provenance at
+  pull time, the clean L3-safe replacement for the build cache we currently disable. That is a bootstrap
+  (wrangle's own verify image verifying the others) we return to with this track, not in the scan MVP.
 - **Separate feature:** emitting an attested container of an adopter's own Go app (the "free container"
   value-add via goreleaser/ko). It reuses some machinery but serves adopter UX, not the goals here.
 - **Left as-is:** tools with official GitHub Actions that gain nothing from containerization stay
   action-pattern (an escape hatch C3 explicitly allows).
 
-## 8. Open questions
+## 8. Testing and tooling
 
-- **Invocation arg convention** — positional `<src> <out>` (matches today's adapters) vs
-  `WRANGLE_SRC`/`WRANGLE_OUTPUT` env (cleaner, more portable).
-- **Catalog schema and overrides** — §3.8 settles the broad shape (a manifest holds *definition* —
-  digest + capabilities — because capabilities can't be action inputs; the action carries *selection*
-  plus an override pointer). Open: the exact on-disk schema, the catalog file's name/location, and
-  whether an adopter override is a file path or inline.
-- **Egress granularity** — accept full egress for network-declaring tools, or invest in a filtering
-  proxy for true per-domain allowlists (the `network: egress` field in §3.8 is the coarse form).
-- **Registry/hosting and multi-arch** — ghcr namespace; amd64-only first or amd64+arm64.
+Premise P-a (tools stay stable while glue iterates) only holds if a tool image can be validated **without
+a full wrangle CI/CD run**. Two pieces:
+
+- **Per-image test harness.** Each tool image has a fast test that runs the *image* against committed
+  fixtures and asserts the contract: exit code per fixture (clean → 0, findings → 1, broken input → 2),
+  output layout (primary output present and schema-valid, `output.md` when expected, nothing written
+  outside `/output`), and the metadata-layout assertions (#169). It runs as a per-image matrix job
+  triggered on that image's change — the fast inner loop for tool updates, independent of the full
+  pipeline. Fixtures live beside the tool (`tools/<name>/testdata/`).
+- **Footgun linters.** New checks (wrangle-lint / a catalog validator) to keep the catalog honest: every
+  `image:` is digest-pinned (no tag, no `@latest`); every entry declares a `kind`; capabilities are
+  default-closed and any `network`/`secret` grant is explicit; curated images come from the allowed
+  registry namespace; and every tool named in a default selection exists in the catalog. Plus the
+  adopter-override rail (warn on a stale/unpinned override, §3.6).
+
+## 9. Open questions
+
+Decided in review: positional `<src> <out>` args; full egress for declaring tools (per-domain filtering
+deferred); amd64 is the baseline (GitHub's hosted runners default to amd64; arm64 runners are opt-in, so
+publish amd64+arm64 but gate nothing on arm64); the catalog (not per-tool action inputs) is the reference
+model. Still open:
+
+- **Catalog schema details** — exact field names, the catalog file's location, and whether an adopter
+  override is a file path or inline.
+- **Registry namespace** — the ghcr path for curated images.
 - **SPEC.md** — fold the kind-parameterized contract into the Adapter Script Interface.
 
-## 9. Plan
+## 10. Plan
 
-1. **Prototype osv end-to-end** (scan kind, built from source): `run.sh` invokes the image via
-   `docker run`, producing a real `output.sarif` through wrangle's existing collectors. Proves the
+1. **Prototype osv end-to-end** (scan kind, installed from `tools/go.mod`): `run.sh` invokes the image
+   via `docker run`, producing a real `output.sarif` through wrangle's existing collectors. Proves the
    run-via-script integration. *(The contract mechanic and the speed win in §4 are already measured.)*
-2. **Freeze the contract in SPEC.md** — the `scan` and `sbom` kinds, the invocation, and the isolation
-   mapping (§3.1–3.3).
-3. **Make the pin toolchain digest-aware** (§6) — required before any image is consumed in a production
+2. **Freeze the contract in SPEC.md** — the `scan` and `sbom` kinds, the invocation, the isolation
+   mapping, and the output-handling rule (§3.1–3.3).
+3. **Stand up the per-image test harness** (§8) — so subsequent migrations are validated fast.
+4. **Make the pin toolchain digest-aware** (§6) — required before any image is consumed in a production
    wrangle workflow.
-4. **Migrate osv for real** — published from source via `build_and_publish_container`, referenced as a
-   curated default (§3.6), `run.sh` rewired to `docker run`.
-5. **Extend to the rest of the adapter tools** — syft as the `sbom` reference implementation (and the
-   first adopter-substitutable contract test), then zizmor.
-6. **Revisit the held items** — the attest/verify toolbox and the adopter container value-add, each on
-   its own merits.
+5. **Go all-in for the `scan` kind.** Rather than a long mixed-mode tail, migrate the scan adapter tools
+   together once the prototype proves out; the catalog's `delivery:` field covers the brief cutover (and
+   any tool that stays adapter/action-pattern). osv, then zizmor, behind the curated catalog.
+6. **Extend to `sbom`** — syft as the reference implementation and the first adopter-substitutable
+   contract test.
+7. **Revisit the held items** — the attest/verify toolbox (with its speed + VSA-caching payoff, §7) and
+   the adopter container value-add, each on its own merits.

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -189,16 +189,26 @@ tools:
     image: ghcr.io/tomhennen/wrangle/syft@sha256:0b72…
     format: spdx-json
     # network omitted → none; no secret
+
+  # owned Go tools can share ONE image — the unified `wrangle` binary — selected by command:
+  wrangle-lint:
+    kind: scan
+    image: ghcr.io/tomhennen/wrangle/wrangle@sha256:c0de…
+    command: ["lint"]
+  wrangle-attest:
+    kind: attest
+    image: ghcr.io/tomhennen/wrangle/wrangle@sha256:c0de…   # same image, different command
+    command: ["attest"]
 ```
 
 (During migration a catalog entry may carry `delivery: adapter` to keep running the old in-process
 adapter for a tool not yet containerized; the default is `delivery: image`. See §10.)
 
-A catalog entry may also carry an optional `command:`/`args:`, so several tools can share **one** image
-(a unified `wrangle` binary or a toolbox image) selected by command rather than a separate image per
-tool — handy for the owned-Go tools (§3.4) and for a BYO image that exposes more than one tool. The
-capability rules (§3.7) and least-privilege defaults still apply per entry; the cost is a larger
-per-entry surface to validate (§8).
+As the `wrangle-lint`/`wrangle-attest` entries above show, an entry can carry an optional
+`command:`/`args:` so several tools share **one** image (a unified `wrangle` binary or a toolbox image),
+selected by command rather than a separate image per tool — handy for the owned-Go tools (§3.4) and for a
+BYO image that exposes more than one tool. The capability rules (§3.7) and least-privilege defaults still
+apply per entry; the cost is a larger per-entry surface to validate (§8).
 
 **Adopter — selecting tools** (pin wrangle, choose which to run, optionally point at an override file):
 

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -155,6 +155,71 @@ orchestrator's decision; otherwise the sandboxed tool would define its own sandb
 recorded in-repo as reviewable lines, default to `network=none, secret=none`, and are relaxed only
 explicitly — consistent with wrangle's least-privilege and input-validation rules.
 
+### 3.8 Configuration, illustrated
+
+The reference model (§3.6) and the capability definition (§3.7) live together in one wrangle-curated
+**catalog** (the `tools.lock` of §3.6). Capabilities — network, secret, output format — don't fit
+cleanly as action inputs, so the catalog file is the natural home for *definition*; the scan action's
+input stays *selection* plus an optional override pointer. Schema below is illustrative; the exact
+format is open (§8).
+
+**Internal — wrangle's curated catalog** (wrangle bumps it; adopters inherit by pinning wrangle):
+
+```yaml
+# tools/catalog.yaml  — wrangle-maintained, one entry per built-in tool
+tools:
+  osv:
+    kind: scan
+    image: ghcr.io/tomhennen/wrangle/osv@sha256:1531…   # built from this repo's go.mod
+    network: egress          # default is none; osv refreshes its advisory DB
+  zizmor:
+    kind: scan
+    image: ghcr.io/tomhennen/wrangle/zizmor@sha256:9a4c…
+    network: egress
+    secret: github-token     # delivered as WRANGLE_EXTRA_GITHUB_TOKEN
+  syft:
+    kind: sbom
+    image: ghcr.io/tomhennen/wrangle/syft@sha256:0b72…
+    format: spdx-json
+    # network omitted → none; no secret
+```
+
+**Adopter — selecting tools** (pin wrangle, choose which to run, optionally point at an override file):
+
+```yaml
+# adopter .github/workflows/scan.yml
+jobs:
+  scan:
+    uses: TomHennen/wrangle/.github/workflows/scan.yml@v0.4.0   # pin → inherit the catalog above
+    with:
+      tools: "osv zizmor:info my-sbom"     # selection + policy (unchanged from today)
+      tool-overrides: .wrangle/tools.yaml  # optional; overrides/extends the catalog
+```
+
+**Adopter — overriding an image and bringing their own tool**:
+
+```yaml
+# adopter .wrangle/tools.yaml  — merged over wrangle's catalog
+tools:
+  osv:                                       # override a curated default with a different digest
+    image: ghcr.io/myorg/osv@sha256:7c1d…    # adopter now owns this pin's freshness
+  my-sbom:                                   # BYO a tool wrangle doesn't ship — full definition
+    kind: sbom
+    image: ghcr.io/myorg/my-sbom-generator@sha256:e88f…
+    format: cyclonedx-json
+    # no network / no secret → runs under the strictest contract by default
+```
+
+What the three pieces demonstrate:
+- **Inheritance** — an adopter who only sets `tools:` runs wrangle's curated, cooldown-vetted images
+  and pins nothing of their own.
+- **Override ownership** — overriding `osv` means pinning a digest the adopter now owns the freshness
+  of; wrangle's pin tooling covers its own catalog, not this entry (wrangle can offer a Dependabot
+  entry / lint warning, §3.6, but not vouch for it).
+- **Trust direction** — `my-sbom`'s capabilities are declared by the *adopter*, in the adopter's file;
+  the image grants itself nothing, and an unspecified capability defaults closed (no network, no
+  secret).
+
 ## 4. Evidence
 
 **Contract mechanic.** A `docker run` invocation of a `scan` adapter and an `sbom` adapter confirms:
@@ -224,11 +289,12 @@ not a meaningful per-delivery signal.)
 
 - **Invocation arg convention** — positional `<src> <out>` (matches today's adapters) vs
   `WRANGLE_SRC`/`WRANGLE_OUTPUT` env (cleaner, more portable).
-- **Reference model** — defaulted action input vs `tools.lock` vs both (lock for defaults, input as
-  per-tool override).
+- **Catalog schema and overrides** — §3.8 settles the broad shape (a manifest holds *definition* —
+  digest + capabilities — because capabilities can't be action inputs; the action carries *selection*
+  plus an override pointer). Open: the exact on-disk schema, the catalog file's name/location, and
+  whether an adopter override is a file path or inline.
 - **Egress granularity** — accept full egress for network-declaring tools, or invest in a filtering
-  proxy for true per-domain allowlists.
-- **Capability-declaration format** — the on-disk shape of the per-tool definition.
+  proxy for true per-domain allowlists (the `network: egress` field in §3.8 is the coarse form).
 - **Registry/hosting and multi-arch** — ghcr namespace; amd64-only first or amd64+arm64.
 - **SPEC.md** — fold the kind-parameterized contract into the Adapter Script Interface.
 

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -1,0 +1,356 @@
+# Tool containerization — design exploration (#596)
+
+Status: **draft for discussion.** Not a committed contract; SPEC.md remains the source of truth.
+
+> **Revised after three independent reviews** (architecture / adversarial-security / strategic).
+> They converged on: **measure before architecting, and do much less than the original sketch.**
+> The full container architecture is recorded below as *the eventual shape, conditional on a spike* —
+> but the committed next step is a measurement spike plus a security-prerequisites decision, not a
+> migration. Review findings and the corrections they forced are in §10.
+
+## 0a. Phase 0 result — gate **CLEARED** (osv, ubuntu-latest amd64, 2026-06-24)
+
+Spike ran the three arms on fresh cold runners (playground repo, checking out real wrangle for the osv
+pin + `download_verify.sh`; all arms produced osv-scanner **2.4.0**):
+
+| Arm | Delivery | **Cold acquire** | Warm acquire | Notes |
+|-----|----------|-----------------:|-------------:|-------|
+| A | `go install` from source | **85.1 s** | 0.29 s | cold = the release/first-run cost; warm only helps PR scans |
+| B | prebuilt binary (download+verify) | **0.65 s** | — | speed *floor*; reference only (no `go.mod`, no sandbox) |
+| C | container (`docker pull`) | **1.73 s** | 0.09 s | build 97 s (publish-time, amortized); image 82 MB |
+
+**Verdict:** C beats A on cold acquire by ~83 s (~49×) and lands within ~1 s of B's floor **while keeping
+the manifest + sandbox** — so it clears both bars of the §11 kill-criteria. → **proceed** to the §3
+contract + the §9.1 consumer-side pin-freshness prerequisite.
+
+Two honest caveats: (1) the win is concentrated on the **cold path** (release + adopter first-run, which
+is forced cold for L3 anyway) — on warm PR scans A is already ~0.3 s, so the gain there is negligible;
+cold is simply the case that matters. (2) Per-arm *run* time (A 8.2 s / B 12.4 s / C 1.4 s) is
+network-dominated (osv's online queries) and noisy — **not** a per-arm signal; a cleaner re-run would
+pin an offline advisory DB to remove it.
+
+## 0. Revised plan (what we actually do next)
+
+1. **Phase 0 — measure (a spike, not a migration).** Containerize **osv only** (the real cold-compile
+   offender — it `go install`s from `tools/go.mod`), build-from-source, amd64-only. Benchmark, on a
+   real GitHub runner, net per-run wall-clock of `docker pull (warm + cold) + run` against **both**:
+   - today's `go install` cold path, **and**
+   - a **verified prebuilt-binary fetch** via the existing `lib/download_verify.sh`.
+   No frozen contract, no SBOM kind, no ko, no Track A. One tool, one number.
+2. **Gate (corrected — owner):** C must **beat A on speed** *and* have a better maintainability/
+   security/extensibility story than B. B (verified prebuilt binary) is a *speed reference, not an
+   option we'd adopt* — a raw binary has no `go.mod` manifest (⇒ no transitive-CVE notices), sits below
+   build-from-source on the integrity ladder, and gets no sandbox. If C's pull cost can't beat A's
+   compile, **stop**; otherwise C clears B on the qualitative axes by construction (build-from-source
+   keeps the manifest + adds the sandbox). B's *speed* never vetoes C.
+3. **Only if the spike wins (it did — §0a):** design the contract (§3) **and the invocation/reference
+   model**: `run.sh` does `docker run` (not `uses:`), and the image digest is a **defaulted input** on
+   the scan action — curated/bumped by wrangle, inherited by adopters via the wrangle pin they already
+   maintain (§9.1). The digest-aware pin work is the **last** build step (gates production *consumption*,
+   not prototyping); the reference model is chosen *now* so it stays tractable.
+4. **Split out and hold Track 2 (attest/verify toolbox)** — it inverts the sandbox model and sits in
+   front of the signing key; it is *riskier* than today as drawn (§10, security).
+5. **Track A (adopter "free attested container") is a separate product feature** — decoupled from
+   #596 entirely; do not let it justify build-tool spend here.
+
+The rest of this doc is the analysis behind that plan.
+
+## 1. Problem
+
+Wrangle's tool layer solves four things at once, each only partially (#596): **dependency
+management** (versions spread across `tools/go.mod` tool directives, syft's `install.sh`, zizmor's
+pip `requirements.txt`, action wrappers — drift is recurring: #264/#277/#286); **speed** (adapter
+tools `go install` from source per run; osv-scanner's tree compiles cold — the scan action bumps
+`WRANGLE_INSTALL_TIMEOUT` from its 300s default to **900s** for osv; `go-cache` is off by default on
+attested paths for L3 reasons); **supply-chain safety** (isolation today is a stripped env + adapter
+contract + filesystem snapshot; #267 deferred stronger sandboxing); **ease of adding a tool** (#137).
+
+**Correction (review):** osv-scanner is a `tools/go.mod` `tool` directive installed by `run.sh`'s
+upfront `go install`, **not** an `install.sh`. syft *is* `install.sh`, but it's a fast
+download-and-verify, not a cold compile. So the speed pain is the `go install` batch (osv), and
+containerizing syft saves an `install.sh` but **none** of the compile time.
+
+## 2. Constraints (hard) and premises
+
+- **C1 — dependency visibility preserved.** Opaque-digest-only pinning (no manifest/SBOM) is out.
+- **C2 — faster** than install-at-runtime. *Hard constraint, currently unmeasured — Phase 0 gates it.*
+- **C3 — broadly applicable** (an occasional non-transitionable tool is OK).
+- **C4 — no harder to coordinate wrangle updates.**
+
+Premises: **P-a** tools are stable lately (we move glue/output more than binaries); **P-b** adopters
+may want to supply their own tool as a container (an outside contributor → a different SBOM generator); **P-c**
+non-GitHub portability is nice-to-have.
+
+> **Advisor's C4 caveat:** the mitigations for the release-before-use cost lean on P-a — but P-a is
+> also why C2's pain is small. *The premise that makes the cost cheap is the premise that makes the
+> benefit small.* This is the central tension; the spike exists to find out which side wins.
+
+## 3. The contract (the eventual shape, if the spike wins)
+
+The adapter contract already mirrors a container API. The generalization is making the container the
+unit of distribution/isolation and parameterizing over **tool kinds**.
+
+### 3.1 Invocation (validated by experiment — §8)
+
+```
+docker run --rm --network <policy> -u <runner_uid>:<gid> \
+  -v <src>:/src:ro -v <out>:/output [-e WRANGLE_KIND=<kind>] [declared tool env] <image> /src /output
+```
+
+- **Mounts** — `/src` read-only, `/output` writable (both confirmed enforced).
+- **Ownership** — **must** run as the runner UID/GID (`-u`), or output is `root`-owned and unusable.
+- **Network** — `--network none` is the **default**, not universal; egress is a **per-*tool*** opt-in
+  (not per-kind): even within `scan`, zizmor-online hits the GitHub API (**+ needs a token** → network
+  *and* secret, the case that most strains the sandbox) and osv refreshes its advisory DB. *Granularity
+  caveat:* Docker's cheap primitives are deny-all vs allow-all — a true *domain* allowlist (zizmor →
+  github.com only) needs an egress proxy / filtering sidecar, so "opt-in" likely means full egress for
+  declared tools unless we invest in filtering (open question, §12).
+- **Secrets** — most `scan`/`sbom` tools get none; a tool needing an authed call (zizmor → token) uses
+  the existing `WRANGLE_EXTRA_` channel. The default stays zero-secrets; secret-bearing is an
+  explicit per-tool declaration.
+
+### 3.2 The isolation contract is part of the contract (review's #1 risk)
+
+`docker run` does **not** just replace dispatch — it replaces `run.sh`'s isolation mechanism, which is
+three concrete things that MUST be re-derived item-by-item, not silently dropped:
+
+| Today (`run.sh`) | Container equivalent | Status |
+|---|---|---|
+| `env -i <allowlist>` — adapter sees only allowed env | bare `docker run` inherits nothing (safer) **+** explicit `-e` for each allowed var | must rebuild deliberately |
+| `WRANGLE_EXTRA_*` forwarding | explicit `-e WRANGLE_EXTRA_*` per declared tool | must rebuild |
+| post-run filesystem snapshot diff (warn-only; a SPEC MUST) | `/src:ro` + `/output`-only mount = **fail-closed** write confinement | **upgrade** — fix today's warn-only gap |
+
+SPEC's Adapter Script Interface (ENVIRONMENT/SECURITY) must be updated in the same change.
+
+### 3.3 Tool kinds
+
+| Kind | Input | Output | Exit | BYO? |
+|------|-------|--------|------|------|
+| `scan` | `src_dir` (ro) | `output.sarif` (SARIF 2.1.0) | 0 clean / 1 findings / 2 error | yes |
+| `sbom` | `src_dir` **or built artifact** | `sbom.<format>.json` (SPDX **or** CycloneDX — declared) | 0 ok / 2 error | yes |
+| `attest/verify` | metadata + targets | signed attestations / verdict | tool-specific | no |
+
+Deltas from today's SARIF-only contract: output is kind-specific and SBOM declares its **format**
+(don't hardcode SPDX); exit codes are per-kind (`sbom` has no "findings"); input may be src **or**
+artifact (a build-path SBOM reads the built binary, not source).
+
+## 4. Packaging — decided by ownership
+
+`ko` builds *Go source you own* into a bare-binary image with the tool's *native* interface; it can't
+bundle a foreign binary + adapter shim. So:
+
+| Class | Examples | Path | Why |
+|---|---|---|---|
+| Own it, Go, adapter in binary | wrangle-lint, wrangle-attest, unified `wrangle` | ko / goreleaser `kos:` | binary *is* contract-native |
+| Adopter's own Go app | (Track A value-add) | ko / goreleaser | their binary, no Dockerfile |
+| Third-party wrap | osv, syft, **zizmor** | Dockerfile via `build_and_publish_container` | needs upstream binary + shim |
+| BYO | a third-party SBOM gen | their choice — wrangle ships only the contract | not our build problem |
+
+**zizmor is a viable container target (owner — corrects the review).** It is action-pattern today only
+because Rust/pip install was awkward, not because the wrapper is essential. The upstream action's one
+special function is the `advanced-security` Security-tab SARIF upload — which wrangle **already performs
+itself** for adapter tools via its own `codeql-action/upload-sarif` steps (osv, wrangle-lint);
+everything else (findings/error disambiguation in `collect_sarif.sh`, the md, the scan manifest) is
+already wrangle-side. Containerizing zizmor (`zizmor --format sarif` → `output.sarif`, then map
+findings→exit 1 since SARIF mode exits 0) would drop the action ladder, the pip install path, **and**
+the upstream-action dependency — plausibly *better*, and exactly the #137 flattening. It's also the
+clean test case for the §3.1 per-tool egress+credential capability: zizmor's online audits need GitHub
+API egress + a token via `WRANGLE_EXTRA_`.
+
+### 4.1 Third-party base: from-source vs FROM-upstream
+
+- **Build-from-source** (`FROM golang AS build → FROM distroless → COPY`): keeps the `go.mod` in-repo
+  ⇒ Dependabot per-dep alerts, osv/govulncheck source scan, and ahead-of-upstream patching intact;
+  moves compile from per-run to per-publish. **Default for security-critical tools.**
+  - *Caveat (review):* osv shares the **single** `tools/go.mod` with cosign/ampel/bnd/govulncheck/
+    wrangle-attest/wrangle-lint. A per-tool from-source image needs its own module file — a new
+    drift surface (the very #264/#277 problem we're trying to reduce).
+- **FROM-upstream-image** (`FROM ghcr.io/google/osv-scanner@sha256:…`): fastest, but the tool's deps
+  leave our `go.mod` so the source scan goes blind (and there is **no image-scan step today**).
+  - **Security blocker (review S3):** a registry digest is a "checksum" served by the *same source*
+    as the bytes — this strains CLAUDE.md's "no checksums from the binary's source" rule. FROM-upstream
+    is permitted **only** with independent provenance verification at pull time (verify upstream's SLSA
+    attestation against a pinned identity, the way `lib/download_verify.sh` fails closed) — digest
+    alone is not sufficient. Detection of CVEs is recoverable via `osv-scanner scan image`; **ahead-of-
+    upstream remediation is not.**
+
+## 5. Tracks (conditional, post-spike)
+
+- **Track B (#596 core)** — wrap third-party tools (osv first) as contract images, Dockerfile
+  from-source.
+- **Track A (separate feature)** — goreleaser emits an attested image of a Go app, serving the adopter
+  value-add *and* wrangle's owned Go tools. **Correction:** the "goreleaser `--skip=publish` then a
+  gated job pushes the digest" flow in the prior draft is a synthesis of two *different* existing
+  flows that **neither implements** — `build_and_publish_go`'s `--skip=publish` uploads checksummed
+  *archives* to a GitHub Release (no registry push, no digest-attest); the digest push+attest lives in
+  `build_and_publish_container` and happens **mid-composite, not in a gated job**. Track A needs a
+  genuinely new gated-image-push job designed, not assumed.
+- **Track 2 (split out, HELD)** — attest/verify toolbox (cosign/ampel/bnd/wrangle-attest). Inverts the
+  sandbox (network + OIDC token in) and interposes an image-supply-chain link **in front of the signing
+  key**. Strictly riskier than today's in-job binaries (§10 S2). Do not ship on this framing.
+
+## 6. Pilot choice — honest version
+
+The syft/SBOM pilot is attractive for **contract** reasons (it's the cheapest tool to containerize,
+and an outside contributor's generator gives a real BYO second implementation — two impls is what makes a contract real). It is
+**not** a speed pilot (syft isn't the compile cost; the container SBOM is BuildKit-derived, not syft).
+So: **osv is the Phase-0 *speed/spike* pilot; syft is the eventual *contract* pilot** — and the
+contract pilot only happens if the spike clears the gate. Don't conflate them, as the first draft did.
+
+## 7. Pros / cons against the constraints
+
+**Pros** — C1: `go.mod` stays in-repo + signed image SBOM is additive. C2 *(if the spike confirms)*:
+pull a layer vs compile per run. Safety: container is a real sandbox (read-only, `--network none`,
+fail-closed write confinement — an *upgrade* over today's warn-only check). C3/portability: `docker
+run` is CI-agnostic (#171), flattens `uses: ./tools/*` (#137). P-b: BYO becomes "ship a conforming
+image."
+
+**Cons / costs** — **C4 release-before-use**: every tool fix needs a publish-then-bump hop, felt by
+the maintainer on every security patch (and see the §2 circularity). **Security tooling is blind to
+OCI digests** (§10 S1 — a blocker, not an open question). **FROM-upstream** strains the checksum-source
+rule (S3). **Track 2** inverts isolation in front of the key (S2). New build-time dep (ko) to vet if
+Track A proceeds. Multi-arch adds CI cost.
+
+> **Weakened claim (advisor):** the prior draft said pinned-digest pull is "cleaner than the
+> build-cache wart that forces `go-cache` off on L3 paths." That's shaky — a pinned image digest is
+> *also* trusting compiled output you didn't build this run, so the L3 bar is the **same**, not lower.
+> Don't lead with this as a benefit.
+
+## 8. Experiment results (Docker, this environment)
+
+Validated the contract mechanic with a from-scratch `scan` adapter and an `sbom` variant:
+`--network none` blocks egress; `/src:ro` blocks writes into src; exit **0/1/2 all propagate**;
+default output is **root-owned**, `-u 1000:1000` fixes it (⇒ orchestrator must set `-u`); `WRANGLE_KIND=sbom`
+writes `sbom.spdx.json` with exit-0/no-findings; a public-registry pull works (FROM-upstream feasible).
+
+Deferred (need Go 1.26 + ko/syft, absent here): the real ko build of wrangle-lint and the **osv
+build-from-source-vs-upstream-vs-prebuilt timing benchmark** — which is now Phase 0 and gates the rest.
+
+## 9. Security prerequisites (BLOCKERS, not open questions)
+
+Before any tool image is *consumed* in a wrangle workflow:
+
+1. **Make the pin toolchain digest-aware** — but note build-from-source already shrinks this (owner).
+   Because the image is built from the in-repo `go.mod`, Dependabot/osv/govulncheck still see the
+   tool's transitive deps and fire CVE notices, and we rebuild + redeploy to remediate — so the
+   *detection/remediation* half of the blocker is handled (this is a concrete reason build-from-source
+   beats both FROM-upstream and B, which throw the manifest away). The **residual** is enforcement, and the
+   **reference model shrinks it further** (owner): the image digest is a **defaulted input** on the scan
+   action, curated and bumped by wrangle, threaded into `run.sh`'s `docker run`. So **adopters inherit
+   the image via the wrangle pin they already maintain** — no new adopter-side pin tooling for the
+   common (default) case. What's left is *wrangle-internal*: bump + freshness/cooldown-check wrangle's
+   **own** default image input(s) — one known field in our `action.yml`, an extension of the existing
+   self-reference bump family (`bump_action_pins`/`self_ref_pin_paths`), **not** a generic "track
+   arbitrary OCI digests everywhere." Adopter **overrides** (BYO image, or a pinned different digest) are
+   adopter-owned for freshness; wrangle offers hooks (a `docker` Dependabot snippet, a wrangle-lint warn
+   on a stale/unpinned override) but can't guarantee an image it doesn't control. This is the **last**
+   build step — it gates production *consumption*, not prototyping — and the reference model is chosen
+   *now* so it stays tractable. (Add a DEP_MGMT.md integrity rung for images regardless.)
+   - **Reference-model options (decide in contract design):** (i) *defaulted action input* per tool;
+     (ii) a **`tools.lock`** — one `tool → digest` file `run.sh` reads — which is the #264 manifest this
+     subsumes and the *cleanest* central store for the bump/freshness/cooldown tooling (one schema, not
+     scattered input defaults); (iii) **both** — `tools.lock` holds wrangle's curated defaults, the
+     action input is a per-tool *override* that beats the lock. `tools.lock` also adds **adopter
+     transparency** (they see exactly what they get) and, in a Dependabot/Renovate-recognized format,
+     lets adopters' own bots manage their *overrides* — the only place the adopter gains; the default
+     path is inherited via the wrangle pin either way, and overriding still means owning freshness.
+2. **Treat tool output as inert, validated data.** Schema-validate (not just JSON-parse) SARIF/SBOM
+   before embedding into any signed predicate; derive the pass/fail `result` orchestrator-side from
+   validated content. wrangle's signature attests *"tool X produced this,"* never *"this is correct."*
+3. **State the BYO trust model** (S5): a BYO image is *adopter-trusted, not wrangle-trusted*; runs
+   under the strictest contract by default (network none, no creds); any relaxation is explicit and
+   logged. Decide whether wrangle verifies a BYO image's own provenance before running it.
+4. **FROM-upstream requires pull-time provenance verification** (S3), not digest-alone.
+5. **Track 2 / OIDC** (S2): if ever containerized, from-source only, verify the toolbox image's
+   provenance before the token is in scope, mint/consume `id-token` in the narrowest step, and re-audit
+   against SLSA_L3_AUDIT "secret material MUST NOT be accessible to the env running user steps."
+6. **Expedited security-bump path** for tool images so the cooldown doesn't delay legitimate fixes (S6).
+
+## 10. Review findings (three independent reviews)
+
+**Architecture** — contract generalization is faithful; but flagged factual errors (osv is go.mod not
+install.sh; container SBOM is BuildKit not syft; the `--skip=publish`/gated-push mapping is unimplemented;
+osv shares one `tools/go.mod`). The review also called zizmor's action wrapper "load-bearing" — the
+owner corrected this: zizmor is action-pattern only for install convenience and is a viable container
+target (see §4). Biggest risk: the container
+boundary silently replaces `run.sh`'s isolation contract (`env -i` allowlist + `WRANGLE_EXTRA_` +
+post-run snapshot, a SPEC MUST) — must be re-derived item-by-item (now §3.2).
+
+**Adversarial security** — net neutral-to-safer for scan/sbom *only if* the pin/verify gaps are built
+first; **Track 2 net-riskier** and should be split/held. Ranked: S1 digest-blind tooling (HIGH **as
+written — but much lower for build-from-source, which keeps the `go.mod` notice loop; residual is
+consumer-side pin freshness, §9.1**),
+S2 OIDC-in-container in front of the key (HIGH), S3 FROM-upstream checksum-source (MED-HIGH), S4
+poisoned-output-signed-clean (MED, pre-existing, widened by BYO), S5 no BYO trust model (MED), S6
+cooldown delays security fixes (LOW-MED). All folded into §9.
+
+**Strategic (advisor)** — "do much less, not yet." The one quantifiable goal (C2) is undiagnosed;
+measure osv before architecting, and beat **both** today's cold path **and** a verified prebuilt-binary
+fetch (`lib/download_verify.sh`) or containerization is an over-build. Cut Track A from #596; defer the
+kind-contract, image-scanning, multi-arch. Drove §0 and §6.
+
+## 11. Phase 0 spike — detailed spec
+
+**Question:** for the worst cold-compile tool (osv-scanner), what is the net per-run wall-clock under
+each delivery model, on a real GitHub-hosted runner — and does the container model beat the cheaper
+alternatives by a margin an adopter notices?
+
+**Three arms** (same pinned osv-scanner version, same fixture, same runner, network policy held
+constant):
+
+| Arm | Delivery | Acquire step | L3 posture |
+|-----|----------|--------------|------------|
+| **A — status quo** | `go install` from `tools/go.mod` | compile from source | builds cold on release (go-cache off for L3); warm cache only helps PR scans |
+| **B — prebuilt binary** | upstream release binary via `lib/download_verify.sh` (hardcoded checksum) | download + verify, no compile | trusts a binary you didn't build — verify upstream provenance to hold L3 |
+| **C — container (from-source)** | distroless image built from source, run via `docker run -u … --network … -v src:ro -v out` | `docker pull` | trusts compiled output you didn't build *this run* — same bar as a cache; image built cold at publish |
+
+**Measure** (median of N≥5 runs each, on `ubuntu-latest`; record arch):
+- **acquire** time and **run** time *separately* (so we see where the cost is).
+- **cold** (fresh runner / cache miss — the real first-run adopter case) **and** **warm** (go build
+  cache for A; image layer cache for C; B is re-download unless cached).
+- bytes pulled/downloaded per arm.
+- osv's own advisory-DB fetch held constant across arms (or run offline-DB) so it doesn't skew `run`.
+
+**Harness sketch** (one workflow, a job per arm, `time` around acquire vs run, fixed fixture repo
+checked out read-only; emit a CSV/step-summary table). No contract, no ko, no Track A.
+
+**Decision rule (kill-criteria) — corrected (owner):** B is a **speed reference, not an adoption
+candidate.** wrangle doesn't want raw-binary installs: B has no `go.mod` manifest (⇒ no transitive-CVE
+notices, no build-from-source integrity tier) and no sandbox. So B's speed does **not** decide anything.
+- **C must beat A** on net wall-clock (if C's pull cost doesn't beat A's compile, there's no speed case
+  → **stop**).
+- **C must beat B on the maintainability / security / extensibility story** — which it does, because
+  C-from-source keeps the `go.mod` (notices + redeploy) and adds the sandbox, while B loses the manifest.
+- If C beats A and clears the qualitative bar over B → proceed to §3 contract + §9 prerequisites.
+- B's number only *bounds how much speed is on the table* — useful context, never a veto.
+
+**Explicitly out of scope for the spike:** the frozen contract, the SBOM kind, ko, Track A, multi-arch,
+image-scanning, any change to `actions/scan`. One tool, three numbers, one decision.
+
+**Note on B's status (owner-decided):** B is a **speed reference, not an adoption candidate** — wrangle
+doesn't want raw-binary installs (no `go.mod` manifest, no sandbox). Its number bounds how much speed is
+on the table; it never decides the outcome.
+
+## 12. Tool-definition surface (catalog vs selection; capability trust direction)
+
+Two layers, easy to conflate:
+- **Selection** (per-run, adopter-facing): *which* tools + policy — today's `tools: "osv zizmor:info …"`
+  string; the `:fail`/`:info` suffix is the precedent. Stays lightweight.
+- **Definition / catalog** (static, per-tool): a tool name resolves to `{image digest, kind, network,
+  secret, output}`. This is the new surface; capabilities live here, not in the selection string.
+
+**Trust direction is the load-bearing rule:** a capability grant (network, a credential) comes from the
+**trusting party** — wrangle, or the adopter for their own BYO tool — **never self-granted by the image.**
+An image self-declaring `network=all, secret=token` would let the sandboxed thing decide how much sandbox
+to remove. It's the phone-app model: the image *manifest* may *request* (an OCI label is fine as a
+documented request), but wrangle/the adopter *grants*. Request ≠ grant. Consequences:
+- **In-repo, reviewable** catalog (the `tools.lock` sibling) beats image-embedded labels — a network/token
+  grant must be a diffable line someone approved (satisfies "validate every input" + least-privilege).
+- **Least privilege by default:** catalog entries default to `network=none, secret=none`; every relaxation
+  is explicit.
+- **BYO ≠ image self-declares:** the *adopter* authors the capability entry for their own tool (they're the
+  trusting party for their image); the image may carry a requested-capabilities label that wrangle/the
+  adopter chooses whether to honor.
+
+(This generalizes today's `WRANGLE_EXTRA_` per-tool credential channel into one declaration: image digest +
+kind + network + which credential + output.)

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -96,10 +96,11 @@ input may be a built artifact, not source.
 
 **Output handling.** A tool's *primary* output (above) drives gating. Beyond it, wrangle gives specific
 filenames special handling — `output.sarif` feeds the result/Security-tab upload, `output.md` feeds the
-GHA step summary — and **persists anything else the tool writes to `/output`** into the published
-metadata (and thus the signed attestation). So the contract is "write your primary output; write
-`output.md` if you have a human-readable summary; anything else under `/output` is carried along," not a
-fixed file list.
+GHA step summary — and **carries anything else the tool writes to `/output`** into the published
+metadata. Not everything in that metadata is signed: for a scan tool the SARIF is the attested artifact;
+`output.md` and any extra files are propagated as metadata without promising a signature over each. So
+the contract is "write your primary output (the gated/attested one); write `output.md` for a
+human-readable summary; anything else under `/output` is carried along," not a fixed file list.
 
 ### 3.4 Packaging
 
@@ -146,11 +147,10 @@ thing for the pin tooling to track and for adopters to read.
   tool version. Wrangle bumps a digest when it updates a tool.
 - **Selection stays short-name + policy** — the existing `tools: "osv zizmor:info …"` interface is
   unchanged; a name resolves through the catalog to an image.
-- **Overrides** are an adopter-supplied catalog fragment (a different digest for a built-in, or a whole
-  new tool). Because selection is by short name, an adopter can swap in a *different* tool that does the
-  same job — not just a different image of the same tool. An override is a pin the adopter now owns the
-  freshness of; wrangle can offer rails (a `docker` Dependabot entry, a lint warning on a stale
-  override) but cannot vouch for an image it does not control.
+- **Overrides** are an adopter-supplied catalog fragment — a different digest for a built-in tool, or a
+  new tool under its own name. An override is a pin the adopter now owns the freshness of; wrangle can
+  offer rails (a `docker` Dependabot entry, a lint warning on a stale override) but cannot vouch for an
+  image it does not control.
 
 ### 3.7 Capability declaration
 
@@ -193,6 +193,12 @@ tools:
 
 (During migration a catalog entry may carry `delivery: adapter` to keep running the old in-process
 adapter for a tool not yet containerized; the default is `delivery: image`. See §10.)
+
+A catalog entry may also carry an optional `command:`/`args:`, so several tools can share **one** image
+(a unified `wrangle` binary or a toolbox image) selected by command rather than a separate image per
+tool — handy for the owned-Go tools (§3.4) and for a BYO image that exposes more than one tool. The
+capability rules (§3.7) and least-privilege defaults still apply per entry; the cost is a larger
+per-entry surface to validate (§8).
 
 **Adopter — selecting tools** (pin wrangle, choose which to run, optionally point at an override file):
 

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -1,356 +1,249 @@
-# Tool containerization — design exploration (#596)
+# Tool containerization — proposal (#596)
 
-Status: **draft for discussion.** Not a committed contract; SPEC.md remains the source of truth.
+Status: **proposal for discussion, not yet implemented.** SPEC.md remains the contract of record until
+this lands.
 
-> **Revised after three independent reviews** (architecture / adversarial-security / strategic).
-> They converged on: **measure before architecting, and do much less than the original sketch.**
-> The full container architecture is recorded below as *the eventual shape, conditional on a spike* —
-> but the committed next step is a measurement spike plus a security-prerequisites decision, not a
-> migration. Review findings and the corrections they forced are in §10.
-
-## 0a. Phase 0 result — gate **CLEARED** (osv, ubuntu-latest amd64, 2026-06-24)
-
-Spike ran the three arms on fresh cold runners (playground repo, checking out real wrangle for the osv
-pin + `download_verify.sh`; all arms produced osv-scanner **2.4.0**):
-
-| Arm | Delivery | **Cold acquire** | Warm acquire | Notes |
-|-----|----------|-----------------:|-------------:|-------|
-| A | `go install` from source | **85.1 s** | 0.29 s | cold = the release/first-run cost; warm only helps PR scans |
-| B | prebuilt binary (download+verify) | **0.65 s** | — | speed *floor*; reference only (no `go.mod`, no sandbox) |
-| C | container (`docker pull`) | **1.73 s** | 0.09 s | build 97 s (publish-time, amortized); image 82 MB |
-
-**Verdict:** C beats A on cold acquire by ~83 s (~49×) and lands within ~1 s of B's floor **while keeping
-the manifest + sandbox** — so it clears both bars of the §11 kill-criteria. → **proceed** to the §3
-contract + the §9.1 consumer-side pin-freshness prerequisite.
-
-Two honest caveats: (1) the win is concentrated on the **cold path** (release + adopter first-run, which
-is forced cold for L3 anyway) — on warm PR scans A is already ~0.3 s, so the gain there is negligible;
-cold is simply the case that matters. (2) Per-arm *run* time (A 8.2 s / B 12.4 s / C 1.4 s) is
-network-dominated (osv's online queries) and noisy — **not** a per-arm signal; a cleaner re-run would
-pin an offline advisory DB to remove it.
-
-## 0. Revised plan (what we actually do next)
-
-1. **Phase 0 — measure (a spike, not a migration).** Containerize **osv only** (the real cold-compile
-   offender — it `go install`s from `tools/go.mod`), build-from-source, amd64-only. Benchmark, on a
-   real GitHub runner, net per-run wall-clock of `docker pull (warm + cold) + run` against **both**:
-   - today's `go install` cold path, **and**
-   - a **verified prebuilt-binary fetch** via the existing `lib/download_verify.sh`.
-   No frozen contract, no SBOM kind, no ko, no Track A. One tool, one number.
-2. **Gate (corrected — owner):** C must **beat A on speed** *and* have a better maintainability/
-   security/extensibility story than B. B (verified prebuilt binary) is a *speed reference, not an
-   option we'd adopt* — a raw binary has no `go.mod` manifest (⇒ no transitive-CVE notices), sits below
-   build-from-source on the integrity ladder, and gets no sandbox. If C's pull cost can't beat A's
-   compile, **stop**; otherwise C clears B on the qualitative axes by construction (build-from-source
-   keeps the manifest + adds the sandbox). B's *speed* never vetoes C.
-3. **Only if the spike wins (it did — §0a):** design the contract (§3) **and the invocation/reference
-   model**: `run.sh` does `docker run` (not `uses:`), and the image digest is a **defaulted input** on
-   the scan action — curated/bumped by wrangle, inherited by adopters via the wrangle pin they already
-   maintain (§9.1). The digest-aware pin work is the **last** build step (gates production *consumption*,
-   not prototyping); the reference model is chosen *now* so it stays tractable.
-4. **Split out and hold Track 2 (attest/verify toolbox)** — it inverts the sandbox model and sits in
-   front of the signing key; it is *riskier* than today as drawn (§10, security).
-5. **Track A (adopter "free attested container") is a separate product feature** — decoupled from
-   #596 entirely; do not let it justify build-tool spend here.
-
-The rest of this doc is the analysis behind that plan.
+This proposes re-homing wrangle's tool layer so each tool ships as a **pinned OCI image implementing the
+adapter contract**, invoked by the orchestrator via `docker run`. The container becomes the unit of
+distribution *and* isolation.
 
 ## 1. Problem
 
-Wrangle's tool layer solves four things at once, each only partially (#596): **dependency
-management** (versions spread across `tools/go.mod` tool directives, syft's `install.sh`, zizmor's
-pip `requirements.txt`, action wrappers — drift is recurring: #264/#277/#286); **speed** (adapter
-tools `go install` from source per run; osv-scanner's tree compiles cold — the scan action bumps
-`WRANGLE_INSTALL_TIMEOUT` from its 300s default to **900s** for osv; `go-cache` is off by default on
-attested paths for L3 reasons); **supply-chain safety** (isolation today is a stripped env + adapter
-contract + filesystem snapshot; #267 deferred stronger sandboxing); **ease of adding a tool** (#137).
+Wrangle's tool layer solves four problems at once, each only partially:
 
-**Correction (review):** osv-scanner is a `tools/go.mod` `tool` directive installed by `run.sh`'s
-upfront `go install`, **not** an `install.sh`. syft *is* `install.sh`, but it's a fast
-download-and-verify, not a cold compile. So the speed pain is the `go install` batch (osv), and
-containerizing syft saves an `install.sh` but **none** of the compile time.
+1. **Dependency management.** Tool versions are spread across `tools/go.mod` tool directives (osv,
+   ampel, bnd, cosign, wrangle-lint, …), a bespoke `install.sh` (syft), a pip `requirements.txt`
+   (zizmor), and action wrappers. Coverage is uneven and drift is a recurring review finding
+   (#264/#277/#286).
+2. **Speed.** Adapter tools are compiled from source on every run: `run.sh` `go install`s osv-scanner's
+   dependency tree cold, which is slow enough that the scan action raises `WRANGLE_INSTALL_TIMEOUT` from
+   its 300 s default to 900 s. The Go build cache that would help is off by default on attested paths
+   for SLSA-L3 reasons.
+3. **Supply-chain isolation.** A tool today is contained by a stripped environment, the adapter
+   contract, and a post-run filesystem snapshot — not a real sandbox. Stronger isolation was deferred
+   (#267), and each bespoke `install.sh` adds audit surface.
+4. **Ease of adding a tool.** A new tool means choosing an install method, wiring verification, and
+   carrying GitHub-Actions-specific dispatch (#137).
 
-## 2. Constraints (hard) and premises
+A single primitive — a pinned image behind a fixed contract — addresses all four: the digest is the
+version, the prebuilt layer removes the per-run compile, the container is the sandbox, and "add a tool"
+becomes "publish an image that honors the contract."
 
-- **C1 — dependency visibility preserved.** Opaque-digest-only pinning (no manifest/SBOM) is out.
-- **C2 — faster** than install-at-runtime. *Hard constraint, currently unmeasured — Phase 0 gates it.*
-- **C3 — broadly applicable** (an occasional non-transitionable tool is OK).
+## 2. Goals and constraints
+
+**Hard constraints:**
+
+- **C1 — dependency visibility preserved.** Pinning by opaque digest alone (no manifest, no SBOM) is out.
+- **C2 — faster** than install-at-runtime.
+- **C3 — broadly applicable** to most tools (an occasional non-transitionable tool is acceptable).
 - **C4 — no harder to coordinate wrangle updates.**
 
-Premises: **P-a** tools are stable lately (we move glue/output more than binaries); **P-b** adopters
-may want to supply their own tool as a container (an outside contributor → a different SBOM generator); **P-c**
-non-GitHub portability is nice-to-have.
+**Premises:** **P-a** tool binaries are stable; the glue and output routing change more often than the
+tools. **P-b** adopters may want to supply their own tool as a conforming image. **P-c** non-GitHub
+portability is desirable but not required.
 
-> **Advisor's C4 caveat:** the mitigations for the release-before-use cost lean on P-a — but P-a is
-> also why C2's pain is small. *The premise that makes the cost cheap is the premise that makes the
-> benefit small.* This is the central tension; the spike exists to find out which side wins.
+**Key risk to weigh.** The proposal adds a publish-then-consume step: a tool fix isn't available until
+its image is published. The mitigations (below) lean on P-a — but P-a is also why the speed pain is
+modest. The design keeps the release-before-use cost small by keeping the volatile parts (output
+routing, policy, signing) on the orchestrator and only the stable binary in the image.
 
-## 3. The contract (the eventual shape, if the spike wins)
+## 3. Proposal
 
-The adapter contract already mirrors a container API. The generalization is making the container the
-unit of distribution/isolation and parameterizing over **tool kinds**.
+### 3.1 The contract
 
-### 3.1 Invocation (validated by experiment — §8)
+The orchestrator runs each tool as:
 
 ```
 docker run --rm --network <policy> -u <runner_uid>:<gid> \
   -v <src>:/src:ro -v <out>:/output [-e WRANGLE_KIND=<kind>] [declared tool env] <image> /src /output
 ```
 
-- **Mounts** — `/src` read-only, `/output` writable (both confirmed enforced).
-- **Ownership** — **must** run as the runner UID/GID (`-u`), or output is `root`-owned and unusable.
-- **Network** — `--network none` is the **default**, not universal; egress is a **per-*tool*** opt-in
-  (not per-kind): even within `scan`, zizmor-online hits the GitHub API (**+ needs a token** → network
-  *and* secret, the case that most strains the sandbox) and osv refreshes its advisory DB. *Granularity
-  caveat:* Docker's cheap primitives are deny-all vs allow-all — a true *domain* allowlist (zizmor →
-  github.com only) needs an egress proxy / filtering sidecar, so "opt-in" likely means full egress for
-  declared tools unless we invest in filtering (open question, §12).
-- **Secrets** — most `scan`/`sbom` tools get none; a tool needing an authed call (zizmor → token) uses
-  the existing `WRANGLE_EXTRA_` channel. The default stays zero-secrets; secret-bearing is an
-  explicit per-tool declaration.
+- **Mounts** — `/src` read-only, `/output` writable; the tool writes nothing outside `/output`.
+- **Ownership** — the container runs as the runner UID/GID, or output files are written as `root` and
+  the runner cannot consume them.
+- **Network** — `--network none` by default; egress is a **per-tool** opt-in (not per-kind). Some tools
+  need it: zizmor's online audits reach the GitHub API, osv refreshes its advisory DB. *Granularity:*
+  Docker offers deny-all vs allow-all cheaply; a true domain allowlist needs an egress proxy, so opt-in
+  initially means full egress for the tools that declare it.
+- **Secrets** — `scan`/`sbom` tools receive none by default; a tool needing an authed call (zizmor → a
+  GitHub token) declares it and receives it through the existing `WRANGLE_EXTRA_` channel.
 
-### 3.2 The isolation contract is part of the contract (review's #1 risk)
+### 3.2 Isolation
 
-`docker run` does **not** just replace dispatch — it replaces `run.sh`'s isolation mechanism, which is
-three concrete things that MUST be re-derived item-by-item, not silently dropped:
+`docker run` replaces `run.sh`'s in-process isolation, so each current mechanism is carried over
+deliberately:
 
-| Today (`run.sh`) | Container equivalent | Status |
-|---|---|---|
-| `env -i <allowlist>` — adapter sees only allowed env | bare `docker run` inherits nothing (safer) **+** explicit `-e` for each allowed var | must rebuild deliberately |
-| `WRANGLE_EXTRA_*` forwarding | explicit `-e WRANGLE_EXTRA_*` per declared tool | must rebuild |
-| post-run filesystem snapshot diff (warn-only; a SPEC MUST) | `/src:ro` + `/output`-only mount = **fail-closed** write confinement | **upgrade** — fix today's warn-only gap |
+| Today (`run.sh`) | Container equivalent |
+|---|---|
+| `env -i <allowlist>` — adapter sees only allowed env | bare `docker run` inherits nothing; allowed vars passed explicitly with `-e` |
+| `WRANGLE_EXTRA_*` forwarding | explicit `-e WRANGLE_EXTRA_*` per declaring tool |
+| post-run filesystem snapshot (warn-only) | `/src:ro` + `/output`-only mount — fail-closed write confinement, an upgrade |
 
-SPEC's Adapter Script Interface (ENVIRONMENT/SECURITY) must be updated in the same change.
+SPEC's Adapter Script Interface (environment/security sections) is updated in the same change.
 
 ### 3.3 Tool kinds
 
-| Kind | Input | Output | Exit | BYO? |
-|------|-------|--------|------|------|
+The contract is parameterized over tool kind:
+
+| Kind | Input | Output | Exit | Adopter-substitutable |
+|------|-------|--------|------|-----------------------|
 | `scan` | `src_dir` (ro) | `output.sarif` (SARIF 2.1.0) | 0 clean / 1 findings / 2 error | yes |
-| `sbom` | `src_dir` **or built artifact** | `sbom.<format>.json` (SPDX **or** CycloneDX — declared) | 0 ok / 2 error | yes |
-| `attest/verify` | metadata + targets | signed attestations / verdict | tool-specific | no |
+| `sbom` | `src_dir` or built artifact | `sbom.<format>.json` (SPDX or CycloneDX, declared) | 0 ok / 2 error | yes |
+| `attest`/`verify` | metadata + targets | signed attestations / verdict | tool-specific | no |
 
-Deltas from today's SARIF-only contract: output is kind-specific and SBOM declares its **format**
-(don't hardcode SPDX); exit codes are per-kind (`sbom` has no "findings"); input may be src **or**
-artifact (a build-path SBOM reads the built binary, not source).
+`sbom` declares its format rather than assuming SPDX; its exit codes have no "findings" state; and its
+input may be a built artifact, not source. Everything else matches today's adapter interface.
 
-## 4. Packaging — decided by ownership
+### 3.4 Packaging
 
-`ko` builds *Go source you own* into a bare-binary image with the tool's *native* interface; it can't
-bundle a foreign binary + adapter shim. So:
+A tool's build path follows from **who owns it**:
 
-| Class | Examples | Path | Why |
-|---|---|---|---|
-| Own it, Go, adapter in binary | wrangle-lint, wrangle-attest, unified `wrangle` | ko / goreleaser `kos:` | binary *is* contract-native |
-| Adopter's own Go app | (Track A value-add) | ko / goreleaser | their binary, no Dockerfile |
-| Third-party wrap | osv, syft, **zizmor** | Dockerfile via `build_and_publish_container` | needs upstream binary + shim |
-| BYO | a third-party SBOM gen | their choice — wrangle ships only the contract | not our build problem |
+| Class | Examples | Build path |
+|---|---|---|
+| Owned Go, adapter in the binary | wrangle-lint, wrangle-attest, a unified `wrangle` | ko / goreleaser `kos:` (the binary is contract-native) |
+| Third-party tool wrapped | osv, syft, zizmor | Dockerfile via `build_and_publish_container` |
+| Adopter's own tool | a BYO SBOM generator | adopter's choice; wrangle ships only the contract |
 
-**zizmor is a viable container target (owner — corrects the review).** It is action-pattern today only
-because Rust/pip install was awkward, not because the wrapper is essential. The upstream action's one
-special function is the `advanced-security` Security-tab SARIF upload — which wrangle **already performs
-itself** for adapter tools via its own `codeql-action/upload-sarif` steps (osv, wrangle-lint);
-everything else (findings/error disambiguation in `collect_sarif.sh`, the md, the scan manifest) is
-already wrangle-side. Containerizing zizmor (`zizmor --format sarif` → `output.sarif`, then map
-findings→exit 1 since SARIF mode exits 0) would drop the action ladder, the pip install path, **and**
-the upstream-action dependency — plausibly *better*, and exactly the #137 flattening. It's also the
-clean test case for the §3.1 per-tool egress+credential capability: zizmor's online audits need GitHub
-API egress + a token via `WRANGLE_EXTRA_`.
+For wrapped third-party tools, the image is **built from source** by default: a multi-stage Dockerfile
+compiles the tool from wrangle's `tools/go.mod` and copies the binary onto a distroless base. This keeps
+the `go.mod` in-repo, so Dependabot, osv, and govulncheck continue to see the tool's transitive
+dependencies and wrangle retains the ability to patch a dependency ahead of upstream. The compile moves
+from every run to image-publish time. (Building a single tool from the shared `tools/go.mod` and
+extracting one binary is validated — see §4.)
 
-### 4.1 Third-party base: from-source vs FROM-upstream
+zizmor moves into this model too. It is action-pattern today only because Rust/pip install was awkward;
+its upstream action's one distinct function — uploading SARIF to the Security tab — is something wrangle
+already does for its adapter tools via its own `upload-sarif` steps. Containerizing it (`zizmor --format
+sarif` → `output.sarif`, mapping findings to exit 1) removes the action wrapper, the pip path, and the
+upstream-action dependency.
 
-- **Build-from-source** (`FROM golang AS build → FROM distroless → COPY`): keeps the `go.mod` in-repo
-  ⇒ Dependabot per-dep alerts, osv/govulncheck source scan, and ahead-of-upstream patching intact;
-  moves compile from per-run to per-publish. **Default for security-critical tools.**
-  - *Caveat (review):* osv shares the **single** `tools/go.mod` with cosign/ampel/bnd/govulncheck/
-    wrangle-attest/wrangle-lint. A per-tool from-source image needs its own module file — a new
-    drift surface (the very #264/#277 problem we're trying to reduce).
-- **FROM-upstream-image** (`FROM ghcr.io/google/osv-scanner@sha256:…`): fastest, but the tool's deps
-  leave our `go.mod` so the source scan goes blind (and there is **no image-scan step today**).
-  - **Security blocker (review S3):** a registry digest is a "checksum" served by the *same source*
-    as the bytes — this strains CLAUDE.md's "no checksums from the binary's source" rule. FROM-upstream
-    is permitted **only** with independent provenance verification at pull time (verify upstream's SLSA
-    attestation against a pinned identity, the way `lib/download_verify.sh` fails closed) — digest
-    alone is not sufficient. Detection of CVEs is recoverable via `osv-scanner scan image`; **ahead-of-
-    upstream remediation is not.**
+### 3.5 Orchestration: run via script, not `uses:`
 
-## 5. Tracks (conditional, post-spike)
+The orchestrator (`run.sh`) issues the `docker run`; tools are **not** wired in as `uses:` action steps.
+This is what lets wrangle own the surface — mounts, network, user, environment, exit-code mapping, and
+output layout — rather than ceding it to whatever an action's `action.yml` chooses to do. It also keeps
+the model CI-agnostic (#171) and flattens the nested `uses: ./tools/*` composition (#137).
 
-- **Track B (#596 core)** — wrap third-party tools (osv first) as contract images, Dockerfile
-  from-source.
-- **Track A (separate feature)** — goreleaser emits an attested image of a Go app, serving the adopter
-  value-add *and* wrangle's owned Go tools. **Correction:** the "goreleaser `--skip=publish` then a
-  gated job pushes the digest" flow in the prior draft is a synthesis of two *different* existing
-  flows that **neither implements** — `build_and_publish_go`'s `--skip=publish` uploads checksummed
-  *archives* to a GitHub Release (no registry push, no digest-attest); the digest push+attest lives in
-  `build_and_publish_container` and happens **mid-composite, not in a gated job**. Track A needs a
-  genuinely new gated-image-push job designed, not assumed.
-- **Track 2 (split out, HELD)** — attest/verify toolbox (cosign/ampel/bnd/wrangle-attest). Inverts the
-  sandbox (network + OIDC token in) and interposes an image-supply-chain link **in front of the signing
-  key**. Strictly riskier than today's in-job binaries (§10 S2). Do not ship on this framing.
+### 3.6 Reference model
 
-## 6. Pilot choice — honest version
+The image digest is a **wrangle-curated default**, not something each adopter pins. Two compatible
+homes:
 
-The syft/SBOM pilot is attractive for **contract** reasons (it's the cheapest tool to containerize,
-and an outside contributor's generator gives a real BYO second implementation — two impls is what makes a contract real). It is
-**not** a speed pilot (syft isn't the compile cost; the container SBOM is BuildKit-derived, not syft).
-So: **osv is the Phase-0 *speed/spike* pilot; syft is the eventual *contract* pilot** — and the
-contract pilot only happens if the spike clears the gate. Don't conflate them, as the first draft did.
+- a **defaulted input** on the scan action (`osv-image: ghcr.io/…@sha256:…`), and/or
+- a **`tools.lock`** — a single `tool → digest` manifest the orchestrator reads (subsuming the #264
+  lock idea), which is the cleaner central store for the pin tooling and gives adopters a transparent
+  view of what they run.
 
-## 7. Pros / cons against the constraints
+Either way, **adopters inherit the image by pinning wrangle**, exactly as they already inherit every
+bundled tool version. Wrangle bumps its own default when it updates a tool. An adopter who *overrides*
+(brings their own image, or pins a different digest) owns that pin's freshness; wrangle can offer rails
+(a `docker` Dependabot entry, a lint warning on a stale override) but cannot vouch for an image it does
+not control.
 
-**Pros** — C1: `go.mod` stays in-repo + signed image SBOM is additive. C2 *(if the spike confirms)*:
-pull a layer vs compile per run. Safety: container is a real sandbox (read-only, `--network none`,
-fail-closed write confinement — an *upgrade* over today's warn-only check). C3/portability: `docker
-run` is CI-agnostic (#171), flattens `uses: ./tools/*` (#137). P-b: BYO becomes "ship a conforming
-image."
+### 3.7 Capability declaration
 
-**Cons / costs** — **C4 release-before-use**: every tool fix needs a publish-then-bump hop, felt by
-the maintainer on every security patch (and see the §2 circularity). **Security tooling is blind to
-OCI digests** (§10 S1 — a blocker, not an open question). **FROM-upstream** strains the checksum-source
-rule (S3). **Track 2** inverts isolation in front of the key (S2). New build-time dep (ko) to vet if
-Track A proceeds. Multi-arch adds CI cost.
+Two distinct layers:
 
-> **Weakened claim (advisor):** the prior draft said pinned-digest pull is "cleaner than the
-> build-cache wart that forces `go-cache` off on L3 paths." That's shaky — a pinned image digest is
-> *also* trusting compiled output you didn't build this run, so the L3 bar is the **same**, not lower.
-> Don't lead with this as a benefit.
+- **Selection** (per run, adopter-facing): which tools to run and at what policy — today's
+  `tools: "osv zizmor:info …"` string.
+- **Definition** (static, per tool): a tool name resolves to `{image digest, kind, network, secret,
+  output}`. Capabilities live here, alongside the reference model, not in the selection string.
 
-## 8. Experiment results (Docker, this environment)
+**A capability grant comes from the trusting party — wrangle, or the adopter for their own tool — never
+from the image itself.** An image may *request* a capability (e.g. an OCI label), but granting it is the
+orchestrator's decision; otherwise the sandboxed tool would define its own sandbox. Grants are therefore
+recorded in-repo as reviewable lines, default to `network=none, secret=none`, and are relaxed only
+explicitly — consistent with wrangle's least-privilege and input-validation rules.
 
-Validated the contract mechanic with a from-scratch `scan` adapter and an `sbom` variant:
-`--network none` blocks egress; `/src:ro` blocks writes into src; exit **0/1/2 all propagate**;
-default output is **root-owned**, `-u 1000:1000` fixes it (⇒ orchestrator must set `-u`); `WRANGLE_KIND=sbom`
-writes `sbom.spdx.json` with exit-0/no-findings; a public-registry pull works (FROM-upstream feasible).
+## 4. Evidence
 
-Deferred (need Go 1.26 + ko/syft, absent here): the real ko build of wrangle-lint and the **osv
-build-from-source-vs-upstream-vs-prebuilt timing benchmark** — which is now Phase 0 and gates the rest.
+**Contract mechanic.** A `docker run` invocation of a `scan` adapter and an `sbom` adapter confirms:
+`--network none` blocks egress, `/src:ro` blocks writes into source, exit codes 0/1/2 propagate, output
+written as `root` unless `-u` is set (hence the ownership requirement), and the `sbom` kind writes
+`sbom.<format>.json` with no findings exit.
 
-## 9. Security prerequisites (BLOCKERS, not open questions)
+**Speed.** osv-scanner, delivered three ways on fresh cold `ubuntu-latest` (amd64) runners, building/
+fetching the pinned v2.4.0:
 
-Before any tool image is *consumed* in a wrangle workflow:
+| Delivery | Cold acquire | Warm acquire | Build (publish-time) |
+|----------|-------------:|-------------:|----------------------|
+| `go install` from source (today) | **85.1 s** | 0.29 s | — |
+| prebuilt binary (download + verify) | 0.65 s | — | — |
+| **container (`docker pull`)** | **1.73 s** | 0.09 s | 97 s build, 82 MB image |
 
-1. **Make the pin toolchain digest-aware** — but note build-from-source already shrinks this (owner).
-   Because the image is built from the in-repo `go.mod`, Dependabot/osv/govulncheck still see the
-   tool's transitive deps and fire CVE notices, and we rebuild + redeploy to remediate — so the
-   *detection/remediation* half of the blocker is handled (this is a concrete reason build-from-source
-   beats both FROM-upstream and B, which throw the manifest away). The **residual** is enforcement, and the
-   **reference model shrinks it further** (owner): the image digest is a **defaulted input** on the scan
-   action, curated and bumped by wrangle, threaded into `run.sh`'s `docker run`. So **adopters inherit
-   the image via the wrangle pin they already maintain** — no new adopter-side pin tooling for the
-   common (default) case. What's left is *wrangle-internal*: bump + freshness/cooldown-check wrangle's
-   **own** default image input(s) — one known field in our `action.yml`, an extension of the existing
-   self-reference bump family (`bump_action_pins`/`self_ref_pin_paths`), **not** a generic "track
-   arbitrary OCI digests everywhere." Adopter **overrides** (BYO image, or a pinned different digest) are
-   adopter-owned for freshness; wrangle offers hooks (a `docker` Dependabot snippet, a wrangle-lint warn
-   on a stale/unpinned override) but can't guarantee an image it doesn't control. This is the **last**
-   build step — it gates production *consumption*, not prototyping — and the reference model is chosen
-   *now* so it stays tractable. (Add a DEP_MGMT.md integrity rung for images regardless.)
-   - **Reference-model options (decide in contract design):** (i) *defaulted action input* per tool;
-     (ii) a **`tools.lock`** — one `tool → digest` file `run.sh` reads — which is the #264 manifest this
-     subsumes and the *cleanest* central store for the bump/freshness/cooldown tooling (one schema, not
-     scattered input defaults); (iii) **both** — `tools.lock` holds wrangle's curated defaults, the
-     action input is a per-tool *override* that beats the lock. `tools.lock` also adds **adopter
-     transparency** (they see exactly what they get) and, in a Dependabot/Renovate-recognized format,
-     lets adopters' own bots manage their *overrides* — the only place the adopter gains; the default
-     path is inherited via the wrangle pin either way, and overriding still means owning freshness.
-2. **Treat tool output as inert, validated data.** Schema-validate (not just JSON-parse) SARIF/SBOM
-   before embedding into any signed predicate; derive the pass/fail `result` orchestrator-side from
-   validated content. wrangle's signature attests *"tool X produced this,"* never *"this is correct."*
-3. **State the BYO trust model** (S5): a BYO image is *adopter-trusted, not wrangle-trusted*; runs
-   under the strictest contract by default (network none, no creds); any relaxation is explicit and
-   logged. Decide whether wrangle verifies a BYO image's own provenance before running it.
-4. **FROM-upstream requires pull-time provenance verification** (S3), not digest-alone.
-5. **Track 2 / OIDC** (S2): if ever containerized, from-source only, verify the toolbox image's
-   provenance before the token is in scope, mint/consume `id-token` in the narrowest step, and re-audit
-   against SLSA_L3_AUDIT "secret material MUST NOT be accessible to the env running user steps."
-6. **Expedited security-bump path** for tool images so the cooldown doesn't delay legitimate fixes (S6).
+The proposed container delivery cuts the cold acquire from 85 s to 1.7 s (~49×). The win is on the
+**cold path** — release builds (forced cold for L3) and adopter first-runs — which is exactly where the
+build cache cannot help; on warm PR scans the status quo is already sub-second. The one-time 97 s build
+is paid at publish, not per run. (Per-run *scan* time is network-bound by osv's online queries and is
+not a meaningful per-delivery signal.)
 
-## 10. Review findings (three independent reviews)
+## 5. Alternatives considered
 
-**Architecture** — contract generalization is faithful; but flagged factual errors (osv is go.mod not
-install.sh; container SBOM is BuildKit not syft; the `--skip=publish`/gated-push mapping is unimplemented;
-osv shares one `tools/go.mod`). The review also called zizmor's action wrapper "load-bearing" — the
-owner corrected this: zizmor is action-pattern only for install convenience and is a viable container
-target (see §4). Biggest risk: the container
-boundary silently replaces `run.sh`'s isolation contract (`env -i` allowlist + `WRANGLE_EXTRA_` +
-post-run snapshot, a SPEC MUST) — must be re-derived item-by-item (now §3.2).
+- **Prebuilt binary (download + verify).** Fastest acquire, but a raw binary carries no `go.mod`
+  manifest (no transitive-CVE notices), sits below build-from-source on the integrity ladder, and gets
+  no sandbox. Rejected as the delivery mechanism; useful only as the speed floor it establishes above.
+- **`FROM <upstream image>`.** Fastest of all (no compile), but the tool's dependencies leave wrangle's
+  `go.mod` so the source scan goes blind, and a registry digest is a checksum served by the same source
+  as the bytes — straining the "checksums not from the binary's source" rule. Permitted only for tools
+  where wrangle accepts delegating build and patch cadence to upstream, and only with the upstream
+  image's provenance verified at pull time. Not the default.
+- **Tools as raw `uses:` action steps.** Cedes the execution surface to GitHub Actions and ties the
+  model to one CI. Rejected in favor of orchestrator-driven `docker run` (§3.5).
 
-**Adversarial security** — net neutral-to-safer for scan/sbom *only if* the pin/verify gaps are built
-first; **Track 2 net-riskier** and should be split/held. Ranked: S1 digest-blind tooling (HIGH **as
-written — but much lower for build-from-source, which keeps the `go.mod` notice loop; residual is
-consumer-side pin freshness, §9.1**),
-S2 OIDC-in-container in front of the key (HIGH), S3 FROM-upstream checksum-source (MED-HIGH), S4
-poisoned-output-signed-clean (MED, pre-existing, widened by BYO), S5 no BYO trust model (MED), S6
-cooldown delays security fixes (LOW-MED). All folded into §9.
+## 6. Security model and prerequisites
 
-**Strategic (advisor)** — "do much less, not yet." The one quantifiable goal (C2) is undiagnosed;
-measure osv before architecting, and beat **both** today's cold path **and** a verified prebuilt-binary
-fetch (`lib/download_verify.sh`) or containerization is an over-build. Cut Track A from #596; defer the
-kind-contract, image-scanning, multi-arch. Drove §0 and §6.
+- **Tool output is an inert assertion.** SARIF/SBOM is schema-validated before wrangle embeds it in any
+  signed predicate, and the pass/fail result is derived orchestrator-side. A wrangle signature attests
+  *"tool X produced this,"* never *"this is correct"* — important for adopter-supplied tools.
+- **Adoption enforcement (the residual prerequisite).** Build-from-source keeps CVE *detection* working
+  via the in-repo `go.mod`. What remains is ensuring a published fix is actually *adopted*: the
+  consuming reference (image digest) must be freshness/ancestry/cooldown-checked so a stale pin cannot
+  pass CI green (the #539/#544 class). This means teaching the pin toolchain (WL005 cooldown,
+  `check_pin_ancestry`, `check_pin_freshness`, `bump_action_pins`, `self_ref_pin_paths`) to understand
+  OCI `@sha256:` digests, adding a `docker` Dependabot ecosystem, and a DEP_MGMT.md integrity rung for
+  images. Because the digest lives in one curated place (§3.6), this is a narrow, wrangle-internal task,
+  and it is required only before *production consumption*, not before prototyping.
+- **Adopter-supplied images** are adopter-trusted, not wrangle-trusted: they run under the strictest
+  contract by default (no network, no secrets), any relaxation is explicit, and wrangle's signature
+  covers provenance of the run, not correctness of the tool.
 
-## 11. Phase 0 spike — detailed spec
+## 7. Scope
 
-**Question:** for the worst cold-compile tool (osv-scanner), what is the net per-run wall-clock under
-each delivery model, on a real GitHub-hosted runner — and does the container model beat the cheaper
-alternatives by a margin an adopter notices?
+- **In scope:** wrapping third-party adapter tools as contract images, osv first.
+- **Held, tracked separately:** the attest/verify toolchain (cosign, ampel, bnd, wrangle-attest). It
+  shares a `go.mod` and runs together, so it would package as one image — but it *inverts* the sandbox
+  (it needs network and the OIDC signing token) and would interpose an image-supply-chain link in front
+  of the signing key. That is a different, higher-stakes problem than the scan path and is not part of
+  this proposal.
+- **Separate feature:** emitting an attested container of an adopter's own Go app (the "free container"
+  value-add via goreleaser/ko). It reuses some machinery but serves adopter UX, not the goals here.
+- **Left as-is:** tools with official GitHub Actions that gain nothing from containerization stay
+  action-pattern (an escape hatch C3 explicitly allows).
 
-**Three arms** (same pinned osv-scanner version, same fixture, same runner, network policy held
-constant):
+## 8. Open questions
 
-| Arm | Delivery | Acquire step | L3 posture |
-|-----|----------|--------------|------------|
-| **A — status quo** | `go install` from `tools/go.mod` | compile from source | builds cold on release (go-cache off for L3); warm cache only helps PR scans |
-| **B — prebuilt binary** | upstream release binary via `lib/download_verify.sh` (hardcoded checksum) | download + verify, no compile | trusts a binary you didn't build — verify upstream provenance to hold L3 |
-| **C — container (from-source)** | distroless image built from source, run via `docker run -u … --network … -v src:ro -v out` | `docker pull` | trusts compiled output you didn't build *this run* — same bar as a cache; image built cold at publish |
+- **Invocation arg convention** — positional `<src> <out>` (matches today's adapters) vs
+  `WRANGLE_SRC`/`WRANGLE_OUTPUT` env (cleaner, more portable).
+- **Reference model** — defaulted action input vs `tools.lock` vs both (lock for defaults, input as
+  per-tool override).
+- **Egress granularity** — accept full egress for network-declaring tools, or invest in a filtering
+  proxy for true per-domain allowlists.
+- **Capability-declaration format** — the on-disk shape of the per-tool definition.
+- **Registry/hosting and multi-arch** — ghcr namespace; amd64-only first or amd64+arm64.
+- **SPEC.md** — fold the kind-parameterized contract into the Adapter Script Interface.
 
-**Measure** (median of N≥5 runs each, on `ubuntu-latest`; record arch):
-- **acquire** time and **run** time *separately* (so we see where the cost is).
-- **cold** (fresh runner / cache miss — the real first-run adopter case) **and** **warm** (go build
-  cache for A; image layer cache for C; B is re-download unless cached).
-- bytes pulled/downloaded per arm.
-- osv's own advisory-DB fetch held constant across arms (or run offline-DB) so it doesn't skew `run`.
+## 9. Plan
 
-**Harness sketch** (one workflow, a job per arm, `time` around acquire vs run, fixed fixture repo
-checked out read-only; emit a CSV/step-summary table). No contract, no ko, no Track A.
-
-**Decision rule (kill-criteria) — corrected (owner):** B is a **speed reference, not an adoption
-candidate.** wrangle doesn't want raw-binary installs: B has no `go.mod` manifest (⇒ no transitive-CVE
-notices, no build-from-source integrity tier) and no sandbox. So B's speed does **not** decide anything.
-- **C must beat A** on net wall-clock (if C's pull cost doesn't beat A's compile, there's no speed case
-  → **stop**).
-- **C must beat B on the maintainability / security / extensibility story** — which it does, because
-  C-from-source keeps the `go.mod` (notices + redeploy) and adds the sandbox, while B loses the manifest.
-- If C beats A and clears the qualitative bar over B → proceed to §3 contract + §9 prerequisites.
-- B's number only *bounds how much speed is on the table* — useful context, never a veto.
-
-**Explicitly out of scope for the spike:** the frozen contract, the SBOM kind, ko, Track A, multi-arch,
-image-scanning, any change to `actions/scan`. One tool, three numbers, one decision.
-
-**Note on B's status (owner-decided):** B is a **speed reference, not an adoption candidate** — wrangle
-doesn't want raw-binary installs (no `go.mod` manifest, no sandbox). Its number bounds how much speed is
-on the table; it never decides the outcome.
-
-## 12. Tool-definition surface (catalog vs selection; capability trust direction)
-
-Two layers, easy to conflate:
-- **Selection** (per-run, adopter-facing): *which* tools + policy — today's `tools: "osv zizmor:info …"`
-  string; the `:fail`/`:info` suffix is the precedent. Stays lightweight.
-- **Definition / catalog** (static, per-tool): a tool name resolves to `{image digest, kind, network,
-  secret, output}`. This is the new surface; capabilities live here, not in the selection string.
-
-**Trust direction is the load-bearing rule:** a capability grant (network, a credential) comes from the
-**trusting party** — wrangle, or the adopter for their own BYO tool — **never self-granted by the image.**
-An image self-declaring `network=all, secret=token` would let the sandboxed thing decide how much sandbox
-to remove. It's the phone-app model: the image *manifest* may *request* (an OCI label is fine as a
-documented request), but wrangle/the adopter *grants*. Request ≠ grant. Consequences:
-- **In-repo, reviewable** catalog (the `tools.lock` sibling) beats image-embedded labels — a network/token
-  grant must be a diffable line someone approved (satisfies "validate every input" + least-privilege).
-- **Least privilege by default:** catalog entries default to `network=none, secret=none`; every relaxation
-  is explicit.
-- **BYO ≠ image self-declares:** the *adopter* authors the capability entry for their own tool (they're the
-  trusting party for their image); the image may carry a requested-capabilities label that wrangle/the
-  adopter chooses whether to honor.
-
-(This generalizes today's `WRANGLE_EXTRA_` per-tool credential channel into one declaration: image digest +
-kind + network + which credential + output.)
+1. **Prototype osv end-to-end** (scan kind, built from source): `run.sh` invokes the image via
+   `docker run`, producing a real `output.sarif` through wrangle's existing collectors. Proves the
+   run-via-script integration. *(The contract mechanic and the speed win in §4 are already measured.)*
+2. **Freeze the contract in SPEC.md** — the `scan` and `sbom` kinds, the invocation, and the isolation
+   mapping (§3.1–3.3).
+3. **Make the pin toolchain digest-aware** (§6) — required before any image is consumed in a production
+   wrangle workflow.
+4. **Migrate osv for real** — published from source via `build_and_publish_container`, referenced as a
+   curated default (§3.6), `run.sh` rewired to `docker run`.
+5. **Extend to the rest of the adapter tools** — syft as the `sbom` reference implementation (and the
+   first adopter-substitutable contract test), then zizmor.
+6. **Revisit the held items** — the attest/verify toolbox and the adopter container value-add, each on
+   its own merits.


### PR DESCRIPTION
## What

A design-exploration doc (`docs/tool_container_design.md`) for #596 — re-homing wrangle's tool layer behind a **container-delivered adapter contract**. This is a **draft for discussion, not a merge candidate**; SPEC.md stays the source of truth.

## Why a PR

Easier to review than an issue comment, and keeps the design diffable. The substance is also summarized in two comments on #596.

## What's in it

- **Measure-first plan** + the **Phase-0 osv spike result** — gate **cleared**: cold acquire on a real runner went from **85.1 s** (`go install` from source) to **1.73 s** (`docker pull`), ~49×, within ~1 s of a raw-binary floor while keeping the `go.mod` manifest + sandbox.
- **Kind-parameterized contract** (`scan`/`sbom`/`attest`), the empirically-validated `docker run` invocation, and the **isolation mapping** (what `docker run` replaces in `run.sh`).
- **Packaging by ownership** (ko for owned Go, Dockerfile-from-source for third-party; build-from-source as the keystone that preserves CVE notices).
- **Run-via-script + reference model** — image digest as a wrangle-curated default (defaulted input and/or a `tools.lock`), inherited by adopters via the wrangle pin; digest-aware pin tooling as the *last* step, not a front-loaded blocker.
- **Capability-declaration surface** (§12) with the trust-direction rule: grants come from wrangle/the adopter, never self-granted by the image.
- Folds in **three independent reviews** (architecture / adversarial-security / strategic) and the corrections they forced.

## Status / open decisions

Per CLAUDE.md, no merge without an `LGTM`. The genuinely-open, design-phase items (none blocking a scan-kind pilot): the `scan` arg convention (positional vs env), defaulted-input vs `tools.lock`, egress-filtering granularity, the capability-catalog format, and the SPEC.md update. Track 2 (attest toolbox) is split out and held; Track A (adopter value-add) is a separate feature.

Looking for a read on the **direction and scope** before any implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
