### PR TITLE
feat(attest): containerize the attest/verify toolbox + begin verify-path wiring (#596)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/prep@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/scan@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      uses: TomHennen/wrangle/build/actions/container@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/verify_release@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/prep@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/scan@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      uses: TomHennen/wrangle/build/actions/container@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/verify_release@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/prep@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/scan@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/build/actions/go/checks@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/build/actions/go/build@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/attest_provenance@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/verify_release@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/prep@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/scan@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/build/actions/go/checks@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/build/actions/go/build@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/attest_provenance@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/verify_release@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/prep@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/scan@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/build/actions/npm@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/attest_provenance@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/verify_release@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/prep@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/scan@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/build/actions/npm@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/attest_provenance@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/verify_release@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/prep@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/scan@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/build/actions/python@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/attest_provenance@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/verify_release@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/prep@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/scan@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/build/actions/python@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/attest_provenance@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/verify_release@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -77,7 +77,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/prep@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -90,7 +90,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/scan@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -134,7 +134,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+        uses: TomHennen/wrangle/build/actions/shell@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -77,7 +77,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/prep@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -90,7 +90,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/scan@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -134,7 +134,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+        uses: TomHennen/wrangle/build/actions/shell@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      - uses: TomHennen/wrangle/actions/prep@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+        uses: TomHennen/wrangle/actions/scan@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      - uses: TomHennen/wrangle/actions/prep@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+        uses: TomHennen/wrangle/actions/scan@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/publish_tool_images.yml
+++ b/.github/workflows/publish_tool_images.yml
@@ -32,6 +32,13 @@ jobs:
         include:
           - path: tools/osv
             imagename: ghcr.io/tomhennen/wrangle/osv
+          # The attest/verify toolbox (ampel + bnd + cosign + wrangle-attest in
+          # one image). Built like the scan images, but it is not a sandboxed
+          # adapter — it is the SLSA-L3 signing path that needs network + the
+          # OIDC token at run time. Publishing the image here is inert; wiring a
+          # signing job to RUN it is a separate, flagged step (#596).
+          - path: tools/attest-toolbox
+            imagename: ghcr.io/tomhennen/wrangle/attest-toolbox
     uses: ./.github/workflows/build_and_publish_container.yml
     with:
       path: ${{ matrix.path }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -133,7 +133,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      uses: TomHennen/wrangle/tools/zizmor@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -141,7 +141,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      uses: TomHennen/wrangle/tools/scorecard@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -153,7 +153,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+      uses: TomHennen/wrangle/tools/dependency-review@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -133,7 +133,7 @@ runs:
     # TODO: replace with $/tools/zizmor when $/ syntax ships (#136, #137)
     - name: Zizmor
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: TomHennen/wrangle/tools/zizmor@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      uses: TomHennen/wrangle/tools/zizmor@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
 
     # Scorecard only runs on push events — it requires GITHUB_TOKEN scopes
     # that aren't available on PRs and uses Docker, which only mounts
@@ -141,7 +141,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      uses: TomHennen/wrangle/tools/scorecard@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -153,7 +153,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+      uses: TomHennen/wrangle/tools/dependency-review@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
 
     - name: Generate step summary
       if: always()

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -94,42 +94,45 @@ wrangle_bnd_sign_args() {
 }
 
 # Run ampel: the in-job binary by default, or — when WRANGLE_VERIFY_AMPEL_IMAGE
-# names a toolbox image (#596, experimental) — that image via `docker run`.
-#
-# Security surface of the container path (the reason it is opt-in, off by
-# default, and excluded from the L3 release path):
-#   - ampel verify reads local bundle/policy files and fetches PUBLIC Sigstore /
-#     Rekor data to verify signatures. It needs network egress (--network host
-#     for the runner's egress) but NO secret: it does not sign, so the OIDC
-#     signing token is never passed in. Signing (bnd) and the store push stay in
-#     the job, outside the container — the token never reaches the image.
-#   - Mounts use IDENTICAL host paths inside the container, so the args built by
-#     wrangle_ampel_verify_args (all absolute) need no rewriting. policy/bundle
-#     dirs mount read-only; only the results dir is writable.
-#   - The `oci:` collector (container build type) needs registry auth inside the
-#     container, which is not yet plumbed — so the container path refuses when
-#     COLLECTOR is set rather than silently degrading. go/npm/python verify
-#     (empty COLLECTOR) is the only path it serves today.
-# Default (unset image): the call is `ampel "$@"`, byte-identical to before.
+# names a toolbox image — that image via `docker run`. The container path is an
+# experimental prototype seam (#596); the catalog-driven capability grant plus
+# digest/provenance gating that must precede wiring it into any workflow are #619.
+# Constraints of the container path: no token enters the container (ampel verify
+# never signs); policy/bundle mount read-only, only the results dir is writable;
+# it fails closed (exit 2) on an oci: collector, whose registry auth isn't plumbed.
 wrangle_ampel() {
     local image="${WRANGLE_VERIFY_AMPEL_IMAGE:-}"
     if [[ -z "$image" ]]; then
         ampel "$@"
         return
     fi
+    # Partial guard for #619: refuse a floating ref so the prototype only ever
+    # runs a digest-pinned image (the catalog/provenance gating is still #619).
+    if [[ ! "$image" =~ @sha256:[0-9a-f]{64}$ ]]; then
+        printf 'wrangle: WRANGLE_VERIFY_AMPEL_IMAGE must be @sha256:-digest-pinned (got %s)\n' "$image" >&2
+        return 2
+    fi
     if [[ -n "${COLLECTOR:-}" ]]; then
         printf 'wrangle: WRANGLE_VERIFY_AMPEL_IMAGE does not yet support an OCI collector (%s)\n' "$COLLECTOR" >&2
         return 2
     fi
-    local results_dir policy_dir
-    results_dir="$(cd "$(dirname "$WRANGLE_AMPEL_RESULTS")" && pwd)"
-    policy_dir="$REPO_ROOT/policies"
-    # No -e for any token; --network host gives ampel the runner's egress to
-    # reach Sigstore/Rekor; non-root as the caller so the unsigned VSA it writes
-    # is consumable by the in-job signing step.
+    local results_dir policy policy_mount
+    results_dir="$(cd "$(dirname "${WRANGLE_AMPEL_RESULTS:?wrangle_ampel needs WRANGLE_AMPEL_RESULTS set}")" && pwd)"
+    # Mount the resolved policy's actual parent, not a hardcoded policies/: a
+    # relative policy resolves to $REPO_ROOT/<policy>, which may sit elsewhere. A
+    # network locator (*://*) is fetched, not read from disk, so it needs no mount.
+    policy="$(wrangle_resolve_policy "$POLICY")"
+    case "$policy" in
+        *://*) policy_mount=() ;;
+        *)     policy_mount=(-v "$(dirname "$policy")":"$(dirname "$policy")":ro) ;;
+    esac
+    # No -e for any token; --network host gives ampel the runner's egress to reach
+    # Sigstore/Rekor; non-root as the caller so the unsigned VSA it writes is
+    # consumable by the in-job signing step. The dist file is intentionally NOT
+    # mounted — file subjects are pre-hashed in-job, so the container never reads them.
     docker run --rm --network host -u "$(id -u):$(id -g)" \
         -v "$BUNDLE_OUT":"$BUNDLE_OUT":ro \
-        -v "$policy_dir":"$policy_dir":ro \
+        "${policy_mount[@]}" \
         -v "$results_dir":"$results_dir" \
         -e HOME=/tmp \
         "$image" ampel "$@"

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -93,6 +93,48 @@ wrangle_bnd_sign_args() {
     printf '%s\n' statement "$1"
 }
 
+# Run ampel: the in-job binary by default, or — when WRANGLE_VERIFY_AMPEL_IMAGE
+# names a toolbox image (#596, experimental) — that image via `docker run`.
+#
+# Security surface of the container path (the reason it is opt-in, off by
+# default, and excluded from the L3 release path):
+#   - ampel verify reads local bundle/policy files and fetches PUBLIC Sigstore /
+#     Rekor data to verify signatures. It needs network egress (--network host
+#     for the runner's egress) but NO secret: it does not sign, so the OIDC
+#     signing token is never passed in. Signing (bnd) and the store push stay in
+#     the job, outside the container — the token never reaches the image.
+#   - Mounts use IDENTICAL host paths inside the container, so the args built by
+#     wrangle_ampel_verify_args (all absolute) need no rewriting. policy/bundle
+#     dirs mount read-only; only the results dir is writable.
+#   - The `oci:` collector (container build type) needs registry auth inside the
+#     container, which is not yet plumbed — so the container path refuses when
+#     COLLECTOR is set rather than silently degrading. go/npm/python verify
+#     (empty COLLECTOR) is the only path it serves today.
+# Default (unset image): the call is `ampel "$@"`, byte-identical to before.
+wrangle_ampel() {
+    local image="${WRANGLE_VERIFY_AMPEL_IMAGE:-}"
+    if [[ -z "$image" ]]; then
+        ampel "$@"
+        return
+    fi
+    if [[ -n "${COLLECTOR:-}" ]]; then
+        printf 'wrangle: WRANGLE_VERIFY_AMPEL_IMAGE does not yet support an OCI collector (%s)\n' "$COLLECTOR" >&2
+        return 2
+    fi
+    local results_dir policy_dir
+    results_dir="$(cd "$(dirname "$WRANGLE_AMPEL_RESULTS")" && pwd)"
+    policy_dir="$REPO_ROOT/policies"
+    # No -e for any token; --network host gives ampel the runner's egress to
+    # reach Sigstore/Rekor; non-root as the caller so the unsigned VSA it writes
+    # is consumable by the in-job signing step.
+    docker run --rm --network host -u "$(id -u):$(id -g)" \
+        -v "$BUNDLE_OUT":"$BUNDLE_OUT":ro \
+        -v "$policy_dir":"$policy_dir":ro \
+        -v "$results_dir":"$results_dir" \
+        -e HOME=/tmp \
+        "$image" ampel "$@"
+}
+
 # ampel verify one subject -> unsigned VSA at $2, streaming the report to the
 # step summary. $1 is the subject; $3 the attest-assembled bundle fed to the
 # policy as the jsonl collector.
@@ -111,7 +153,9 @@ wrangle_verify_emit_vsa() {
     # the policy verdict, and piping straight into the truncating sanitizer could
     # SIGPIPE ampel and flip a PASS into a blocked release.
     report="$(mktemp)"
-    wrangle_retry_once "$report" ampel "${args[@]}" || rc=$?
+    # The container ampel path (opt-in) mounts the dir holding the unsigned VSA.
+    local WRANGLE_AMPEL_RESULTS="$results_path"
+    wrangle_retry_once "$report" wrangle_ampel "${args[@]}" || rc=$?
     wrangle_sanitize_output < "$report" >> "$GITHUB_STEP_SUMMARY"
     # The step summary is easy to miss, so echo a failed report to the job log.
     if [[ "$rc" -ne 0 ]]; then

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -915,7 +915,35 @@ SHIM
     [[ "$(wc -l < "$shim.calls")" -eq 2 ]]
 }
 
+@test "wrangle_ampel: default (no image) runs the in-job ampel binary unchanged" {
+    # Shim ampel to record it was the binary invoked, with the args passed through.
+    cat > "$TEST_DIR/ampel" <<EOF
+#!/bin/bash
+printf '%s\n' "\$@" > "$TEST_DIR/ampel.args"
+EOF
+    chmod +x "$TEST_DIR/ampel"
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_IMAGE="" run wrangle_ampel verify --policy=p
+    [ "$status" -eq 0 ]
+    grep -q -- '--policy=p' "$TEST_DIR/ampel.args"
+    # No docker on the default path.
+    [ ! -f "$TEST_DIR/docker.called" ]
+}
+
+@test "wrangle_ampel: container path refuses an OCI collector (fail-closed, no docker)" {
+    cat > "$TEST_DIR/docker" <<EOF
+#!/bin/bash
+touch "$TEST_DIR/docker.called"
+EOF
+    chmod +x "$TEST_DIR/docker"
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_IMAGE="img:test" COLLECTOR="oci:ghcr.io/x@sha256:abc" \
+        run wrangle_ampel verify
+    [ "$status" -eq 2 ]
+    [ ! -f "$TEST_DIR/docker.called" ]
+}
+
 @test "retry: ampel and bnd invocations both route through wrangle_retry_once" {
-    grep -q 'wrangle_retry_once "$report" ampel' "$SCRIPT"
+    # ampel runs via the wrangle_ampel dispatcher (in-job binary or, opt-in, the
+    # toolbox image) — still through the retry helper.
+    grep -q 'wrangle_retry_once "$report" wrangle_ampel' "$SCRIPT"
     grep -q 'wrangle_retry_once "$vsa" bnd' "$SCRIPT"
 }

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -929,13 +929,26 @@ EOF
     [ ! -f "$TEST_DIR/docker.called" ]
 }
 
+@test "wrangle_ampel: a non-digest-pinned image is rejected (fail-closed, no docker)" {
+    cat > "$TEST_DIR/docker" <<EOF
+#!/bin/bash
+touch "$TEST_DIR/docker.called"
+EOF
+    chmod +x "$TEST_DIR/docker"
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_IMAGE="img:test" \
+        run wrangle_ampel verify
+    [ "$status" -eq 2 ]
+    [ ! -f "$TEST_DIR/docker.called" ]
+}
+
 @test "wrangle_ampel: container path refuses an OCI collector (fail-closed, no docker)" {
     cat > "$TEST_DIR/docker" <<EOF
 #!/bin/bash
 touch "$TEST_DIR/docker.called"
 EOF
     chmod +x "$TEST_DIR/docker"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_IMAGE="img:test" COLLECTOR="oci:ghcr.io/x@sha256:abc" \
+    local digest_img="img@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_IMAGE="$digest_img" COLLECTOR="oci:ghcr.io/x@sha256:abc" \
         run wrangle_ampel verify
     [ "$status" -eq 2 ]
     [ ! -f "$TEST_DIR/docker.called" ]

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@b60e9daf023a34ddd5a9544596833403bf79da5e # feat/container-root-context-dockerfile 2026-06-24
+    - uses: TomHennen/wrangle/actions/verify@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@36efa42df227a012f138557ebdf2243bbc08330c # track2-attest-toolbox-container 2026-06-25
+    - uses: TomHennen/wrangle/actions/verify@4d1926d55aca6bfbfa729952dce0644d27536f90 # track2-attest-toolbox-container 2026-06-25
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -310,6 +310,12 @@ not a meaningful per-delivery signal.)
   is what would unlock **VSA-verified caching** of all tool images — verifying each image's provenance at
   pull time, the clean L3-safe replacement for the build cache we currently disable. That is a bootstrap
   (wrangle's own verify image verifying the others) we return to with this track, not in the scan MVP.
+  **Status (#596 Track 2):** the toolbox image (`tools/attest-toolbox/`, all four binaries from
+  `tools/go.mod`) is built and published like the scan images, and `actions/verify` has an opt-in
+  `WRANGLE_VERIFY_AMPEL_IMAGE` that runs *ampel verify only* (no signing token, network egress only) via
+  that image — off by default, byte-identical when unset, and not on the L3 release path. Containerizing
+  the signing steps (bnd/cosign, which need the OIDC token) and the OCI-collector verify path remain
+  deferred.
 - **Separate feature:** emitting an attested container of an adopter's own Go app (the "free container"
   value-add via goreleaser/ko). It reuses some machinery but serves adopter UX, not the goals here.
 - **Left as-is:** tools with official GitHub Actions that gain nothing from containerization stay

--- a/test/fixtures/image-contract/entrypoint.sh
+++ b/test/fixtures/image-contract/entrypoint.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 set -f  # disable globbing — processes external input paths
 
 # Mock tool honoring the wrangle adapter contract, used only to test the image
-# harness (test/lib/image_test_harness.bash). A real tool can't produce a
+# harness (test/lib/image_test_harness.sh). A real tool can't produce a
 # controlled exit-2 / malformed-SARIF on demand, so a mock drives each path.
 # Behavior is selected by the contents of <src>/MODE.
 

--- a/test/image/test_attest_toolbox_image.bats
+++ b/test/image/test_attest_toolbox_image.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+# Builds the attest/verify toolbox image (tools/attest-toolbox/Dockerfile) and
+# asserts the four signing-path binaries are present, runnable, and that the
+# image runs non-root with HOME=/tmp. Needs docker, so it lives under test/image/
+# (outside the Makefile's unit `bats` glob) and runs in the dogfooded shell
+# build, which auto-detects every .bats on a docker-capable runner.
+
+setup_file() {
+    load "../lib/bats_helpers"
+    command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1 || return 0
+    local root
+    root="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    # Build context is the repo root (the Dockerfile builds from tools/go.mod).
+    docker build -q -t wrangle-attest-toolbox:test \
+        -f "$root/tools/attest-toolbox/Dockerfile" "$root" >/dev/null
+}
+
+setup() {
+    load "../lib/bats_helpers"
+    load "../lib/image_test_harness.sh"
+    wrangle_require_docker
+    IMG=wrangle-attest-toolbox:test
+}
+
+@test "attest-toolbox: ampel, bnd, cosign, wrangle-attest are on PATH" {
+    local bin
+    for bin in ampel bnd cosign wrangle-attest; do
+        run docker run --rm --entrypoint sh "$IMG" -c "command -v $bin"
+        [ "$status" -eq 0 ]
+    done
+}
+
+@test "attest-toolbox: ampel reports its version" {
+    run docker run --rm "$IMG" ampel version
+    [ "$status" -eq 0 ]
+    [[ "$output" == *v1.3.0* ]]
+}
+
+@test "attest-toolbox: cosign reports its version" {
+    run docker run --rm "$IMG" cosign version
+    [ "$status" -eq 0 ]
+    [[ "$output" == *v3.0.6* ]]
+}
+
+@test "attest-toolbox: bnd runs" {
+    run docker run --rm "$IMG" bnd version
+    [ "$status" -eq 0 ]
+}
+
+@test "attest-toolbox: runs as a non-root user with HOME=/tmp" {
+    run docker run --rm --entrypoint sh "$IMG" -c 'id -u; printf "%s" "$HOME"'
+    [ "$status" -eq 0 ]
+    [[ "${lines[0]}" != "0" ]]
+    [[ "${lines[1]}" == "/tmp" ]]
+}

--- a/test/image/test_attest_toolbox_image.bats
+++ b/test/image/test_attest_toolbox_image.bats
@@ -43,9 +43,10 @@ setup() {
     [[ "$output" == *v3.0.6* ]]
 }
 
-@test "attest-toolbox: bnd runs" {
+@test "attest-toolbox: bnd reports its version" {
     run docker run --rm "$IMG" bnd version
     [ "$status" -eq 0 ]
+    [[ "$output" == *v0.4.3* ]]
 }
 
 @test "attest-toolbox: runs as a non-root user with HOME=/tmp" {

--- a/test/image/test_image_harness.bats
+++ b/test/image/test_image_harness.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Validates the image test harness (test/lib/image_test_harness.bash) against a
+# Validates the image test harness (test/lib/image_test_harness.sh) against a
 # mock contract-conforming tool image, so the harness itself is trustworthy
 # before real tool images rely on it. Needs docker, so it lives under test/image/
 # (outside the Makefile's unit `bats` glob) and runs in the dogfooded shell

--- a/test/lib/image_test_harness.sh
+++ b/test/lib/image_test_harness.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 set -f
 
-# test/lib/image_test_harness.bash — helpers for testing a tool container
+# test/lib/image_test_harness.sh — helpers for testing a tool container
 # image against the wrangle adapter contract:
 #   docker run <image> /src /output  ->  writes /output/output.sarif,
 #   exits 0 (clean) / 1 (findings) / 2 (tool error); writes nothing outside

--- a/tools/attest-toolbox/Dockerfile
+++ b/tools/attest-toolbox/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+# Wrangle attest/verify toolbox image. Builds the four signing-path binaries
+# from the pinned tools/go.mod (manifest-preserving — keeps vuln scanning of
+# their deps) onto a hardened wolfi base, all four on PATH:
+#   ampel          — evaluate a release against a PolicySet, emit the VSA
+#   bnd            — keyless-sign statements (provenance, SBOM, VSA)
+#   cosign         — push attestations as OCI referrers
+#   wrangle-attest — build the unsigned scan/build in-toto statements
+# Unlike the scan-tool images this is NOT a sandboxed adapter: the verify/attest
+# path needs network egress (Sigstore/Rekor, the GitHub attestation store, the
+# registry) and, when signing, the workflow's OIDC token. It therefore ships no
+# adapter ENTRYPOINT — the orchestrator invokes a specific binary with its own
+# args. The egress + token surface is the reason §7 of docs/tool_container_design.md
+# flags this path as higher-stakes than the scan images.
+# Build context is the repo root (the build needs tools/go.mod + go.sum).
+FROM golang:1.26.4@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5 AS build
+WORKDIR /src
+COPY tools/ ./tools/
+ENV CGO_ENABLED=0
+RUN cd tools \
+ && go build -trimpath -o /out/ampel github.com/carabiner-dev/ampel/cmd/ampel \
+ && go build -trimpath -o /out/bnd github.com/carabiner-dev/bnd \
+ && go build -trimpath -o /out/cosign github.com/sigstore/cosign/v3/cmd/cosign \
+ && go build -trimpath -o /out/wrangle-attest github.com/TomHennen/wrangle/tools/wrangle-attest
+
+# Minimal hardened base (Chainguard wolfi). ca-certificates is required: every
+# binary here makes outbound TLS calls (Sigstore, Rekor, the attestation store,
+# the registry). jq is bundled because the verify/attest glue normalizes the
+# tools' JSON output; bash for any wrapper invocation.
+FROM cgr.dev/chainguard/wolfi-base@sha256:0b613d8101fae27cf76186351db831ab3db25bfb2ec7161e897cd7e22c6413a3
+RUN apk add --no-cache bash jq ca-certificates \
+ && adduser -D -u 1000 wrangle
+COPY --from=build /out/ampel /out/bnd /out/cosign /out/wrangle-attest /usr/local/bin/
+ENV HOME=/tmp
+USER wrangle


### PR DESCRIPTION
## Summary

Track 2 of #596: package wrangle's **SLSA-L3 signing path** (ampel, bnd, cosign, wrangle-attest) as one OCI image, and *begin* — carefully, opt-in — wiring `actions/verify` to run via that image. Every change is **additive and default-preserving**: with the new flag off, the existing in-job verify/attest path is byte-identical to `main`.

This path is the higher-stakes half flagged in `docs/tool_container_design.md` §7 — unlike the scan images it *inverts* the sandbox (it needs network egress and, for signing, the OIDC token). So the bulk of the value here is the **image + a published matrix entry**; the wiring is a deliberately narrow, experimental first step.

## What shipped: the image (inert, safe)

- **`tools/attest-toolbox/Dockerfile`** — multi-stage build of all four binaries from the pinned `tools/go.mod` (`CGO_ENABLED=0`, `-trimpath`) onto a digest-pinned `cgr.dev/chainguard/wolfi-base`, non-root (uid 1000), `HOME=/tmp`, `ca-certificates` for the outbound TLS every binary makes. Mirrors `tools/osv/Dockerfile`, **minus an adapter ENTRYPOINT** — this is not a sandboxed contract tool; the orchestrator invokes a named binary with its own args.
- **`publish_tool_images.yml`** — one matrix line publishes to `ghcr.io/tomhennen/wrangle/attest-toolbox`, exactly like the osv image.

Built locally; all four binaries are on PATH and report versions matching `go.mod` (**ampel v1.3.0, cosign v3.0.6** — cosign matches the `cosign-installer` pin too). Image is 409 MB.

## What's flagged + experimental: the verify wiring

`actions/verify/run_verify.sh` gains a `wrangle_ampel` dispatcher:
- **`WRANGLE_VERIFY_AMPEL_IMAGE` unset (default)** → runs `ampel "$@"`, the in-job binary — **byte-identical to before** (a unit test asserts the default path invokes the in-job ampel and never touches docker).
- **Set** → runs `ampel verify` via the toolbox image with `docker run`.

`WRANGLE_VERIFY_AMPEL_IMAGE` is an **experimental prototype seam**, not a supported workflow input: it is off by default, wired into no reusable workflow, and accepts only an `@sha256:`-digest-pinned image (a floating tag is rejected). The catalog-driven capability grant plus the digest/provenance gating that must land before it is wired into any workflow are tracked in **#619**.

### Security analysis (the crux: OIDC + network into a container)

The wiring containerizes **`ampel verify` only**, which is the safe subset to move first, precisely because:

- **No OIDC token ever enters the container.** ampel verify reads local bundle/policy files and fetches *public* Sigstore/Rekor data to check signatures — it does not sign. The OIDC signing token, `bnd`, `cosign`, and the attestation-store push all stay **in the job, outside the image**. So this introduces an image-supply-chain link in front of *verification*, never in front of the signing key. (Containerizing the signing steps — where the token *would* have to enter a container — is the genuinely higher-stakes change, and is left deferred with a plan, below.)
- **Network is scoped to egress.** `--network host` gives ampel the runner's outbound reach for Sigstore/Rekor; no ports are opened, no inbound. The exfiltration surface is "a compromised toolbox image could read the bundle/policy files it's handed and phone home" — which is why the image is wrangle-built from `tools/go.mod` (manifest-preserving, scannable) and digest-pinned, not an opaque upstream image.
- **Filesystem is least-privilege.** Mounts use **identical host paths inside the container**, so the existing (all-absolute) ampel args need no rewriting; bundle and `policies/` mount **read-only**, only the unsigned-VSA results dir is writable, and the container runs as the caller's UID so the in-job signing step can consume the output.
- **Fail-closed on the unsupported path.** The `oci:` collector (container build type) needs registry auth inside the container, which is not yet plumbed, so the container path **refuses (exit 2) when an OCI collector is set** rather than silently degrading. Only the go/npm/python verify path (empty collector) is served.

### Default-unchanged guarantee

- The only change to the default code path is `ampel "${args[@]}"` → `wrangle_ampel "${args[@]}"`, which with the flag unset executes `ampel "$@"`.
- The flag is **not wired into any reusable workflow or the L3 release path** — it is an env-var opt-in for experimentation.
- A unit test asserts the default dispatcher path runs the in-job binary and invokes no docker; the existing emit/run integration tests (shimmed ampel) still pass unchanged.

## Deliberately left as a plan (too risky to ship now)

The task's "land the plan, not risky wiring" guidance applies to two pieces I did **not** ship:

1. **Containerizing the signing steps (bnd/cosign).** This is where the OIDC token *must* enter the container, interposing an image link directly in front of the signing key. That is the §7 "inverts the sandbox" risk in full and needs its own design (token scoping, image provenance verified at pull, the VSA-verified-caching bootstrap) before any token crosses a container boundary.
2. **The OCI-collector verify path in a container.** Needs ghcr credentials plumbed into the container for the `oci:` collector. Until then the container path fails closed on that input. Wiring it requires deciding how registry auth enters the image as narrowly as the token question above.

Also note: moving `ampel verify` into a container means the unsigned VSA crosses the docker volume boundary before the in-job `bnd` signs it. The existing "unsigned VSA never lives on disk across a *step* boundary" invariant is preserved (sign still happens in the same `run_verify.sh` process); but this is a property to keep in mind when the signing step itself is eventually containerized.

## Validation (all run locally, all green)

- `make shellcheck`, `make shellstyle` (wrangle-shell-lint), `make workflowstyle` (wrangle-workflow-lint), `actionlint` (all workflows) — pass.
- `make bats` — full unit suite passes, including `actions/verify/test_run_verify.bats` (dispatcher default path, non-digest-pinned rejection, OCI-collector refusal, and the ampel-routes-through-retry structural assertion).
- `test/image/test_attest_toolbox_image.bats` — docker-gated (`wrangle_require_docker`/`skip_or_fail`), lives under `test/image/` so it's **out of the unit `make bats` glob**; builds the image and asserts the four binaries + their pinned versions (ampel/cosign/bnd) + non-root + `HOME=/tmp`. Passes locally against a real docker build.
- Image built locally; ampel/bnd/cosign/wrangle-attest all run and report versions.

**Do not merge** without owner LGTM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
