### PR TITLE
feat(osv): container image + reusable image test harness (#596)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,3 +49,13 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+
+  # Tool-image and test Dockerfiles: keep pinned base-image digests fresh.
+  - package-ecosystem: "docker"
+    directories:
+      - "/**"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/test/fixtures/image-contract/Dockerfile
+++ b/test/fixtures/image-contract/Dockerfile
@@ -1,5 +1,5 @@
 # Mock contract-conforming tool image — fixture for the image test harness.
-FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
+FROM debian:12-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/test/fixtures/image-contract/Dockerfile
+++ b/test/fixtures/image-contract/Dockerfile
@@ -1,0 +1,5 @@
+# Mock contract-conforming tool image — fixture for the image test harness.
+FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/test/fixtures/image-contract/entrypoint.sh
+++ b/test/fixtures/image-contract/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Mock tool honoring the wrangle adapter contract, used only to test the image
+# harness (test/lib/image_test_harness.bash). A real tool can't produce a
+# controlled exit-2 / malformed-SARIF on demand, so a mock drives each path.
+# Behavior is selected by the contents of /src/MODE.
+set -eu
+src="$1"
+out="$2"
+mode="$(cat "$src/MODE" 2>/dev/null || printf 'clean')"
+case "$mode" in
+  findings)
+    printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"mock"}},"results":[{"ruleId":"X"}]}]}\n' > "$out/output.sarif"
+    exit 1 ;;
+  error)
+    printf 'mock: simulated tool error\n' >&2
+    exit 2 ;;
+  malformed)
+    printf 'not valid json{' > "$out/output.sarif"
+    exit 0 ;;
+  *)
+    printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"mock"}},"results":[]}]}\n' > "$out/output.sarif"
+    exit 0 ;;
+esac

--- a/test/fixtures/image-contract/entrypoint.sh
+++ b/test/fixtures/image-contract/entrypoint.sh
@@ -1,23 +1,27 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — processes external input paths
+
 # Mock tool honoring the wrangle adapter contract, used only to test the image
 # harness (test/lib/image_test_harness.bash). A real tool can't produce a
 # controlled exit-2 / malformed-SARIF on demand, so a mock drives each path.
-# Behavior is selected by the contents of /src/MODE.
-set -eu
+# Behavior is selected by the contents of <src>/MODE.
+
 src="$1"
 out="$2"
 mode="$(cat "$src/MODE" 2>/dev/null || printf 'clean')"
+
 case "$mode" in
-  findings)
-    printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"mock"}},"results":[{"ruleId":"X"}]}]}\n' > "$out/output.sarif"
-    exit 1 ;;
-  error)
-    printf 'mock: simulated tool error\n' >&2
-    exit 2 ;;
-  malformed)
-    printf 'not valid json{' > "$out/output.sarif"
-    exit 0 ;;
-  *)
-    printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"mock"}},"results":[]}]}\n' > "$out/output.sarif"
-    exit 0 ;;
+    findings)
+        printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"mock"}},"results":[{"ruleId":"X"}]}]}\n' > "$out/output.sarif"
+        exit 1 ;;
+    error)
+        printf 'mock: simulated tool error\n' >&2
+        exit 2 ;;
+    malformed)
+        printf 'not valid json{' > "$out/output.sarif"
+        exit 0 ;;
+    *)
+        printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"mock"}},"results":[]}]}\n' > "$out/output.sarif"
+        exit 0 ;;
 esac

--- a/test/image/test_image_harness.bats
+++ b/test/image/test_image_harness.bats
@@ -17,7 +17,7 @@ setup_file() {
 
 setup() {
     load "../lib/bats_helpers"
-    load "../lib/image_test_harness"
+    load "../lib/image_test_harness.sh"
     wrangle_require_docker
 
     TMP_DIR="$(mktemp -d "${BATS_TMPDIR:-/tmp}/wrangle-img.XXXXXX")"

--- a/test/image/test_image_harness.bats
+++ b/test/image/test_image_harness.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+
+# Validates the image test harness (test/lib/image_test_harness.bash) against a
+# mock contract-conforming tool image, so the harness itself is trustworthy
+# before real tool images rely on it. Needs docker, so it lives under test/image/
+# (outside the Makefile's unit `bats` glob) and runs in the dogfooded shell
+# build, which auto-detects every .bats on a docker-capable runner.
+
+setup_file() {
+    load "../lib/bats_helpers"
+    command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1 || return 0
+    local root
+    root="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    docker build -q -t wrangle-mock-tool:test \
+        "$root/test/fixtures/image-contract" >/dev/null
+}
+
+setup() {
+    load "../lib/bats_helpers"
+    load "../lib/image_test_harness"
+    wrangle_require_docker
+
+    TMP_DIR="$(mktemp -d "${BATS_TMPDIR:-/tmp}/wrangle-img.XXXXXX")"
+    OUT="$TMP_DIR/out"
+    mkdir -p "$OUT"
+}
+
+teardown() {
+    [[ -n "${TMP_DIR:-}" ]] && rm -rf "$TMP_DIR"
+}
+
+# Make a src fixture dir whose MODE file selects the mock's behavior.
+_src_with_mode() {
+    local mode="$1" dir="$TMP_DIR/src-$1"
+    mkdir -p "$dir"
+    printf '%s' "$mode" > "$dir/MODE"
+    printf '%s' "$dir"
+}
+
+@test "harness: clean input -> exit 0 and valid empty SARIF" {
+    local src
+    src="$(_src_with_mode clean)"
+    run wrangle_image_scan wrangle-mock-tool:test "$src" "$OUT"
+    [ "$status" -eq 0 ]
+    wrangle_assert_sarif "$OUT"
+    [ "$(jq '[.runs[].results[]] | length' "$OUT/output.sarif")" -eq 0 ]
+}
+
+@test "harness: findings -> exit 1 and SARIF with results" {
+    local src
+    src="$(_src_with_mode findings)"
+    run wrangle_image_scan wrangle-mock-tool:test "$src" "$OUT"
+    [ "$status" -eq 1 ]
+    wrangle_assert_sarif "$OUT"
+    [ "$(jq '[.runs[].results[]] | length' "$OUT/output.sarif")" -gt 0 ]
+}
+
+@test "harness: tool error -> exit 2" {
+    local src
+    src="$(_src_with_mode error)"
+    run wrangle_image_scan wrangle-mock-tool:test "$src" "$OUT"
+    [ "$status" -eq 2 ]
+}
+
+@test "harness: assert_sarif catches malformed output" {
+    local src
+    src="$(_src_with_mode malformed)"
+    run wrangle_image_scan wrangle-mock-tool:test "$src" "$OUT"
+    [ "$status" -eq 0 ]
+    run wrangle_assert_sarif "$OUT"
+    [ "$status" -ne 0 ]
+}
+
+@test "harness: read-only src is enforced" {
+    local src
+    src="$(_src_with_mode clean)"
+    run docker run --rm --network none -u "$(id -u):$(id -g)" \
+        -v "$src":/src:ro -v "$OUT":/output --entrypoint /bin/sh \
+        wrangle-mock-tool:test -c 'touch /src/x'
+    [ "$status" -ne 0 ]
+    wrangle_assert_src_unchanged "$src" 1
+}

--- a/test/lib/image_test_harness.bash
+++ b/test/lib/image_test_harness.bash
@@ -1,0 +1,49 @@
+# test/lib/image_test_harness.bash — helpers for testing a tool container
+# image against the wrangle adapter contract:
+#   docker run <image> /src /output  ->  writes /output/output.sarif,
+#   exits 0 (clean) / 1 (findings) / 2 (tool error); writes nothing outside
+#   /output; runs as the caller's UID so output is consumable.
+#
+# Source after test/lib/bats_helpers (for skip_or_fail). Intended for per-tool
+# `test_image.bats` files; gate every test on `wrangle_require_docker`.
+
+# Fail in CI / skip locally when docker isn't usable.
+wrangle_require_docker() {
+    if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+        skip_or_fail "docker not available (needed to run tool images)"
+    fi
+}
+
+# wrangle_image_scan <image> <src_dir> <out_dir> [network]
+# Runs the image under the contract sandbox (read-only src, writable output,
+# non-root as the caller, network off by default) and returns its exit code.
+wrangle_image_scan() {
+    local image="$1" src="$2" out="$3" network="${4:-none}"
+    docker run --rm --network "$network" -u "$(id -u):$(id -g)" \
+        -v "$src":/src:ro -v "$out":/output "$image" /src /output
+}
+
+# wrangle_assert_sarif <out_dir> — output.sarif exists and is valid JSON.
+wrangle_assert_sarif() {
+    local out="$1"
+    if [[ ! -f "$out/output.sarif" ]]; then
+        printf 'contract: missing %s/output.sarif\n' "$out" >&2
+        return 1
+    fi
+    if ! jq empty "$out/output.sarif" 2>/dev/null; then
+        printf 'contract: %s/output.sarif is not valid JSON\n' "$out" >&2
+        return 1
+    fi
+}
+
+# wrangle_assert_src_unchanged <src_dir> <expected_file_count>
+# The contract forbids writes outside /output; src is mounted read-only, so a
+# tool that tries to write there fails. This double-checks src is untouched.
+wrangle_assert_src_unchanged() {
+    local src="$1" expected="$2" actual
+    actual="$(find "$src" -type f | wc -l | tr -d ' ')"
+    if [[ "$actual" != "$expected" ]]; then
+        printf 'contract: src tree changed (%s files, expected %s)\n' "$actual" "$expected" >&2
+        return 1
+    fi
+}

--- a/test/lib/image_test_harness.sh
+++ b/test/lib/image_test_harness.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
 # test/lib/image_test_harness.bash — helpers for testing a tool container
 # image against the wrangle adapter contract:
 #   docker run <image> /src /output  ->  writes /output/output.sarif,

--- a/tools/osv/Dockerfile
+++ b/tools/osv/Dockerfile
@@ -10,11 +10,11 @@ COPY tools/ ./tools/
 RUN cd tools && CGO_ENABLED=0 go build -trimpath \
       -o /out/osv-scanner github.com/google/osv-scanner/v2/cmd/osv-scanner
 
-FROM debian:12-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
-RUN apt-get update \
- && apt-get install -y --no-install-recommends jq ca-certificates \
- && rm -rf /var/lib/apt/lists/* \
- && useradd -u 1000 -m wrangle
+# Minimal hardened base (Chainguard wolfi); the adapter entrypoint needs a
+# shell + jq, which distroless lacks.
+FROM cgr.dev/chainguard/wolfi-base@sha256:0b613d8101fae27cf76186351db831ab3db25bfb2ec7161e897cd7e22c6413a3
+RUN apk add --no-cache bash jq ca-certificates \
+ && adduser -D -u 1000 wrangle
 COPY --from=build /out/osv-scanner /usr/local/bin/osv-scanner
 # Preserve the tools/osv + lib layout the adapter expects
 # (adapter.sh -> render_md.sh -> ../../lib/sanitize.sh).

--- a/tools/osv/Dockerfile
+++ b/tools/osv/Dockerfile
@@ -4,7 +4,7 @@
 # runs the existing wrangle osv adapter as the contract entrypoint:
 #   docker run <image> <src> <output>  ->  <output>/output.sarif, exit 0/1/2
 # Build context is the repo root (the build needs tools/go.mod + lib/).
-FROM golang:1.26.4@sha256:792443b89f65105abba56b9bd5e97f680a80074ac62fc844a584212f8c8102c3 AS build
+FROM golang:1.26.4@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5 AS build
 WORKDIR /src
 COPY tools/ ./tools/
 RUN cd tools && CGO_ENABLED=0 go build -trimpath \

--- a/tools/osv/Dockerfile
+++ b/tools/osv/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+# Wrangle osv-scanner tool image. Builds osv-scanner from the pinned
+# tools/go.mod (manifest-preserving — keeps vuln scanning of its deps) and
+# runs the existing wrangle osv adapter as the contract entrypoint:
+#   docker run <image> <src> <output>  ->  <output>/output.sarif, exit 0/1/2
+# Build context is the repo root (the build needs tools/go.mod + lib/).
+FROM golang:1.26.4@sha256:792443b89f65105abba56b9bd5e97f680a80074ac62fc844a584212f8c8102c3 AS build
+WORKDIR /src
+COPY tools/ ./tools/
+RUN cd tools && CGO_ENABLED=0 go build -trimpath \
+      -o /out/osv-scanner github.com/google/osv-scanner/v2/cmd/osv-scanner
+
+FROM debian:12-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends jq ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd -u 1000 -m wrangle
+COPY --from=build /out/osv-scanner /usr/local/bin/osv-scanner
+# Preserve the tools/osv + lib layout the adapter expects
+# (adapter.sh -> render_md.sh -> ../../lib/sanitize.sh).
+COPY tools/osv/adapter.sh tools/osv/render_md.sh /wrangle/tools/osv/
+COPY lib/sanitize.sh /wrangle/lib/sanitize.sh
+ENV HOME=/tmp
+USER wrangle
+ENTRYPOINT ["/wrangle/tools/osv/adapter.sh"]


### PR DESCRIPTION
## What

First implementation slice of #596 (depends on the design in #603). Containerizes **osv** and lands a **reusable image test harness**. Ready for review — what is here is validated + green; the two decisions below gate the *next* steps (publish + PR2), not this PR.

## Validated locally (evidence)

The key de-risking result: the image **reuses the existing `tools/osv/adapter.sh` + `render_md.sh` + `lib/sanitize.sh` verbatim as its entrypoint**, so a containerized run is byte-identical to today's adapter — no new adapter logic.

```
clean source        -> exit 0, valid empty SARIF
vulnerable go.mod    -> exit 1, 2 findings, osv markdown (CVE-2021-3121, HIGH, fixed version)
-u 4242:4242 (arb.)  -> works (HOME=/tmp), output owned by the caller UID
```

The harness self-test is **5/5 green**, and `shellcheck` + `wrangle-shell-lint` pass.

## In this PR

- `tools/osv/Dockerfile` — multi-stage: builds osv-scanner from the pinned `tools/go.mod` (manifest-preserving — keeps Dependabot/osv/govulncheck visibility; **not** a git-clone-rebuild), then runs the existing adapter as the contract entrypoint on a digest-pinned distroless-ish base.
- `test/lib/image_test_harness.bash` — reusable: run any tool image under the contract sandbox (`--network`, `-u`, `/src:ro`, `/output`) and assert exit code + SARIF validity + write confinement.
- `test/fixtures/image-contract/` — a mock conforming image driving each contract path so the harness self-validates (a mock is justified here: a real tool can't emit a controlled exit-2 / malformed SARIF on demand).
- `test/image/test_image_harness.bats` — the harness self-test. Placed outside the Makefile's unit `bats` glob (it needs docker, absent in the unit test container); the dogfooded shell build auto-detects it on a docker-capable runner.

## Open decisions for your review

1. **Publish wiring.** `build_and_publish_container` sets `context: {{defaultContext}}:<path>`, i.e. the build context is the *path subdir*. A wrangle tool image's build needs **repo-root files** (`tools/go.mod`, `lib/sanitize.sh`), which a subdir context can't reach. Options: (a) add a `context`/`dockerfile` input to `build/actions/container` so the Dockerfile and context can differ (touches the L3 build path — your call), or (b) a dedicated tool-image build workflow. I did **not** change the L3 path unsupervised.

2. **Where/how tool-image tests build + run in CI.** The osv image test builds osv-from-source (~GB of modules) — heavy enough that running it inside the shell build's every-`.bats` pass risks disk/time blowups (it filled my local disk). The lightweight harness self-test runs green now; the **osv image test is written and locally validated but held** pending an image build/cache strategy for CI (e.g. build-and-cache the image once, then point tests at the tag).

## Follow-ups

- **PR2** (run.sh `docker run` seam) is stacked on this and bootstrap-blocked until the osv image is actually published (decision 1).
- The osv image test (`tools/osv/test_image.bats`) is ready to add once decision 2 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
