### PR TITLE
feat(verify): #619 Phase 1 — token-less verify governance (catalog grant + verify-before-run)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      uses: TomHennen/wrangle/build/actions/container@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      uses: TomHennen/wrangle/build/actions/container@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      uses: TomHennen/wrangle/build/actions/container@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      uses: TomHennen/wrangle/build/actions/container@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      uses: TomHennen/wrangle/build/actions/container@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/verify_release@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      uses: TomHennen/wrangle/build/actions/container@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      uses: TomHennen/wrangle/build/actions/container@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      uses: TomHennen/wrangle/build/actions/container@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      uses: TomHennen/wrangle/build/actions/container@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/verify_release@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      uses: TomHennen/wrangle/build/actions/container@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      uses: TomHennen/wrangle/build/actions/container@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/checks@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/build@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/checks@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/build@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/checks@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/build@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/checks@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/build@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/checks@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/build@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/build/actions/go/checks@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/build/actions/go/build@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/attest_provenance@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/verify_release@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/checks@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/build@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/checks@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/build@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/checks@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/build@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/checks@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/go/build@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/build/actions/go/checks@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/build/actions/go/build@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/attest_provenance@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/verify_release@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/build/actions/npm@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/attest_provenance@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/verify_release@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/npm@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/npm@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/npm@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/npm@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/npm@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/npm@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/npm@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/npm@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/build/actions/npm@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/attest_provenance@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/verify_release@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/npm@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/build/actions/python@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/attest_provenance@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/verify_release@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/python@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/python@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/python@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/python@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/python@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/python@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/python@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/python@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/build/actions/python@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/attest_provenance@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/verify_release@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/build/actions/python@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/attest_provenance@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/verify_release@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+        uses: TomHennen/wrangle/build/actions/shell@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+        uses: TomHennen/wrangle/build/actions/shell@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+        uses: TomHennen/wrangle/build/actions/shell@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+        uses: TomHennen/wrangle/build/actions/shell@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+        uses: TomHennen/wrangle/build/actions/shell@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+        uses: TomHennen/wrangle/build/actions/shell@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+        uses: TomHennen/wrangle/build/actions/shell@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+        uses: TomHennen/wrangle/build/actions/shell@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+        uses: TomHennen/wrangle/build/actions/shell@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+        uses: TomHennen/wrangle/build/actions/shell@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/scan@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+        uses: TomHennen/wrangle/build/actions/shell@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+        uses: TomHennen/wrangle/actions/scan@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+        uses: TomHennen/wrangle/actions/scan@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+        uses: TomHennen/wrangle/actions/scan@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+        uses: TomHennen/wrangle/actions/scan@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+        uses: TomHennen/wrangle/actions/scan@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+        uses: TomHennen/wrangle/actions/scan@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+        uses: TomHennen/wrangle/actions/scan@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+        uses: TomHennen/wrangle/actions/scan@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+        uses: TomHennen/wrangle/actions/scan@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+        uses: TomHennen/wrangle/actions/scan@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      - uses: TomHennen/wrangle/actions/prep@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+        uses: TomHennen/wrangle/actions/scan@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -146,7 +146,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/scorecard@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -158,7 +158,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/dependency-review@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -118,8 +118,6 @@ runs:
         WRANGLE_TOOLS: ${{ inputs.tools }}
         WRANGLE_ROOT: ${{ github.action_path }}/../..
         WRANGLE_EXTRA_GITHUB_TOKEN: ${{ inputs.github-token }}
-        # run.sh's curated-image VSA gate runs `gh` in its own process, not an
-        # adapter, so it needs gh's own token (adapters stay isolated under env -i).
         GH_TOKEN: ${{ inputs.github-token }}
         WRANGLE_INSTALL_TIMEOUT: "900"
       run: |

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -118,6 +118,10 @@ runs:
         WRANGLE_TOOLS: ${{ inputs.tools }}
         WRANGLE_ROOT: ${{ github.action_path }}/../..
         WRANGLE_EXTRA_GITHUB_TOKEN: ${{ inputs.github-token }}
+        # run.sh's curated-image VSA gate runs `gh attestation verify` in its own
+        # process (not an adapter), so it needs gh's own token; adapters stay
+        # isolated (env -i) and read only WRANGLE_EXTRA_GITHUB_TOKEN.
+        GH_TOKEN: ${{ inputs.github-token }}
         WRANGLE_INSTALL_TIMEOUT: "900"
       run: |
         # shellcheck source=../../lib/env.sh

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -58,11 +58,9 @@ inputs:
     default: ""
   github-token:
     description: >
-      Token forwarded to tools that perform online audits (e.g. zizmor's
-      GitHub-API checks), and used by the pull-time VSA gate to verify each
-      curated tool image's attestation. Defaults to the workflow token; passing
-      empty keeps audit tools offline but fails the curated-image VSA gate closed
-      (set WRANGLE_VERIFY_TOOL_IMAGES=0 to bypass the gate for offline runs).
+      Token for online-audit tools (zizmor) and the pull-time VSA gate that
+      verifies curated tool images. Defaults to the workflow token; empty fails
+      the curated-image gate closed (bypass: WRANGLE_VERIFY_TOOL_IMAGES=0).
     required: false
     default: ${{ github.token }}
 

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -141,7 +141,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/scorecard@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -153,7 +153,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/dependency-review@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      uses: TomHennen/wrangle/tools/scorecard@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+      uses: TomHennen/wrangle/tools/dependency-review@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -141,7 +141,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/scorecard@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -153,7 +153,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/dependency-review@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -145,7 +145,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/scorecard@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -157,7 +157,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/dependency-review@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -141,7 +141,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      uses: TomHennen/wrangle/tools/scorecard@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -153,7 +153,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+      uses: TomHennen/wrangle/tools/dependency-review@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -144,7 +144,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/scorecard@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -156,7 +156,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/dependency-review@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -146,7 +146,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/scorecard@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -158,7 +158,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/dependency-review@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -141,7 +141,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      uses: TomHennen/wrangle/tools/scorecard@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -153,7 +153,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+      uses: TomHennen/wrangle/tools/dependency-review@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -59,8 +59,10 @@ inputs:
   github-token:
     description: >
       Token forwarded to tools that perform online audits (e.g. zizmor's
-      GitHub-API checks). Defaults to the workflow token; pass empty to keep
-      those tools offline.
+      GitHub-API checks), and used by the pull-time VSA gate to verify each
+      curated tool image's attestation. Defaults to the workflow token; passing
+      empty keeps audit tools offline but fails the curated-image VSA gate closed
+      (set WRANGLE_VERIFY_TOOL_IMAGES=0 to bypass the gate for offline runs).
     required: false
     default: ${{ github.token }}
 
@@ -118,9 +120,8 @@ runs:
         WRANGLE_TOOLS: ${{ inputs.tools }}
         WRANGLE_ROOT: ${{ github.action_path }}/../..
         WRANGLE_EXTRA_GITHUB_TOKEN: ${{ inputs.github-token }}
-        # run.sh's curated-image VSA gate runs `gh attestation verify` in its own
-        # process (not an adapter), so it needs gh's own token; adapters stay
-        # isolated (env -i) and read only WRANGLE_EXTRA_GITHUB_TOKEN.
+        # run.sh's curated-image VSA gate runs `gh` in its own process, not an
+        # adapter, so it needs gh's own token (adapters stay isolated under env -i).
         GH_TOKEN: ${{ inputs.github-token }}
         WRANGLE_INSTALL_TIMEOUT: "900"
       run: |

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      uses: TomHennen/wrangle/tools/scorecard@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+      uses: TomHennen/wrangle/tools/dependency-review@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/scorecard@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+      uses: TomHennen/wrangle/tools/dependency-review@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
 
     - name: Generate step summary
       if: always()

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -44,6 +44,20 @@ wrangle_resolve_policy() {
 # shellcheck source=../../lib/sign_metadata.sh
 source "$LIB_DIR/sign_metadata.sh"
 
+# Catalog reader + pull-time VSA gate: the in-container ampel-verify path resolves
+# the toolbox image from the curated catalog and verifies its provenance host-side
+# before running it (the bootstrap invariant — the verifier is host gh, never the
+# container vouching for itself).
+# shellcheck source=../../lib/read_catalog.sh
+source "$LIB_DIR/read_catalog.sh"
+# shellcheck source=../../lib/verify_image_vsa.sh
+source "$LIB_DIR/verify_image_vsa.sh"
+
+# Curated catalog the toolbox grant lives in; WRANGLE_CATALOG-overridable for tests.
+WRANGLE_CATALOG="${WRANGLE_CATALOG:-$REPO_ROOT/tools/catalog.json}"
+# The catalog key for the attest/verify toolbox image.
+WRANGLE_VERIFY_TOOLBOX_TOOL="attest-toolbox"
+
 # Emit the ampel subject flag for one subject, one arg per line. A digest-form
 # subject (algo:hex, e.g. a container) passes through; a file subject is hashed
 # to sha256 ourselves and passed as --subject-hash so the VSA subject carries a
@@ -93,30 +107,61 @@ wrangle_bnd_sign_args() {
     printf '%s\n' statement "$1"
 }
 
-# Run ampel: the in-job binary by default, or — when WRANGLE_VERIFY_AMPEL_IMAGE
-# names a toolbox image — that image via `docker run`. The container path is an
-# experimental prototype seam (#596); the catalog-driven capability grant plus
-# digest/provenance gating that must precede wiring it into any workflow are #619.
-# Constraints of the container path: no token enters the container (ampel verify
-# never signs); policy/bundle mount read-only, only the results dir is writable;
-# it fails closed (exit 2) on an oci: collector, whose registry auth isn't plumbed.
+# Resolve the toolbox image's catalog network grant to a docker --network value.
+# Default closed (none); "egress" maps to the default bridge — the egress ampel
+# verify needs to reach Sigstore/Rekor, the access the in-job binary has today.
+wrangle_toolbox_network() {
+    case "$(read_catalog_field "$WRANGLE_CATALOG" "$WRANGLE_VERIFY_TOOLBOX_TOOL" network)" in
+        egress) printf 'bridge\n' ;;
+        *)      printf 'none\n' ;;
+    esac
+}
+
+# Run ampel: the in-job binary by default, or — when WRANGLE_VERIFY_AMPEL_TOOLBOX
+# is set — the curated attest-toolbox image via `docker run`. The image, its egress
+# grant, and the no-token capability come from the catalog (a reviewable,
+# default-closed grant), not the call site. Before the container runs, the image's
+# own wrangle provenance/VSA is verified host-side (verify_image_vsa, gh) so a
+# substituted image can't produce a forged verdict — the bootstrap invariant: the
+# verifier is the host, never the container. Constraints: no token enters the
+# container (ampel verify never signs); policy/bundle mount read-only, only the
+# results dir is writable; it fails closed (exit 2) on an oci: collector, whose
+# in-container registry auth is deferred (the container build type, #619).
 wrangle_ampel() {
-    local image="${WRANGLE_VERIFY_AMPEL_IMAGE:-}"
-    if [[ -z "$image" ]]; then
+    if [[ -z "${WRANGLE_VERIFY_AMPEL_TOOLBOX:-}" ]]; then
         ampel "$@"
         return
     fi
-    # Partial guard for #619: refuse a floating ref so the prototype only ever
-    # runs a digest-pinned image (the catalog/provenance gating is still #619).
-    if [[ ! "$image" =~ @sha256:[0-9a-f]{64}$ ]]; then
-        printf 'wrangle: WRANGLE_VERIFY_AMPEL_IMAGE must be @sha256:-digest-pinned (got %s)\n' "$image" >&2
-        return 2
-    fi
+    # An oci: collector (the container build type) needs in-container registry
+    # auth, which is deferred — fail closed rather than silently mis-verify.
     if [[ -n "${COLLECTOR:-}" ]]; then
-        printf 'wrangle: WRANGLE_VERIFY_AMPEL_IMAGE does not yet support an OCI collector (%s)\n' "$COLLECTOR" >&2
+        printf 'wrangle: in-container ampel verify does not support an oci collector (%s); the container build type stays on the in-job binary (#619)\n' "$COLLECTOR" >&2
         return 2
     fi
-    local results_dir policy policy_mount
+    local image
+    image="$(read_catalog_field "$WRANGLE_CATALOG" "$WRANGLE_VERIFY_TOOLBOX_TOOL" image)"
+    # Fail closed: the grant is enabled but the catalog has no toolbox image — a
+    # wiring error, never a silent fall-back to the in-job binary.
+    if [[ -z "$image" ]]; then
+        printf 'wrangle: WRANGLE_VERIFY_AMPEL_TOOLBOX set but catalog %s has no %s image\n' "$WRANGLE_CATALOG" "$WRANGLE_VERIFY_TOOLBOX_TOOL" >&2
+        return 2
+    fi
+    if [[ ! "$image" =~ @sha256:[0-9a-f]{64}$ ]]; then
+        printf 'wrangle: toolbox image must be @sha256:-digest-pinned (got %s)\n' "$image" >&2
+        return 2
+    fi
+    # Verify the image's own provenance host-side before it runs. Fail closed on a
+    # non-PASSED VSA; WRANGLE_VERIFY_TOOL_IMAGES=0 is the single break-glass for a
+    # sustained Sigstore-TUF outage, matching the scan path.
+    if [[ "${WRANGLE_VERIFY_TOOL_IMAGES:-1}" == "0" ]]; then
+        printf 'wrangle: toolbox-image VSA verification disabled by configuration\n' >&2
+    elif verify_image_vsa "$image"; then
+        printf 'wrangle: toolbox-image VSA verified PASSED\n' >&2
+    else
+        printf 'wrangle: toolbox-image VSA verification failed (image not provably PASSED)\n' >&2
+        return 2
+    fi
+    local results_dir policy policy_mount net
     results_dir="$(cd "$(dirname "${WRANGLE_AMPEL_RESULTS:?wrangle_ampel needs WRANGLE_AMPEL_RESULTS set}")" && pwd)"
     # Mount the resolved policy's actual parent, not a hardcoded policies/: a
     # relative policy resolves to $REPO_ROOT/<policy>, which may sit elsewhere. A
@@ -126,11 +171,12 @@ wrangle_ampel() {
         *://*) policy_mount=() ;;
         *)     policy_mount=(-v "$(dirname "$policy")":"$(dirname "$policy")":ro) ;;
     esac
-    # No -e for any token; --network host gives ampel the runner's egress to reach
-    # Sigstore/Rekor; non-root as the caller so the unsigned VSA it writes is
-    # consumable by the in-job signing step. The dist file is intentionally NOT
+    net="$(wrangle_toolbox_network)"
+    # No -e for any token; the catalog egress grant (bridge) gives ampel the egress
+    # to reach Sigstore/Rekor; non-root as the caller so the unsigned VSA it writes
+    # is consumable by the in-job signing step. The dist file is intentionally NOT
     # mounted — file subjects are pre-hashed in-job, so the container never reads them.
-    docker run --rm --network host -u "$(id -u):$(id -g)" \
+    docker run --rm --network "$net" -u "$(id -u):$(id -g)" \
         -v "$BUNDLE_OUT":"$BUNDLE_OUT":ro \
         "${policy_mount[@]}" \
         -v "$results_dir":"$results_dir" \

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -44,18 +44,12 @@ wrangle_resolve_policy() {
 # shellcheck source=../../lib/sign_metadata.sh
 source "$LIB_DIR/sign_metadata.sh"
 
-# Catalog reader + pull-time VSA gate: the in-container ampel-verify path resolves
-# the toolbox image from the curated catalog and verifies its provenance host-side
-# before running it (the bootstrap invariant — the verifier is host gh, never the
-# container vouching for itself).
 # shellcheck source=../../lib/read_catalog.sh
 source "$LIB_DIR/read_catalog.sh"
 # shellcheck source=../../lib/verify_image_vsa.sh
 source "$LIB_DIR/verify_image_vsa.sh"
 
-# Curated catalog the toolbox grant lives in; WRANGLE_CATALOG-overridable for tests.
 WRANGLE_CATALOG="${WRANGLE_CATALOG:-$REPO_ROOT/tools/catalog.json}"
-# The catalog key for the attest/verify toolbox image.
 WRANGLE_VERIFY_TOOLBOX_TOOL="attest-toolbox"
 
 # Emit the ampel subject flag for one subject, one arg per line. A digest-form
@@ -107,9 +101,7 @@ wrangle_bnd_sign_args() {
     printf '%s\n' statement "$1"
 }
 
-# Resolve the toolbox image's catalog network grant to a docker --network value.
-# Default closed (none); "egress" maps to the default bridge — the egress ampel
-# verify needs to reach Sigstore/Rekor, the access the in-job binary has today.
+# "egress" -> docker's default bridge; anything else -> no network.
 wrangle_toolbox_network() {
     case "$(read_catalog_field "$WRANGLE_CATALOG" "$WRANGLE_VERIFY_TOOLBOX_TOOL" network)" in
         egress) printf 'bridge\n' ;;
@@ -117,31 +109,21 @@ wrangle_toolbox_network() {
     esac
 }
 
-# Run ampel: the in-job binary by default, or — when WRANGLE_VERIFY_AMPEL_TOOLBOX
-# is 1/true — the curated attest-toolbox image via `docker run`. The image, its
-# egress grant, and the no-token capability come from the catalog (a reviewable,
-# default-closed grant), not the call site. Before the container runs, the image's
-# own wrangle provenance/VSA is verified host-side (verify_image_vsa, gh): the
-# bootstrap invariant — the verifier is the host, never the container. No token
-# enters the container (ampel verify never signs); policy/bundle mount read-only,
-# only the results dir is writable; it refuses (exit 2) an oci: collector, whose
-# in-container registry auth is deferred (#619).
+# Dispatch ampel: the in-job binary, or — when WRANGLE_VERIFY_AMPEL_TOOLBOX is
+# 1/true — the catalog's attest-toolbox image, verified host-side before it runs
+# (the host is the verifier, never the container). No token enters the container.
 wrangle_ampel() {
     case "${WRANGLE_VERIFY_AMPEL_TOOLBOX:-}" in
         1|true) ;;
         *) ampel "$@"; return ;;
     esac
-    # An oci: collector (the container build type) needs in-container registry
-    # auth, which is deferred — refuse rather than silently mis-verify. The
-    # container build type must leave WRANGLE_VERIFY_AMPEL_TOOLBOX unset.
+    # An oci: collector needs in-container registry auth, which is deferred.
     if [[ -n "${COLLECTOR:-}" ]]; then
-        printf 'wrangle: in-container ampel verify does not support an oci collector (%s); leave WRANGLE_VERIFY_AMPEL_TOOLBOX unset for the container build type (#619)\n' "$COLLECTOR" >&2
+        printf 'wrangle: in-container ampel verify does not support an oci collector (%s); leave WRANGLE_VERIFY_AMPEL_TOOLBOX unset for the container build type\n' "$COLLECTOR" >&2
         return 2
     fi
     local image
     image="$(read_catalog_field "$WRANGLE_CATALOG" "$WRANGLE_VERIFY_TOOLBOX_TOOL" image)"
-    # Fail closed: the grant is enabled but the catalog has no toolbox image — a
-    # wiring error, never a silent fall-back to the in-job binary.
     if [[ -z "$image" ]]; then
         printf 'wrangle: WRANGLE_VERIFY_AMPEL_TOOLBOX set but catalog %s has no %s image\n' "$WRANGLE_CATALOG" "$WRANGLE_VERIFY_TOOLBOX_TOOL" >&2
         return 2
@@ -150,9 +132,7 @@ wrangle_ampel() {
         printf 'wrangle: toolbox image must be @sha256:-digest-pinned (got %s)\n' "$image" >&2
         return 2
     fi
-    # Verify the image's own provenance host-side before it runs. Fail closed on a
-    # non-PASSED VSA; WRANGLE_VERIFY_TOOL_IMAGES=0 is the single break-glass for a
-    # sustained Sigstore-TUF outage, matching the scan path.
+    # WRANGLE_VERIFY_TOOL_IMAGES=0 is the break-glass for a sustained Sigstore outage.
     if [[ "${WRANGLE_VERIFY_TOOL_IMAGES:-1}" == "0" ]]; then
         printf 'wrangle: toolbox-image VSA verification disabled by configuration\n' >&2
     elif verify_image_vsa "$image"; then
@@ -172,10 +152,8 @@ wrangle_ampel() {
         *)     policy_mount=(-v "$(dirname "$policy")":"$(dirname "$policy")":ro) ;;
     esac
     net="$(wrangle_toolbox_network)"
-    # No -e for any token; the catalog egress grant (bridge) gives ampel the egress
-    # to reach Sigstore/Rekor; non-root as the caller so the unsigned VSA it writes
-    # is consumable by the in-job signing step. The dist file is intentionally NOT
-    # mounted — file subjects are pre-hashed in-job, so the container never reads them.
+    # No token env; non-root so the in-job step can read the VSA; no dist mount
+    # (subjects are pre-hashed in-job).
     docker run --rm --network "$net" -u "$(id -u):$(id -g)" \
         -v "$BUNDLE_OUT":"$BUNDLE_OUT":ro \
         "${policy_mount[@]}" \

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -118,24 +118,24 @@ wrangle_toolbox_network() {
 }
 
 # Run ampel: the in-job binary by default, or — when WRANGLE_VERIFY_AMPEL_TOOLBOX
-# is set — the curated attest-toolbox image via `docker run`. The image, its egress
-# grant, and the no-token capability come from the catalog (a reviewable,
+# is 1/true — the curated attest-toolbox image via `docker run`. The image, its
+# egress grant, and the no-token capability come from the catalog (a reviewable,
 # default-closed grant), not the call site. Before the container runs, the image's
-# own wrangle provenance/VSA is verified host-side (verify_image_vsa, gh) so a
-# substituted image can't produce a forged verdict — the bootstrap invariant: the
-# verifier is the host, never the container. Constraints: no token enters the
-# container (ampel verify never signs); policy/bundle mount read-only, only the
-# results dir is writable; it fails closed (exit 2) on an oci: collector, whose
-# in-container registry auth is deferred (the container build type, #619).
+# own wrangle provenance/VSA is verified host-side (verify_image_vsa, gh): the
+# bootstrap invariant — the verifier is the host, never the container. No token
+# enters the container (ampel verify never signs); policy/bundle mount read-only,
+# only the results dir is writable; it refuses (exit 2) an oci: collector, whose
+# in-container registry auth is deferred (#619).
 wrangle_ampel() {
-    if [[ -z "${WRANGLE_VERIFY_AMPEL_TOOLBOX:-}" ]]; then
-        ampel "$@"
-        return
-    fi
+    case "${WRANGLE_VERIFY_AMPEL_TOOLBOX:-}" in
+        1|true) ;;
+        *) ampel "$@"; return ;;
+    esac
     # An oci: collector (the container build type) needs in-container registry
-    # auth, which is deferred — fail closed rather than silently mis-verify.
+    # auth, which is deferred — refuse rather than silently mis-verify. The
+    # container build type must leave WRANGLE_VERIFY_AMPEL_TOOLBOX unset.
     if [[ -n "${COLLECTOR:-}" ]]; then
-        printf 'wrangle: in-container ampel verify does not support an oci collector (%s); the container build type stays on the in-job binary (#619)\n' "$COLLECTOR" >&2
+        printf 'wrangle: in-container ampel verify does not support an oci collector (%s); leave WRANGLE_VERIFY_AMPEL_TOOLBOX unset for the container build type (#619)\n' "$COLLECTOR" >&2
         return 2
     fi
     local image

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -1028,6 +1028,29 @@ EOF
     [ ! -f "$TEST_DIR/docker.args" ]
 }
 
+@test "wrangle_ampel: WRANGLE_VERIFY_TOOL_IMAGES=0 break-glass skips verify and still runs" {
+    # The sole path that dispatches without verifying — gh must never be consulted.
+    cat > "$TEST_DIR/gh" <<EOF
+#!/bin/bash
+touch "$TEST_DIR/gh.called"
+EOF
+    chmod +x "$TEST_DIR/gh"
+    cat > "$TEST_DIR/docker" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" > "$TEST_DIR/docker.args"
+EOF
+    chmod +x "$TEST_DIR/docker"
+    _stub_toolbox_catalog
+    export WRANGLE_AMPEL_RESULTS="$TEST_DIR/results/vsa.json"
+    mkdir -p "$TEST_DIR/results" "$BUNDLE_OUT"
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 WRANGLE_VERIFY_TOOL_IMAGES=0 \
+        run wrangle_ampel verify --policy=p
+    [ "$status" -eq 0 ]
+    grep -q "verification disabled by configuration" <<< "$output"
+    [ ! -f "$TEST_DIR/gh.called" ]
+    grep -q -- "$_toolbox_image ampel verify" "$TEST_DIR/docker.args"
+}
+
 @test "retry: ampel and bnd invocations both route through wrangle_retry_once" {
     # ampel runs via the wrangle_ampel dispatcher (in-job binary or, opt-in, the
     # toolbox image) — still through the retry helper.

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -928,43 +928,104 @@ SHIM
     [[ "$(wc -l < "$shim.calls")" -eq 2 ]]
 }
 
-@test "wrangle_ampel: default (no image) runs the in-job ampel binary unchanged" {
+# A digest-pinned curated toolbox image (wrangle namespace) for the gate tests.
+_toolbox_image="ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+# Write a stub catalog with the attest-toolbox grant ($1 = image; default the
+# pinned curated image) and export WRANGLE_CATALOG at it.
+_stub_toolbox_catalog() {
+    local image="${1:-$_toolbox_image}"
+    cat > "$TEST_DIR/catalog.json" <<JSON
+{"tools":{"attest-toolbox":{"kind":"attest","image":"$image","network":"egress"}}}
+JSON
+    export WRANGLE_CATALOG="$TEST_DIR/catalog.json"
+}
+
+# Install a docker shim that records its argv, and a gh shim whose attestation
+# verdict is PASSED (the real --format json shape) or, with GH_FAIL=1, FAILED.
+_install_toolbox_shims() {
+    cat > "$TEST_DIR/docker" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" > "$TEST_DIR/docker.args"
+EOF
+    chmod +x "$TEST_DIR/docker"
+    cat > "$TEST_DIR/gh" <<EOF
+#!/bin/bash
+verdict=PASSED
+[[ -n "\${GH_FAIL:-}" ]] && verdict=FAILED
+cat <<JSON
+[{"verificationResult":{"statement":{"predicate":{"verificationResult":"\$verdict","resourceUri":"$_toolbox_image","verifiedLevels":["SLSA_BUILD_LEVEL_3"]}}}}]
+JSON
+EOF
+    chmod +x "$TEST_DIR/gh"
+}
+
+@test "wrangle_ampel: toggle off runs the in-job ampel binary unchanged" {
     # Shim ampel to record it was the binary invoked, with the args passed through.
     cat > "$TEST_DIR/ampel" <<EOF
 #!/bin/bash
 printf '%s\n' "\$@" > "$TEST_DIR/ampel.args"
 EOF
     chmod +x "$TEST_DIR/ampel"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_IMAGE="" run wrangle_ampel verify --policy=p
+    PATH="$TEST_DIR:$PATH" run wrangle_ampel verify --policy=p
     [ "$status" -eq 0 ]
     grep -q -- '--policy=p' "$TEST_DIR/ampel.args"
     # No docker on the default path.
-    [ ! -f "$TEST_DIR/docker.called" ]
+    [ ! -f "$TEST_DIR/docker.args" ]
 }
 
-@test "wrangle_ampel: a non-digest-pinned image is rejected (fail-closed, no docker)" {
-    cat > "$TEST_DIR/docker" <<EOF
-#!/bin/bash
-touch "$TEST_DIR/docker.called"
-EOF
-    chmod +x "$TEST_DIR/docker"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_IMAGE="img:test" \
-        run wrangle_ampel verify
+@test "wrangle_ampel: toggle on resolves the catalog image, verifies it, runs it on the egress bridge" {
+    _install_toolbox_shims
+    _stub_toolbox_catalog
+    export WRANGLE_AMPEL_RESULTS="$TEST_DIR/results/vsa.json"
+    mkdir -p "$TEST_DIR/results" "$BUNDLE_OUT"
+    export POLICY="policies/release.json"  # parent gets mounted ro
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 run wrangle_ampel verify --policy=p
+    [ "$status" -eq 0 ]
+    grep -q "toolbox-image VSA verified PASSED" <<< "$output"
+    # The catalog image ran, on the bridge (egress) network — not host.
+    grep -q -- "--network bridge" "$TEST_DIR/docker.args"
+    grep -q -- "$_toolbox_image ampel verify" "$TEST_DIR/docker.args"
+}
+
+@test "wrangle_ampel: toggle on but a non-PASSED VSA fails closed (no docker)" {
+    _install_toolbox_shims
+    _stub_toolbox_catalog
+    export WRANGLE_AMPEL_RESULTS="$TEST_DIR/results/vsa.json"
+    mkdir -p "$TEST_DIR/results"
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 GH_FAIL=1 run wrangle_ampel verify
     [ "$status" -eq 2 ]
-    [ ! -f "$TEST_DIR/docker.called" ]
+    grep -q "verification failed" <<< "$output"
+    [ ! -f "$TEST_DIR/docker.args" ]
+}
+
+@test "wrangle_ampel: toggle on but no catalog toolbox entry fails closed (no docker)" {
+    _install_toolbox_shims
+    echo '{"tools":{}}' > "$TEST_DIR/catalog.json"
+    export WRANGLE_CATALOG="$TEST_DIR/catalog.json"
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 run wrangle_ampel verify
+    [ "$status" -eq 2 ]
+    grep -q "no attest-toolbox image" <<< "$output"
+    [ ! -f "$TEST_DIR/docker.args" ]
+}
+
+@test "wrangle_ampel: toggle on but a non-digest-pinned catalog image is rejected (no docker)" {
+    _install_toolbox_shims
+    _stub_toolbox_catalog "ghcr.io/tomhennen/wrangle/attest-toolbox:latest"
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 run wrangle_ampel verify
+    [ "$status" -eq 2 ]
+    grep -q "digest-pinned" <<< "$output"
+    [ ! -f "$TEST_DIR/docker.args" ]
 }
 
 @test "wrangle_ampel: container path refuses an OCI collector (fail-closed, no docker)" {
-    cat > "$TEST_DIR/docker" <<EOF
-#!/bin/bash
-touch "$TEST_DIR/docker.called"
-EOF
-    chmod +x "$TEST_DIR/docker"
-    local digest_img="img@sha256:0000000000000000000000000000000000000000000000000000000000000000"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_IMAGE="$digest_img" COLLECTOR="oci:ghcr.io/x@sha256:abc" \
+    _install_toolbox_shims
+    _stub_toolbox_catalog
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 COLLECTOR="oci:ghcr.io/x@sha256:abc" \
         run wrangle_ampel verify
     [ "$status" -eq 2 ]
-    [ ! -f "$TEST_DIR/docker.called" ]
+    grep -q "oci collector" <<< "$output"
+    [ ! -f "$TEST_DIR/docker.args" ]
 }
 
 @test "retry: ampel and bnd invocations both route through wrangle_retry_once" {

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -974,12 +974,23 @@ EOF
     [ ! -f "$TEST_DIR/docker.args" ]
 }
 
+@test "wrangle_ampel: WRANGLE_VERIFY_AMPEL_TOOLBOX=0 stays on the in-job binary (no footgun)" {
+    cat > "$TEST_DIR/ampel" <<EOF
+#!/bin/bash
+printf '%s\n' "\$@" > "$TEST_DIR/ampel.args"
+EOF
+    chmod +x "$TEST_DIR/ampel"
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=0 run wrangle_ampel verify --policy=p
+    [ "$status" -eq 0 ]
+    grep -q -- '--policy=p' "$TEST_DIR/ampel.args"
+    [ ! -f "$TEST_DIR/docker.args" ]
+}
+
 @test "wrangle_ampel: toggle on resolves the catalog image, verifies it, runs it on the egress bridge" {
     _install_toolbox_shims
     _stub_toolbox_catalog
     export WRANGLE_AMPEL_RESULTS="$TEST_DIR/results/vsa.json"
     mkdir -p "$TEST_DIR/results" "$BUNDLE_OUT"
-    export POLICY="policies/release.json"  # parent gets mounted ro
     PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 run wrangle_ampel verify --policy=p
     [ "$status" -eq 0 ]
     grep -q "toolbox-image VSA verified PASSED" <<< "$output"

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
+    - uses: TomHennen/wrangle/actions/verify@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
+    - uses: TomHennen/wrangle/actions/verify@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
+    - uses: TomHennen/wrangle/actions/verify@843a8a3787e3a2da8129c3347f5af4539790ede4 # main 2026-06-27
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@da0d201ed70d321919ed883e4052dae68b9aa350 # fix/dispatch-test-flakiness 2026-06-27
+    - uses: TomHennen/wrangle/actions/verify@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
+    - uses: TomHennen/wrangle/actions/verify@1f65e7b7576b8321a6b15e5394e7669964755e96 # main 2026-06-27
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@bc77cf8b8e562a10004433696ee2a37635166f74 # main 2026-06-28
+    - uses: TomHennen/wrangle/actions/verify@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@6498f3b620aae2651042de49fb245b6e6f5415c8 # main 2026-06-27
+    - uses: TomHennen/wrangle/actions/verify@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@8a720ade8498de5efa18ff789924f563d7f748e1 # main 2026-06-28
+    - uses: TomHennen/wrangle/actions/verify@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@24cb9c27b13c93125435cba42b7c9d1b896abf59 # main 2026-06-27
+    - uses: TomHennen/wrangle/actions/verify@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@97a63aec109987ec9e0ac8a773424f235140f975 # main 2026-06-27
+    - uses: TomHennen/wrangle/actions/verify@08427ff1949fe53e8b4474639682d7377ff72c6f # main 2026-06-27
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@c6a776f01109d587982b059a057d5a8bbae10015 # main 2026-06-27
+    - uses: TomHennen/wrangle/actions/verify@36ae7b7d3dd47f8bbd694c9383da68c420814987 # main 2026-06-27
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -158,12 +158,17 @@ thing for the pin tooling to track and for adopters to read.
   offer rails (a `docker` Dependabot entry, a lint warning on a stale override) but cannot vouch for an
   image it does not control.
 
-The shipped catalog (`tools/catalog.json`) is keyed by the short name the `tools:` selection uses, parsed
-with `jq` (`lib/read_catalog.sh`). Capabilities default closed: an absent `network`/`secret` means none,
-and a tool not listed — or one with `delivery: adapter` — runs the in-process adapter path. The `kind`
-field is recorded but unused today; the `command:`/`args:`/`WRANGLE_KIND` passthrough and kind-based
-(scan vs sbom) dispatch land when a command-shared or sbom tool does. `osv` carries `network: egress`
-because it refreshes its advisory DB from osv.dev.
+The shipped catalog (`tools/catalog.json`) is parsed with `jq` (`lib/read_catalog.sh`) and has **two
+consumers**: the scan orchestrator dispatches entries the `tools:` selection names that carry
+`delivery: image` (the docker-run path; a tool not listed — or one with `delivery: adapter`/no `delivery`
+— takes the in-process adapter path), and the verify action resolves one **fixed key**
+(`attest-toolbox`) for its in-container `ampel verify`. An entry may therefore omit `delivery` to opt out
+of scan dispatch while still being a reviewable grant the verify path resolves; `check_catalog` pin- and
+namespace-lints any entry naming an `image`, regardless of `delivery`. Capabilities default closed: an
+absent `network`/`secret` means none. The `kind` field is recorded but unused today; the
+`command:`/`args:`/`WRANGLE_KIND` passthrough and kind-based (scan vs sbom) dispatch land when a
+command-shared or sbom tool does. `osv` carries `network: egress` because it refreshes its advisory DB
+from osv.dev.
 
 ### 3.7 Capability declaration
 

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -352,10 +352,13 @@ not a meaningful per-delivery signal.)
   having to verify its own verifier.
   **Status (#596 Track 2):** the toolbox image (`tools/attest-toolbox/`, all four binaries from
   `tools/go.mod`) is built and published like the scan images, and `actions/verify` has an opt-in
-  `WRANGLE_VERIFY_AMPEL_IMAGE` that runs *ampel verify only* (no signing token, network egress only) via
-  that image — off by default, byte-identical when unset, and not on the L3 release path. Containerizing
-  the signing steps (bnd/cosign, which need the OIDC token) and the OCI-collector verify path remain
-  deferred.
+  `WRANGLE_VERIFY_AMPEL_TOOLBOX` toggle that runs *ampel verify only* (no signing token) via that image —
+  resolved from the curated catalog's `attest-toolbox` grant (digest-pinned, `network: egress`, no token)
+  and provenance-verified host-side (`verify_image_vsa`) before it runs. Off by default, byte-identical
+  when unset, and not on the L3 release path; supported for the go/python/npm build types only (the
+  container build type's `oci:` collector needs in-container registry auth, fail-closed and deferred).
+  Containerizing the signing steps (bnd/cosign, which need the OIDC token) and the OCI-collector verify
+  path remain deferred.
 - **Separate feature:** emitting an attested container of an adopter's own Go app (the "free container"
   value-add via goreleaser/ko). It reuses some machinery but serves adopter UX, not the goals here.
 - **Left as-is:** tools with official GitHub Actions that gain nothing from containerization stay

--- a/test/image/test_verify_tool_image_real_gh.bats
+++ b/test/image/test_verify_tool_image_real_gh.bats
@@ -54,9 +54,7 @@ _gh_verify() {
 }
 
 @test "real gh: gate PASSES against the catalog-pinned attest-toolbox image" {
-    # The verify path's in-container ampel-verify gate runs on this image; the pin
-    # the workflow consumes must itself be a PASSED, L3 wrangle VSA. Read it from
-    # the live catalog so a stale pin fails here, not only at runtime.
+    # Read the live pin so a stale toolbox digest fails here, not only at runtime.
     local image
     image="$(jq -r '.tools["attest-toolbox"].image // empty' "$ROOT/tools/catalog.json")"
     [ -n "$image" ]

--- a/test/image/test_verify_tool_image_real_gh.bats
+++ b/test/image/test_verify_tool_image_real_gh.bats
@@ -53,6 +53,17 @@ _gh_verify() {
     [ "$status" -eq 0 ]
 }
 
+@test "real gh: gate PASSES against the catalog-pinned attest-toolbox image" {
+    # The verify path's in-container ampel-verify gate runs on this image; the pin
+    # the workflow consumes must itself be a PASSED, L3 wrangle VSA. Read it from
+    # the live catalog so a stale pin fails here, not only at runtime.
+    local image
+    image="$(jq -r '.tools["attest-toolbox"].image // empty' "$ROOT/tools/catalog.json")"
+    [ -n "$image" ]
+    run timeout 120 bash "$ROOT/lib/verify_image_vsa.sh" "$image"
+    [ "$status" -eq 0 ]
+}
+
 @test "real gh: gate FAILS closed against an unattested image" {
     run timeout 120 bash "$ROOT/lib/verify_image_vsa.sh" "$UNATTESTED_IMAGE"
     [ "$status" -eq 1 ]

--- a/test/test_check_catalog.bats
+++ b/test/test_check_catalog.bats
@@ -81,6 +81,26 @@ write_catalog() { printf '%s\n' "$1" > "$CATALOG"; }
     [ "$status" -eq 1 ]
 }
 
+@test "check_catalog: a no-delivery entry with a curated digest-pinned image passes (the toolbox grant)" {
+    write_catalog '{"tools":{"attest-toolbox":{"kind":"attest","image":"ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:'"$(printf 'a%.0s' {1..64})"'","network":"egress"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "check_catalog: a no-delivery entry with a mutable image is rejected (pin enforced without delivery)" {
+    write_catalog '{"tools":{"attest-toolbox":{"kind":"attest","image":"ghcr.io/tomhennen/wrangle/attest-toolbox:latest"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not digest-pinned"* ]]
+}
+
+@test "check_catalog: a no-delivery entry with an off-namespace image is rejected" {
+    write_catalog '{"tools":{"attest-toolbox":{"kind":"attest","image":"ghcr.io/someoneelse/attest-toolbox@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"curated namespace"* ]]
+}
+
 @test "check_catalog: extra argument is a usage error (exit 2)" {
     write_catalog '{"tools":{}}'
     run "$SCRIPT" unexpected

--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -19,6 +19,11 @@
       "delivery": "image",
       "image": "ghcr.io/tomhennen/wrangle/wrangle-lint@sha256:d04bc484426550135d7e2d597da3b6637cfba9225c8f6477b1f60bea9efc7f3d",
       "network": "none"
+    },
+    "attest-toolbox": {
+      "kind": "attest",
+      "image": "ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:638972885a6ebb3966aaa47954bad5d10ab4bf009288818a3abd4bdb641b270b",
+      "network": "egress"
     }
   }
 }

--- a/tools/check_catalog.sh
+++ b/tools/check_catalog.sh
@@ -85,9 +85,7 @@ validate_catalog() {
             fi
         fi
 
-        # Any entry that names an image — image-delivery or not (e.g. the
-        # attest-toolbox grant the verify path resolves) — must be curated and
-        # digest-pinned, so a mutable or off-namespace ref can't pass CI green.
+        # Any entry naming an image, with or without delivery: image.
         image="$(read_catalog_field "$file" "$tool" image)"
         if [[ -n "$image" ]]; then
             if [[ "$image" =~ $IMAGE_STRICT_RE ]]; then

--- a/tools/check_catalog.sh
+++ b/tools/check_catalog.sh
@@ -9,11 +9,11 @@ set -f  # disable globbing — handles external tool/field names
 #
 # For every tool it asserts: the file is valid JSON, a `kind` is declared, the
 # `delivery` (if set) is one run.sh recognizes, and a declared `network`/`secret`
-# is from the allowed, default-closed set. For every `delivery: image` entry it
-# additionally asserts the image is digest-pinned (@sha256: + 64 hex, never a bare
-# tag / :latest / @latest) on the curated namespace ghcr.io/tomhennen/wrangle/<tool>
-# — adopter overrides never live in this in-repo catalog (§3.6), so a different
-# host or namespace is a violation.
+# is from the allowed, default-closed set. A `delivery: image` entry must also name
+# an image. Any entry naming an `image` (image-delivery or not) must be digest-pinned
+# (@sha256: + 64 hex, never a bare tag / :latest / @latest) on the curated namespace
+# ghcr.io/tomhennen/wrangle/<tool> — adopter overrides never live in this in-repo
+# catalog (§3.6), so a different host or namespace is a violation.
 #
 # Catalog path: $WRANGLE_CATALOG, else the catalog beside this script.
 #
@@ -82,7 +82,15 @@ validate_catalog() {
             if [[ -z "$image" ]]; then
                 printf 'check_catalog: %s: delivery: image but no image\n' "$tool" >&2
                 rc=1
-            elif [[ "$image" =~ $IMAGE_STRICT_RE ]]; then
+            fi
+        fi
+
+        # Any entry that names an image — image-delivery or not (e.g. the
+        # attest-toolbox grant the verify path resolves) — must be curated and
+        # digest-pinned, so a mutable or off-namespace ref can't pass CI green.
+        image="$(read_catalog_field "$file" "$tool" image)"
+        if [[ -n "$image" ]]; then
+            if [[ "$image" =~ $IMAGE_STRICT_RE ]]; then
                 : # curated, digest-pinned — ok
             elif [[ "$image" == "$CURATED_PREFIX"* ]]; then
                 printf 'check_catalog: %s: image not digest-pinned (needs ghcr.io/tomhennen/wrangle/<tool>@sha256:<64hex>): %s\n' "$tool" "$image" >&2


### PR DESCRIPTION
claude: **#619 Phase 1 (token-less)** — replaces the `WRANGLE_VERIFY_AMPEL_IMAGE` env-flag prototype with a catalog grant + verify-before-run on the in-container `ampel verify` path. No signing, no OIDC token; strictly safer than today. Refs #619.

## What changed
- **Catalog grant (`tools/catalog.json`):** new `attest-toolbox` entry — `kind: attest`, the digest-pinned `@sha256:` index image, `network: egress`, and **no `secret`/`token`** (token-less by omission, default-closed). Deliberately **omits `delivery: image`** so the bootstrap toolbox stays out of the scan freshness/auto-bump/`run.sh`-dispatch pipeline (its freshness is sequenced to #633).
- **`tools/check_catalog.sh`:** pin/namespace enforcement now applies to **any entry naming an `image`** (not only `delivery: image`), so the toolbox grant is still digest-pin-linted every PR — without scan-delivery coupling.
- **`actions/verify/run_verify.sh`:** `wrangle_ampel` resolves the toolbox image + egress grant from the catalog; a new boolean **`WRANGLE_VERIFY_AMPEL_TOOLBOX`** toggle opts in (off = byte-identical in-job `ampel`). When on: calls `verify_image_vsa` host-side (`gh`) **before** `docker run` (fail-closed), narrows `--network host` → catalog `egress` bridge, keeps `WRANGLE_VERIFY_TOOL_IMAGES=0` as the single break-glass, and fails closed if the grant is enabled but the catalog entry is missing/non-digest-pinned.
- **Bootstrap invariant preserved:** the toolbox's own provenance/VSA is verified by host-side `gh`, never the container verifying itself.

## OCI-collector finding / scope
Only the **container** build type passes `collector: oci:`; **go / python / npm** pass no collector. The `oci:` branch stays **fail-closed (exit 2)** — in-container registry auth is explicitly deferred in #619. So Phase 1 supports **go/python/npm**; the container build type remains on the in-job binary, flagged in the status banner (`docs/tool_container_design.md` §7).

## Tests
- `actions/verify/test_run_verify.bats`: toggle-off→in-job binary; toggle-on→catalog image resolved + `verify_image_vsa` called + `--network bridge` before `docker run`; non-PASSED VSA / missing entry / non-digest-pinned image → fail closed, no docker; `oci:` collector → fail closed.
- `test/test_check_catalog.bats`: no-`delivery` entry gets pin + namespace enforcement.
- `test/image/test_verify_tool_image_real_gh.bats`: real `gh` gate PASSES against the **catalog-pinned** `attest-toolbox` digest (read live from the catalog, so a stale pin fails here).
- `#631`'s under-`-u` ampel-in-image smoke test already covers the container runtime.

## Merge note
Self-ref pins were re-converged (2 cycles) after editing `run_verify.sh` — **land as a merge commit, not a squash**, or the intermediate pins re-orphan.

Do not merge — owner review/`LGTM` required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR: a #630 fix (forced by convergence, flagged for review)

Converging the self-ref pins to fixpoint (mandatory after editing `run_verify.sh`) bumped the dogfood's `actions/scan@` pin to a commit that **includes #630's pull-time VSA gate** — main's pin still predated it, so that gate had **never been dogfooded**. The gate runs `gh attestation verify` in `run.sh`'s own process, but `actions/scan/action.yml` set only `WRANGLE_EXTRA_GITHUB_TOKEN` (forwarded to *adapters*, which run under `env -i`), so the gate's `gh` had no token and exited 4 — failing `build-shell / scan` and the companion `*/scan` jobs.

Fix: `actions/scan/action.yml` now also sets `GH_TOKEN: ${{ inputs.github-token }}` on that step. Security-safe: adapters stay isolated (`env -i`), the image path passes only explicit `-e`, so the token reaches only the gate; no new permission (the token was already present as `WRANGLE_EXTRA_GITHUB_TOKEN`). My own verify path has no equivalent gap — the "Verify and sign" step already exports `GITHUB_TOKEN: ${{ github.token }}`.

This is a #630 concern that landed here only because convergence forces it. **Owner's call** whether to split it to its own PR. Known limitation (pre-existing #630 behavior, not a regression): an adopter passing an empty `github-token` to keep tools offline now fails the curated-image gate closed; `WRANGLE_VERIFY_TOOL_IMAGES=0` is the break-glass.

**Bridge-egress-to-Sigstore is untested end-to-end** — #631's smoke test runs `--network none` and the toolbox path is off-by-default; validated when the toggle is enabled.
