### PR TITLE
fix(verify): make release-create concurrency-safe (dispatch-test flake)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      uses: TomHennen/wrangle/build/actions/container@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      uses: TomHennen/wrangle/build/actions/container@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/checks@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/build@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/checks@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/build@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/npm@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/npm@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/python@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/python@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -77,7 +77,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -90,7 +90,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -134,7 +134,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+        uses: TomHennen/wrangle/build/actions/shell@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -77,7 +77,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -90,7 +90,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -134,7 +134,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+        uses: TomHennen/wrangle/build/actions/shell@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+        uses: TomHennen/wrangle/actions/scan@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+        uses: TomHennen/wrangle/actions/scan@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -141,7 +141,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      uses: TomHennen/wrangle/tools/scorecard@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -153,7 +153,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+      uses: TomHennen/wrangle/tools/dependency-review@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -141,7 +141,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      uses: TomHennen/wrangle/tools/scorecard@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -153,7 +153,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+      uses: TomHennen/wrangle/tools/dependency-review@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
 
     - name: Generate step summary
       if: always()

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -253,12 +253,13 @@ wrangle_run() {
 # (goreleaser built but published nothing). Enumerate via a temp file, not a
 # process substitution, so a find that dies mid-traversal fails closed.
 wrangle_attach_release() {
-    local ref="$GITHUB_REF_NAME"
-    # No release for the tag: create an empty published release to fill with only
-    # attested assets. Fail closed if creation fails — never fall through to upload.
+    local ref="$GITHUB_REF_NAME" create_err
+    # Create the tag's release if absent. A peer build-type job sharing it can win
+    # the create race, so re-check existence and fail closed only if still absent.
     if ! gh release view "$ref" >/dev/null 2>&1; then
-        if ! gh release create "$ref" --generate-notes --title "$ref"; then
-            printf 'wrangle: failed to create GitHub release for %s\n' "$ref" >&2
+        if ! create_err="$(gh release create "$ref" --generate-notes --title "$ref" 2>&1)" \
+            && ! gh release view "$ref" >/dev/null 2>&1; then
+            printf 'wrangle: failed to create GitHub release for %s: %s\n' "$ref" "$create_err" >&2
             return 1
         fi
     fi

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -830,12 +830,25 @@ _require_zip() {
     _install_gh_shim
     _stage_release_assets
     export BUILD_TYPE="python"
-    export GH_VIEW_SEQ="1"            # view fails (no release)
+    export GH_VIEW_SEQ="1 1"          # release absent before and after the failed create
     export GH_CREATE_CODE="1"        # create fails
     run "$SCRIPT" attach
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"failed to create GitHub release"* ]]
     if grep -q "release upload" "$GH_LOG"; then return 1; fi
+}
+
+@test "run_verify attach: a create that loses the concurrent race still uploads" {
+    _require_zip
+    _install_gh_shim
+    _stage_release_assets
+    export BUILD_TYPE="python"
+    export GH_VIEW_SEQ="1 0"          # absent, then a peer job's release appears
+    export GH_CREATE_CODE="1"        # our create loses the race
+    run "$SCRIPT" attach
+    [[ "$status" -eq 0 ]]
+    grep -qx "release create v1.2.3 --generate-notes --title v1.2.3" "$GH_LOG"
+    grep -qx "release upload v1.2.3 $BUNDLE_OUT/a.tgz.intoto.jsonl --clobber" "$GH_LOG"
 }
 
 # The verify job has no checkout, so gh resolves the base repo from GH_REPO

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@3ba1e4fba153b332ebada17450bf0c6d91bccb00 # deps/bump-checkout-v7-uniform 2026-06-27
+    - uses: TomHennen/wrangle/actions/verify@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@c887feb4fa5b76c2534a5fb2c5a42b20ebaf2bcc # fix/dispatch-test-flakiness 2026-06-27
+    - uses: TomHennen/wrangle/actions/verify@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}


### PR DESCRIPTION
claude: Hardens the intermittently-failing **`dispatch`** integration test (the "Dispatch companion repo and wait" step) by fixing the real transient root cause. This is a CI-reliability fix, not part of #596 — it just surfaced there (#631 failed on a test-only PR that can't affect it).

## Diagnosis (from real logs, not guessed)

I pulled the failed-step logs from several recent `dispatch` failures and their companion runs. Every failure is internal to the **companion run** — `dispatch.sh`'s own dispatch/locate/watch never failed — so the fix belongs in the verify action, not the harness. Distribution:

- **Release-create race (confirmed flake, fixed here):** `actions/verify/run_verify.sh` `wrangle_attach_release` does a get-or-create on the tag's GitHub release. The companion runs every build type's `verify_release` in parallel, all attaching to the **one shared tag release**. They race: the first creates it, the rest hit `HTTP 422 Validation Failed … Release.tag_name already exists` and fail closed → the whole companion run fails → the dispatch test goes red. Reproduced on **#631, #620, #604**, all unrelated to the code under test (#631 also *passed* on identical code).
- **Tag instability under cancel-in-progress (out of scope, follow-up):** golden/build checkout `The ref … does not point to the expected commit … may have been updated after the workflow was triggered`. The two cleanest cases (#614, #622) are on **cancelled/superseded** wrangle runs that don't gate the PR (a re-push cancels the prior run, whose cleanup deletes that run's tag mid-flight). The reaper (`cleanup-integration.yml`) can't be the cause — it only reaps tags older than 7 days. #602 is a substantive feature PR with multiple failures, not a clean PR-unrelated flake. This is a separate harness-concurrency concern; I'm tracking it for a follow-up issue rather than bundling a riskier change here.
- **Genuine failures (correctly left failing):** #620's `scan` failures (a scan-tooling PR) and generic checkout transients on `build` are not masked.

## The fix

After a failed `gh release create`, re-check whether the release now exists (a peer job won the race) and proceed only then; otherwise still fail closed and upload nothing.

```sh
if ! gh release view "$ref" >/dev/null 2>&1; then
    if ! gh release create "$ref" --generate-notes --title "$ref" \
        && ! gh release view "$ref" >/dev/null 2>&1; then
        printf 'wrangle: failed to create GitHub release for %s\n' "$ref" >&2
        return 1
    fi
fi
```

This also helps real adopters with multiple build types attaching to one release tag, not just the test.

## Why it can't mask a real failure

The discriminator is **"does the release actually exist now"**, not the error text. Behavior changes only when the release exists after a failed create (the race). A genuine create failure (bad token, invalid tag) leaves the release absent, so the re-`view` fails and the function still `return 1`s with no upload. Scan verdicts and every other genuine companion failure are nowhere near this code path — a real companion scan failure still fails the dispatch test.

## Tests

- New: a create that loses the race (`GH_VIEW_SEQ="1 0"`, create fails) proceeds to upload, exit 0.
- Updated fail-closed test to assert the release is absent both before and after the failed create (`GH_VIEW_SEQ="1 1"`) → still exits non-zero, uploads nothing.
- Full `actions/verify/test_run_verify.bats` green; `shellcheck` clean (only pre-existing SC1091 source-follow info).

## Pre-merge coverage caveat

The `dispatch` integration test on this PR does **not** exercise this fix. Per [`docs/e2e_testing.md`](docs/e2e_testing.md) (the nested self-ref resolves at *main's* SHA during PR-time integration), the companion run executes main's old racy code, so a green `dispatch` here is not evidence of the fix. Pre-merge confidence rests on the action's own bats (the race + fail-closed tests above); the fix takes effect post-merge once the self-ref pins are bumped to it.

Self-ref pins are converged in-PR (2 `chore: converge` commits), so **merge as a merge commit, not a squash** — squashing re-orphans the intermediate pin.

Not for merge — owner LGTM required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
