### PR TITLE
test(attest-toolbox): smoke-test ampel verify under -u in the image

### DIFF
--- a/test/image/test_attest_toolbox_image.bats
+++ b/test/image/test_attest_toolbox_image.bats
@@ -24,18 +24,13 @@ setup() {
     ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
 }
 
-# A zero subject digest and a fixed context satisfy the consumer policy's
-# required context keys; the verdict is irrelevant to these smoke tests.
 ZERO_SUBJECT=sha256:0000000000000000000000000000000000000000000000000000000000000000
 VSA_CONTEXT=expectedResourceUri:ghcr.io/x/y@sha256:abc,sourceRepo:https://github.com/x/y
 
-# Run `ampel verify` in the image as $1 (a `docker run -u` value), mounting the
-# policy dir read-only and a writable results dir, exactly as the opt-in
-# in-container path does (actions/verify/run_verify.sh). --network none keeps it
-# offline: the consumer VSA policy is the one bundled policy that fetches no
-# remote ampel fragments. An empty collector yields a FAILED verdict (exit 1
-# under --exit-code=true), but the VSA is still written — the smoke test asserts
-# the run reaches that write, not the verdict.
+# Run `ampel verify` in the image as the `docker run -u` value $1. The consumer
+# VSA policy fetches no remote fragments, so --network none proves no egress is
+# needed; the empty collector makes FAILED the expected verdict, but the VSA is
+# still written.
 wrangle_ampel_verify_in_image() {
     local user="$1" results="$2"
     mkdir -p "$results"
@@ -102,4 +97,7 @@ wrangle_ampel_verify_in_image() {
     chmod 0777 "$results"
     run wrangle_ampel_verify_in_image "99999:99999" "$results"
     [ -f "$results/vsa.json" ]
+    run jq -r '.predicateType' "$results/vsa.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = "https://slsa.dev/verification_summary/v1" ]
 }

--- a/test/image/test_attest_toolbox_image.bats
+++ b/test/image/test_attest_toolbox_image.bats
@@ -21,6 +21,35 @@ setup() {
     load "../lib/image_test_harness.sh"
     wrangle_require_docker
     IMG=wrangle-attest-toolbox:test
+    ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+}
+
+# A zero subject digest and a fixed context satisfy the consumer policy's
+# required context keys; the verdict is irrelevant to these smoke tests.
+ZERO_SUBJECT=sha256:0000000000000000000000000000000000000000000000000000000000000000
+VSA_CONTEXT=expectedResourceUri:ghcr.io/x/y@sha256:abc,sourceRepo:https://github.com/x/y
+
+# Run `ampel verify` in the image as $1 (a `docker run -u` value), mounting the
+# policy dir read-only and a writable results dir, exactly as the opt-in
+# in-container path does (actions/verify/run_verify.sh). --network none keeps it
+# offline: the consumer VSA policy is the one bundled policy that fetches no
+# remote ampel fragments. An empty collector yields a FAILED verdict (exit 1
+# under --exit-code=true), but the VSA is still written — the smoke test asserts
+# the run reaches that write, not the verdict.
+wrangle_ampel_verify_in_image() {
+    local user="$1" results="$2"
+    mkdir -p "$results"
+    : > "$results/bundle.jsonl"
+    docker run --rm -u "$user" --network none -e HOME=/tmp \
+        -v "$ROOT/policies":"$ROOT/policies":ro \
+        -v "$results":"$results" \
+        "$IMG" ampel verify \
+        --subject="$ZERO_SUBJECT" \
+        --collector="jsonl:$results/bundle.jsonl" \
+        --policy="$ROOT/policies/wrangle-vsa-consumer-nonstrict-v1.hjson" \
+        --context "$VSA_CONTEXT" \
+        --workers=32 --exit-code=true --attest-results --attest-format=vsa \
+        --results-path="$results/vsa.json" --format=html
 }
 
 @test "attest-toolbox: ampel, bnd, cosign, wrangle-attest are on PATH" {
@@ -54,4 +83,23 @@ setup() {
     [ "$status" -eq 0 ]
     [[ "${lines[0]}" != "0" ]]
     [[ "${lines[1]}" == "/tmp" ]]
+}
+
+@test "attest-toolbox: ampel verify writes a SLSA VSA under the runner UID" {
+    local results="$BATS_TEST_TMPDIR/results"
+    run wrangle_ampel_verify_in_image "$(id -u):$(id -g)" "$results"
+    [ -f "$results/vsa.json" ]
+    run jq -r '.predicateType' "$results/vsa.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = "https://slsa.dev/verification_summary/v1" ]
+}
+
+@test "attest-toolbox: ampel verify has no /etc/passwd dependency (arbitrary UID)" {
+    local results="$BATS_TEST_TMPDIR/anon"
+    # World-writable so a UID absent from /etc/passwd (owning nothing) can write
+    # the VSA — isolating the passwd question from the file-ownership constraint.
+    mkdir -p "$results"
+    chmod 0777 "$results"
+    run wrangle_ampel_verify_in_image "99999:99999" "$results"
+    [ -f "$results/vsa.json" ]
 }


### PR DESCRIPTION
claude: Closes precondition #4 of #619 — the attest-toolbox image bats previously only checked `version`/PATH/non-root; this adds the missing real `ampel verify`-under-`-u` smoke test (no signing-path or catalog changes).

## What it adds
Two integration tests in `test/image/test_attest_toolbox_image.bats`, sharing a `wrangle_ampel_verify_in_image` helper that runs `ampel verify` in the real image exactly as the opt-in in-container path does (`actions/verify/run_verify.sh`): policy dir mounted read-only, results dir writable, `HOME=/tmp`.

1. **Writes a SLSA VSA under the runner UID** — `-u "$(id -u):$(id -g)"`; asserts a `vsa.json` is produced with `.predicateType == https://slsa.dev/verification_summary/v1`.
2. **No `/etc/passwd` dependency (arbitrary UID)** — `-u 99999:99999` (a UID with no passwd entry) against a world-writable results dir, isolating the passwd question from the file-ownership constraint; asserts the same valid VSA is written.

## Design notes
- **Real, no shim** — runs the actual built image (the file is already a docker-required integration bats that builds the image in `setup_file`).
- **Hermetic / `--network none`** — uses `policies/wrangle-vsa-consumer-nonstrict-v1.hjson`, the one bundled wrangle policy that fetches no remote ampel fragments, so the test needs no network. The other bundled policies pull `git+https://github.com/carabiner-dev/policies@<pin>` and would couple the test to external availability.
- An empty collector yields a `FAILED` verdict (exit 1 under `--exit-code=true`); the VSA is still written. The assertion keys on the VSA file being present and well-formed, not the exit code — a failed run writes no VSA file.

## Results
- `bats test/image/test_attest_toolbox_image.bats` — 7/7 green (5 existing + 2 new).
- `./test.sh quick` — 1294 tests, exit 0.

Refs #619 (precondition 4; does not fully resolve the issue).
