### PR TITLE
feat(build): allow repo-root context + dockerfile path for tool images (#596)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/prep@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/scan@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      uses: TomHennen/wrangle/build/actions/container@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/verify_release@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -4,17 +4,11 @@ on:
   workflow_call:
     inputs:
       path:
-        description: "A path, within the repo, to the folder containiner a Dockerfile you want to build."
+        description: "The path within the repo that should be used when building the image."
         required: true
         type: string
       dockerfile:
-        description: |
-          Optional relative path to a Dockerfile when the build needs
-          repo-root files (e.g. a monorepo tool image that COPYs sources from
-          outside `path`). Empty (default) builds the `path` subdirectory as
-          the context with its own Dockerfile; set, it builds the repo root as
-          the context with the Dockerfile at this subpath. `path` still drives
-          the metadata short name in both cases.
+        description: "Path to the Dockerfile. Defaults to {path}/Dockerfile. When set, the build context becomes the repo root, so the Dockerfile can COPY files from outside {path}."
         required: false
         type: string
         default: ""

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/prep@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/scan@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      uses: TomHennen/wrangle/build/actions/container@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/verify_release@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -7,6 +7,17 @@ on:
         description: "A path, within the repo, to the folder containiner a Dockerfile you want to build."
         required: true
         type: string
+      dockerfile:
+        description: |
+          Optional relative path to a Dockerfile when the build needs
+          repo-root files (e.g. a monorepo tool image that COPYs sources from
+          outside `path`). Empty (default) builds the `path` subdirectory as
+          the context with its own Dockerfile; set, it builds the repo root as
+          the context with the Dockerfile at this subpath. `path` still drives
+          the metadata short name in both cases.
+        required: false
+        type: string
+        default: ""
       imagename:
         description: "The full path, including registry, specifying where the image should be published."
         required: true
@@ -171,6 +182,7 @@ jobs:
       uses: TomHennen/wrangle/build/actions/container@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
       with:
         path: ${{ inputs.path }}
+        dockerfile: ${{ inputs.dockerfile }}
         imagename: ${{ inputs.imagename }}
         registry: ${{ inputs.registry }}
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/prep@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/scan@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/build/actions/go/checks@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/build/actions/go/build@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/attest_provenance@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/verify_release@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/prep@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/scan@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/build/actions/go/checks@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/build/actions/go/build@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/attest_provenance@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/verify_release@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/prep@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/scan@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/build/actions/npm@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/attest_provenance@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/verify_release@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/prep@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/scan@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/build/actions/npm@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/attest_provenance@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/verify_release@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/prep@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/scan@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/build/actions/python@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/attest_provenance@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/verify_release@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/prep@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/scan@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/build/actions/python@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/attest_provenance@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/verify_release@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -77,7 +77,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/prep@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -90,7 +90,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/scan@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -134,7 +134,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+        uses: TomHennen/wrangle/build/actions/shell@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -77,7 +77,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/prep@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -90,7 +90,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/scan@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -134,7 +134,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+        uses: TomHennen/wrangle/build/actions/shell@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/prep@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+        uses: TomHennen/wrangle/actions/scan@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      - uses: TomHennen/wrangle/actions/prep@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+        uses: TomHennen/wrangle/actions/scan@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -133,7 +133,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      uses: TomHennen/wrangle/tools/zizmor@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -141,7 +141,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      uses: TomHennen/wrangle/tools/scorecard@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -153,7 +153,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+      uses: TomHennen/wrangle/tools/dependency-review@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -133,7 +133,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      uses: TomHennen/wrangle/tools/zizmor@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -141,7 +141,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      uses: TomHennen/wrangle/tools/scorecard@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -153,7 +153,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+      uses: TomHennen/wrangle/tools/dependency-review@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
+    - uses: TomHennen/wrangle/actions/verify@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@bced262e824e11ac234ebb801a9596ff8e0f0e70 # main 2026-06-22
+    - uses: TomHennen/wrangle/actions/verify@6bc0bdc56adeaef3bb3cc9b45323707b018052f5 # feat/container-root-context-dockerfile 2026-06-24
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -22,7 +22,6 @@ Copy [`build_and_publish_containers.yml`](../../../gh_workflow_examples/build_an
 
 ## Good to know
 
-- **`dockerfile`** (optional) lets a Dockerfile `COPY` files from outside `path` — e.g. a monorepo image needing repo-root sources. Set it and the build context becomes the repo root with the Dockerfile read from that subpath; leave it empty (default) and `path` is the self-contained context. `path` still names the artifacts either way. See [`SPEC.md`](./SPEC.md#inputs-and-outputs).
 - **`release-events`** (default: `non-pull-request`) gates provenance generation and verification — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating". The docker push itself happens earlier and is gated by your workflow's own `on:` triggers.
 - **Release builds never use a cache** — BuildKit's shared cache isn't re-verified on hits, so a poisoned entry could reach the attested image. PR builds get a per-PR isolated cache by default, which closes PR-to-PR cache poisoning; tune that with the `pr-cache` input, documented in [`build_and_publish_container.yml`](../../../.github/workflows/build_and_publish_container.yml).
 - **`pull_request_target` can't trigger this workflow** — that trigger (and `workflow_run` chained from it) is a common exploit vector, so wrangle blocks both at startup.

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -22,6 +22,7 @@ Copy [`build_and_publish_containers.yml`](../../../gh_workflow_examples/build_an
 
 ## Good to know
 
+- **`dockerfile`** (optional) lets a Dockerfile `COPY` files from outside `path` — e.g. a monorepo image needing repo-root sources. Set it and the build context becomes the repo root with the Dockerfile read from that subpath; leave it empty (default) and `path` is the self-contained context. `path` still names the artifacts either way. See [`SPEC.md`](./SPEC.md#inputs-and-outputs).
 - **`release-events`** (default: `non-pull-request`) gates provenance generation and verification — see [`docs/SPEC.md`](../../../docs/SPEC.md) "Release-events gating". The docker push itself happens earlier and is gated by your workflow's own `on:` triggers.
 - **Release builds never use a cache** — BuildKit's shared cache isn't re-verified on hits, so a poisoned entry could reach the attested image. PR builds get a per-PR isolated cache by default, which closes PR-to-PR cache poisoning; tune that with the `pr-cache` input, documented in [`build_and_publish_container.yml`](../../../.github/workflows/build_and_publish_container.yml).
 - **`pull_request_target` can't trigger this workflow** — that trigger (and `workflow_run` chained from it) is a common exploit vector, so wrangle blocks both at startup.

--- a/build/actions/container/SPEC.md
+++ b/build/actions/container/SPEC.md
@@ -26,7 +26,7 @@ Multi-registry support is a planned extension. See "Known limitations" for the s
 | Input | Required | Description |
 |-------|----------|-------------|
 | `path` | yes | Relative path to the directory containing the Dockerfile |
-| `dockerfile` | no | Optional relative path to a Dockerfile when the build needs files from outside `path` (e.g. a monorepo tool image whose Dockerfile `COPY`s repo-root sources). Empty (default): the build context is the `path` subdirectory and its root `Dockerfile` is used — the self-contained-app-dir behavior. Set: the build context is the **repo root** and the Dockerfile is read from this subpath. `path` still drives short-name / metadata naming in both cases. Context size does not affect the L3 provenance claims (materials are `repo@commit` regardless — see `docs/SLSA_L3_AUDIT.md`). |
+| `dockerfile` | no | Path to the Dockerfile. Default: `{path}/Dockerfile` with `path` as the build context. When set, the build context is the repo root (so the Dockerfile can `COPY` files outside `path`). `path` still names the artifacts. |
 | `imagename` | yes | Full image name including registry (e.g., `ghcr.io/owner/repo/image`) |
 | `registry` | yes | Container registry hostname (e.g., `ghcr.io`) |
 | `github_token` | yes | `GITHUB_TOKEN` with `packages:write` scope |

--- a/build/actions/container/SPEC.md
+++ b/build/actions/container/SPEC.md
@@ -26,6 +26,7 @@ Multi-registry support is a planned extension. See "Known limitations" for the s
 | Input | Required | Description |
 |-------|----------|-------------|
 | `path` | yes | Relative path to the directory containing the Dockerfile |
+| `dockerfile` | no | Optional relative path to a Dockerfile when the build needs files from outside `path` (e.g. a monorepo tool image whose Dockerfile `COPY`s repo-root sources). Empty (default): the build context is the `path` subdirectory and its root `Dockerfile` is used — the self-contained-app-dir behavior. Set: the build context is the **repo root** and the Dockerfile is read from this subpath. `path` still drives short-name / metadata naming in both cases. Context size does not affect the L3 provenance claims (materials are `repo@commit` regardless — see `docs/SLSA_L3_AUDIT.md`). |
 | `imagename` | yes | Full image name including registry (e.g., `ghcr.io/owner/repo/image`) |
 | `registry` | yes | Container registry hostname (e.g., `ghcr.io`) |
 | `github_token` | yes | `GITHUB_TOKEN` with `packages:write` scope |
@@ -43,6 +44,7 @@ Multi-registry support is a planned extension. See "Known limitations" for the s
 | Input | Required | Description |
 |-------|----------|-------------|
 | `path` | yes | Passed through to composite action |
+| `dockerfile` | no | Passed through to composite action (see the composite-action input above) |
 | `imagename` | yes | Passed through to composite action |
 | `registry` | yes | Passed through to composite action |
 
@@ -117,6 +119,7 @@ All inputs are passed through `env:` blocks — never interpolated directly in `
 | Input | Validation |
 |-------|-----------|
 | `path` | Must be relative (no leading `/`), no `..` traversal, characters match `^[a-zA-Z0-9_./-]+$` |
+| `dockerfile` | When set, same rules as `path` (relative, no `..`, `^[a-zA-Z0-9_./-]+$`) via `lib/validate_path.sh` — it flows into the build as `docker/build-push-action`'s `file`. Empty is allowed and selects the default `path`-subdirectory context. |
 | `registry` | Characters match `^[a-z0-9.-]+$` |
 | `imagename` | Characters match `^[a-z0-9./:_-]+$` |
 

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -8,6 +8,17 @@ inputs:
   path:
     description: "Relative path within the repo to the folder containing a Dockerfile."
     required: true
+  dockerfile:
+    description: |
+      Optional relative path to a Dockerfile when the build needs repo-root
+      files (e.g. a monorepo tool image whose Dockerfile COPYs sources from
+      outside `path`). When empty (default), the build context is the `path`
+      subdirectory and its Dockerfile is read from that directory's root —
+      the self-contained-app-dir default. When set, the build context is the
+      repo root and the Dockerfile is read from this subpath. `path` still
+      drives the short name / metadata naming in both cases.
+    required: false
+    default: ""
   imagename:
     description: "Full image name (e.g., ghcr.io/owner/repo/image)"
     required: true
@@ -94,9 +105,10 @@ runs:
         INPUT_PATH: ${{ inputs.path }}
         INPUT_REGISTRY: ${{ inputs.registry }}
         INPUT_CACHE: ${{ inputs.cache }}
+        INPUT_DOCKERFILE: ${{ inputs.dockerfile }}
       run: |
         set -euo pipefail
-        "${{ github.action_path }}/validate_inputs.sh" "$INPUT_PATH" "$INPUT_REGISTRY" "$INPUT_IMAGENAME" "$INPUT_CACHE"
+        "${{ github.action_path }}/validate_inputs.sh" "$INPUT_PATH" "$INPUT_REGISTRY" "$INPUT_IMAGENAME" "$INPUT_CACHE" "$INPUT_DOCKERFILE"
 
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
@@ -184,8 +196,9 @@ runs:
       # record of record, not this debug bundle.
       env:
         DOCKER_BUILD_RECORD_UPLOAD: "false"
-      with: # zizmor: ignore[template-injection] value is from steps.normalize.outputs.path, validated against ^[a-zA-Z0-9_./-]+$ and not shell-evaluated
-        context: "{{defaultContext}}:${{ steps.normalize.outputs.path }}"
+      with: # zizmor: ignore[template-injection] context/file come from steps.normalize.outputs, computed from path + dockerfile each validated against ^[a-zA-Z0-9_./-]+$ and not shell-evaluated
+        context: ${{ steps.normalize.outputs.context }}
+        file: ${{ steps.normalize.outputs.file }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -189,7 +189,7 @@ runs:
       # record of record, not this debug bundle.
       env:
         DOCKER_BUILD_RECORD_UPLOAD: "false"
-      with: # zizmor: ignore[template-injection] value is from steps.normalize.outputs, validated against ^[a-zA-Z0-9_./-]+$ and not shell-evaluated
+      with:
         context: ${{ steps.normalize.outputs.context }}
         file: ${{ steps.normalize.outputs.file }}
         push: true

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -6,17 +6,10 @@ description: |
 
 inputs:
   path:
-    description: "Relative path within the repo to the folder containing a Dockerfile."
+    description: "The path within the repo that should be used when building the image."
     required: true
   dockerfile:
-    description: |
-      Optional relative path to a Dockerfile when the build needs repo-root
-      files (e.g. a monorepo tool image whose Dockerfile COPYs sources from
-      outside `path`). When empty (default), the build context is the `path`
-      subdirectory and its Dockerfile is read from that directory's root —
-      the self-contained-app-dir default. When set, the build context is the
-      repo root and the Dockerfile is read from this subpath. `path` still
-      drives the short name / metadata naming in both cases.
+    description: "Path to the Dockerfile. Defaults to {path}/Dockerfile. When set, the build context becomes the repo root, so the Dockerfile can COPY files from outside {path}."
     required: false
     default: ""
   imagename:
@@ -196,7 +189,7 @@ runs:
       # record of record, not this debug bundle.
       env:
         DOCKER_BUILD_RECORD_UPLOAD: "false"
-      with: # zizmor: ignore[template-injection] context/file come from steps.normalize.outputs, computed from path + dockerfile each validated against ^[a-zA-Z0-9_./-]+$ and not shell-evaluated
+      with: # zizmor: ignore[template-injection] value is from steps.normalize.outputs, validated against ^[a-zA-Z0-9_./-]+$ and not shell-evaluated
         context: ${{ steps.normalize.outputs.context }}
         file: ${{ steps.normalize.outputs.file }}
         push: true

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -69,6 +69,88 @@ teardown() {
     grep -q '^shortname=$' "$GITHUB_OUTPUT"
 }
 
+# --- Build context / dockerfile selection (#596) ---
+
+@test "container: default (no dockerfile) builds the <path> subdir as context, empty file" {
+    # The self-contained-app-dir default: context is the path subdirectory's
+    # own Dockerfile, file empty. This is the pre-#596 behavior and MUST be
+    # byte-identical for existing callers.
+    run "$ACTION_DIR/validate_inputs.sh" "pkg/foo" "ghcr.io" "ghcr.io/owner/img" "enabled"
+    [[ "$status" -eq 0 ]]
+    grep -qx 'context={{defaultContext}}:pkg/foo' "$GITHUB_OUTPUT"
+    grep -qx 'file=' "$GITHUB_OUTPUT"
+}
+
+@test "container: empty dockerfile arg is treated as the default" {
+    # An explicitly-empty dockerfile (the workflow passes "" by default) must
+    # behave exactly like omitting it — context = path subdir, file empty.
+    run "$ACTION_DIR/validate_inputs.sh" "pkg/foo" "ghcr.io" "ghcr.io/owner/img" "enabled" ""
+    [[ "$status" -eq 0 ]]
+    grep -qx 'context={{defaultContext}}:pkg/foo' "$GITHUB_OUTPUT"
+    grep -qx 'file=' "$GITHUB_OUTPUT"
+}
+
+@test "container: dockerfile set builds the repo root as context with the Dockerfile at that subpath" {
+    run "$ACTION_DIR/validate_inputs.sh" "tools/img" "ghcr.io" "ghcr.io/owner/img" "enabled" "tools/img/Dockerfile"
+    [[ "$status" -eq 0 ]]
+    grep -qx 'context={{defaultContext}}' "$GITHUB_OUTPUT"
+    grep -qx 'file=tools/img/Dockerfile' "$GITHUB_OUTPUT"
+    # path still drives shortname/metadata naming in the dockerfile case.
+    grep -qx 'shortname=tools_img' "$GITHUB_OUTPUT"
+}
+
+@test "container: dockerfile input is validated — absolute path rejected" {
+    run "$ACTION_DIR/validate_inputs.sh" "tools/img" "ghcr.io" "ghcr.io/owner/img" "enabled" "/etc/Dockerfile"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"path must be relative"* ]]
+}
+
+@test "container: dockerfile input is validated — traversal rejected" {
+    run "$ACTION_DIR/validate_inputs.sh" "tools/img" "ghcr.io" "ghcr.io/owner/img" "enabled" "../../etc/Dockerfile"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"traversal"* ]]
+}
+
+@test "container: dockerfile input is validated — bad characters rejected" {
+    run "$ACTION_DIR/validate_inputs.sh" "tools/img" "ghcr.io" "ghcr.io/owner/img" "enabled" 'tools/img/Docker;file'
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"invalid characters in path"* ]]
+}
+
+@test "container: action.yml exposes a dockerfile input defaulting to empty" {
+    run grep -E '^  dockerfile:' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+    run bash -c "sed -n '/^  dockerfile:/,/^  [a-z]/p' \"$ACTION_DIR/action.yml\" | grep -E 'default:[[:space:]]*\"\"'"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: action.yml passes dockerfile to validate_inputs.sh" {
+    run grep -E 'validate_inputs.sh.*INPUT_DOCKERFILE' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: reusable workflow exposes a dockerfile input and threads it to the composite" {
+    local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
+    run grep -E '^      dockerfile:' "$wf"
+    [[ "$status" -eq 0 ]]
+    run grep -F 'dockerfile: ${{ inputs.dockerfile }}' "$wf"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "container: build-push reads context and file from the normalize step (no inline {{defaultContext}} ternary)" {
+    # context/file are computed in validate_inputs.sh and read back as step
+    # outputs, never assembled with an inline GHA expression in the with:
+    # block — that would force {{defaultContext}} brace-escaping and reopen
+    # the template-injection surface this normalization closes.
+    run grep -F 'context: ${{ steps.normalize.outputs.context }}' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+    run grep -F 'file: ${{ steps.normalize.outputs.file }}' "$ACTION_DIR/action.yml"
+    [[ "$status" -eq 0 ]]
+    # The old inline form must not creep back.
+    run grep -F 'context: "{{defaultContext}}:${{ steps.normalize.outputs.path }}"' "$ACTION_DIR/action.yml"
+    [[ "$status" -ne 0 ]]
+}
+
 # --- Cache gating (SLSA L3 isolation, #224 / SLSA_L3_AUDIT.md Finding 2) ---
 
 @test "container: validate_inputs.sh accepts every cache policy value" {

--- a/build/actions/container/validate_inputs.sh
+++ b/build/actions/container/validate_inputs.sh
@@ -7,11 +7,9 @@
 # imagename are checked here against narrow allowlists because they
 # are container-specific.
 #
-# The optional dockerfile selects the build context: empty (default) builds
-# the <path> subdirectory as context with its own Dockerfile at the root; a
-# set value builds the repo root as context with the Dockerfile at that
-# subpath, so a Dockerfile can COPY files from outside <path> (e.g. a
-# monorepo tool image needing repo-root sources).
+# The optional dockerfile sets build-push-action's file + context: empty
+# (default) = the <path> subdir is the context; set = the repo root is the
+# context, so the Dockerfile can COPY files outside <path>.
 #
 # Usage: build/actions/container/validate_inputs.sh <path> <registry> <imagename> <cache> [dockerfile]
 

--- a/build/actions/container/validate_inputs.sh
+++ b/build/actions/container/validate_inputs.sh
@@ -7,13 +7,19 @@
 # imagename are checked here against narrow allowlists because they
 # are container-specific.
 #
-# Usage: build/actions/container/validate_inputs.sh <path> <registry> <imagename> <cache>
+# The optional dockerfile selects the build context: empty (default) builds
+# the <path> subdirectory as context with its own Dockerfile at the root; a
+# set value builds the repo root as context with the Dockerfile at that
+# subpath, so a Dockerfile can COPY files from outside <path> (e.g. a
+# monorepo tool image needing repo-root sources).
+#
+# Usage: build/actions/container/validate_inputs.sh <path> <registry> <imagename> <cache> [dockerfile]
 
 set -euo pipefail
 set -f  # disable globbing — processes external input
 
-if [[ $# -ne 4 ]]; then
-    printf 'Usage: %s <path> <registry> <imagename> <cache>\n' "$0" >&2
+if [[ $# -lt 4 || $# -gt 5 ]]; then
+    printf 'Usage: %s <path> <registry> <imagename> <cache> [dockerfile]\n' "$0" >&2
     exit 1
 fi
 
@@ -21,6 +27,7 @@ INPUT_PATH="$1"
 INPUT_REGISTRY="$2"
 INPUT_IMAGENAME="$3"
 INPUT_CACHE="$4"
+INPUT_DOCKERFILE="${5:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/shortname.sh
 source "$SCRIPT_DIR/../../../lib/shortname.sh"
@@ -40,6 +47,13 @@ fi
 
 "$SCRIPT_DIR/../../../lib/validate_path.sh" "$INPUT_PATH"
 
+# When set, the dockerfile flows into the build context selection (it becomes
+# docker/build-push-action's `file`), so it gets the same strict allowlist as
+# `path`: relative, no traversal, charset [a-zA-Z0-9_./-].
+if [[ -n "$INPUT_DOCKERFILE" ]]; then
+    "$SCRIPT_DIR/../../../lib/validate_path.sh" "$INPUT_DOCKERFILE"
+fi
+
 if [[ ! "$INPUT_REGISTRY" =~ ^[a-z0-9.-]+$ ]]; then
     printf 'Error: invalid registry: %s\n' "$INPUT_REGISTRY" >&2
     exit 1
@@ -49,8 +63,23 @@ if [[ ! "$INPUT_IMAGENAME" =~ ^[a-z0-9./:_-]+$ ]]; then
     exit 1
 fi
 
+# Select the docker/build-push-action `context` and `file`. Default (no
+# dockerfile): the <path> subdirectory is the context, with its own root
+# Dockerfile (file empty). With a dockerfile: the repo root is the context,
+# and the Dockerfile lives at that subpath — so it can COPY repo-root files.
+# `path` still drives shortname/metadata naming either way.
+if [[ -z "$INPUT_DOCKERFILE" ]]; then
+    BUILD_CONTEXT="{{defaultContext}}:$INPUT_PATH"
+    BUILD_FILE=""
+else
+    BUILD_CONTEXT="{{defaultContext}}"
+    BUILD_FILE="$INPUT_DOCKERFILE"
+fi
+
 {
     printf 'imagename=%s\n' "${INPUT_IMAGENAME,,}"
     printf 'path=%s\n' "$INPUT_PATH"
     printf 'shortname=%s\n' "$(derive_shortname "$INPUT_PATH")"
+    printf 'context=%s\n' "$BUILD_CONTEXT"
+    printf 'file=%s\n' "$BUILD_FILE"
 } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Adds an optional `dockerfile` input to the container build composite action (`build/actions/container/action.yml`) and the reusable workflow (`build_and_publish_container.yml`).

- **Empty (default):** unchanged — build context is the `path` subdirectory, default `Dockerfile` at its root, `file` empty.
- **Set:** build context is the **repo root** and the Dockerfile is read from that subpath, so a Dockerfile can `COPY` files from outside `path`.

`path` still drives the short name / metadata naming in both cases.

## Why

This is a general capability, not wrangle-specific: any monorepo / tool-image build whose Dockerfile needs sources from outside its own directory (e.g. a wrangle tool image that COPYs `tools/go.mod` and `lib/`) currently can't build, because the context is locked to the `path` subdirectory. See #596.

## Default-unchanged guarantee

When `dockerfile` is empty (the default for every existing caller), the computed values are byte-identical to before — `context = {{defaultContext}}:<path>`, `file = ""`, and `docker/build-push-action` uses the default root `Dockerfile`. A bats test asserts this exact pair, and a guard test rejects any reintroduction of the old inline `context: "{{defaultContext}}:${{ steps.normalize.outputs.path }}"` form.

## How

- The context/file selection moved into `validate_inputs.sh`, emitted as `steps.normalize.outputs.context` / `.file` — so the `with:` block carries no inline `{{defaultContext}}` brace-escaping ternary, keeping the template-injection suppression accurate.
- The `dockerfile` input is validated by `lib/validate_path.sh` (relative, no `..`, `^[A-Za-z0-9_./-]+$`) before it flows into the build as `docker/build-push-action`'s `file`.

## Provenance note

Context size does not affect the SLSA L3 provenance claims: the provenance materials are `repo@commit` regardless of how much of the tree BuildKit receives. Sending the repo root vs. a subdirectory changes the build inputs sent to the daemon, not the recorded source identity.

## Tests / checks (local)

- `bats build/actions/container/test.bats` — 74/74 pass (10 new: default context, empty-arg-as-default, repo-root+file, dockerfile validation rejecting absolute/traversal/bad-chars, action+workflow wiring).
- `shellcheck -x` and the repo `run_shellcheck.sh` runner — clean.
- `tools/wrangle-shell-lint/lint.sh` — clean.
- `actionlint` on the workflow — clean.

Also updated `SPEC.md` (inputs + validation tables) and the `README.md` "Good to know" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)