### PR TITLE
perf(ci): cache the test-image build with buildx + GHA layer cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,31 @@ jobs:
           key: gotest-${{ runner.os }}-${{ hashFiles('test/Dockerfile', 'tools/go.sum') }}
           restore-keys: gotest-${{ runner.os }}-
 
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # Prebuild the test image with a GitHub Actions layer cache so the
+      # ephemeral runner reuses the toolchain layers (Go, actionlint, …) instead
+      # of redownloading them every run (#308). load makes the image available to
+      # the docker run in test.sh, which skips its own build on the prebuilt env.
+      # provenance/sbom off: this is a test tool that attests nothing, so its
+      # cache stays off release builds' L3 cache-isolation surface (docs/SLSA_L3_AUDIT.md).
+      - name: Prebuild test image (cached)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: test/Dockerfile
+          tags: wrangle-test
+          load: true
+          push: false
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=wrangle-test
+          cache-to: type=gha,mode=max,scope=wrangle-test
+
       - name: Run tests
         env:
           WRANGLE_GOCACHE_DIR: ${{ runner.temp }}/gocache
+          WRANGLE_TEST_IMAGE_PREBUILT: "1"
         run: ./test.sh
 
   # Real keyless signing through the engine: the unit suite is hermetic

--- a/test.sh
+++ b/test.sh
@@ -38,9 +38,16 @@ if ! docker info >/dev/null 2>&1; then
     exit 1
 fi
 
-# Build the test container (cached after first run)
-echo "=== Building test container ==="
-docker build -t "$IMAGE_NAME" -f "$SCRIPT_DIR/test/Dockerfile" "$SCRIPT_DIR"
+# Build the test container. Locally this relies on the Docker daemon's layer
+# cache (warm across runs). In CI the runner is ephemeral, so the workflow
+# prebuilds the image with a GitHub Actions layer cache and sets
+# WRANGLE_TEST_IMAGE_PREBUILT to have this script reuse it instead of rebuilding
+# (#308). The image is a test tool that attests nothing, so caching it is L3-safe
+# (docs/SLSA_L3_AUDIT.md).
+if [[ -z "${WRANGLE_TEST_IMAGE_PREBUILT:-}" ]]; then
+    echo "=== Building test container ==="
+    docker build -t "$IMAGE_NAME" -f "$SCRIPT_DIR/test/Dockerfile" "$SCRIPT_DIR"
+fi
 
 # Map the script-level alias to the Makefile target list. Array form so
 # `quick` can pass multiple targets to one `make` invocation without

--- a/test.sh
+++ b/test.sh
@@ -42,8 +42,7 @@ fi
 # cache (warm across runs). In CI the runner is ephemeral, so the workflow
 # prebuilds the image with a GitHub Actions layer cache and sets
 # WRANGLE_TEST_IMAGE_PREBUILT to have this script reuse it instead of rebuilding
-# (#308). The image is a test tool that attests nothing, so caching it is L3-safe
-# (docs/SLSA_L3_AUDIT.md).
+# (#308).
 if [[ -z "${WRANGLE_TEST_IMAGE_PREBUILT:-}" ]]; then
     echo "=== Building test container ==="
     docker build -t "$IMAGE_NAME" -f "$SCRIPT_DIR/test/Dockerfile" "$SCRIPT_DIR"


### PR DESCRIPTION
claude:

Fixes #308.

## Problem

The `test` job in `test.yml` runs `./test.sh`, which builds `test/Dockerfile` with a plain `docker build`. GitHub runners are ephemeral and nothing persisted the Docker layer cache, so **every** run redownloaded and reinstalled the full toolchain (Go, govulncheck, actionlint, shellcheck, ast-grep, bats, the zizmor/ast-grep/PyYAML venvs).

## Diagnosis (two findings)

1. **Layer ordering was already fine.** `test/Dockerfile` does *not* `COPY` the repo source — the source is bind-mounted read-only at `docker run` time. It only `COPY`s three tiny `requirements.txt` files, and those COPYs come *after* the expensive apt/Go/actionlint installs. So a source change cannot bust the toolchain layers; no reordering was needed. The real fix is purely a cache backend.
2. **No cache backend in CI.** With ephemeral runners and no exporter, the layer cache was empty every run. This is the whole cost.

## Fix (buildx + GitHub Actions layer cache)

- In the `test` job: add `docker/setup-buildx-action` and a `docker/build-push-action` "Prebuild test image" step with `cache-from/to type=gha,mode=max,scope=wrangle-test` and `load: true`. The toolchain layers are restored from the Actions cache instead of rebuilt.
- `test.sh` reuses the prebuilt image: when `WRANGLE_TEST_IMAGE_PREBUILT` is set (only in CI) it skips its own `docker build` and goes straight to `docker run`.

### Local vs CI
Developers have no GHA cache, so the local path is unchanged: `./test.sh` still runs plain `docker build`, which hits the Docker daemon's own layer cache (warm across a dev's runs). Only CI sets `WRANGLE_TEST_IMAGE_PREBUILT`.

### Zero new dependencies
Both `docker/setup-buildx-action@d7f5e7f5… # v4.1.0` and `docker/build-push-action@f9f3042f… # v7.2.0` are **already pinned and used** by `build/actions/container/` — reusing the exact same SHAs (no pin drift, no new third-party action).

### Considered alternative (A)
Have `test.sh` itself run `docker buildx build --cache-to type=gha` behind a `${GITHUB_ACTIONS}` branch. A manual buildx invocation in a `run:` step does **not** inherit the cache backend env (`ACTIONS_RUNTIME_TOKEN` / `ACTIONS_CACHE_URL` / `ACTIONS_RESULTS_URL`) — per Docker's docs it requires exposing them via `crazy-max/ghaction-github-runtime`, which would be the repo's first non-org third-party action. I chose the build-push-action approach to avoid adding a CI dependency to a supply-chain tool. Happy to switch if you'd rather keep the build logic entirely in `test.sh`.

### Cache scope / quota
Single shared scope `scope=wrangle-test` (not per-PR `isolated` like the container release action) — the test image attests nothing, so PR-to-PR poisoning can at worst affect a test run, never an attestation; this matches the posture of the existing shared gotest gocache. Per-PR scoping would also defeat the warm hit. Footprint is one image's layers (Ubuntu base + ~80 MB Go + the venvs), comfortably within the 10 GB quota alongside the existing ~1.5–3 GB Go caches; `mode=max` keeps intermediate layers so the toolchain installs actually cache.

## L3 boundary
Only the **test** path is touched. Per `docs/SLSA_L3_AUDIT.md` the shell/test path signs nothing and none of its caches can poison an attestation, so caching the test image is L3-safe. No release/attested path (`build/actions/*`, the go/npm/python/container reusable workflows, `attest`/`verify` jobs) is modified — the build step sets `provenance: false`, `sbom: false`, `push: false` to make "this publishes nothing" explicit.

## Verification
- Full local suite green (`WRANGLE_TEST_IMAGE_PREBUILT=1 ./test.sh all`, exit 0) — the prebuilt image runs the suite identically; the local fallback (plain `docker build`) and the skip-build path both confirmed.
- `shellcheck`, `actionlint`, `wrangle-workflow-lint`, `wrangle-shell-lint`, and `zizmor` all clean on the diff (`push: false` keeps zizmor's cache-poisoning audit green with no suppression).
- **Cold/warm CI timings to follow** in a comment: this win is only measurable on the runner (no GHA backend exists locally). Measured at the `test` job's image-prebuild step, not the unrelated `Run shell build` step in `build_shell.yml` (which installs tools via `setup_integration.sh` and never builds this image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)