### PR TITLE
build: group Dependabot updates across directories to unclog the pin pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,13 @@ updates:
       - "/tools/dependency-review"
       - "/tools/scorecard"
       - "/tools/zizmor"
+    # An action pinned in several of these directories must move in one PR;
+    # group-by dependency-name bumps every copy together so no two files diverge.
+    groups:
+      across-directories:
+        patterns:
+          - "*"
+        group-by: dependency-name
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -33,6 +40,11 @@ updates:
   - package-ecosystem: "pip"
     directories:
       - "/tools/**"
+    groups:
+      across-directories:
+        patterns:
+          - "*"
+        group-by: dependency-name
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -44,6 +56,11 @@ updates:
       - "/**"
     exclude-paths:
       - "tools/osv/testdata/**"
+    groups:
+      across-directories:
+        patterns:
+          - "*"
+        group-by: dependency-name
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -54,6 +71,11 @@ updates:
   - package-ecosystem: "docker"
     directories:
       - "/**"
+    groups:
+      across-directories:
+        patterns:
+          - "*"
+        group-by: dependency-name
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5

--- a/DEP_MGMT.md
+++ b/DEP_MGMT.md
@@ -110,8 +110,8 @@ whatever is already set.
   edits a composite `action.yml` leaves the self-ref pins that resolve that
   composite stale (`check_pin_freshness` red); before merging, run
   `make converge-action-pins` and land the PR as a **merge commit** (never a
-  squash, or the converged pins re-orphan), or merge as-is and roll the pins
-  forward on main with `make bump-action-pins`.
+  squash, or the converged pins re-orphan). If one lands un-converged, main goes
+  red and `make bump-action-pins <main-sha>` rolls the pins forward to recover.
 - **`make bump-action-pins`** rewrites wrangle's own self-references after a
   composite changes, across `.github/workflows/`, `actions/`, `build/`, and
   `tools/` (the shared `tools/self_ref_pin_paths.sh` set, which

--- a/DEP_MGMT.md
+++ b/DEP_MGMT.md
@@ -104,6 +104,14 @@ whatever is already set.
 - **Dependabot** (`.github/dependabot.yml`) — configure it for each ecosystem in
   use, weekly, no auto-merge, with a cooldown that implements the 7-day "adopt
   after a delay" rule. This automatic patching is *why* branch 1 is the default.
+  Updates are grouped `group-by: dependency-name` so a pin duplicated across
+  directories (a shared action, a tool in two `requirements.txt`) moves in one
+  PR rather than a stale-leaving per-directory PR each. A grouped bump that
+  edits a composite `action.yml` leaves the self-ref pins that resolve that
+  composite stale (`check_pin_freshness` red); before merging, run
+  `make converge-action-pins` and land the PR as a **merge commit** (never a
+  squash, or the converged pins re-orphan), or merge as-is and roll the pins
+  forward on main with `make bump-action-pins`.
 - **`make bump-action-pins`** rewrites wrangle's own self-references after a
   composite changes, across `.github/workflows/`, `actions/`, `build/`, and
   `tools/` (the shared `tools/self_ref_pin_paths.sh` set, which

--- a/gh_workflow_examples/README.md
+++ b/gh_workflow_examples/README.md
@@ -12,7 +12,7 @@ Starting points for adopting wrangle. Copy to `.github/workflows/` in your repo 
 | `build_npm.yml` | `npm pack` / `pnpm pack`, test, SBOM, SLSA L3 provenance. Publishes via npm Trusted Publishing — publish job stays in the caller workflow ([npm constraint](https://github.com/npm/documentation/issues/1755)). | [`../build/actions/npm/README.md`](../build/actions/npm/README.md) |
 | `build_python.yml` | Wheel + sdist, pytest, SBOM, SLSA L3 provenance. Publishes via PyPI Trusted Publishing — publish job stays in the caller. | [`../build/actions/python/README.md`](../build/actions/python/README.md) |
 
-`dependabot.yml` is a starter Dependabot config — copy it to `.github/dependabot.yml` (not the workflows dir). Do NOT enable auto-merge: wrangle adopts upstream versions after a ~7-day cooldown so supply-chain attacks can surface first.
+`dependabot.yml` is a starter Dependabot config — copy it to `.github/dependabot.yml` (not the workflows dir). It groups updates `by dependency-name` so a pin duplicated across files (e.g. your `uses: TomHennen/wrangle/...` ref in several workflows) bumps in one PR instead of drifting. Do NOT enable auto-merge: wrangle adopts upstream versions after a ~7-day cooldown so supply-chain attacks can surface first.
 
 The npm and python READMEs each have a "Before first use" section covering Trusted Publishing setup — bootstrap publish (npm only), trusted-publisher registration, and disabling legacy token uploads. Read those before your first run.
 

--- a/gh_workflow_examples/README.md
+++ b/gh_workflow_examples/README.md
@@ -12,7 +12,7 @@ Starting points for adopting wrangle. Copy to `.github/workflows/` in your repo 
 | `build_npm.yml` | `npm pack` / `pnpm pack`, test, SBOM, SLSA L3 provenance. Publishes via npm Trusted Publishing — publish job stays in the caller workflow ([npm constraint](https://github.com/npm/documentation/issues/1755)). | [`../build/actions/npm/README.md`](../build/actions/npm/README.md) |
 | `build_python.yml` | Wheel + sdist, pytest, SBOM, SLSA L3 provenance. Publishes via PyPI Trusted Publishing — publish job stays in the caller. | [`../build/actions/python/README.md`](../build/actions/python/README.md) |
 
-`dependabot.yml` is a starter Dependabot config — copy it to `.github/dependabot.yml` (not the workflows dir). It groups updates `by dependency-name` so a pin duplicated across files (e.g. your `uses: TomHennen/wrangle/...` ref in several workflows) bumps in one PR instead of drifting. Do NOT enable auto-merge: wrangle adopts upstream versions after a ~7-day cooldown so supply-chain attacks can surface first.
+`dependabot.yml` is a starter Dependabot config — copy it to `.github/dependabot.yml` (not the workflows dir). Do NOT enable auto-merge: wrangle adopts upstream versions after a ~7-day cooldown so supply-chain attacks can surface first.
 
 The npm and python READMEs each have a "Before first use" section covering Trusted Publishing setup — bootstrap publish (npm only), trusted-publisher registration, and disabling legacy token uploads. Read those before your first run.
 

--- a/gh_workflow_examples/dependabot.yml
+++ b/gh_workflow_examples/dependabot.yml
@@ -14,6 +14,14 @@ updates:
     # directory entry per action — github-actions globs don't recurse into
     # nested action.yml files.
     directory: "/"
+    # An action pinned in several files (a wrangle ref in multiple workflows,
+    # or across "/" and your composites) moves in one PR under group-by, so no
+    # two copies diverge.
+    groups:
+      across-directories:
+        patterns:
+          - "*"
+        group-by: dependency-name
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -24,6 +32,11 @@ updates:
   # - package-ecosystem: "npm"
   #   directories:
   #     - "/**"
+  #   groups:
+  #     across-directories:
+  #       patterns:
+  #         - "*"
+  #       group-by: dependency-name
   #   schedule:
   #     interval: "weekly"
   #   open-pull-requests-limit: 5
@@ -33,6 +46,11 @@ updates:
   # - package-ecosystem: "pip"
   #   directories:
   #     - "/**"
+  #   groups:
+  #     across-directories:
+  #       patterns:
+  #         - "*"
+  #       group-by: dependency-name
   #   schedule:
   #     interval: "weekly"
   #   open-pull-requests-limit: 5
@@ -42,6 +60,11 @@ updates:
   # - package-ecosystem: "gomod"
   #   directories:
   #     - "/**"
+  #   groups:
+  #     across-directories:
+  #       patterns:
+  #         - "*"
+  #       group-by: dependency-name
   #   schedule:
   #     interval: "weekly"
   #   open-pull-requests-limit: 5
@@ -51,6 +74,11 @@ updates:
   # - package-ecosystem: "docker"   # base-image updates (Dockerfile FROM lines)
   #   directories:
   #     - "/**"
+  #   groups:
+  #     across-directories:
+  #       patterns:
+  #         - "*"
+  #       group-by: dependency-name
   #   schedule:
   #     interval: "weekly"
   #   open-pull-requests-limit: 5


### PR DESCRIPTION
claude: Almost every open Dependabot PR is failing and un-mergeable, clogging the dependency-update pipeline. This fixes the root cause.

## Root cause: multi-place pins vs. per-directory bumps

Several dependencies are pinned in **more than one file** — e.g. `actions/setup-go` is pinned at the same SHA in **6** files (`.github/workflows/{test,build_shell}.yml` plus the composites `actions/scan`, `actions/verify-vsa`, `build/actions/go/{build,checks}`). The `pip` config's `/tools/**` also scans `/tools` recursively **and** each nested dir, so `zizmor` / `ast-grep-cli` (each in one file) get counted twice.

Dependabot opened a **separate per-directory PR** for each occurrence (5 `setup-go` PRs: #650, #655–658; duplicate zizmor #651/#654, ast-grep #652/#653). Each bumps *one* copy and leaves the rest stale, so CI fails two ways — confirmed from the failing logs:

- **Divergence guard** — `test_thirdparty_pin_consistency` (`not ok 288 ... third-party action pins are uniform`) fails the moment two files disagree on a SHA:
  ```
  Third-party actions pinned to >1 SHA across wrangle internals:
  actions/setup-go@4a36011...  actions/setup-go@924ae3a...
  ```
- **Pin freshness** — for the PRs that edit a *composite*, the self-ref pins that resolve that composite go stale:
  ```
  STALE: build/actions/go/build@d6bcaf511 — resolves non-pin content that differs from HEAD (re-bump with tools/converge_action_pins.sh)
  ```

## Fix

**1. Group by dependency-name across directories** (`.github/dependabot.yml`). Each ecosystem gets a `group-by: dependency-name` group, so one PR bumps *every* copy of a dependency across all its directories atomically — no divergence, and the `/tools` duplicates collapse. This turns the 5 `setup-go` PRs into 1 and dedupes the pip pairs. Cooldown / no-auto-merge / limits unchanged.

**2. Composite re-converge (documented, not automated).** A grouped bump that edits a composite still leaves its self-ref pins stale. An auto-push workflow was rejected: it needs `pull_request_target` + `contents: write` running PR-tree scripts (the exact surface wrangle forbids), Dependabot force-pushes would clobber it, and a squash merge re-orphans the converged pins anyway. Since dependency PRs are already reviewed and merged by hand, `DEP_MGMT.md` now documents the merge-time step: run `make converge-action-pins` and land as a **merge commit**, or roll the pins forward post-merge with `make bump-action-pins`.

## Verification

- `dependabot.yml` is valid YAML; `group-by: dependency-name` + `patterns: ["*"]` matches GitHub's schema and real-world configs.
- Reproduced #657's `STALE: build/actions/go/build@d6bcaf511` from a simulated composite bump, then confirmed `converge_action_pins.sh` clears it in **1 commit** (freshness + ancestry both green).

## What the existing stuck PRs need

Dependabot re-evaluates on its next run and, seeing the group, will **supersede** the per-directory PRs with grouped ones (or `@dependabot recreate` forces it now). The old ungrouped PRs can be closed. Note: the **zizmor 1.26.1** bump (#651/#654) will still fail after grouping — v1.26.1 adds audits that surface **4 new low findings** on wrangle's own workflows; that needs a code fix or justified suppression, separate from this PR.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

> Scope note: `group-by: dependency-name` covers **version updates** (what this clog is). If Dependabot *security-alert* updates are enabled, an alert-driven bump of a multi-place pin still needs a manual converge — the divergence guard fails closed, so nothing ships silently, but the maintainer hits one manual step.
