### PR TITLE
claude: OCI provenance source-freshness gate for curated tool images (#633)

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -117,6 +117,21 @@ All three must hold before you ask the owner to cut. Do not shortcut.
    it does not prove the digest was built from current source.) **Exit 2
    (registry unreachable) means the precondition is UNVERIFIED — do not proceed.**
    Retry until the result is 0 or 1; a visible exit-2 is not a satisfied gate.
+
+   Then confirm each digest was built from the **current** tool source (the
+   stronger §11 guarantee the adoption-lag check does not prove — and the gate
+   for the containerized signing path, #633). Run on a full-history checkout
+   (`git fetch --unshallow` if shallow):
+
+   ```bash
+   ./tools/check_catalog_provenance_freshness.sh   # 0 fresh; 1 a digest's source changed since its build; 2 backend unreachable
+   ```
+
+   On exit 1, the pinned image predates a change to its tool source (`tools/<tool>/`,
+   `lib/`, or `tools/go.mod`/`go.sum`): re-publish the image, then bump the catalog
+   digest, then re-check. **Exit 2 fails closed — the precondition is UNVERIFIED,
+   do not proceed** (the blocking gate inverts the weekly advisory workflow, which
+   warns on exit 2).
 3. **Empirically-verified download + verify commands.** Re-run the consumer
    download-and-verify recipe in
    [docs/verifying_artifacts.md](../../../docs/verifying_artifacts.md) against a **real**

--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -127,9 +127,8 @@ All three must hold before you ask the owner to cut. Do not shortcut.
    ./tools/check_catalog_provenance_freshness.sh   # 0 fresh; 1 a digest's source changed since its build; 2 backend unreachable
    ```
 
-   On exit 1, the pinned image predates a change to its tool source (`tools/<tool>/`,
-   `lib/`, or `tools/go.mod`/`go.sum`): re-publish the image, then bump the catalog
-   digest, then re-check. **Exit 2 fails closed — the precondition is UNVERIFIED,
+   On exit 1, the pinned image predates a change under `tools/` or `lib/`:
+   re-publish the image, then bump the catalog digest, then re-check. **Exit 2 fails closed — the precondition is UNVERIFIED,
    do not proceed** (the blocking gate inverts the weekly advisory workflow, which
    warns on exit 2).
 3. **Empirically-verified download + verify commands.** Re-run the consumer

--- a/.github/workflows/catalog_provenance_freshness.yml
+++ b/.github/workflows/catalog_provenance_freshness.yml
@@ -1,11 +1,7 @@
 name: Catalog Provenance Freshness
 
-# Checks weekly that each published tool image was built from current source —
-# that nothing under tools/ or lib/ changed since the commit the image was built
-# from. The adoption-lag check (catalog_freshness.yml) only proves the catalog
-# tracks :latest; a stale image is still validly attested, so this is what
-# catches it. Advisory here (a registry/Sigstore blip only warns); the same check
-# is a blocking release gate in the cut-release runbook, where exit 2 fails closed.
+# Weekly advisory that each published tool image was built from current source.
+# The cut-release runbook runs the same check as a blocking gate.
 
 on:
   schedule:
@@ -24,14 +20,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-          # The check resolves each image's build commit and diffs it against
-          # HEAD, so it needs full history.
-          fetch-depth: 0
+          fetch-depth: 0   # the diff needs each image's build commit in history
 
-      # Source drift (exit 1) fails the run as the actionable signal; a transient
-      # registry/Sigstore-unreachable (exit 2) warns but does not, so a backend
-      # blip can't page on a false negative. The blocking release gate inverts
-      # this — exit 2 there means the precondition is UNVERIFIED.
+      # Advisory: a registry/Sigstore blip (exit 2) warns but does not fail.
       - name: Check catalog image provenance freshness
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/catalog_provenance_freshness.yml
+++ b/.github/workflows/catalog_provenance_freshness.yml
@@ -1,14 +1,11 @@
 name: Catalog Provenance Freshness
 
-# Advisory source-freshness check (#633): weekly, reads each curated tool-image
-# digest's signed SLSA build provenance and fails if the image was not built
-# from the current tool source (the tool dir, lib/, tools/go.mod + go.sum at the
-# build commit differ from HEAD). This is the §11 guarantee the adoption-lag
-# check (catalog_freshness.yml) cannot prove: a stale image is still validly
-# attested, so only this catches it. Kept off the per-PR path (network +
-# attestation reads); the same check is a blocking release precondition (see the
-# cut-release runbook), where exit 2 fails closed. Advisory here because it
-# depends on a live registry + Sigstore — a failed run notifies.
+# Checks weekly that each published tool image was built from current source —
+# that nothing under tools/ or lib/ changed since the commit the image was built
+# from. The adoption-lag check (catalog_freshness.yml) only proves the catalog
+# tracks :latest; a stale image is still validly attested, so this is what
+# catches it. Advisory here (a registry/Sigstore blip only warns); the same check
+# is a blocking release gate in the cut-release runbook, where exit 2 fails closed.
 
 on:
   schedule:

--- a/.github/workflows/catalog_provenance_freshness.yml
+++ b/.github/workflows/catalog_provenance_freshness.yml
@@ -1,0 +1,49 @@
+name: Catalog Provenance Freshness
+
+# Advisory source-freshness check (#633): weekly, reads each curated tool-image
+# digest's signed SLSA build provenance and fails if the image was not built
+# from the current tool source (the tool dir, lib/, tools/go.mod + go.sum at the
+# build commit differ from HEAD). This is the §11 guarantee the adoption-lag
+# check (catalog_freshness.yml) cannot prove: a stale image is still validly
+# attested, so only this catches it. Kept off the per-PR path (network +
+# attestation reads); the same check is a blocking release precondition (see the
+# cut-release runbook), where exit 2 fails closed. Advisory here because it
+# depends on a live registry + Sigstore — a failed run notifies.
+
+on:
+  schedule:
+    - cron: "37 9 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  provenance-freshness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # The check resolves each image's build commit and diffs it against
+          # HEAD, so it needs full history.
+          fetch-depth: 0
+
+      # Source drift (exit 1) fails the run as the actionable signal; a transient
+      # registry/Sigstore-unreachable (exit 2) warns but does not, so a backend
+      # blip can't page on a false negative. The blocking release gate inverts
+      # this — exit 2 there means the precondition is UNVERIFIED.
+      - name: Check catalog image provenance freshness
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          ./tools/check_catalog_provenance_freshness.sh
+          rc=$?
+          if [[ "$rc" -eq 2 ]]; then
+            printf '::warning::registry/attestation unreachable; provenance freshness undetermined this run\n'
+            exit 0
+          fi
+          exit "$rc"

--- a/DEP_MGMT.md
+++ b/DEP_MGMT.md
@@ -118,9 +118,9 @@ whatever is already set.
   registry calls off PRs). It proves adoption-lag only;
   `tools/check_catalog_provenance_freshness.sh` proves the stronger half — it
   reads each pinned digest's signed SLSA provenance, takes the build commit, and
-  fails if the tool's source (its dir, `lib/`, `tools/go.mod`/`go.sum`) changed
-  between that commit and HEAD (also a release gate, needs full git history). A
-  digest cooldown remains deferred (#623).
+  fails if any image build input (`tools/` + `lib/`, the publish trigger's paths,
+  excluding the catalog file) changed between that commit and HEAD (also a release
+  gate, needs full git history). A digest cooldown remains deferred (#623).
 - **Manual today:** the binary+provenance installs (branch 2) and the base-image
   digest. Automating that surface — ideally one mechanism that also covers
   wrangle's own self-references — is #264.

--- a/DEP_MGMT.md
+++ b/DEP_MGMT.md
@@ -95,7 +95,7 @@ whatever is already set.
 | Python tool | `==version --hash=sha256:` in `requirements.txt` |
 | Binary with no package manager | version pinned in the install script |
 | Container base image | OCI `@sha256:` digest |
-| Curated tool image (`tools/catalog.json`) | `ghcr.io/tomhennen/wrangle/<tool>@sha256:` digest — static-checked by `tools/check_catalog.sh` (per-PR), adoption-lag-checked by `tools/check_catalog_freshness.sh` (release gate). Rationale: [docs/tool_container_design.md](docs/tool_container_design.md) §8, §11 |
+| Curated tool image (`tools/catalog.json`) | `ghcr.io/tomhennen/wrangle/<tool>@sha256:` digest — static-checked by `tools/check_catalog.sh` (per-PR), adoption-lag-checked by `tools/check_catalog_freshness.sh` and source-freshness-checked by `tools/check_catalog_provenance_freshness.sh` (release gates). Rationale: [docs/tool_container_design.md](docs/tool_container_design.md) §8, §11 |
 
 `@main` MUST NOT appear in any `uses:` line, anywhere — including examples and docs.
 
@@ -115,8 +115,12 @@ whatever is already set.
   `tools/check_catalog_freshness.sh` compares each pinned digest against the
   registry's `:latest` and prints a `tools/bump_catalog_digest.sh` remediation
   when the catalog is behind (a release precondition, not a per-PR gate, to keep
-  registry calls off PRs). It proves adoption-lag only, not that the digest was
-  built from current source (the stronger provenance check is deferred).
+  registry calls off PRs). It proves adoption-lag only;
+  `tools/check_catalog_provenance_freshness.sh` proves the stronger half — it
+  reads each pinned digest's signed SLSA provenance, takes the build commit, and
+  fails if the tool's source (its dir, `lib/`, `tools/go.mod`/`go.sum`) changed
+  between that commit and HEAD (also a release gate, needs full git history). A
+  digest cooldown remains deferred (#623).
 - **Manual today:** the binary+provenance installs (branch 2) and the base-image
   digest. Automating that surface — ideally one mechanism that also covers
   wrangle's own self-references — is #264.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test lint shellcheck shellstyle workflowstyle gotest bats zizmor integration bump-action-pins converge-action-pins check-catalog check-catalog-freshness bump-catalog-digest
+.PHONY: all test lint shellcheck shellstyle workflowstyle gotest bats zizmor integration bump-action-pins converge-action-pins check-catalog check-catalog-freshness check-catalog-provenance-freshness bump-catalog-digest
 
 # bash, not the default sh: the integration recipe sources lib/env.sh,
 # whose `set -o pipefail` dash doesn't reliably support.
@@ -94,6 +94,13 @@ check-catalog:
 # gate. See tools/check_catalog_freshness.sh.
 check-catalog-freshness:
 	@./tools/check_catalog_freshness.sh
+
+# Provenance source-freshness: reads each pinned image's signed SLSA provenance
+# and fails if its build commit's tool source differs from HEAD (network + full
+# git history). A release precondition, not a per-PR gate. See
+# tools/check_catalog_provenance_freshness.sh.
+check-catalog-provenance-freshness:
+	@./tools/check_catalog_provenance_freshness.sh
 
 # One-command fix when check-catalog-freshness reports drift.
 # Usage: make bump-catalog-digest TOOL=osv DIGEST=sha256:<64hex>

--- a/Makefile
+++ b/Makefile
@@ -95,10 +95,9 @@ check-catalog:
 check-catalog-freshness:
 	@./tools/check_catalog_freshness.sh
 
-# Provenance source-freshness: reads each pinned image's signed SLSA provenance
-# and fails if its build commit's tool source differs from HEAD (network + full
-# git history). A release precondition, not a per-PR gate. See
-# tools/check_catalog_provenance_freshness.sh.
+# Provenance source-freshness: fails if a pinned image's build commit differs
+# from HEAD's tool source (network + full git history). A release precondition,
+# not a per-PR gate. See tools/check_catalog_provenance_freshness.sh.
 check-catalog-provenance-freshness:
 	@./tools/check_catalog_provenance_freshness.sh
 

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -313,12 +313,18 @@ not a meaningful per-delivery signal.)
   published fix is actually *adopted*: the catalog's image digest must be freshness-checked so a stale
   pin cannot pass CI green (the #539/#544 class). The OCI axis is served by a *parallel* set of
   catalog-aware checks — `tools/check_catalog.sh` (static digest/namespace hygiene, per-PR),
-  `tools/check_catalog_freshness.sh` (adoption-lag vs `:latest`, a release gate), `tools/bump_catalog_digest.sh`
-  (the fix) — plus the DEP_MGMT.md image integrity rung; the git-pin tools (`check_pin_ancestry`,
-  `check_pin_freshness`, `bump_action_pins`, WL005) are left untouched, since digests and git SHAs are
-  different axes. Because the digest lives in one curated place (§3.6), this stays a narrow,
-  wrangle-internal task, required only before *production consumption*, not before prototyping. Still open:
-  provenance-based source-freshness, a digest cooldown, and the advisory→blocking promotion (#623).
+  `tools/check_catalog_freshness.sh` (adoption-lag vs `:latest`, a release gate),
+  `tools/check_catalog_provenance_freshness.sh` (built-from-current-source: each pinned digest's signed
+  SLSA provenance → build commit → diff the tool dir + `lib/` + `tools/go.mod`/`go.sum` against HEAD; an
+  ancestor-bound release gate that is the OCI analog of `check_pin_ancestry`/`check_pin_freshness`),
+  `tools/bump_catalog_digest.sh` (the fix) — plus the DEP_MGMT.md image integrity rung; the git-pin tools
+  (`check_pin_ancestry`, `check_pin_freshness`, `bump_action_pins`, WL005) are left untouched, since
+  digests and git SHAs are different axes. Because the digest lives in one curated place (§3.6), this
+  stays a narrow, wrangle-internal task, required only before *production consumption*, not before
+  prototyping. Provenance source-freshness is what gates the containerized signing path (#619): a stale
+  image is still validly attested, so the pull-time VSA gate passes it — only source-freshness catches a
+  stale image about to run with the signing token. Still open (#623): a digest cooldown and the
+  adoption-lag check's advisory→blocking promotion.
 - **Pull-time consumer VSA gate.** Before a curated image runs, the orchestrator verifies it carries a
   PASSED, SLSA-Build-L3 wrangle verification-summary attestation signed by the container build+publish
   workflow, fail-closed (`run.sh` `verify_tool_image`, `lib/verify_image_vsa.sh`). The signer identity is
@@ -425,9 +431,10 @@ release does not rebuild or re-tag tool images.**
   bump PR — not a manual double-bump. A catalog-only digest change touches no Dockerfile, so it triggers
   no rebuild (no loop).
 - **Release tag** — precondition: the catalog is fresh. `check_catalog_freshness.sh` proves the shipped
-  half — no digest is behind its published `:latest` (adoption lag); the stronger "every digest is the
-  image built from the current tool source" guarantee is the deferred provenance check (#623). Then tag.
-  No image is built or re-tagged at release time.
+  half — no digest is behind its published `:latest` (adoption lag); `check_catalog_provenance_freshness.sh`
+  proves the stronger half — every digest is the image built from the current tool source, read from each
+  image's signed provenance. Both are blocking release gates that fail closed on a backend error (exit 2 =
+  precondition unverified). Then tag. No image is built or re-tagged at release time.
 
 Consequences:
 - The catalog at a release commit references images built from *ancestor* commits. That is correct as

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -315,7 +315,8 @@ not a meaningful per-delivery signal.)
   catalog-aware checks — `tools/check_catalog.sh` (static digest/namespace hygiene, per-PR),
   `tools/check_catalog_freshness.sh` (adoption-lag vs `:latest`, a release gate),
   `tools/check_catalog_provenance_freshness.sh` (built-from-current-source: each pinned digest's signed
-  SLSA provenance → build commit → diff the tool dir + `lib/` + `tools/go.mod`/`go.sum` against HEAD; an
+  SLSA provenance → build commit → diff `tools/` + `lib/` (the publish trigger's own paths, so a binary
+  built from a sibling package is covered) against HEAD, excluding the catalog file itself; an
   ancestor-bound release gate that is the OCI analog of `check_pin_ancestry`/`check_pin_freshness`),
   `tools/bump_catalog_digest.sh` (the fix) — plus the DEP_MGMT.md image integrity rung; the git-pin tools
   (`check_pin_ancestry`, `check_pin_freshness`, `bump_action_pins`, WL005) are left untouched, since

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -314,10 +314,9 @@ not a meaningful per-delivery signal.)
   pin cannot pass CI green (the #539/#544 class). The OCI axis is served by a *parallel* set of
   catalog-aware checks — `tools/check_catalog.sh` (static digest/namespace hygiene, per-PR),
   `tools/check_catalog_freshness.sh` (adoption-lag vs `:latest`, a release gate),
-  `tools/check_catalog_provenance_freshness.sh` (built-from-current-source: each pinned digest's signed
-  SLSA provenance → build commit → diff `tools/` + `lib/` (the publish trigger's own paths, so a binary
-  built from a sibling package is covered) against HEAD, excluding the catalog file itself; an
-  ancestor-bound release gate that is the OCI analog of `check_pin_ancestry`/`check_pin_freshness`),
+  `tools/check_catalog_provenance_freshness.sh` (checks each pinned image was built from current source:
+  it reads the image's signed provenance for the commit it was built from, and fails if anything under
+  `tools/` or `lib/` changed since — a release gate, the OCI analog of `check_pin_ancestry`/`check_pin_freshness`),
   `tools/bump_catalog_digest.sh` (the fix) — plus the DEP_MGMT.md image integrity rung; the git-pin tools
   (`check_pin_ancestry`, `check_pin_freshness`, `bump_action_pins`, WL005) are left untouched, since
   digests and git SHAs are different axes. Because the digest lives in one curated place (§3.6), this

--- a/test/test_check_catalog_provenance_freshness.bats
+++ b/test/test_check_catalog_provenance_freshness.bats
@@ -1,12 +1,8 @@
 #!/usr/bin/env bats
 
-# Unit tests for tools/check_catalog_provenance_freshness.sh — the provenance
-# "built-from-current-source" gate. The build commit comes from a signed SLSA
-# provenance read via `gh attestation verify`; a fake `gh` on PATH returns a
-# fixture provenance whose resolvedDependency names a caller-chosen commit, so
-# the real jq extraction + git ancestry/diff logic runs against a real throwaway
-# git repo without any live attestation API. The repo's HEAD and history stand
-# in for the release checkout (fetch-depth: 0).
+# Unit tests for tools/check_catalog_provenance_freshness.sh. A fake `gh` on PATH
+# returns a fixture provenance naming a chosen commit, so the real jq + git
+# ancestry/diff logic runs against a throwaway git repo with no live API.
 
 DIGEST="sha256:$(printf 'a%.0s' {1..64})"
 CURATED="ghcr.io/tomhennen/wrangle/osv@$DIGEST"
@@ -17,11 +13,9 @@ setup() {
 
     REPO="$BATS_TEST_TMPDIR/repo"
     BIN_DIR="$BATS_TEST_TMPDIR/bin"
-    # Catalog lives OUTSIDE the repo so the fixture's `git add -A` can't stage it
-    # and drop it on a branch switch.
+    # Catalog outside the repo so the fixture's `git add -A` can't stage it.
     CATALOG="$BATS_TEST_TMPDIR/catalog.json"
     mkdir -p "$BIN_DIR"
-    # A retry must not stall the suite; the fixture is deterministic.
     export PATH="$BIN_DIR:$PATH" WRANGLE_RETRY_DELAY=0
 
     _init_repo
@@ -29,8 +23,7 @@ setup() {
     export WRANGLE_CATALOG="$CATALOG"
 }
 
-# _init_repo — a throwaway repo carrying the image's build inputs (the tool dir,
-# lib/, tools/go.mod + go.sum). C1 is exported as the initial build commit.
+# C1 is exported as the initial build commit.
 _init_repo() {
     mkdir -p "$REPO/tools/osv" "$REPO/lib"
     git -C "$REPO" init -q
@@ -60,9 +53,8 @@ _catalog() {
 JSON
 }
 
-# install_gh — a fake `gh` returning a signed-provenance shape. SHIM_COMMIT is
-# the build commit; SHIM_URI overrides the source repo; SHIM_COMMIT2 adds a
-# second distinct commit (ambiguity); SHIM_GH_FAIL makes the read fail.
+# Fake `gh`: SHIM_COMMIT is the build commit; SHIM_URI overrides the source repo;
+# SHIM_COMMIT2 adds a second distinct commit; SHIM_GH_FAIL makes the read fail.
 install_gh() {
     cat >"$BIN_DIR/gh" <<'SHIM'
 #!/usr/bin/env bash
@@ -102,8 +94,6 @@ RUN true'
     [[ "$output" == *"source changed"* ]]
 }
 
-# The load-bearing gap the adoption-lag check cannot see: a go.mod-only tool
-# version bump that never re-published the image.
 @test "provenance freshness: a tools/go.mod bump with no republish is stale (exit 1)" {
     install_gh
     _commit tools/go.mod 'module wrangle/tools
@@ -123,17 +113,13 @@ require x v1.2.3'
     [[ "$output" == *"built from current source"* ]]
 }
 
-# Regression: an image that compiles a first-party binary from a SIBLING package
-# (e.g. attest-toolbox builds tools/wrangle-attest) must be flagged when the
-# sibling changes — a per-tool-dir diff would miss it and call the stale signing
-# image fresh.
 @test "provenance freshness: a change to a sibling source package the image compiles is stale (exit 1)" {
     install_gh
     mkdir -p "$REPO/tools/sibpkg"
     printf 'package main\n' > "$REPO/tools/sibpkg/sign.go"
     git -C "$REPO" add -A && git -C "$REPO" commit -qm sibpkg
     local base; base="$(git -C "$REPO" rev-parse HEAD)"
-    # The catalog image is sibtool; its source lives in the sibling dir, not osv/.
+    # sibtool's source lives in the sibling dir, not osv/.
     _catalog "ghcr.io/tomhennen/wrangle/sibtool@$DIGEST"
     _commit tools/sibpkg/sign.go 'package main
 // changed'
@@ -143,8 +129,6 @@ require x v1.2.3'
     [[ "$output" == *"source changed"* ]]
 }
 
-# Regression: a catalog-only digest bump is itself a tools/ change; it must NOT
-# flag the freshly-built image it points at as stale (the §11 no-loop rule).
 @test "provenance freshness: a catalog-only digest bump does not flag its own image stale (exit 0)" {
     install_gh
     printf '{}\n' > "$REPO/tools/catalog.json"
@@ -215,10 +199,8 @@ RUN true'
     [[ "$output" == *"all 0 curated"* ]]
 }
 
-# Stale (1) must not be masked by another tool's backend error (2).
 @test "provenance freshness: a stale image wins over a second tool's backend error (exit 1)" {
-    # toolb's image dir does not exist; only its provenance read fails. toola is
-    # stale. The fake gh fails only for toolb's image ref.
+    # The fake gh fails only for toolb; toola is made stale.
     mkdir -p "$REPO/tools/toola" "$REPO/tools/toolb"
     printf 'FROM scratch\n' > "$REPO/tools/toola/Dockerfile"
     printf 'FROM scratch\n' > "$REPO/tools/toolb/Dockerfile"
@@ -247,8 +229,7 @@ SHIM
 }
 
 @test "provenance freshness: missing gh is an env error (exit 2)" {
-    # A clean PATH with the coreutils the script needs to reach its tool guard,
-    # but no gh — proving the guard, not a host gh leak, decides.
+    # Clean PATH with the coreutils the script needs, but no gh.
     local clean="$BATS_TEST_TMPDIR/clean"
     mkdir -p "$clean"
     for t in jq git bash dirname cat mktemp grep; do

--- a/test/test_check_catalog_provenance_freshness.bats
+++ b/test/test_check_catalog_provenance_freshness.bats
@@ -1,0 +1,227 @@
+#!/usr/bin/env bats
+
+# Unit tests for tools/check_catalog_provenance_freshness.sh — the provenance
+# "built-from-current-source" gate. The build commit comes from a signed SLSA
+# provenance read via `gh attestation verify`; a fake `gh` on PATH returns a
+# fixture provenance whose resolvedDependency names a caller-chosen commit, so
+# the real jq extraction + git ancestry/diff logic runs against a real throwaway
+# git repo without any live attestation API. The repo's HEAD and history stand
+# in for the release checkout (fetch-depth: 0).
+
+DIGEST="sha256:$(printf 'a%.0s' {1..64})"
+CURATED="ghcr.io/tomhennen/wrangle/osv@$DIGEST"
+
+setup() {
+    SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/tools/check_catalog_provenance_freshness.sh"
+    command -v jq >/dev/null 2>&1 || { printf 'jq not on PATH\n' >&2; return 1; }
+
+    REPO="$BATS_TEST_TMPDIR/repo"
+    BIN_DIR="$BATS_TEST_TMPDIR/bin"
+    # Catalog lives OUTSIDE the repo so the fixture's `git add -A` can't stage it
+    # and drop it on a branch switch.
+    CATALOG="$BATS_TEST_TMPDIR/catalog.json"
+    mkdir -p "$BIN_DIR"
+    # A retry must not stall the suite; the fixture is deterministic.
+    export PATH="$BIN_DIR:$PATH" WRANGLE_RETRY_DELAY=0
+
+    _init_repo
+    _catalog "$CURATED"
+    export WRANGLE_CATALOG="$CATALOG"
+}
+
+# _init_repo — a throwaway repo carrying the image's build inputs (the tool dir,
+# lib/, tools/go.mod + go.sum). C1 is exported as the initial build commit.
+_init_repo() {
+    mkdir -p "$REPO/tools/osv" "$REPO/lib"
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email t@example.com
+    git -C "$REPO" config user.name test
+    printf 'FROM scratch\n' > "$REPO/tools/osv/Dockerfile"
+    printf 'echo hi\n' > "$REPO/lib/foo.sh"
+    printf 'module wrangle/tools\n' > "$REPO/tools/go.mod"
+    printf 'h1:abc\n' > "$REPO/tools/go.sum"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -qm c1
+    C1="$(git -C "$REPO" rev-parse HEAD)"
+    export C1
+}
+
+_commit() {  # _commit <relpath> <content> -> exports the new HEAD sha in $LAST
+    printf '%s\n' "$2" > "$REPO/$1"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -qm "edit $1"
+    LAST="$(git -C "$REPO" rev-parse HEAD)"
+    export LAST
+}
+
+_catalog() {
+    cat > "$CATALOG" <<JSON
+{"tools":{"osv":{"kind":"scan","delivery":"image","image":"$1","network":"egress"}}}
+JSON
+}
+
+# install_gh — a fake `gh` returning a signed-provenance shape. SHIM_COMMIT is
+# the build commit; SHIM_URI overrides the source repo; SHIM_COMMIT2 adds a
+# second distinct commit (ambiguity); SHIM_GH_FAIL makes the read fail.
+install_gh() {
+    cat >"$BIN_DIR/gh" <<'SHIM'
+#!/usr/bin/env bash
+[[ -n "${SHIM_GH_FAIL:-}" ]] && { printf 'gh: attestation backend unreachable\n' >&2; exit 1; }
+uri="${SHIM_URI:-git+https://github.com/TomHennen/wrangle@refs/heads/main}"
+deps='{"uri":"'"$uri"'","digest":{"gitCommit":"'"${SHIM_COMMIT:-}"'"}}'
+[[ -n "${SHIM_COMMIT2:-}" ]] && deps="$deps"',{"uri":"'"$uri"'","digest":{"gitCommit":"'"$SHIM_COMMIT2"'"}}'
+printf '[{"verificationResult":{"statement":{"predicateType":"https://slsa.dev/provenance/v1","predicate":{"buildDefinition":{"resolvedDependencies":['"$deps"']}}}}}]\n'
+SHIM
+    chmod +x "$BIN_DIR/gh"
+}
+
+@test "provenance freshness: image built from current source passes (exit 0)" {
+    install_gh
+    cd "$REPO"
+    SHIM_COMMIT="$C1" run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"built from current source"* ]]
+}
+
+@test "provenance freshness: a later change to the tool dir is stale (exit 1)" {
+    install_gh
+    _commit tools/osv/Dockerfile 'FROM scratch
+RUN true'
+    cd "$REPO"
+    SHIM_COMMIT="$C1" run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"source changed"* ]]
+}
+
+@test "provenance freshness: a later lib/ change is stale (exit 1)" {
+    install_gh
+    _commit lib/foo.sh 'echo changed'
+    cd "$REPO"
+    SHIM_COMMIT="$C1" run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"source changed"* ]]
+}
+
+# The load-bearing gap the adoption-lag check cannot see: a go.mod-only tool
+# version bump that never re-published the image.
+@test "provenance freshness: a tools/go.mod bump with no republish is stale (exit 1)" {
+    install_gh
+    _commit tools/go.mod 'module wrangle/tools
+require x v1.2.3'
+    cd "$REPO"
+    SHIM_COMMIT="$C1" run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"source changed"* ]]
+}
+
+@test "provenance freshness: an unrelated later change is still fresh (exit 0)" {
+    install_gh
+    _commit README.md 'hello'
+    cd "$REPO"
+    SHIM_COMMIT="$C1" run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"built from current source"* ]]
+}
+
+@test "provenance freshness: attestation backend unreachable is an env error (exit 2)" {
+    install_gh
+    cd "$REPO"
+    SHIM_GH_FAIL=1 SHIM_COMMIT="$C1" run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"could not read build provenance"* ]]
+}
+
+@test "provenance freshness: provenance naming a non-wrangle repo binds no commit (exit 1)" {
+    install_gh
+    cd "$REPO"
+    SHIM_URI="git+https://github.com/evil/fork@refs/heads/main" SHIM_COMMIT="$C1" run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no single wrangle source commit"* ]]
+}
+
+@test "provenance freshness: two distinct wrangle commits are ambiguous (exit 1)" {
+    install_gh
+    _commit tools/osv/Dockerfile 'FROM scratch
+RUN true'
+    cd "$REPO"
+    SHIM_COMMIT="$C1" SHIM_COMMIT2="$LAST" run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no single wrangle source commit"* ]]
+}
+
+@test "provenance freshness: a build commit absent from history fails closed (exit 1)" {
+    install_gh
+    cd "$REPO"
+    local absent; absent="$(printf 'f%.0s' {1..40})"
+    SHIM_COMMIT="$absent" run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"absent"* ]]
+}
+
+@test "provenance freshness: a non-ancestor build commit fails closed (exit 1)" {
+    install_gh
+    # A commit on a divergent branch, not reachable from HEAD.
+    git -C "$REPO" checkout -q -b side "$C1"
+    _commit tools/osv/Dockerfile 'side branch'
+    local side="$LAST"
+    git -C "$REPO" checkout -q -
+    cd "$REPO"
+    SHIM_COMMIT="$side" run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not an ancestor"* ]]
+}
+
+@test "provenance freshness: a non-curated entry is skipped (exit 0)" {
+    install_gh
+    _catalog "registry.example.com/x/osv@$DIGEST"
+    cd "$REPO"
+    # gh failing proves the entry was never resolved.
+    SHIM_GH_FAIL=1 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"all 0 curated"* ]]
+}
+
+# Stale (1) must not be masked by another tool's backend error (2).
+@test "provenance freshness: a stale image wins over a second tool's backend error (exit 1)" {
+    # toolb's image dir does not exist; only its provenance read fails. toola is
+    # stale. The fake gh fails only for toolb's image ref.
+    mkdir -p "$REPO/tools/toola" "$REPO/tools/toolb"
+    printf 'FROM scratch\n' > "$REPO/tools/toola/Dockerfile"
+    printf 'FROM scratch\n' > "$REPO/tools/toolb/Dockerfile"
+    git -C "$REPO" add -A && git -C "$REPO" commit -qm tools
+    local base; base="$(git -C "$REPO" rev-parse HEAD)"
+    _commit tools/toola/Dockerfile 'FROM scratch
+RUN true'  # toola now stale vs base
+    cat > "$CATALOG" <<JSON
+{"tools":{
+  "toola":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toola@$DIGEST"},
+  "toolb":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toolb@$DIGEST"}}}
+JSON
+    cat >"$BIN_DIR/gh" <<SHIM
+#!/usr/bin/env bash
+for a in "\$@"; do case "\$a" in
+  *toolb*) printf 'gh: backend unreachable\n' >&2; exit 1 ;;
+esac; done
+printf '[{"verificationResult":{"statement":{"predicateType":"https://slsa.dev/provenance/v1","predicate":{"buildDefinition":{"resolvedDependencies":[{"uri":"git+https://github.com/TomHennen/wrangle@refs/heads/main","digest":{"gitCommit":"$base"}}]}}}}}]\n'
+SHIM
+    chmod +x "$BIN_DIR/gh"
+    cd "$REPO"
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"source changed"* ]]
+    [[ "$output" == *"could not read build provenance"* ]]
+}
+
+@test "provenance freshness: missing gh is an env error (exit 2)" {
+    # A clean PATH with the coreutils the script needs to reach its tool guard,
+    # but no gh — proving the guard, not a host gh leak, decides.
+    local clean="$BATS_TEST_TMPDIR/clean"
+    mkdir -p "$clean"
+    for t in jq git bash dirname cat mktemp grep; do
+        p="$(command -v "$t" 2>/dev/null)" && ln -sf "$p" "$clean/$t"
+    done
+    cd "$REPO"
+    PATH="$clean" run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"gh and jq are required"* ]]
+}

--- a/test/test_check_catalog_provenance_freshness.bats
+++ b/test/test_check_catalog_provenance_freshness.bats
@@ -123,6 +123,40 @@ require x v1.2.3'
     [[ "$output" == *"built from current source"* ]]
 }
 
+# Regression: an image that compiles a first-party binary from a SIBLING package
+# (e.g. attest-toolbox builds tools/wrangle-attest) must be flagged when the
+# sibling changes — a per-tool-dir diff would miss it and call the stale signing
+# image fresh.
+@test "provenance freshness: a change to a sibling source package the image compiles is stale (exit 1)" {
+    install_gh
+    mkdir -p "$REPO/tools/sibpkg"
+    printf 'package main\n' > "$REPO/tools/sibpkg/sign.go"
+    git -C "$REPO" add -A && git -C "$REPO" commit -qm sibpkg
+    local base; base="$(git -C "$REPO" rev-parse HEAD)"
+    # The catalog image is sibtool; its source lives in the sibling dir, not osv/.
+    _catalog "ghcr.io/tomhennen/wrangle/sibtool@$DIGEST"
+    _commit tools/sibpkg/sign.go 'package main
+// changed'
+    cd "$REPO"
+    SHIM_COMMIT="$base" run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"source changed"* ]]
+}
+
+# Regression: a catalog-only digest bump is itself a tools/ change; it must NOT
+# flag the freshly-built image it points at as stale (the §11 no-loop rule).
+@test "provenance freshness: a catalog-only digest bump does not flag its own image stale (exit 0)" {
+    install_gh
+    printf '{}\n' > "$REPO/tools/catalog.json"
+    git -C "$REPO" add -A && git -C "$REPO" commit -qm "in-repo catalog"
+    local base; base="$(git -C "$REPO" rev-parse HEAD)"
+    _commit tools/catalog.json '{"bumped":true}'
+    cd "$REPO"
+    SHIM_COMMIT="$base" run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"built from current source"* ]]
+}
+
 @test "provenance freshness: attestation backend unreachable is an env error (exit 2)" {
     install_gh
     cd "$REPO"

--- a/tools/check_catalog_provenance_freshness.sh
+++ b/tools/check_catalog_provenance_freshness.sh
@@ -2,54 +2,39 @@
 set -euo pipefail
 set -f  # disable globbing — handles external tool names
 
-# tools/check_catalog_provenance_freshness.sh — checks that each curated tool
-# image in tools/catalog.json was built from the current tool source. The §11
-# guarantee check_catalog_freshness.sh does not give: it only proves the catalog
-# tracks :latest, not that the pinned digest was built from current source.
+# tools/check_catalog_provenance_freshness.sh — checks each curated tool image in
+# tools/catalog.json was built from the current tool source, by reading the
+# image's signed SLSA provenance for its build commit and diffing that commit
+# against HEAD. A release gate: needs the network and full history (fetch-depth: 0).
 #
-# Per curated `delivery: image` entry it reads the image's signed SLSA provenance
-# with `gh attestation verify` (signer identity single-sourced from
-# lib/verify_image_vsa.sh), takes the build commit, and fails unless that commit
-# is an ancestor of HEAD with nothing changed since under tools/ or lib/ (the
-# publish trigger's paths), excluding tools/catalog.json. Diffing all of tools/,
-# not one tool's dir, is deliberate: an image may compile a binary from a sibling
-# package, and missing that would call a stale signing image fresh. catalog.json
-# is excluded so a digest bump can't flag the image it points at as stale.
-#
-# A release gate, never per-PR: needs the network and full history (fetch-depth: 0).
 # Catalog path: $WRANGLE_CATALOG, else the catalog beside this script.
 #
 # Exit: 0 all built from current source; 1 a source changed since build, or the
-#       provenance binds no wrangle commit; 2 backend unreachable (an image with
-#       no provenance lands here, fail-closed), or gh/jq/git missing.
+#       provenance binds no wrangle commit; 2 backend unreachable (no provenance
+#       lands here, fail-closed) or gh/jq/git missing.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/read_catalog.sh
 source "$SCRIPT_DIR/../lib/read_catalog.sh"
-# The signer identity + retry come from the pull-time VSA gate (same trust anchor).
 # shellcheck source=../lib/verify_image_vsa.sh
 source "$SCRIPT_DIR/../lib/verify_image_vsa.sh"
 
 PROVENANCE_PREDICATE_TYPE='https://slsa.dev/provenance/v1'
 CURATED_PREFIX_RE='^ghcr\.io/tomhennen/wrangle/[a-z][a-z0-9_-]*$'
 COMMIT_RE='^[0-9a-f]{40}$'
-# The source repo the provenance must name (case-insensitive); a build commit is
-# only trusted from a resolvedDependency on wrangle's own repo.
+# A build commit is trusted only from a resolvedDependency on wrangle's own repo.
 WRANGLE_SOURCE_URI_PREFIX='git+https://github.com/tomhennen/wrangle@'
-# Image build inputs = the publish trigger's paths, minus the catalog file (a
-# digest bump must not flag its own image stale). Whole tools/ covers sibling
-# first-party packages; go.mod/go.sum live under it.
+# Whole tools/ so a binary built from a sibling package counts; minus the catalog
+# file, so a digest bump can't flag its own image stale.
 PROVENANCE_DIFF_PATHS=(tools lib ':(exclude)tools/catalog.json')
 
-# provenance_build_commit <image> — print the single wrangle source commit the
-# image's signed build provenance names. Non-zero on a backend failure (gh) or
-# when no single, unambiguous wrangle commit is bound.
+# provenance_build_commit <image> — print the single wrangle build commit from
+# <image>'s signed provenance. Returns 2 on a read failure, 1 if no single
+# unambiguous commit is bound.
 provenance_build_commit() {
     local image="$1" json rc=0 commits
     local timeout_s="${WRANGLE_VERIFY_TIMEOUT:-120}"
     json="$(mktemp)"
-    # `timeout` bounds the local release-gate path (the runbook is not job-bounded
-    # like the weekly workflow), matching lib/verify_image_vsa.sh.
     wrangle_retry_once "$json" timeout "$timeout_s" gh attestation verify "oci://${image}" \
         --repo TomHennen/wrangle \
         --bundle-from-oci \
@@ -59,12 +44,10 @@ provenance_build_commit() {
         --format json || rc=$?
     if [[ "$rc" -ne 0 ]]; then
         rm -f "$json"
-        return 2  # backend/attestation read failed
+        return 2
     fi
 
-    # gh bound the signature + identity; the source-repo binding and the build
-    # commit are ours to read. Collect the DISTINCT gitCommit of every resolved
-    # dependency on wrangle's repo — exactly one unambiguous commit is required.
+    # gh verified the signature + identity; the build commit is ours to read.
     commits="$(jq -r --arg p "$WRANGLE_SOURCE_URI_PREFIX" '
         [ .[].verificationResult.statement.predicate.buildDefinition.resolvedDependencies[]?
           | select((.uri // "" | ascii_downcase) | startswith($p))
@@ -73,7 +56,7 @@ provenance_build_commit() {
     rm -f "$json"
 
     if [[ "$(printf '%s' "$commits" | grep -c .)" -ne 1 ]]; then
-        return 1  # no, or ambiguous, wrangle source commit
+        return 1
     fi
     [[ "$commits" =~ $COMMIT_RE ]] || return 1
     printf '%s' "$commits"
@@ -109,8 +92,7 @@ check_provenance_freshness() {
         image="$(read_catalog_field "$file" "$tool" image)"
         imagename="${image%@sha256:*}"
 
-        # Adopter-override entries never live in this catalog; their provenance
-        # signer is not wrangle's, so skip them like the adoption-lag check.
+        # Skip adopter-override entries — not wrangle-signed.
         [[ "$imagename" =~ $CURATED_PREFIX_RE ]] || continue
         checked=$((checked + 1))
 
@@ -138,14 +120,11 @@ check_provenance_freshness() {
             continue
         fi
 
-        # Stale iff any image build input changed between the build commit and
-        # HEAD. The diff set is the publish trigger's paths (not the catalog key's
-        # dir), so a binary built from a sibling package is covered. --quiet exits
-        # 1 on differences, 0 on none, >1 on error.
+        # git diff --quiet: 0 no change, 1 changed, >1 error.
         local diff_rc=0
         git -C "$repo_root" diff --quiet "$commit" HEAD -- "${PROVENANCE_DIFF_PATHS[@]}" 2>/dev/null || diff_rc=$?
         case "$diff_rc" in
-            0) ;;  # built from current source
+            0) ;;
             1)
                 printf 'check_catalog_provenance_freshness: %s: source changed since the pinned image was built at %s — republish, then bump\n' "$tool" "${commit:0:12}" >&2
                 stale=1 ;;
@@ -155,8 +134,7 @@ check_provenance_freshness() {
         esac
     done < <(jq -r '.tools // {} | keys[]' "$file")
 
-    # A confirmed stale image (1) is actionable regardless of another tool's
-    # reachability and must not be masked by a transient backend error (2).
+    # A confirmed stale (1) must not be masked by another tool's backend error (2).
     if [[ "$stale" -eq 1 ]]; then
         rc=1
     elif [[ "$backend_err" -eq 1 ]]; then

--- a/tools/check_catalog_provenance_freshness.sh
+++ b/tools/check_catalog_provenance_freshness.sh
@@ -2,50 +2,31 @@
 set -euo pipefail
 set -f  # disable globbing — handles external tool names
 
-# tools/check_catalog_provenance_freshness.sh — provenance-based
-# "built-from-current-source" freshness for the curated image entries in
-# tools/catalog.json. The true docs/tool_container_design.md §11 guarantee, and
-# the one check_catalog_freshness.sh's adoption-lag compare deliberately leaves
-# open: it proves the catalog tracks the published :latest, NOT that the pinned
-# digest was built from the tool's CURRENT source.
+# tools/check_catalog_provenance_freshness.sh — checks that each curated tool
+# image in tools/catalog.json was built from the current tool source. The §11
+# guarantee check_catalog_freshness.sh does not give: it only proves the catalog
+# tracks :latest, not that the pinned digest was built from current source.
 #
-# For each curated `delivery: image` entry it reads the pinned image's SLSA build
-# provenance via `gh attestation verify`, pinned to wrangle's container
-# build+publish signer identity (the same trust anchor lib/verify_image_vsa.sh
-# uses — single-sourced here), takes the source commit the image was built from,
-# and asserts that commit is an ancestor of HEAD whose tool source is unchanged
-# up to HEAD. The diff set is the publish trigger's own inputs — all of tools/
-# and lib/ (.github/workflows/local_publish_images.yml rebuilds the whole image
-# matrix on any tools/** or lib/** change) — minus the catalog file itself. The
-# whole-tools/ set is deliberate: an image may compile a first-party binary from
-# a SIBLING package (attest-toolbox builds tools/wrangle-attest), so a per-tool
-# dir would miss a sibling change and report a stale SIGNING image as fresh — a
-# false-fresh in the exact case the gate exists for. False-stale (a tools/ change
-# outside the image) is acceptable and matches the trigger; false-fresh is not.
-# tools/catalog.json is excluded because a digest bump is itself a tools/ change
-# that must not flag its own freshly-built image stale (the §11 no-loop rule).
+# Per curated `delivery: image` entry it reads the image's signed SLSA provenance
+# with `gh attestation verify` (signer identity single-sourced from
+# lib/verify_image_vsa.sh), takes the build commit, and fails unless that commit
+# is an ancestor of HEAD with nothing changed since under tools/ or lib/ (the
+# publish trigger's paths), excluding tools/catalog.json. Diffing all of tools/,
+# not one tool's dir, is deliberate: an image may compile a binary from a sibling
+# package, and missing that would call a stale signing image fresh. catalog.json
+# is excluded so a digest bump can't flag the image it points at as stale.
 #
-# This is THE gate for the containerized signing path: a stale toolbox image is
-# still validly attested, so the pull-time VSA gate (verify_image_vsa) passes it;
-# only source-freshness catches a stale image about to run with the signing token.
-#
-# Network + full git history — a release gate, never the per-PR path; run with
-# fetch-depth: 0 so the build commit is present.
-#
+# A release gate, never per-PR: needs the network and full history (fetch-depth: 0).
 # Catalog path: $WRANGLE_CATALOG, else the catalog beside this script.
 #
-# Exit: 0 every curated image is built from current source,
-#       1 a tool's source changed since its pinned image was built (republish +
-#         bump needed), or the provenance does not bind a wrangle source commit,
-#       2 the registry/attestation backend was unreachable (an image carrying NO
-#         provenance lands here too — gh exits non-zero, fail-closed), or gh/jq/
-#         git missing.
+# Exit: 0 all built from current source; 1 a source changed since build, or the
+#       provenance binds no wrangle commit; 2 backend unreachable (an image with
+#       no provenance lands here, fail-closed), or gh/jq/git missing.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/read_catalog.sh
 source "$SCRIPT_DIR/../lib/read_catalog.sh"
-# Single-source the signer identity + retry from the pull-time VSA gate so the
-# provenance read trusts exactly the identities that gate does.
+# The signer identity + retry come from the pull-time VSA gate (same trust anchor).
 # shellcheck source=../lib/verify_image_vsa.sh
 source "$SCRIPT_DIR/../lib/verify_image_vsa.sh"
 

--- a/tools/check_catalog_provenance_freshness.sh
+++ b/tools/check_catalog_provenance_freshness.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — handles external tool names
+
+# tools/check_catalog_provenance_freshness.sh — provenance-based
+# "built-from-current-source" freshness for the curated image entries in
+# tools/catalog.json. The true docs/tool_container_design.md §11 guarantee, and
+# the one check_catalog_freshness.sh's adoption-lag compare deliberately leaves
+# open: it proves the catalog tracks the published :latest, NOT that the pinned
+# digest was built from the tool's CURRENT source.
+#
+# For each curated `delivery: image` entry it reads the pinned image's SLSA build
+# provenance via `gh attestation verify`, pinned to wrangle's container
+# build+publish signer identity (the same trust anchor lib/verify_image_vsa.sh
+# uses — single-sourced here), takes the source commit the image was built from,
+# and asserts that commit is an ancestor of HEAD whose tool source is unchanged
+# up to HEAD. The diff set is the image's build inputs: the tool dir, lib/, and
+# the shared tools/go.mod + tools/go.sum the binary is compiled from
+# (.github/workflows/local_publish_images.yml builds the context from those). A
+# go.mod-only tool-version bump that never re-published the image is exactly the
+# stale-but-green-with-the-signing-token hole the adoption-lag check cannot see.
+#
+# This is THE gate for the containerized signing path: a stale toolbox image is
+# still validly attested, so the pull-time VSA gate (verify_image_vsa) passes it;
+# only source-freshness catches a stale image about to run with the signing token.
+#
+# Network + full git history — a release gate, never the per-PR path; run with
+# fetch-depth: 0 so the build commit is present.
+#
+# Catalog path: $WRANGLE_CATALOG, else the catalog beside this script.
+#
+# Exit: 0 every curated image is built from current source,
+#       1 a tool's source changed since its pinned image was built (republish +
+#         bump needed), or the provenance does not bind a wrangle source commit,
+#       2 the registry/attestation backend was unreachable, or gh/jq/git missing.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/read_catalog.sh
+source "$SCRIPT_DIR/../lib/read_catalog.sh"
+# Single-source the signer identity + retry from the pull-time VSA gate so the
+# provenance read trusts exactly the identities that gate does.
+# shellcheck source=../lib/verify_image_vsa.sh
+source "$SCRIPT_DIR/../lib/verify_image_vsa.sh"
+
+PROVENANCE_PREDICATE_TYPE='https://slsa.dev/provenance/v1'
+CURATED_PREFIX_RE='^ghcr\.io/tomhennen/wrangle/[a-z][a-z0-9_-]*$'
+COMMIT_RE='^[0-9a-f]{40}$'
+# The source repo the provenance must name (case-insensitive); a build commit is
+# only trusted from a resolvedDependency on wrangle's own repo.
+WRANGLE_SOURCE_URI_PREFIX='git+https://github.com/tomhennen/wrangle@'
+# Image build inputs, relative to the repo root — what a republish would change.
+PROVENANCE_DIFF_SHARED=(lib tools/go.mod tools/go.sum)
+
+# provenance_build_commit <image> — print the single wrangle source commit the
+# image's signed build provenance names. Non-zero on a backend failure (gh) or
+# when no single, unambiguous wrangle commit is bound.
+provenance_build_commit() {
+    local image="$1" json rc=0 commits
+    json="$(mktemp)"
+    wrangle_retry_once "$json" gh attestation verify "oci://${image}" \
+        --repo TomHennen/wrangle \
+        --bundle-from-oci \
+        --cert-identity-regex "$WRANGLE_CONTAINER_SIGNER_REGEX" \
+        --cert-oidc-issuer "$WRANGLE_VSA_OIDC_ISSUER" \
+        --predicate-type "$PROVENANCE_PREDICATE_TYPE" \
+        --format json || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        rm -f "$json"
+        return 2  # backend/attestation read failed
+    fi
+
+    # gh bound the signature + identity; the source-repo binding and the build
+    # commit are ours to read. Collect the DISTINCT gitCommit of every resolved
+    # dependency on wrangle's repo — exactly one unambiguous commit is required.
+    commits="$(jq -r --arg p "$WRANGLE_SOURCE_URI_PREFIX" '
+        [ .[].verificationResult.statement.predicate.buildDefinition.resolvedDependencies[]?
+          | select((.uri // "" | ascii_downcase) | startswith($p))
+          | .digest.gitCommit // empty ]
+        | unique | .[]' < "$json" 2>/dev/null)" || { rm -f "$json"; return 2; }
+    rm -f "$json"
+
+    if [[ "$(printf '%s' "$commits" | grep -c .)" -ne 1 ]]; then
+        return 1  # no, or ambiguous, wrangle source commit
+    fi
+    [[ "$commits" =~ $COMMIT_RE ]] || return 1
+    printf '%s' "$commits"
+}
+
+# check_provenance_freshness <catalog_file> — 0 all fresh, 1 a stale/unbound
+# image, 2 backend/env error.
+check_provenance_freshness() {
+    local file="$1" rc=0 stale=0 backend_err=0
+    local tool delivery image imagename commit checked=0 repo_root
+
+    if ! command -v gh >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+        printf 'check_catalog_provenance_freshness: gh and jq are required\n' >&2
+        return 2
+    fi
+    if ! repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+        printf 'check_catalog_provenance_freshness: not inside a git work tree\n' >&2
+        return 2
+    fi
+    if [[ ! -f "$file" ]]; then
+        printf 'check_catalog_provenance_freshness: catalog not found: %s\n' "$file" >&2
+        return 2
+    fi
+    if ! jq -e . "$file" >/dev/null 2>&1; then
+        printf 'check_catalog_provenance_freshness: %s is not valid JSON\n' "$file" >&2
+        return 2
+    fi
+
+    while IFS= read -r tool; do
+        [[ -z "$tool" ]] && continue
+        delivery="$(read_catalog_field "$file" "$tool" delivery)"
+        [[ "$delivery" == "image" ]] || continue
+        image="$(read_catalog_field "$file" "$tool" image)"
+        imagename="${image%@sha256:*}"
+
+        # Adopter-override entries never live in this catalog; their provenance
+        # signer is not wrangle's, so skip them like the adoption-lag check.
+        [[ "$imagename" =~ $CURATED_PREFIX_RE ]] || continue
+        checked=$((checked + 1))
+
+        local prov_rc=0
+        commit="$(provenance_build_commit "$image")" || prov_rc=$?
+        if [[ "$prov_rc" -ne 0 ]]; then
+            if [[ "$prov_rc" -eq 2 ]]; then
+                printf 'check_catalog_provenance_freshness: %s: could not read build provenance for %s\n' "$tool" "$image" >&2
+                backend_err=1
+            else
+                printf 'check_catalog_provenance_freshness: %s: provenance binds no single wrangle source commit for %s\n' "$tool" "$image" >&2
+                stale=1
+            fi
+            continue
+        fi
+
+        if ! git -C "$repo_root" cat-file -e "${commit}^{commit}" 2>/dev/null; then
+            printf 'check_catalog_provenance_freshness: %s: build commit %s absent — shallow clone? the gate needs fetch-depth: 0\n' "$tool" "${commit:0:12}" >&2
+            stale=1
+            continue
+        fi
+        if ! git -C "$repo_root" merge-base --is-ancestor "$commit" HEAD 2>/dev/null; then
+            printf 'check_catalog_provenance_freshness: %s: build commit %s is not an ancestor of HEAD (built off-line)\n' "$tool" "${commit:0:12}" >&2
+            stale=1
+            continue
+        fi
+
+        # Stale iff the tool's build inputs changed between the build commit and
+        # HEAD. --quiet exits 1 on differences, 0 on none, >1 on error.
+        local diff_rc=0
+        git -C "$repo_root" diff --quiet "$commit" HEAD -- "tools/$tool" "${PROVENANCE_DIFF_SHARED[@]}" 2>/dev/null || diff_rc=$?
+        case "$diff_rc" in
+            0) ;;  # built from current source
+            1)
+                printf 'check_catalog_provenance_freshness: %s: source changed since the pinned image was built at %s — republish, then bump\n' "$tool" "${commit:0:12}" >&2
+                stale=1 ;;
+            *)
+                printf 'check_catalog_provenance_freshness: %s: could not diff against build commit %s\n' "$tool" "${commit:0:12}" >&2
+                backend_err=1 ;;
+        esac
+    done < <(jq -r '.tools // {} | keys[]' "$file")
+
+    # A confirmed stale image (1) is actionable regardless of another tool's
+    # reachability and must not be masked by a transient backend error (2).
+    if [[ "$stale" -eq 1 ]]; then
+        rc=1
+    elif [[ "$backend_err" -eq 1 ]]; then
+        rc=2
+    else
+        printf 'check_catalog_provenance_freshness: all %d curated image(s) built from current source\n' "$checked"
+    fi
+    return "$rc"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [[ "$#" -gt 0 ]]; then
+        printf 'Usage: %s   (catalog: WRANGLE_CATALOG env, else %s/catalog.json)\n' "${0##*/}" "$SCRIPT_DIR" >&2
+        exit 2
+    fi
+    check_provenance_freshness "${WRANGLE_CATALOG:-$SCRIPT_DIR/catalog.json}"
+fi

--- a/tools/check_catalog_provenance_freshness.sh
+++ b/tools/check_catalog_provenance_freshness.sh
@@ -14,11 +14,16 @@ set -f  # disable globbing — handles external tool names
 # build+publish signer identity (the same trust anchor lib/verify_image_vsa.sh
 # uses — single-sourced here), takes the source commit the image was built from,
 # and asserts that commit is an ancestor of HEAD whose tool source is unchanged
-# up to HEAD. The diff set is the image's build inputs: the tool dir, lib/, and
-# the shared tools/go.mod + tools/go.sum the binary is compiled from
-# (.github/workflows/local_publish_images.yml builds the context from those). A
-# go.mod-only tool-version bump that never re-published the image is exactly the
-# stale-but-green-with-the-signing-token hole the adoption-lag check cannot see.
+# up to HEAD. The diff set is the publish trigger's own inputs — all of tools/
+# and lib/ (.github/workflows/local_publish_images.yml rebuilds the whole image
+# matrix on any tools/** or lib/** change) — minus the catalog file itself. The
+# whole-tools/ set is deliberate: an image may compile a first-party binary from
+# a SIBLING package (attest-toolbox builds tools/wrangle-attest), so a per-tool
+# dir would miss a sibling change and report a stale SIGNING image as fresh — a
+# false-fresh in the exact case the gate exists for. False-stale (a tools/ change
+# outside the image) is acceptable and matches the trigger; false-fresh is not.
+# tools/catalog.json is excluded because a digest bump is itself a tools/ change
+# that must not flag its own freshly-built image stale (the §11 no-loop rule).
 #
 # This is THE gate for the containerized signing path: a stale toolbox image is
 # still validly attested, so the pull-time VSA gate (verify_image_vsa) passes it;
@@ -32,7 +37,9 @@ set -f  # disable globbing — handles external tool names
 # Exit: 0 every curated image is built from current source,
 #       1 a tool's source changed since its pinned image was built (republish +
 #         bump needed), or the provenance does not bind a wrangle source commit,
-#       2 the registry/attestation backend was unreachable, or gh/jq/git missing.
+#       2 the registry/attestation backend was unreachable (an image carrying NO
+#         provenance lands here too — gh exits non-zero, fail-closed), or gh/jq/
+#         git missing.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/read_catalog.sh
@@ -48,16 +55,21 @@ COMMIT_RE='^[0-9a-f]{40}$'
 # The source repo the provenance must name (case-insensitive); a build commit is
 # only trusted from a resolvedDependency on wrangle's own repo.
 WRANGLE_SOURCE_URI_PREFIX='git+https://github.com/tomhennen/wrangle@'
-# Image build inputs, relative to the repo root — what a republish would change.
-PROVENANCE_DIFF_SHARED=(lib tools/go.mod tools/go.sum)
+# Image build inputs = the publish trigger's paths, minus the catalog file (a
+# digest bump must not flag its own image stale). Whole tools/ covers sibling
+# first-party packages; go.mod/go.sum live under it.
+PROVENANCE_DIFF_PATHS=(tools lib ':(exclude)tools/catalog.json')
 
 # provenance_build_commit <image> — print the single wrangle source commit the
 # image's signed build provenance names. Non-zero on a backend failure (gh) or
 # when no single, unambiguous wrangle commit is bound.
 provenance_build_commit() {
     local image="$1" json rc=0 commits
+    local timeout_s="${WRANGLE_VERIFY_TIMEOUT:-120}"
     json="$(mktemp)"
-    wrangle_retry_once "$json" gh attestation verify "oci://${image}" \
+    # `timeout` bounds the local release-gate path (the runbook is not job-bounded
+    # like the weekly workflow), matching lib/verify_image_vsa.sh.
+    wrangle_retry_once "$json" timeout "$timeout_s" gh attestation verify "oci://${image}" \
         --repo TomHennen/wrangle \
         --bundle-from-oci \
         --cert-identity-regex "$WRANGLE_CONTAINER_SIGNER_REGEX" \
@@ -145,10 +157,12 @@ check_provenance_freshness() {
             continue
         fi
 
-        # Stale iff the tool's build inputs changed between the build commit and
-        # HEAD. --quiet exits 1 on differences, 0 on none, >1 on error.
+        # Stale iff any image build input changed between the build commit and
+        # HEAD. The diff set is the publish trigger's paths (not the catalog key's
+        # dir), so a binary built from a sibling package is covered. --quiet exits
+        # 1 on differences, 0 on none, >1 on error.
         local diff_rc=0
-        git -C "$repo_root" diff --quiet "$commit" HEAD -- "tools/$tool" "${PROVENANCE_DIFF_SHARED[@]}" 2>/dev/null || diff_rc=$?
+        git -C "$repo_root" diff --quiet "$commit" HEAD -- "${PROVENANCE_DIFF_PATHS[@]}" 2>/dev/null || diff_rc=$?
         case "$diff_rc" in
             0) ;;  # built from current source
             1)


### PR DESCRIPTION
claude: Implements the high-value, Phase-3-gating subset of #633 (folds in the freshness items of #623). Builds on the merged #625 adoption-lag baseline.

## Why this gates #619 Phase 3
Catalog tool images are pinned by `@sha256:` digest. The pull-time VSA gate (`lib/verify_image_vsa.sh`, #630) proves an image is validly wrangle-attested — but a **stale** image is *still validly attested*, so verify-before-run cannot catch it. Once the signing path is containerized (#619 Phase 3), a stale toolbox digest would run vulnerable code **with the OIDC signing token**. That is the one net-new risk, and only source-freshness catches it.

## Implemented
- **`tools/check_catalog_provenance_freshness.sh`** — the load-bearing piece. For each curated `delivery: image` entry it:
  1. reads the pinned digest's **signed SLSA build provenance** via `gh attestation verify ... --predicate-type https://slsa.dev/provenance/v1`, pinned to wrangle's container build+publish **signer identity** (single-sourced from `lib/verify_image_vsa.sh` — same trust anchor the VSA gate uses, `wrangle_retry_once` for transient I/O);
  2. takes the source commit from `resolvedDependencies[].digest.gitCommit`, **asserting** the dependency `uri` is wrangle's own repo and that exactly one unambiguous commit is bound (no forged/foreign/ambiguous provenance trusted);
  3. asserts that commit is an **ancestor of HEAD** (`git merge-base --is-ancestor` — the OCI analog of `check_pin_ancestry`) whose **build inputs are unchanged up to HEAD**: `tools/<tool>/`, `lib/`, and `tools/go.mod` + `tools/go.sum`.
  - Exit `0` all built-from-current-source / `1` a digest's source changed (or provenance binds no single wrangle commit / non-ancestor / absent) / `2` backend or env error. A confirmed stale (1) wins over a transient backend error (2), mirroring the adoption-lag check.
  - The `go.mod`/`go.sum` diff set closes the one hole adoption-lag cannot see: a tool-version bump that **never re-published** the image leaves `:latest` unmoved.
- **Wiring (network → release-gate, not per-PR):** `make check-catalog-provenance-freshness`; a weekly **advisory** workflow (`catalog_provenance_freshness.yml`, `fetch-depth: 0`, warns on exit 2); and a **blocking release gate** in the cut-release runbook that **fails closed on exit 2** (inverting the advisory) — the blocking-gate-hardening item.
- **Docs:** `docs/tool_container_design.md` §6/§11 and `DEP_MGMT.md` updated.
- **Tests:** `test/test_check_catalog_provenance_freshness.bats` (13 cases) — mocks `gh` provenance reads against a **real throwaway git repo** so the jq extraction + ancestry/diff logic runs for real (fresh, tool/lib/go.mod staleness, backend-error, non-wrangle-repo, ambiguous, absent, non-ancestor, non-curated skip, stale-wins-over-backend, missing-tool).
- **Dependabot (item 4): confirmed, no change** — `docker` `/**` already discovers the digest-pinned `FROM` lines in all `tools/*/Dockerfile`; `catalog.json` itself is not a dependabot-trackable ecosystem (#623).

## Deferred (flagged, tracked in #623 — not built)
- **Digest cooldown (item 2):** deferred *with rationale*. It does **not** gate Phase 3 (source-freshness does), and a 7-day cooldown on wrangle's *own* images delays adopting wrangle's own fix — counter to this gate's purpose (#623 calls it "owner call"). With no cooldown shipping there is **no polarity to reconcile**; the blocking promotion only needed fail-closed-on-exit-2, which is done. If built, the timestamp source should be the build commit's git timestamp (no new auth), not the GHCR Packages API.
- **Automated post-publish bump PR** and **adopter-override staleness (WL007)** — unchanged, deferred per the task.
- The adoption-lag check's own advisory→blocking promotion — left as-is (its weekly cron stays advisory by design).

Refs #633 #596. Do not merge — routing for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)