### PR TITLE
claude: bump catalog digests to :latest (osv, zizmor, wrangle-lint) — freshness catch-up

### DIFF
--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -10,7 +10,7 @@
     "zizmor": {
       "kind": "scan",
       "delivery": "image",
-      "image": "ghcr.io/tomhennen/wrangle/zizmor@sha256:03653b75ef7026b4ca156efbea8c470da79c6943e43bb743cb5cc30279d5fcf4",
+      "image": "ghcr.io/tomhennen/wrangle/zizmor@sha256:5dec66fd1e455a65fbddc2cc2d50f3af5b3ed32af114cda4e3baa52d6cbd7a92",
       "network": "egress",
       "secret": "github-token"
     },

--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -4,7 +4,7 @@
     "osv": {
       "kind": "scan",
       "delivery": "image",
-      "image": "ghcr.io/tomhennen/wrangle/osv@sha256:c8abda59e3a64520128c427d2fe9bd223c27e0a2056181ead1b9d3c6a5fb3b75",
+      "image": "ghcr.io/tomhennen/wrangle/osv@sha256:e70475f23604c327edd00432c960f4ef93d8a16ec5382223303ce69703898a2b",
       "network": "egress"
     },
     "zizmor": {

--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -17,7 +17,7 @@
     "wrangle-lint": {
       "kind": "scan",
       "delivery": "image",
-      "image": "ghcr.io/tomhennen/wrangle/wrangle-lint@sha256:d04bc484426550135d7e2d597da3b6637cfba9225c8f6477b1f60bea9efc7f3d",
+      "image": "ghcr.io/tomhennen/wrangle/wrangle-lint@sha256:6d7c6ff05f45411e5b1bc4c1d239e258f5885f913dca8a16222369ed2eacf9e3",
       "network": "none"
     },
     "syft": {


### PR DESCRIPTION
claude: §11 republish+bump catch-up, greening the merged #639 OCI-freshness crons.

Bumps the curated catalog digests for `osv`, `zizmor`, and `wrangle-lint` to the current `:latest` index digests. These are source/attestation rebuilds only — **no tool-version change** between the pinned build (`1d7e474`) and HEAD (the go.mod diff is indirect-only; zizmor's `requirements.txt` is untouched) — so **no WL005 cooldown applies** (cf #628). Each digest's VSA was verified PASSED against `TomHennen/wrangle` before bumping.

Refs #633 #596

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>