### PR TITLE
fix(catalog): repin osv to attested main build (#596)

### DIFF
--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -4,7 +4,7 @@
     "osv": {
       "kind": "scan",
       "delivery": "image",
-      "image": "ghcr.io/tomhennen/wrangle/osv@sha256:2c5ee9994a09ceb4b6957b6f528e63dcf2c83862fc2b626d1e2602e6f117ec54",
+      "image": "ghcr.io/tomhennen/wrangle/osv@sha256:c8abda59e3a64520128c427d2fe9bd223c27e0a2056181ead1b9d3c6a5fb3b75",
       "network": "egress"
     }
   }


### PR DESCRIPTION
claude: The osv image used in production scans was pinned in `tools/catalog.json` to an **unattested feature-branch build** (`sha256:2c5ee9…`) — empty OCI referrers and HTTP 404 in the GitHub attestation store. This repins to the **attested main build** (`sha256:c8abda…`), which carries a PASSED SLSA VSA and is what `:latest` resolves to.

This is a pure attestation-hygiene fix, **not** a version adoption: both digests run osv-scanner **2.4.0** / osv-scalibr **0.4.5** (verified via `osv-scanner --version` in each image), so the 7-day cooldown / WL005 does not apply.

Verification performed:
- `osv-scanner --version` on both digests → 2.4.0 / scalibr 0.4.5 (identical).
- `gh attestation verify oci://…@sha256:c8abda… --repo TomHennen/wrangle --predicate-type https://slsa.dev/verification_summary/v1` → VSA `PASSED`.
- New digest is an OCI image **index** (`application/vnd.oci.image.index.v1+json` — linux/amd64 + an attestation manifest, not multi-arch), digest-pinned — matches osv's existing pinning convention.
- `./test.sh quick` (1270 tests) and `./test.sh zizmor` green; `check_pin_freshness` / `check_pin_ancestry` both green (no self-ref re-converge needed).

Refs #596.
