### PR TITLE
feat(catalog): digest-aware pin hygiene for OCI tool images (#596)

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -116,8 +116,7 @@ All three must hold before you ask the owner to cut. Do not shortcut.
    land it as a normal PR under the cooldown, then re-check. (Adoption-lag only —
    it does not prove the digest was built from current source.) **Exit 2
    (registry unreachable) means the precondition is UNVERIFIED — do not proceed.**
-   Retry (or install `crane`) until the result is 0 or 1; a visible exit-2 is not
-   a satisfied gate.
+   Retry until the result is 0 or 1; a visible exit-2 is not a satisfied gate.
 3. **Empirically-verified download + verify commands.** Re-run the consumer
    download-and-verify recipe in
    [docs/verifying_artifacts.md](../../../docs/verifying_artifacts.md) against a **real**

--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -105,6 +105,16 @@ All three must hold before you ask the owner to cut. Do not shortcut.
    `showcase` concurrency group; cancel a hung job (releases persist) to free the queue.
 2. **Explicit owner sign-off on release contents.** Present exactly what's in the release
    (the milestone, the diff highlights) and get an explicit yes — separate from "cut it".
+   Also confirm the curated tool-image catalog is fresh — no entry is behind its
+   published `:latest` (the §11 release precondition):
+
+   ```bash
+   ./tools/check_catalog_freshness.sh   # exit 0 in-sync; 1 drift (bump per its remediation); 2 registry unreachable
+   ```
+
+   On drift, run the printed `tools/bump_catalog_digest.sh <tool> <digest>`, land
+   it as a normal PR under the cooldown, then re-check. (Adoption-lag only — it
+   does not prove the digest was built from current source.)
 3. **Empirically-verified download + verify commands.** Re-run the consumer
    download-and-verify recipe in
    [docs/verifying_artifacts.md](../../../docs/verifying_artifacts.md) against a **real**

--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -112,9 +112,12 @@ All three must hold before you ask the owner to cut. Do not shortcut.
    ./tools/check_catalog_freshness.sh   # exit 0 in-sync; 1 drift (bump per its remediation); 2 registry unreachable
    ```
 
-   On drift, run the printed `tools/bump_catalog_digest.sh <tool> <digest>`, land
-   it as a normal PR under the cooldown, then re-check. (Adoption-lag only — it
-   does not prove the digest was built from current source.)
+   On drift (exit 1), run the printed `tools/bump_catalog_digest.sh <tool> <digest>`,
+   land it as a normal PR under the cooldown, then re-check. (Adoption-lag only —
+   it does not prove the digest was built from current source.) **Exit 2
+   (registry unreachable) means the precondition is UNVERIFIED — do not proceed.**
+   Retry (or install `crane`) until the result is 0 or 1; a visible exit-2 is not
+   a satisfied gate.
 3. **Empirically-verified download + verify commands.** Re-run the consumer
    download-and-verify recipe in
    [docs/verifying_artifacts.md](../../../docs/verifying_artifacts.md) against a **real**

--- a/.github/workflows/catalog_freshness.yml
+++ b/.github/workflows/catalog_freshness.yml
@@ -4,8 +4,10 @@ name: Catalog Freshness
 # digest in tools/catalog.json against its :latest tag in the registry. A drift
 # means a newer tool image was published but the catalog still pins the old one.
 # Kept off the per-PR path to avoid per-PR registry calls; the same check is a
-# release precondition (see the cut-release runbook). Advisory today — a failed
-# run notifies; the intended rollout is to a blocking release gate.
+# release precondition (see the cut-release runbook). Advisory first because it
+# depends on a live registry (network/registry flake), unlike the deterministic
+# git-only pin checks which block directly — a failed run notifies; the intended
+# rollout is to a blocking release gate that fails closed on exit 2.
 
 on:
   schedule:

--- a/.github/workflows/catalog_freshness.yml
+++ b/.github/workflows/catalog_freshness.yml
@@ -1,0 +1,39 @@
+name: Catalog Freshness
+
+# Advisory adoption-lag check (#596): weekly, compares each curated tool-image
+# digest in tools/catalog.json against its :latest tag in the registry. A drift
+# means a newer tool image was published but the catalog still pins the old one.
+# Kept off the per-PR path to avoid per-PR registry calls; the same check is a
+# release precondition (see the cut-release runbook). Advisory today — a failed
+# run notifies; the intended rollout is to a blocking release gate.
+
+on:
+  schedule:
+    - cron: "17 9 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # Drift (exit 1) fails the run as the actionable signal; a transient
+      # registry-unreachable (exit 2) warns but does not, so a registry blip
+      # can't page on a false negative.
+      - name: Check catalog image freshness
+        run: |
+          set +e
+          ./tools/check_catalog_freshness.sh
+          rc=$?
+          if [[ "$rc" -eq 2 ]]; then
+            printf '::warning::registry unreachable; catalog freshness undetermined this run\n'
+            exit 0
+          fi
+          exit "$rc"

--- a/.github/workflows/catalog_freshness.yml
+++ b/.github/workflows/catalog_freshness.yml
@@ -17,6 +17,7 @@ permissions: {}
 jobs:
   freshness:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/local_build_shell.yml
+++ b/.github/workflows/local_build_shell.yml
@@ -60,3 +60,9 @@ jobs:
       # at merge.
       - name: Check action pin freshness
         run: ./tools/check_pin_freshness.sh
+
+      # Static catalog hygiene (#596): every curated tool image is digest-pinned
+      # on the wrangle namespace and capabilities are default-closed. Network-free,
+      # so it runs every PR; the registry adoption-lag check is a release gate.
+      - name: Validate tool catalog
+        run: ./tools/check_catalog.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ All shell conventions — preamble form, quoting, `printf` over `echo`, `[[ ]]` 
 - **Action reference pinning** — required pin format per context, the `@main` prohibition, and self-reference bumping: [DEP_MGMT.md](DEP_MGMT.md).
 - **Installing and verifying tools** — install-method decision tree, integrity-tier ladder, and freshness-first rule: [DEP_MGMT.md](DEP_MGMT.md). Install-script mechanics (`lib/download_verify.sh`, `$WRANGLE_BIN_DIR`, idempotency, atomic `mv`) are the Install Script Interface contract in SPEC.md.
 - **Pin drift across files** — single-source or a divergence-fail test: [DEP_MGMT.md § Drift](DEP_MGMT.md#drift).
+- **Curated tool-image digests** (`tools/catalog.json`) — digest-pinned on the wrangle namespace, enforced by `tools/check_catalog.sh`; adoption-lag against `:latest` checked at release by `tools/check_catalog_freshness.sh` (fix with `tools/bump_catalog_digest.sh`).
 
 ## Adapter contract (full: SPEC.md §Adapter Script Interface)
 

--- a/DEP_MGMT.md
+++ b/DEP_MGMT.md
@@ -95,6 +95,7 @@ whatever is already set.
 | Python tool | `==version --hash=sha256:` in `requirements.txt` |
 | Binary with no package manager | version pinned in the install script |
 | Container base image | OCI `@sha256:` digest |
+| Curated tool image (`tools/catalog.json`) | `ghcr.io/tomhennen/wrangle/<tool>@sha256:` digest — static-checked by `tools/check_catalog.sh` (per-PR), adoption-lag-checked by `tools/check_catalog_freshness.sh` (release gate). Rationale: [docs/tool_container_design.md](docs/tool_container_design.md) §8, §11 |
 
 `@main` MUST NOT appear in any `uses:` line, anywhere — including examples and docs.
 
@@ -109,6 +110,13 @@ whatever is already set.
   `check_pin_ancestry` reuses). **`make converge-action-pins`** repeats the bump
   across commits when a nested chain needs more than one cycle — land its commits
   as a merge commit (see [docs/e2e_testing.md](docs/e2e_testing.md)).
+- **Curated tool images** (`tools/catalog.json`) — `tools/check_catalog.sh`
+  fails any entry that isn't digest-pinned on the wrangle namespace (per-PR);
+  `tools/check_catalog_freshness.sh` compares each pinned digest against the
+  registry's `:latest` and prints a `tools/bump_catalog_digest.sh` remediation
+  when the catalog is behind (a release precondition, not a per-PR gate, to keep
+  registry calls off PRs). It proves adoption-lag only, not that the digest was
+  built from current source (the stronger provenance check is deferred).
 - **Manual today:** the binary+provenance installs (branch 2) and the base-image
   digest. Automating that surface — ideally one mechanism that also covers
   wrangle's own self-references — is #264.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test lint shellcheck shellstyle workflowstyle gotest bats zizmor integration bump-action-pins converge-action-pins
+.PHONY: all test lint shellcheck shellstyle workflowstyle gotest bats zizmor integration bump-action-pins converge-action-pins check-catalog check-catalog-freshness bump-catalog-digest
 
 # bash, not the default sh: the integration recipe sources lib/env.sh,
 # whose `set -o pipefail` dash doesn't reliably support.
@@ -83,3 +83,19 @@ bump-action-pins:
 # See tools/converge_action_pins.sh, #539, and #552.
 converge-action-pins:
 	@./tools/converge_action_pins.sh
+
+# Static, network-free catalog validator (digest-pinned, on-namespace, capability
+# enum). Runs every PR; see tools/check_catalog.sh.
+check-catalog:
+	@./tools/check_catalog.sh
+
+# Adoption-lag freshness check: compares each curated image digest against its
+# :latest tag in the registry (network). A release precondition, not a per-PR
+# gate. See tools/check_catalog_freshness.sh.
+check-catalog-freshness:
+	@./tools/check_catalog_freshness.sh
+
+# One-command fix when check-catalog-freshness reports drift.
+# Usage: make bump-catalog-digest TOOL=osv DIGEST=sha256:<64hex>
+bump-catalog-digest:
+	@./tools/bump_catalog_digest.sh $(TOOL) $(DIGEST)

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -125,8 +125,6 @@ runs:
           type=ref,event=tag
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
-          # tools/check_catalog_freshness.sh reads this :latest tag to detect
-          # catalog adoption lag; dropping it breaks that release gate.
           type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
     - name: Log in to the Container registry

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -125,6 +125,8 @@ runs:
           type=ref,event=tag
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
+          # tools/check_catalog_freshness.sh reads this :latest tag to detect
+          # catalog adoption lag; dropping it breaks that release gate.
           type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
     - name: Log in to the Container registry

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -378,8 +378,8 @@ model. Still open:
 2. **Freeze the contract in SPEC.md** — the `scan` and `sbom` kinds, the invocation, the isolation
    mapping, and the output-handling rule (§3.1–3.3).
 3. **Stand up the per-image test harness** (§8) — so subsequent migrations are validated fast.
-4. **Make the pin toolchain digest-aware** (§6) — required before any image is consumed in a production
-   wrangle workflow.
+4. **Make the catalog digest-aware** (§6) — the parallel `check_catalog*` / `bump_catalog_digest` checks;
+   required before any image is consumed in a production wrangle workflow.
 5. **Go all-in for the `scan` kind.** Rather than a long mixed-mode tail, migrate the scan adapter tools
    together once the prototype proves out; the catalog's `delivery:` field covers the brief cutover (and
    any tool that stays adapter/action-pattern). osv, then zizmor, behind the curated catalog.
@@ -404,9 +404,10 @@ release does not rebuild or re-tag tool images.**
   entry to that digest under the WL005 cooldown, exactly like a Dependabot bump. One source PR + one bot
   bump PR — not a manual double-bump. A catalog-only digest change touches no Dockerfile, so it triggers
   no rebuild (no loop).
-- **Release tag** — precondition: the catalog is fresh (every digest is the image built from the current
-  tool source — the §6 freshness/ancestry check, extended to OCI digests). Then tag. No image is built
-  or re-tagged at release time.
+- **Release tag** — precondition: the catalog is fresh. `check_catalog_freshness.sh` proves the shipped
+  half — no digest is behind its published `:latest` (adoption lag); the stronger "every digest is the
+  image built from the current tool source" guarantee is the deferred provenance check (#623). Then tag.
+  No image is built or re-tagged at release time.
 
 Consequences:
 - The catalog at a release commit references images built from *ancestor* commits. That is correct as

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -304,12 +304,15 @@ not a meaningful per-delivery signal.)
   *"tool X produced this,"* never *"this is correct"* — important for adopter-supplied tools.
 - **Adoption enforcement (the residual prerequisite).** Installing via the canonical package manager
   keeps the dependency manifest in-repo, so CVE *detection* keeps working. What remains is ensuring a
-  published fix is actually *adopted*: the catalog's image digest must be freshness/ancestry/cooldown-
-  checked so a stale pin cannot pass CI green (the #539/#544 class). This means teaching the pin
-  toolchain (WL005 cooldown, `check_pin_ancestry`, `check_pin_freshness`, `bump_action_pins`,
-  `self_ref_pin_paths`) to understand OCI `@sha256:` digests, adding a `docker` Dependabot ecosystem, and
-  a DEP_MGMT.md integrity rung for images. Because the digest lives in one curated place (§3.6), this is a
-  narrow, wrangle-internal task, required only before *production consumption*, not before prototyping.
+  published fix is actually *adopted*: the catalog's image digest must be freshness-checked so a stale
+  pin cannot pass CI green (the #539/#544 class). The OCI axis is served by a *parallel* set of
+  catalog-aware checks — `tools/check_catalog.sh` (static digest/namespace hygiene, per-PR),
+  `tools/check_catalog_freshness.sh` (adoption-lag vs `:latest`, a release gate), `tools/bump_catalog_digest.sh`
+  (the fix) — plus the DEP_MGMT.md image integrity rung; the git-pin tools (`check_pin_ancestry`,
+  `check_pin_freshness`, `bump_action_pins`, WL005) are left untouched, since digests and git SHAs are
+  different axes. Because the digest lives in one curated place (§3.6), this stays a narrow,
+  wrangle-internal task, required only before *production consumption*, not before prototyping. Still open:
+  provenance-based source-freshness, a digest cooldown, and the advisory→blocking promotion (#623).
 - **Adopter-supplied images** are adopter-trusted, not wrangle-trusted: they run under the strictest
   contract by default (no network, no secrets), any relaxation is explicit, and wrangle's signature
   covers provenance of the run, not correctness of the tool.

--- a/test/test_bump_catalog_digest.bats
+++ b/test/test_bump_catalog_digest.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+# Unit tests for tools/bump_catalog_digest.sh — the one-command catalog digest
+# fix. Hermetic: each test operates on a fixture catalog via $WRANGLE_CATALOG.
+
+DIGEST_A="sha256:$(printf 'a%.0s' {1..64})"
+DIGEST_B="sha256:$(printf 'b%.0s' {1..64})"
+
+setup() {
+    SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/tools/bump_catalog_digest.sh"
+    CATALOG="$BATS_TEST_TMPDIR/catalog.json"
+    export WRANGLE_CATALOG="$CATALOG"
+    command -v jq >/dev/null 2>&1 || { printf 'jq not on PATH\n' >&2; return 1; }
+    printf '%s\n' \
+        '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@'"$DIGEST_A"'","network":"egress"}}}' \
+        > "$CATALOG"
+}
+
+image_of() { jq -r '.tools.osv.image' "$CATALOG"; }
+
+@test "bump_catalog_digest: happy path repoints to new digest, keeps namespace" {
+    run "$SCRIPT" osv "$DIGEST_B"
+    [ "$status" -eq 0 ]
+    [ "$(image_of)" = "ghcr.io/tomhennen/wrangle/osv@$DIGEST_B" ]
+    # Untouched fields survive.
+    [ "$(jq -r '.tools.osv.network' "$CATALOG")" = "egress" ]
+}
+
+@test "bump_catalog_digest: bad digest is rejected (exit 2)" {
+    run "$SCRIPT" osv "sha256:nothex"
+    [ "$status" -eq 2 ]
+    [ "$(image_of)" = "ghcr.io/tomhennen/wrangle/osv@$DIGEST_A" ]
+}
+
+@test "bump_catalog_digest: unknown tool is rejected (exit 2)" {
+    run "$SCRIPT" nosuchtool "$DIGEST_B"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"unknown tool"* ]]
+}
+
+@test "bump_catalog_digest: non-image tool is rejected (exit 2)" {
+    printf '%s\n' '{"tools":{"foo":{"kind":"scan","delivery":"adapter"}}}' > "$CATALOG"
+    run "$SCRIPT" foo "$DIGEST_B"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not an image-delivery tool"* ]]
+}
+
+@test "bump_catalog_digest: idempotent re-run leaves the file byte-identical" {
+    run "$SCRIPT" osv "$DIGEST_B"
+    [ "$status" -eq 0 ]
+    local after_first; after_first="$(cat "$CATALOG")"
+    run "$SCRIPT" osv "$DIGEST_B"
+    [ "$status" -eq 0 ]
+    [ "$(cat "$CATALOG")" = "$after_first" ]
+}
+
+@test "bump_catalog_digest: wrong arg count is a usage error (exit 2)" {
+    run "$SCRIPT" osv
+    [ "$status" -eq 2 ]
+}

--- a/test/test_check_catalog.bats
+++ b/test/test_check_catalog.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+# Unit tests for tools/check_catalog.sh — the static, network-free catalog
+# validator. Hermetic: each test writes a fixture catalog and points the script
+# at it via $WRANGLE_CATALOG.
+
+setup() {
+    SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/tools/check_catalog.sh"
+    CATALOG="$BATS_TEST_TMPDIR/catalog.json"
+    export WRANGLE_CATALOG="$CATALOG"
+    command -v jq >/dev/null 2>&1 || { printf 'jq not on PATH\n' >&2; return 1; }
+}
+
+write_catalog() { printf '%s\n' "$1" > "$CATALOG"; }
+
+@test "check_catalog: valid curated catalog passes" {
+    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'","network":"egress"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "check_catalog: mutable tag (no digest) fails" {
+    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv:latest"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"osv"* ]]
+}
+
+@test "check_catalog: off-namespace ghcr image fails" {
+    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/someoneelse/osv@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"curated namespace"* ]]
+}
+
+@test "check_catalog: missing kind fails" {
+    write_catalog '{"tools":{"osv":{"delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing kind"* ]]
+}
+
+@test "check_catalog: bad network value fails" {
+    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'","network":"full"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"invalid network"* ]]
+}
+
+@test "check_catalog: bad secret name fails" {
+    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'","secret":"Bad_Name"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"invalid secret"* ]]
+}
+
+@test "check_catalog: malformed JSON fails with exit 1" {
+    printf '{ not json\n' > "$CATALOG"
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not valid JSON"* ]]
+}
+
+@test "check_catalog: non-ghcr digest-pinned image passes (fallback)" {
+    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"registry.example.com/team/osv@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "check_catalog: extra argument is a usage error (exit 2)" {
+    write_catalog '{"tools":{}}'
+    run "$SCRIPT" unexpected
+    [ "$status" -eq 2 ]
+}

--- a/test/test_check_catalog.bats
+++ b/test/test_check_catalog.bats
@@ -19,11 +19,11 @@ write_catalog() { printf '%s\n' "$1" > "$CATALOG"; }
     [ "$status" -eq 0 ]
 }
 
-@test "check_catalog: mutable tag (no digest) fails" {
+@test "check_catalog: mutable tag on the curated namespace reports not-digest-pinned" {
     write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv:latest"}}}'
     run "$SCRIPT"
     [ "$status" -eq 1 ]
-    [[ "$output" == *"osv"* ]]
+    [[ "$output" == *"not digest-pinned"* ]]
 }
 
 @test "check_catalog: off-namespace ghcr image fails" {
@@ -61,10 +61,24 @@ write_catalog() { printf '%s\n' "$1" > "$CATALOG"; }
     [[ "$output" == *"not valid JSON"* ]]
 }
 
-@test "check_catalog: non-ghcr digest-pinned image passes (fallback)" {
+@test "check_catalog: non-ghcr digest-pinned image is off-namespace (fails)" {
     write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"registry.example.com/team/osv@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
     run "$SCRIPT"
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"off the curated namespace"* ]]
+}
+
+@test "check_catalog: typo'd delivery value fails (no silent image-check skip)" {
+    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"imagge","image":"ghcr.io/tomhennen/wrangle/osv:latest"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"unrecognized delivery"* ]]
+}
+
+@test "check_catalog: dot-dot tool segment is rejected" {
+    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/..@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
 }
 
 @test "check_catalog: extra argument is a usage error (exit 2)" {

--- a/test/test_check_catalog_freshness.bats
+++ b/test/test_check_catalog_freshness.bats
@@ -6,8 +6,19 @@
 # prefers crane when present, so the shim deterministically drives the resolve
 # path without any real registry call.
 
+load "lib/bats_helpers"
+
 DIGEST_A="sha256:$(printf 'a%.0s' {1..64})"
 DIGEST_B="sha256:$(printf 'b%.0s' {1..64})"
+
+# The curl-fallback path is only reached when crane is absent (the script prefers
+# crane). A real crane on a dev host would hit the live registry, so force the
+# intent: skip locally / fail in CI (where crane is absent, so this is a no-op).
+require_craneless() {
+    if command -v crane >/dev/null 2>&1; then
+        skip_or_fail "crane present; curl fallback not exercised"
+    fi
+}
 
 setup() {
     SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/tools/check_catalog_freshness.sh"
@@ -31,6 +42,19 @@ case "$1" in
     insync) printf '%s\n' "$DIGEST_A" ;;     # matches the catalog pin
     drift)  printf '%s\n' "$DIGEST_B" ;;     # newer :latest than the pin
     down)   exit 1 ;;                          # registry unreachable
+esac
+SHIM
+    chmod +x "$BIN_DIR/crane"
+}
+
+# install_crane_per_image — a fake `crane` that behaves per image ($2 is
+# <imagename>:latest): toola drifts, toolb's registry lookup fails.
+install_crane_per_image() {
+    cat >"$BIN_DIR/crane" <<SHIM
+#!/usr/bin/env bash
+case "\$2" in
+    *toola*) printf '%s\n' "$DIGEST_B" ;;    # resolves != pinned DIGEST_A -> drift
+    *toolb*) exit 1 ;;                          # backend unreachable
 esac
 SHIM
     chmod +x "$BIN_DIR/crane"
@@ -96,9 +120,23 @@ SHIM
     [[ "$output" == *"not valid JSON"* ]]
 }
 
+# Security-critical precedence: a confirmed drift must not be masked by another
+# tool's backend error.
+@test "check_catalog_freshness: drift wins over a second tool's backend error (exit 1)" {
+    install_crane_per_image
+    printf '%s\n' \
+        '{"tools":{"toola":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toola@'"$DIGEST_A"'"},"toolb":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toolb@'"$DIGEST_A"'"}}}' \
+        > "$CATALOG"
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"behind :latest"* ]]
+    [[ "$output" == *"could not resolve"* ]]
+}
+
 # The craneless production path (weekly workflow + release gate run on a runner
 # without crane), exercised via a curl shim.
 @test "check_catalog_freshness: curl fallback in-sync passes (exit 0)" {
+    require_craneless
     install_curl
     SHIM_DIGEST="$DIGEST_A" run "$SCRIPT"
     [ "$status" -eq 0 ]
@@ -106,6 +144,7 @@ SHIM
 }
 
 @test "check_catalog_freshness: curl fallback drift fails with remediation (exit 1)" {
+    require_craneless
     install_curl
     SHIM_DIGEST="$DIGEST_B" run "$SCRIPT"
     [ "$status" -eq 1 ]
@@ -113,8 +152,17 @@ SHIM
 }
 
 @test "check_catalog_freshness: curl fallback token failure is an env error (exit 2)" {
+    require_craneless
     install_curl
     SHIM_TOKEN_FAIL=1 SHIM_DIGEST="$DIGEST_A" run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"could not resolve"* ]]
+}
+
+@test "check_catalog_freshness: curl fallback malformed digest header is an env error (exit 2)" {
+    require_craneless
+    install_curl
+    SHIM_DIGEST="not-a-digest" run "$SCRIPT"
     [ "$status" -eq 2 ]
     [[ "$output" == *"could not resolve"* ]]
 }

--- a/test/test_check_catalog_freshness.bats
+++ b/test/test_check_catalog_freshness.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+# Unit tests for tools/check_catalog_freshness.sh — the network freshness check.
+# This is wrangle's first network-dependent pin check, so the registry CLI is
+# shimmed: a fake `crane` on PATH echoes a fixture digest (or fails). The script
+# prefers crane when present, so the shim deterministically drives the resolve
+# path without any real registry call.
+
+DIGEST_A="sha256:$(printf 'a%.0s' {1..64})"
+DIGEST_B="sha256:$(printf 'b%.0s' {1..64})"
+
+setup() {
+    SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/tools/check_catalog_freshness.sh"
+    CATALOG="$BATS_TEST_TMPDIR/catalog.json"
+    BIN_DIR="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$BIN_DIR"
+    export WRANGLE_CATALOG="$CATALOG" PATH="$BIN_DIR:$PATH"
+    command -v jq >/dev/null 2>&1 || { printf 'jq not on PATH\n' >&2; return 1; }
+
+    printf '%s\n' \
+        '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@'"$DIGEST_A"'","network":"egress"}}}' \
+        > "$CATALOG"
+}
+
+# install_crane <mode> — a fake `crane` whose `digest` output/return is fixed.
+install_crane() {
+    cat >"$BIN_DIR/crane" <<SHIM
+#!/usr/bin/env bash
+case "$1" in
+    insync) printf '%s\n' "$DIGEST_A" ;;     # matches the catalog pin
+    drift)  printf '%s\n' "$DIGEST_B" ;;     # newer :latest than the pin
+    down)   exit 1 ;;                          # registry unreachable
+esac
+SHIM
+    chmod +x "$BIN_DIR/crane"
+}
+
+@test "check_catalog_freshness: in-sync digest passes (exit 0)" {
+    install_crane insync
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"match :latest"* ]]
+}
+
+@test "check_catalog_freshness: drifted digest fails with bump remediation (exit 1)" {
+    install_crane drift
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"behind :latest"* ]]
+    [[ "$output" == *"bump_catalog_digest.sh osv $DIGEST_B"* ]]
+}
+
+@test "check_catalog_freshness: registry unreachable is an env error (exit 2)" {
+    install_crane down
+    run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"could not resolve"* ]]
+}
+
+@test "check_catalog_freshness: non-curated entry is skipped" {
+    install_crane down
+    printf '%s\n' \
+        '{"tools":{"adopter":{"kind":"scan","delivery":"image","image":"registry.example.com/x/y@'"$DIGEST_A"'"}}}' \
+        > "$CATALOG"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"0 curated image"* ]]
+}

--- a/test/test_check_catalog_freshness.bats
+++ b/test/test_check_catalog_freshness.bats
@@ -23,6 +23,7 @@ setup() {
 }
 
 # install_crane <mode> — a fake `crane` whose `digest` output/return is fixed.
+# Heredoc is expanded at write time, so each mode bakes its constant in.
 install_crane() {
     cat >"$BIN_DIR/crane" <<SHIM
 #!/usr/bin/env bash
@@ -33,6 +34,26 @@ case "$1" in
 esac
 SHIM
     chmod +x "$BIN_DIR/crane"
+}
+
+# install_curl — a fake `curl` exercising the craneless production fallback
+# (_digest_via_curl). It dispatches on the request URL and reads $SHIM_DIGEST /
+# $SHIM_TOKEN_FAIL from the environment at run time.
+install_curl() {
+    cat >"$BIN_DIR/curl" <<'SHIM'
+#!/usr/bin/env bash
+for a in "$@"; do
+  case "$a" in
+    */token\?*)
+      [[ -n "${SHIM_TOKEN_FAIL:-}" ]] && exit 22
+      printf '{"token":"t"}\n'; exit 0 ;;
+    *manifests/*)
+      printf 'HTTP/2 200\r\ndocker-content-digest: %s\r\n\r\n' "${SHIM_DIGEST}"; exit 0 ;;
+  esac
+done
+exit 0
+SHIM
+    chmod +x "$BIN_DIR/curl"
 }
 
 @test "check_catalog_freshness: in-sync digest passes (exit 0)" {
@@ -65,4 +86,35 @@ SHIM
     run "$SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"0 curated image"* ]]
+}
+
+@test "check_catalog_freshness: malformed catalog is an env error (exit 2)" {
+    install_crane insync
+    printf '{ not json\n' > "$CATALOG"
+    run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not valid JSON"* ]]
+}
+
+# The craneless production path (weekly workflow + release gate run on a runner
+# without crane), exercised via a curl shim.
+@test "check_catalog_freshness: curl fallback in-sync passes (exit 0)" {
+    install_curl
+    SHIM_DIGEST="$DIGEST_A" run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"match :latest"* ]]
+}
+
+@test "check_catalog_freshness: curl fallback drift fails with remediation (exit 1)" {
+    install_curl
+    SHIM_DIGEST="$DIGEST_B" run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"bump_catalog_digest.sh osv $DIGEST_B"* ]]
+}
+
+@test "check_catalog_freshness: curl fallback token failure is an env error (exit 2)" {
+    install_curl
+    SHIM_TOKEN_FAIL=1 SHIM_DIGEST="$DIGEST_A" run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"could not resolve"* ]]
 }

--- a/test/test_check_catalog_freshness.bats
+++ b/test/test_check_catalog_freshness.bats
@@ -1,24 +1,12 @@
 #!/usr/bin/env bats
 
 # Unit tests for tools/check_catalog_freshness.sh — the network freshness check.
-# This is wrangle's first network-dependent pin check, so the registry CLI is
-# shimmed: a fake `crane` on PATH echoes a fixture digest (or fails). The script
-# prefers crane when present, so the shim deterministically drives the resolve
-# path without any real registry call.
-
-load "lib/bats_helpers"
+# Digest resolution is curl-only, so a fake `curl` on PATH stands in for the GHCR
+# registry API: it dispatches on the request URL and returns a fixture digest (or
+# fails), exercising the real token + manifest parse without any live call.
 
 DIGEST_A="sha256:$(printf 'a%.0s' {1..64})"
 DIGEST_B="sha256:$(printf 'b%.0s' {1..64})"
-
-# The curl-fallback path is only reached when crane is absent (the script prefers
-# crane). A real crane on a dev host would hit the live registry, so force the
-# intent: skip locally / fail in CI (where crane is absent, so this is a no-op).
-require_craneless() {
-    if command -v crane >/dev/null 2>&1; then
-        skip_or_fail "crane present; curl fallback not exercised"
-    fi
-}
 
 setup() {
     SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/tools/check_catalog_freshness.sh"
@@ -33,36 +21,8 @@ setup() {
         > "$CATALOG"
 }
 
-# install_crane <mode> — a fake `crane` whose `digest` output/return is fixed.
-# Heredoc is expanded at write time, so each mode bakes its constant in.
-install_crane() {
-    cat >"$BIN_DIR/crane" <<SHIM
-#!/usr/bin/env bash
-case "$1" in
-    insync) printf '%s\n' "$DIGEST_A" ;;     # matches the catalog pin
-    drift)  printf '%s\n' "$DIGEST_B" ;;     # newer :latest than the pin
-    down)   exit 1 ;;                          # registry unreachable
-esac
-SHIM
-    chmod +x "$BIN_DIR/crane"
-}
-
-# install_crane_per_image — a fake `crane` that behaves per image ($2 is
-# <imagename>:latest): toola drifts, toolb's registry lookup fails.
-install_crane_per_image() {
-    cat >"$BIN_DIR/crane" <<SHIM
-#!/usr/bin/env bash
-case "\$2" in
-    *toola*) printf '%s\n' "$DIGEST_B" ;;    # resolves != pinned DIGEST_A -> drift
-    *toolb*) exit 1 ;;                          # backend unreachable
-esac
-SHIM
-    chmod +x "$BIN_DIR/crane"
-}
-
-# install_curl — a fake `curl` exercising the craneless production fallback
-# (_digest_via_curl). It dispatches on the request URL and reads $SHIM_DIGEST /
-# $SHIM_TOKEN_FAIL from the environment at run time.
+# install_curl — a fake `curl` for the registry API. It dispatches on the request
+# URL and reads $SHIM_DIGEST / $SHIM_TOKEN_FAIL from the environment at run time.
 install_curl() {
     cat >"$BIN_DIR/curl" <<'SHIM'
 #!/usr/bin/env bash
@@ -80,50 +40,56 @@ SHIM
     chmod +x "$BIN_DIR/curl"
 }
 
+# install_curl_per_image — a fake `curl` that behaves per image: toola resolves a
+# drifted digest, toolb's registry lookup fails.
+install_curl_per_image() {
+    cat >"$BIN_DIR/curl" <<SHIM
+#!/usr/bin/env bash
+for a in "\$@"; do
+  case "\$a" in
+    *toolb*) exit 22 ;;                                 # toolb: registry unreachable
+    *token\?*) printf '{"token":"t"}\n'; exit 0 ;;
+    *toola/manifests*) printf 'HTTP/2 200\r\ndocker-content-digest: $DIGEST_B\r\n\r\n'; exit 0 ;;
+  esac
+done
+exit 0
+SHIM
+    chmod +x "$BIN_DIR/curl"
+}
+
 @test "check_catalog_freshness: in-sync digest passes (exit 0)" {
-    install_crane insync
-    run "$SCRIPT"
+    install_curl
+    SHIM_DIGEST="$DIGEST_A" run "$SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"match :latest"* ]]
 }
 
 @test "check_catalog_freshness: drifted digest fails with bump remediation (exit 1)" {
-    install_crane drift
-    run "$SCRIPT"
+    install_curl
+    SHIM_DIGEST="$DIGEST_B" run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"behind :latest"* ]]
     [[ "$output" == *"bump_catalog_digest.sh osv $DIGEST_B"* ]]
 }
 
 @test "check_catalog_freshness: registry unreachable is an env error (exit 2)" {
-    install_crane down
-    run "$SCRIPT"
+    install_curl
+    SHIM_TOKEN_FAIL=1 run "$SCRIPT"
     [ "$status" -eq 2 ]
     [[ "$output" == *"could not resolve"* ]]
 }
 
-@test "check_catalog_freshness: non-curated entry is skipped" {
-    install_crane down
-    printf '%s\n' \
-        '{"tools":{"adopter":{"kind":"scan","delivery":"image","image":"registry.example.com/x/y@'"$DIGEST_A"'"}}}' \
-        > "$CATALOG"
-    run "$SCRIPT"
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"0 curated image"* ]]
-}
-
-@test "check_catalog_freshness: malformed catalog is an env error (exit 2)" {
-    install_crane insync
-    printf '{ not json\n' > "$CATALOG"
-    run "$SCRIPT"
+@test "check_catalog_freshness: malformed digest header is an env error (exit 2)" {
+    install_curl
+    SHIM_DIGEST="not-a-digest" run "$SCRIPT"
     [ "$status" -eq 2 ]
-    [[ "$output" == *"not valid JSON"* ]]
+    [[ "$output" == *"could not resolve"* ]]
 }
 
 # Security-critical precedence: a confirmed drift must not be masked by another
 # tool's backend error.
 @test "check_catalog_freshness: drift wins over a second tool's backend error (exit 1)" {
-    install_crane_per_image
+    install_curl_per_image
     printf '%s\n' \
         '{"tools":{"toola":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toola@'"$DIGEST_A"'"},"toolb":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toolb@'"$DIGEST_A"'"}}}' \
         > "$CATALOG"
@@ -133,36 +99,20 @@ SHIM
     [[ "$output" == *"could not resolve"* ]]
 }
 
-# The craneless production path (weekly workflow + release gate run on a runner
-# without crane), exercised via a curl shim.
-@test "check_catalog_freshness: curl fallback in-sync passes (exit 0)" {
-    require_craneless
+@test "check_catalog_freshness: non-curated entry is skipped" {
+    # Token-fail shim: if a non-curated entry were resolved, this would exit 2.
     install_curl
-    SHIM_DIGEST="$DIGEST_A" run "$SCRIPT"
+    printf '%s\n' \
+        '{"tools":{"adopter":{"kind":"scan","delivery":"image","image":"registry.example.com/x/y@'"$DIGEST_A"'"}}}' \
+        > "$CATALOG"
+    SHIM_TOKEN_FAIL=1 run "$SCRIPT"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"match :latest"* ]]
+    [[ "$output" == *"0 curated image"* ]]
 }
 
-@test "check_catalog_freshness: curl fallback drift fails with remediation (exit 1)" {
-    require_craneless
-    install_curl
-    SHIM_DIGEST="$DIGEST_B" run "$SCRIPT"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"bump_catalog_digest.sh osv $DIGEST_B"* ]]
-}
-
-@test "check_catalog_freshness: curl fallback token failure is an env error (exit 2)" {
-    require_craneless
-    install_curl
-    SHIM_TOKEN_FAIL=1 SHIM_DIGEST="$DIGEST_A" run "$SCRIPT"
+@test "check_catalog_freshness: malformed catalog is an env error (exit 2)" {
+    printf '{ not json\n' > "$CATALOG"
+    run "$SCRIPT"
     [ "$status" -eq 2 ]
-    [[ "$output" == *"could not resolve"* ]]
-}
-
-@test "check_catalog_freshness: curl fallback malformed digest header is an env error (exit 2)" {
-    require_craneless
-    install_curl
-    SHIM_DIGEST="not-a-digest" run "$SCRIPT"
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"could not resolve"* ]]
+    [[ "$output" == *"not valid JSON"* ]]
 }

--- a/tools/bump_catalog_digest.sh
+++ b/tools/bump_catalog_digest.sh
@@ -15,6 +15,8 @@ set -f
 #       non-image tool / bad digest / unreadable catalog.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/read_catalog.sh
+source "$SCRIPT_DIR/../lib/read_catalog.sh"
 
 DIGEST_RE='^sha256:[0-9a-f]{64}$'
 
@@ -33,8 +35,8 @@ bump_catalog_digest() {
     fi
 
     local delivery image
-    delivery="$(jq -r --arg t "$tool" '.tools[$t].delivery // empty' "$file")"
-    image="$(jq -r --arg t "$tool" '.tools[$t].image // empty' "$file")"
+    delivery="$(read_catalog_field "$file" "$tool" delivery)"
+    image="$(read_catalog_field "$file" "$tool" image)"
     if [[ -z "$delivery" && -z "$image" ]]; then
         printf 'bump_catalog_digest: unknown tool: %s\n' "$tool" >&2
         return 2

--- a/tools/bump_catalog_digest.sh
+++ b/tools/bump_catalog_digest.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# tools/bump_catalog_digest.sh — repoint one curated tool's image to a new
+# @sha256: digest in tools/catalog.json, preserving its registry namespace. The
+# catalog analog of bump_action_pins.sh: the one-command fix when
+# check_catalog_freshness.sh reports an entry behind :latest.
+#
+# Catalog path: $WRANGLE_CATALOG, else the catalog beside this script.
+#
+# Usage: bump_catalog_digest.sh <tool> <digest>      # digest: sha256:<64 hex>
+#
+# Exit: 0 written (or already current — idempotent), 2 bad usage / unknown tool /
+#       non-image tool / bad digest / unreadable catalog.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DIGEST_RE='^sha256:[0-9a-f]{64}$'
+
+# bump_catalog_digest <catalog_file> <tool> <digest> — atomically set the tool's
+# image to <namespace>@<digest>. Returns 0 on success or no-op, 2 on any error.
+bump_catalog_digest() {
+    local file="$1" tool="$2" digest="$3"
+
+    if [[ ! "$digest" =~ $DIGEST_RE ]]; then
+        printf 'bump_catalog_digest: digest must be sha256:<64 hex>, got: %s\n' "$digest" >&2
+        return 2
+    fi
+    if [[ ! -f "$file" ]] || ! jq -e . "$file" >/dev/null 2>&1; then
+        printf 'bump_catalog_digest: catalog missing or not valid JSON: %s\n' "$file" >&2
+        return 2
+    fi
+
+    local delivery image
+    delivery="$(jq -r --arg t "$tool" '.tools[$t].delivery // empty' "$file")"
+    image="$(jq -r --arg t "$tool" '.tools[$t].image // empty' "$file")"
+    if [[ -z "$delivery" && -z "$image" ]]; then
+        printf 'bump_catalog_digest: unknown tool: %s\n' "$tool" >&2
+        return 2
+    fi
+    if [[ "$delivery" != "image" || -z "$image" ]]; then
+        printf 'bump_catalog_digest: %s is not an image-delivery tool\n' "$tool" >&2
+        return 2
+    fi
+
+    local namespace="${image%@sha256:*}" new="${image%@sha256:*}@${digest}"
+    if [[ "$namespace" == "$image" ]]; then
+        printf 'bump_catalog_digest: %s image is not digest-pinned: %s\n' "$tool" "$image" >&2
+        return 2
+    fi
+    if [[ "$new" == "$image" ]]; then
+        return 0  # idempotent — already at this digest
+    fi
+
+    # Sibling tempfile + atomic mv: $TMPDIR is often a different mount where mv
+    # degrades to copy+unlink.
+    local tmp
+    tmp="$(mktemp "$file.XXXXXX")"
+    trap 'rm -f "${tmp:-}"' EXIT INT TERM
+    jq --arg t "$tool" --arg img "$new" '.tools[$t].image = $img' "$file" >"$tmp"
+    mv "$tmp" "$file"
+    printf 'bump_catalog_digest: %s -> %s\n' "$tool" "$new"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [[ "$#" -ne 2 ]]; then
+        printf 'Usage: %s <tool> <digest>\n' "${0##*/}" >&2
+        exit 2
+    fi
+    bump_catalog_digest "${WRANGLE_CATALOG:-$SCRIPT_DIR/catalog.json}" "$1" "$2"
+fi

--- a/tools/check_catalog.sh
+++ b/tools/check_catalog.sh
@@ -7,25 +7,28 @@ set -f  # disable globbing — handles external tool/field names
 # docs/tool_container_design.md §8: keep the catalog honest so a mutable or
 # off-namespace image reference can't pass CI green.
 #
-# For every tool it asserts: the file is valid JSON, a `kind` is declared, and a
-# declared `network`/`secret` is from the allowed, default-closed set. For every
-# `delivery: image` entry it additionally asserts the image is digest-pinned
-# (@sha256: + 64 hex, never a bare tag / :latest / @latest) on the curated
-# registry namespace ghcr.io/tomhennen/wrangle/<name>; a digest-pinned image on a
-# genuinely different host is allowed as a fallback, but anything on the curated
-# host that is off-namespace is rejected.
+# For every tool it asserts: the file is valid JSON, a `kind` is declared, the
+# `delivery` (if set) is one run.sh recognizes, and a declared `network`/`secret`
+# is from the allowed, default-closed set. For every `delivery: image` entry it
+# additionally asserts the image is digest-pinned (@sha256: + 64 hex, never a bare
+# tag / :latest / @latest) on the curated namespace ghcr.io/tomhennen/wrangle/<tool>
+# — adopter overrides never live in this in-repo catalog (§3.6), so a different
+# host or namespace is a violation.
 #
 # Catalog path: $WRANGLE_CATALOG, else the catalog beside this script.
 #
 # Exit: 0 clean, 1 a violation (offending tool+field printed), 2 usage/env error.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/read_catalog.sh
+source "$SCRIPT_DIR/../lib/read_catalog.sh"
 
 NETWORK_ALLOWED_RE='^(none|egress)$'
 SECRET_NAME_RE='^[a-z][a-z0-9-]*$'
-IMAGE_STRICT_RE='^ghcr\.io/tomhennen/wrangle/[a-z0-9._-]+@sha256:[0-9a-f]{64}$'
-IMAGE_GHCR_RE='^ghcr\.io/'
-IMAGE_DIGEST_RE='^[a-z0-9._-]+(:[0-9]+)?(/[a-z0-9._-]+)*@sha256:[0-9a-f]{64}$'
+# Tool segment matches run.sh's tool-name shape, so no leading dot/dash or `..`
+# can survive into a registry path.
+CURATED_PREFIX='ghcr.io/tomhennen/wrangle/'
+IMAGE_STRICT_RE='^ghcr\.io/tomhennen/wrangle/[a-z][a-z0-9_-]*@sha256:[0-9a-f]{64}$'
 
 # validate_catalog <catalog_file> — print one line per violation to stderr.
 # Returns 0 clean, 1 any violation. A malformed/unparseable catalog is itself a
@@ -46,39 +49,46 @@ validate_catalog() {
     while IFS= read -r tool; do
         [[ -z "$tool" ]] && continue
 
-        kind="$(jq -r --arg t "$tool" '.tools[$t].kind // empty' "$file")"
+        kind="$(read_catalog_field "$file" "$tool" kind)"
         if [[ -z "$kind" ]]; then
             printf 'check_catalog: %s: missing kind\n' "$tool" >&2
             rc=1
         fi
 
-        network="$(jq -r --arg t "$tool" '.tools[$t].network // empty' "$file")"
+        network="$(read_catalog_field "$file" "$tool" network)"
         if [[ -n "$network" ]] && [[ ! "$network" =~ $NETWORK_ALLOWED_RE ]]; then
             printf 'check_catalog: %s: invalid network value: %s\n' "$tool" "$network" >&2
             rc=1
         fi
 
-        secret="$(jq -r --arg t "$tool" '.tools[$t].secret // empty' "$file")"
+        secret="$(read_catalog_field "$file" "$tool" secret)"
         if [[ -n "$secret" ]] && [[ ! "$secret" =~ $SECRET_NAME_RE ]]; then
             printf 'check_catalog: %s: invalid secret name: %s\n' "$tool" "$secret" >&2
             rc=1
         fi
 
-        delivery="$(jq -r --arg t "$tool" '.tools[$t].delivery // empty' "$file")"
+        # Same allowlist run.sh enforces: empty/adapter/image. A typo'd value must
+        # not skip image enforcement and pass green.
+        delivery="$(read_catalog_field "$file" "$tool" delivery)"
+        case "$delivery" in
+            ''|adapter|image) ;;
+            *)
+                printf 'check_catalog: %s: unrecognized delivery: %s\n' "$tool" "$delivery" >&2
+                rc=1 ;;
+        esac
+
         if [[ "$delivery" == "image" ]]; then
-            image="$(jq -r --arg t "$tool" '.tools[$t].image // empty' "$file")"
+            image="$(read_catalog_field "$file" "$tool" image)"
             if [[ -z "$image" ]]; then
                 printf 'check_catalog: %s: delivery: image but no image\n' "$tool" >&2
                 rc=1
             elif [[ "$image" =~ $IMAGE_STRICT_RE ]]; then
                 : # curated, digest-pinned — ok
-            elif [[ "$image" =~ $IMAGE_GHCR_RE ]]; then
-                printf 'check_catalog: %s: image off the curated namespace ghcr.io/tomhennen/wrangle/: %s\n' "$tool" "$image" >&2
+            elif [[ "$image" == "$CURATED_PREFIX"* ]]; then
+                printf 'check_catalog: %s: image not digest-pinned (needs ghcr.io/tomhennen/wrangle/<tool>@sha256:<64hex>): %s\n' "$tool" "$image" >&2
                 rc=1
-            elif [[ "$image" =~ $IMAGE_DIGEST_RE ]]; then
-                : # non-curated host, still digest-pinned — ok
             else
-                printf 'check_catalog: %s: image not digest-pinned (needs @sha256:<64hex>): %s\n' "$tool" "$image" >&2
+                printf 'check_catalog: %s: image off the curated namespace ghcr.io/tomhennen/wrangle/: %s\n' "$tool" "$image" >&2
                 rc=1
             fi
         fi

--- a/tools/check_catalog.sh
+++ b/tools/check_catalog.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — handles external tool/field names
+
+# tools/check_catalog.sh — static, network-free validator for wrangle's curated
+# tool catalog (tools/catalog.json). The footgun linter from
+# docs/tool_container_design.md §8: keep the catalog honest so a mutable or
+# off-namespace image reference can't pass CI green.
+#
+# For every tool it asserts: the file is valid JSON, a `kind` is declared, and a
+# declared `network`/`secret` is from the allowed, default-closed set. For every
+# `delivery: image` entry it additionally asserts the image is digest-pinned
+# (@sha256: + 64 hex, never a bare tag / :latest / @latest) on the curated
+# registry namespace ghcr.io/tomhennen/wrangle/<name>; a digest-pinned image on a
+# genuinely different host is allowed as a fallback, but anything on the curated
+# host that is off-namespace is rejected.
+#
+# Catalog path: $WRANGLE_CATALOG, else the catalog beside this script.
+#
+# Exit: 0 clean, 1 a violation (offending tool+field printed), 2 usage/env error.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+NETWORK_ALLOWED_RE='^(none|egress)$'
+SECRET_NAME_RE='^[a-z][a-z0-9-]*$'
+IMAGE_STRICT_RE='^ghcr\.io/tomhennen/wrangle/[a-z0-9._-]+@sha256:[0-9a-f]{64}$'
+IMAGE_GHCR_RE='^ghcr\.io/'
+IMAGE_DIGEST_RE='^[a-z0-9._-]+(:[0-9]+)?(/[a-z0-9._-]+)*@sha256:[0-9a-f]{64}$'
+
+# validate_catalog <catalog_file> — print one line per violation to stderr.
+# Returns 0 clean, 1 any violation. A malformed/unparseable catalog is itself a
+# violation (1), not an env error.
+validate_catalog() {
+    local file="$1" rc=0
+
+    if [[ ! -f "$file" ]]; then
+        printf 'check_catalog: catalog not found: %s\n' "$file" >&2
+        return 1
+    fi
+    if ! jq -e . "$file" >/dev/null 2>&1; then
+        printf 'check_catalog: %s is not valid JSON\n' "$file" >&2
+        return 1
+    fi
+
+    local tool kind delivery image network secret
+    while IFS= read -r tool; do
+        [[ -z "$tool" ]] && continue
+
+        kind="$(jq -r --arg t "$tool" '.tools[$t].kind // empty' "$file")"
+        if [[ -z "$kind" ]]; then
+            printf 'check_catalog: %s: missing kind\n' "$tool" >&2
+            rc=1
+        fi
+
+        network="$(jq -r --arg t "$tool" '.tools[$t].network // empty' "$file")"
+        if [[ -n "$network" ]] && [[ ! "$network" =~ $NETWORK_ALLOWED_RE ]]; then
+            printf 'check_catalog: %s: invalid network value: %s\n' "$tool" "$network" >&2
+            rc=1
+        fi
+
+        secret="$(jq -r --arg t "$tool" '.tools[$t].secret // empty' "$file")"
+        if [[ -n "$secret" ]] && [[ ! "$secret" =~ $SECRET_NAME_RE ]]; then
+            printf 'check_catalog: %s: invalid secret name: %s\n' "$tool" "$secret" >&2
+            rc=1
+        fi
+
+        delivery="$(jq -r --arg t "$tool" '.tools[$t].delivery // empty' "$file")"
+        if [[ "$delivery" == "image" ]]; then
+            image="$(jq -r --arg t "$tool" '.tools[$t].image // empty' "$file")"
+            if [[ -z "$image" ]]; then
+                printf 'check_catalog: %s: delivery: image but no image\n' "$tool" >&2
+                rc=1
+            elif [[ "$image" =~ $IMAGE_STRICT_RE ]]; then
+                : # curated, digest-pinned — ok
+            elif [[ "$image" =~ $IMAGE_GHCR_RE ]]; then
+                printf 'check_catalog: %s: image off the curated namespace ghcr.io/tomhennen/wrangle/: %s\n' "$tool" "$image" >&2
+                rc=1
+            elif [[ "$image" =~ $IMAGE_DIGEST_RE ]]; then
+                : # non-curated host, still digest-pinned — ok
+            else
+                printf 'check_catalog: %s: image not digest-pinned (needs @sha256:<64hex>): %s\n' "$tool" "$image" >&2
+                rc=1
+            fi
+        fi
+    done < <(jq -r '.tools | keys[]' "$file")
+
+    return "$rc"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [[ "$#" -gt 0 ]]; then
+        printf 'Usage: %s   (catalog: WRANGLE_CATALOG env, else %s/catalog.json)\n' "${0##*/}" "$SCRIPT_DIR" >&2
+        exit 2
+    fi
+    catalog="${WRANGLE_CATALOG:-$SCRIPT_DIR/catalog.json}"
+    if validate_catalog "$catalog"; then
+        printf 'check_catalog: %s is valid\n' "$catalog"
+        exit 0
+    fi
+    exit 1
+fi

--- a/tools/check_catalog.sh
+++ b/tools/check_catalog.sh
@@ -82,7 +82,7 @@ validate_catalog() {
                 rc=1
             fi
         fi
-    done < <(jq -r '.tools | keys[]' "$file")
+    done < <(jq -r '.tools // {} | keys[]' "$file")
 
     return "$rc"
 }

--- a/tools/check_catalog_freshness.sh
+++ b/tools/check_catalog_freshness.sh
@@ -43,11 +43,11 @@ _digest_via_curl() {
     registry="${imagename%%/*}"
     repo="${imagename#*/}"
 
-    token="$(curl -fsSL "https://${registry}/token?scope=repository:${repo}:pull" 2>/dev/null \
+    token="$(curl -fsSL --connect-timeout 10 --max-time 30 "https://${registry}/token?scope=repository:${repo}:pull" 2>/dev/null \
         | jq -r '.token // empty' 2>/dev/null)" || return 1
     [[ -n "$token" ]] || return 1
 
-    digest="$(curl -fsS -I -X GET \
+    digest="$(curl -fsS -I -X GET --connect-timeout 10 --max-time 30 \
         -H "Authorization: Bearer ${token}" \
         -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json' \
         "https://${registry}/v2/${repo}/manifests/latest" 2>/dev/null \
@@ -80,6 +80,10 @@ check_freshness() {
         printf 'check_catalog_freshness: catalog not found: %s\n' "$file" >&2
         return 2
     fi
+    if ! jq -e . "$file" >/dev/null 2>&1; then
+        printf 'check_catalog_freshness: %s is not valid JSON\n' "$file" >&2
+        return 2
+    fi
 
     while IFS= read -r tool; do
         [[ -z "$tool" ]] && continue
@@ -103,12 +107,14 @@ check_freshness() {
             printf '  remediation: tools/bump_catalog_digest.sh %s %s\n' "$tool" "$resolved" >&2
             drift=1
         fi
-    done < <(jq -r '.tools | keys[]' "$file")
+    done < <(jq -r '.tools // {} | keys[]' "$file")
 
-    if [[ "$backend_err" -eq 1 ]]; then
-        rc=2
-    elif [[ "$drift" -eq 1 ]]; then
+    # A confirmed drift (1) wins over a transient backend error (2): the drift is
+    # actionable regardless of another tool's reachability, and must not be masked.
+    if [[ "$drift" -eq 1 ]]; then
         rc=1
+    elif [[ "$backend_err" -eq 1 ]]; then
+        rc=2
     else
         printf 'check_catalog_freshness: all %d curated image digest(s) match :latest\n' "$checked"
     fi

--- a/tools/check_catalog_freshness.sh
+++ b/tools/check_catalog_freshness.sh
@@ -24,14 +24,22 @@ set -f  # disable globbing — handles external tool names
 # Digest resolution prefers `crane digest`; with no crane it falls back to an
 # anonymous GHCR registry-API call over curl (the curated images are public).
 #
+# Coupling: this is only meaningful because build/actions/container/action.yml
+# pushes the `:latest` tag on main; if that tag stops being published, every
+# curated entry resolves a backend error (exit 2), not a false in-sync.
+#
 # Catalog path: $WRANGLE_CATALOG, else the catalog beside this script.
 #
 # Exit: 0 all in sync, 1 a digest drifted (bump remediation printed),
 #       2 the registry was unreachable or a backend failed (NOT a false failure).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/read_catalog.sh
+source "$SCRIPT_DIR/../lib/read_catalog.sh"
 
-CURATED_PREFIX_RE='^ghcr\.io/tomhennen/wrangle/[a-z0-9._-]+$'
+# Tool segment matches run.sh's tool-name shape, so a crafted `..` segment can't
+# turn curl's path into a cross-repo query.
+CURATED_PREFIX_RE='^ghcr\.io/tomhennen/wrangle/[a-z][a-z0-9_-]*$'
 DIGEST_RE='^sha256:[0-9a-f]{64}$'
 
 # _digest_via_curl <imagename> — anonymous GHCR digest of <imagename>:latest via
@@ -87,9 +95,9 @@ check_freshness() {
 
     while IFS= read -r tool; do
         [[ -z "$tool" ]] && continue
-        delivery="$(jq -r --arg t "$tool" '.tools[$t].delivery // empty' "$file")"
+        delivery="$(read_catalog_field "$file" "$tool" delivery)"
         [[ "$delivery" == "image" ]] || continue
-        image="$(jq -r --arg t "$tool" '.tools[$t].image // empty' "$file")"
+        image="$(read_catalog_field "$file" "$tool" image)"
         imagename="${image%@sha256:*}"
         pinned="${image##*@}"
 

--- a/tools/check_catalog_freshness.sh
+++ b/tools/check_catalog_freshness.sh
@@ -21,8 +21,9 @@ set -f  # disable globbing — handles external tool names
 #       :latest unchanged. The publish trigger covers tools/** and lib/**, so the
 #       window is small but real.
 #
-# Digest resolution prefers `crane digest`; with no crane it falls back to an
-# anonymous GHCR registry-API call over curl (the curated images are public).
+# Digest resolution is an anonymous GHCR registry-API call over curl (the curated
+# images are public); the index media types in Accept return the same multi-arch
+# index digest the catalog pins.
 #
 # Coupling: this is only meaningful because build/actions/container/action.yml
 # pushes the `:latest` tag on main; if that tag stops being published, every
@@ -42,11 +43,10 @@ source "$SCRIPT_DIR/../lib/read_catalog.sh"
 CURATED_PREFIX_RE='^ghcr\.io/tomhennen/wrangle/[a-z][a-z0-9_-]*$'
 DIGEST_RE='^sha256:[0-9a-f]{64}$'
 
-# _digest_via_curl <imagename> — anonymous GHCR digest of <imagename>:latest via
-# the registry API. Prints the index/manifest digest on success; non-zero on any
-# failure. The index media types in Accept make this return the same digest
-# `crane digest` does for a multi-arch image.
-_digest_via_curl() {
+# resolve_latest_digest <imagename> — anonymous GHCR digest of <imagename>:latest
+# via the registry API. Prints the index digest on success; non-zero on any
+# backend failure (token fetch, registry read, or a missing/malformed digest).
+resolve_latest_digest() {
     local imagename="$1" registry repo token digest
     registry="${imagename%%/*}"
     repo="${imagename#*/}"
@@ -62,21 +62,6 @@ _digest_via_curl() {
         | tr -d '\r' | sed -n 's/^[Dd]ocker-[Cc]ontent-[Dd]igest:[[:space:]]*//p')" || return 1
     [[ "$digest" =~ $DIGEST_RE ]] || return 1
     printf '%s' "$digest"
-}
-
-# resolve_latest_digest <imagename> — digest of <imagename>:latest. Prints it on
-# success; non-zero on backend failure. Crane (when present) is authoritative;
-# only without crane does it fall back to curl, so tests that shim crane stay
-# hermetic.
-resolve_latest_digest() {
-    local imagename="$1" digest
-    if command -v crane >/dev/null 2>&1; then
-        digest="$(crane digest "${imagename}:latest" 2>/dev/null)" || return 1
-        [[ "$digest" =~ $DIGEST_RE ]] || return 1
-        printf '%s' "$digest"
-    else
-        _digest_via_curl "$imagename"
-    fi
 }
 
 # check_freshness <catalog_file> — returns 0 in sync, 1 drift, 2 backend error.

--- a/tools/check_catalog_freshness.sh
+++ b/tools/check_catalog_freshness.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — handles external tool names
+
+# tools/check_catalog_freshness.sh — adoption-lag freshness check for the curated
+# image entries in tools/catalog.json. For each curated `delivery: image` entry on
+# the registry namespace ghcr.io/tomhennen/wrangle/*, it resolves the registry
+# digest of the tool's moving `:latest` tag and compares it to the catalog's
+# pinned @sha256: digest. A mismatch means wrangle published a newer tool image
+# but the catalog still points at the old one (the #264/#539 stale-but-green hole).
+#
+# BOUNDARY — what this proves and what it does NOT:
+#   It proves only ADOPTION LAG: the catalog has not picked up a newer published
+#   image. It does NOT prove the pinned digest was built from current tool source
+#   (the stronger §11 provenance guarantee — image SLSA provenance → source commit
+#   → diff against HEAD — is a separate, deferred check). Two consequences:
+#     - False positive: a cold-cache rebuild can repoint :latest to a new digest
+#       with unchanged source (container builds aren't bit-reproducible); the
+#       remediation (a digest bump) is harmless then.
+#     - False negative: a source change that doesn't republish the image leaves
+#       :latest unchanged. The publish trigger covers tools/** and lib/**, so the
+#       window is small but real.
+#
+# Digest resolution prefers `crane digest`; with no crane it falls back to an
+# anonymous GHCR registry-API call over curl (the curated images are public).
+#
+# Catalog path: $WRANGLE_CATALOG, else the catalog beside this script.
+#
+# Exit: 0 all in sync, 1 a digest drifted (bump remediation printed),
+#       2 the registry was unreachable or a backend failed (NOT a false failure).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CURATED_PREFIX_RE='^ghcr\.io/tomhennen/wrangle/[a-z0-9._-]+$'
+DIGEST_RE='^sha256:[0-9a-f]{64}$'
+
+# _digest_via_curl <imagename> — anonymous GHCR digest of <imagename>:latest via
+# the registry API. Prints the index/manifest digest on success; non-zero on any
+# failure. The index media types in Accept make this return the same digest
+# `crane digest` does for a multi-arch image.
+_digest_via_curl() {
+    local imagename="$1" registry repo token digest
+    registry="${imagename%%/*}"
+    repo="${imagename#*/}"
+
+    token="$(curl -fsSL "https://${registry}/token?scope=repository:${repo}:pull" 2>/dev/null \
+        | jq -r '.token // empty' 2>/dev/null)" || return 1
+    [[ -n "$token" ]] || return 1
+
+    digest="$(curl -fsS -I -X GET \
+        -H "Authorization: Bearer ${token}" \
+        -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json' \
+        "https://${registry}/v2/${repo}/manifests/latest" 2>/dev/null \
+        | tr -d '\r' | sed -n 's/^[Dd]ocker-[Cc]ontent-[Dd]igest:[[:space:]]*//p')" || return 1
+    [[ "$digest" =~ $DIGEST_RE ]] || return 1
+    printf '%s' "$digest"
+}
+
+# resolve_latest_digest <imagename> — digest of <imagename>:latest. Prints it on
+# success; non-zero on backend failure. Crane (when present) is authoritative;
+# only without crane does it fall back to curl, so tests that shim crane stay
+# hermetic.
+resolve_latest_digest() {
+    local imagename="$1" digest
+    if command -v crane >/dev/null 2>&1; then
+        digest="$(crane digest "${imagename}:latest" 2>/dev/null)" || return 1
+        [[ "$digest" =~ $DIGEST_RE ]] || return 1
+        printf '%s' "$digest"
+    else
+        _digest_via_curl "$imagename"
+    fi
+}
+
+# check_freshness <catalog_file> — returns 0 in sync, 1 drift, 2 backend error.
+check_freshness() {
+    local file="$1" rc=0 drift=0 backend_err=0
+    local tool delivery image imagename pinned resolved checked=0
+
+    if [[ ! -f "$file" ]]; then
+        printf 'check_catalog_freshness: catalog not found: %s\n' "$file" >&2
+        return 2
+    fi
+
+    while IFS= read -r tool; do
+        [[ -z "$tool" ]] && continue
+        delivery="$(jq -r --arg t "$tool" '.tools[$t].delivery // empty' "$file")"
+        [[ "$delivery" == "image" ]] || continue
+        image="$(jq -r --arg t "$tool" '.tools[$t].image // empty' "$file")"
+        imagename="${image%@sha256:*}"
+        pinned="${image##*@}"
+
+        # Skip non-curated/adopter-override entries: their tag scheme is unknown.
+        [[ "$imagename" =~ $CURATED_PREFIX_RE ]] || continue
+        checked=$((checked + 1))
+
+        if ! resolved="$(resolve_latest_digest "$imagename")"; then
+            printf 'check_catalog_freshness: %s: could not resolve %s:latest from the registry\n' "$tool" "$imagename" >&2
+            backend_err=1
+            continue
+        fi
+        if [[ "$resolved" != "$pinned" ]]; then
+            printf 'check_catalog_freshness: %s: catalog digest %s is behind :latest %s\n' "$tool" "$pinned" "$resolved" >&2
+            printf '  remediation: tools/bump_catalog_digest.sh %s %s\n' "$tool" "$resolved" >&2
+            drift=1
+        fi
+    done < <(jq -r '.tools | keys[]' "$file")
+
+    if [[ "$backend_err" -eq 1 ]]; then
+        rc=2
+    elif [[ "$drift" -eq 1 ]]; then
+        rc=1
+    else
+        printf 'check_catalog_freshness: all %d curated image digest(s) match :latest\n' "$checked"
+    fi
+    return "$rc"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [[ "$#" -gt 0 ]]; then
+        printf 'Usage: %s   (catalog: WRANGLE_CATALOG env, else %s/catalog.json)\n' "${0##*/}" "$SCRIPT_DIR" >&2
+        exit 2
+    fi
+    check_freshness "${WRANGLE_CATALOG:-$SCRIPT_DIR/catalog.json}"
+fi


### PR DESCRIPTION
claude: WS2 of #596 — teach wrangle's pin/freshness controls to understand the OCI `@sha256:` digests in `tools/catalog.json`. Today a stale catalog digest sits false-green: nothing flags that wrangle published a newer tool image while the catalog still points at the old one (#264/#539 class). This adds three catalog-aware controls mirroring the existing git-pin toolchain on the OCI axis.

## What's here
- **`tools/check_catalog.sh`** — static, network-free validator (the docs/tool_container_design.md §8 footgun linter). Generic over the catalog: every `delivery: image` entry must be digest-pinned (`@sha256:`+64hex, never a mutable tag) on the `ghcr.io/tomhennen/wrangle/` namespace; `kind` required; `network`∈{none,egress} and `secret` validated when present; malformed JSON fails. Exit 0/1/2. **Wired into the per-PR pin-checks job** in `local_build_shell.yml`.
- **`tools/check_catalog_freshness.sh`** — adoption-lag check (network). For each curated `ghcr.io/tomhennen/wrangle/*` image, resolves the registry digest of `:latest` (prefers `crane digest`, else an anonymous GHCR registry-API call over curl — public images, no auth) and compares to the catalog pin. Drift → exit 1 with a copy-pasteable `bump_catalog_digest.sh <tool> <digest>` remediation; registry-unreachable → exit 2 (not a false failure); in-sync → 0. **Not on the per-PR path** (no per-PR registry calls); wired as a **release precondition** (cut-release Phase 4 gate) + a **weekly advisory workflow** (`catalog_freshness.yml`).
- **`tools/bump_catalog_digest.sh <tool> <digest>`** — one-command fix; jq-set the image preserving its namespace, atomic tempfile + `mv`, idempotent. Exit 2 on bad digest / unknown / non-image tool.
- Makefile targets, `DEP_MGMT.md` + `CLAUDE.md` rules, and bats for all three.

## Boundary (important)
The freshness check proves **adoption lag only** — that the catalog hasn't picked up a newer published image. It does NOT prove the digest was built from current source (the stronger §11 provenance check). Documented in-script and in the deferred-items issue. Known caveats: a cold-cache rebuild can repoint `:latest` to a new digest with unchanged source (remediation is a harmless bump); a source change that doesn't republish leaves `:latest` unchanged (publish triggers on `tools/**`+`lib/**`, so the window is small).

## Real-world finding
Running the freshness check against the live registry shows **osv is currently drifted** — `catalog.json` pins `sha256:2c5ee9…` but `:latest` is `sha256:c8abda…`. Exactly the false-green this closes. Not fixed here (a separate bump under cooldown; the digest may be a same-source rebuild).

## Advisory → blocking rollout
The freshness check ships advisory (weekly workflow notifies; cut-release gate is a manual run). Once low-flake, promote to a hard release-gate job — tracked in the deferred issue.

## Deferred (filed as #623)
Provenance-based source-freshness, automated post-publish bump PR, digest cooldown timer, adopter-override staleness (WL007), and the advisory→blocking promotion.

## Tests
`./test.sh quick` green (1291 ok), `./test.sh zizmor` green. 19 new bats; the freshness bats shim `crane` on PATH (wrangle's first network-dependent pin check). Curl fallback verified end-to-end against the live public registry.

Refs #596, #623. Not a closing keyword — follow-on slices remain.