### PR TITLE
chore(catalog): pin syft image to published digest

### DIFF
--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -23,7 +23,7 @@
     "syft": {
       "kind": "sbom",
       "delivery": "image",
-      "image": "ghcr.io/tomhennen/wrangle/syft@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "image": "ghcr.io/tomhennen/wrangle/syft@sha256:a8c074e45182fb2b51935f5947e92d95e40154e22295144552297b72fd6eb386",
       "network": "none"
     },
     "attest-toolbox": {


### PR DESCRIPTION
claude: Clears the sbom-image bootstrap left by #641. The syft catalog entry still pinned the `sha256:0000…0000` placeholder; the weekly catalog freshness crons fail-closed on the unresolvable digest.

The `publish tool images` run [`28550505210`](https://github.com/TomHennen/wrangle/actions/runs/28550505210) built, signed, and attested the syft image. This bumps the catalog to the real published index digest.

**Digest:** `ghcr.io/tomhennen/wrangle/syft@sha256:a8c074e45182fb2b51935f5947e92d95e40154e22295144552297b72fd6eb386`
- OCI image index (linux/amd64 + attestation manifest), same shape as the osv entry.
- Pushed to `:main` and `:latest` in the publish run.

**Verification (worktree off `origin/main` + this bump):**
- `gh attestation verify … --predicate-type https://slsa.dev/verification_summary/v1` → VSA **PASSED**; SLSA provenance present.
- `tools/check_catalog.sh` → pass.
- `tools/check_catalog_provenance_freshness.sh` → syft not flagged (freshly built from current source; #639 gate green).
- `tools/check_catalog_freshness.sh` → syft not flagged (adoption-lag 0).

The osv / wrangle-lint / zizmor entries are flagged by both freshness checks, but that staleness is pre-existing on `main` (this PR touches only the syft line) and is a separate follow-up.

Refs #641, #596