### PR TITLE
fix(build): correct unsound go-cache ternary defeating release cache isolation

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -154,7 +154,7 @@ jobs:
           retention-days: 1
           # Cold on release: the scan gates an attested build, so a
           # poisoned tool cache must not be able to forge a passing scan.
-          go-cache: ${{ needs.prep.outputs.should-release == 'true' && '' || inputs.go-cache }}
+          go-cache: ${{ needs.prep.outputs.should-release != 'true' && inputs.go-cache || '' }}
 
   build:
     # needs `scan` so a load-bearing finding blocks the mid-composite push.

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      uses: TomHennen/wrangle/build/actions/container@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/verify_release@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -191,7 +191,7 @@ jobs:
           retention-days: 1
           # Cold on release: the scan gates an attested build, so a
           # poisoned tool cache must not be able to forge a passing scan.
-          go-cache: ${{ needs.prep.outputs.should-release == 'true' && '' || inputs.go-cache }}
+          go-cache: ${{ needs.prep.outputs.should-release != 'true' && inputs.go-cache || '' }}
 
   # Quality gates with `contents: read` only. `go test` executes
   # arbitrary adopter test code; the minimum-permissions posture

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -161,7 +161,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         id: prep
         with:
           build-type: go
@@ -180,7 +180,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/build/actions/go/checks@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/build/actions/go/build@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         id: release
         with:
           path: ${{ inputs.path }}
@@ -369,7 +369,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/attest_provenance@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         id: attest
         with:
           build-type: go
@@ -395,7 +395,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/verify_release@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -179,7 +179,7 @@ jobs:
           retention-days: 1
           # Cold on release: the scan gates an attested build, so a
           # poisoned tool cache must not be able to forge a passing scan.
-          go-cache: ${{ needs.prep.outputs.should-release == 'true' && '' || inputs.go-cache }}
+          go-cache: ${{ needs.prep.outputs.should-release != 'true' && inputs.go-cache || '' }}
 
   build:
     # needs `scan` to fold the untrusted scan output into the metadata dir.

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -149,7 +149,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         id: prep
         with:
           build-type: npm
@@ -168,7 +168,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/build/actions/npm@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         id: build
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/attest_provenance@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         id: attest
         with:
           build-type: npm
@@ -306,7 +306,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/verify_release@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -156,7 +156,7 @@ jobs:
           retention-days: 1
           # Cold on release: the scan gates an attested build, so a
           # poisoned tool cache must not be able to forge a passing scan.
-          go-cache: ${{ needs.prep.outputs.should-release == 'true' && '' || inputs.go-cache }}
+          go-cache: ${{ needs.prep.outputs.should-release != 'true' && inputs.go-cache || '' }}
 
   build:
     # needs `scan` so the untrusted scan job's output can be folded into the

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -126,7 +126,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         id: prep
         with:
           build-type: python
@@ -145,7 +145,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/build/actions/python@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         id: build
         with:
           path: ${{ inputs.path }}
@@ -270,7 +270,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/attest_provenance@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         id: attest
         with:
           build-type: python
@@ -293,7 +293,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/verify_release@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/scan@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+        uses: TomHennen/wrangle/build/actions/shell@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      - uses: TomHennen/wrangle/actions/prep@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+        uses: TomHennen/wrangle/actions/scan@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      uses: TomHennen/wrangle/tools/scorecard@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+      uses: TomHennen/wrangle/tools/dependency-review@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@d6bcaf511af9b83e24a5cd268139836de7ab42e7 # main 2026-06-28
+    - uses: TomHennen/wrangle/actions/verify@caed02478e25ee8e94f77ab95d38388c08051d3e # main 2026-07-02
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -238,7 +238,7 @@ teardown() {
     # The scan gates the attested build; its Go tool cache must build cold on
     # release so a poisoned cache cannot forge a passing scan.
     local wf="$REPO_ROOT/.github/workflows/build_and_publish_container.yml"
-    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$wf\" | grep -E \"go-cache:.*should-release == 'true' && ''\""
+    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$wf\" | grep -E \"go-cache:.*should-release != 'true' && inputs.go-cache\""
     [[ "$status" -eq 0 ]]
 }
 

--- a/build/actions/go/test.bats
+++ b/build/actions/go/test.bats
@@ -693,7 +693,7 @@ func main() {}
     # The scan gates the attested release; its Go tool cache must build cold
     # on release so a poisoned cache cannot forge a passing scan.
     section="$(awk '/^  [a-z][a-z_-]*:$/ { in_section = ($0 == "  scan:") } in_section' "$WORKFLOW")"
-    grep -qE "go-cache:.*should-release == 'true' && ''" <<<"$section"
+    grep -qE "go-cache:.*should-release != 'true' && inputs.go-cache" <<<"$section"
 }
 
 @test "go: workflow release job needs scan (load-bearing finding blocks publish)" {

--- a/build/actions/npm/test.bats
+++ b/build/actions/npm/test.bats
@@ -743,7 +743,7 @@ write_pkg_json() {
 @test "npm: scan job forces go-cache off on release" {
     # The scan gates the attested release; its Go tool cache must build cold
     # on release so a poisoned cache cannot forge a passing scan.
-    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E \"go-cache:.*should-release == 'true' && ''\""
+    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E \"go-cache:.*should-release != 'true' && inputs.go-cache\""
     [[ "$status" -eq 0 ]]
 }
 

--- a/build/actions/python/test.bats
+++ b/build/actions/python/test.bats
@@ -430,7 +430,7 @@ write_pyproject() {
 @test "python: scan job forces go-cache off on release" {
     # The scan gates the attested release; its Go tool cache must build cold
     # on release so a poisoned cache cannot forge a passing scan.
-    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E \"go-cache:.*should-release == 'true' && ''\""
+    run bash -c "sed -n '/^  scan:/,/^  [a-z]/p' \"$WORKFLOW\" | grep -E \"go-cache:.*should-release != 'true' && inputs.go-cache\""
     [[ "$status" -eq 0 ]]
 }
 


### PR DESCRIPTION
claude: zizmor 1.26.1's `unsound-ternary` audit flagged an expression bug in all four `build_and_publish_*` reusable workflows that silently defeats a SLSA-L3 cache-isolation control.

## The bug
The source-scan `go-cache` input was:
```
go-cache: ${{ needs.prep.outputs.should-release == 'true' && '' || inputs.go-cache }}
```
In GitHub Actions, `X && '' || Y` **always returns `Y`** — the true branch `''` is falsy, so the expression collapses to `inputs.go-cache` in *both* branches. The `should-release` check did nothing.

## The defeated control
The intent (per the inline comment and `docs/SLSA_L3_AUDIT.md`) is to **force a cold cache on release**: the source scan gates an attested release, so its tools (osv-scanner et al., built from source) must build cold — a poisoned Go module/build cache must not be able to forge a passing scan. The buggy expression let the release scan reuse a warm cache, so this L3 cache-isolation control was silently off.

## The fix
Invert to the sound form:
```
go-cache: ${{ needs.prep.outputs.should-release != 'true' && inputs.go-cache || '' }}
```
- release (`should-release == 'true'`) → `''` (cold)
- non-release → `inputs.go-cache`

Truth table verified both ways. zizmor 1.26.1 (isolated env) goes **4 → 0** for `unsound-ternary` across these workflows, and **0** across all workflows + `action.yml` files. A repo-wide grep for the sibling patterns `&& '' ||` / `&& "" ||` (all extensions) is clean. The other `should-release && … || …` expressions (`cache: … && 'disabled' || 'enabled'`, `retention-days`, metadata selection) are sound — their true branch is a truthy literal.

## Exposure verdict
**Live hole, scoped to opt-in adopters.** The scan action restores/saves the Go cache only when `go-cache == 'enabled'` (`actions/scan/action.yml`). `go-cache` defaults to `""`, so default adopters resolve to `''` even with the bug — cold, unaffected. An adopter who sets `go-cache: enabled` on a release-capable caller **did** get a warm cache on the release scan: a real L3 hole this fixes. Wrangle's own repo is **not** exposed — but not for the reason first stated: `.github/workflows/local_publish_images.yml` *is* a release-capable caller of the buggy workflow (it calls `build_and_publish_container.yml` with `release-events: main-and-tags`). It is safe only because it leaves `go-cache` at its `""` default, so the scan never enabled the cache — the same default that protects most adopters.

## Consolidation
Not consolidated. The `should-release && X || Y` shape is the inherent spine of these four parallel per-build-type workflows (it recurs for `cache`, `retention-days`, metadata); GitHub Actions has no include mechanism for reusable workflows, and threading `inputs.go-cache` through the self-ref-pinned `prep` action just to re-emit it would be a forced abstraction for a one-line `with:` expression. Fixed all four consistently instead.

## Docs
`docs/SLSA_L3_AUDIT.md` states this control abstractly ("force-disabled on release") and never reproduces the buggy expression form; the fix makes that claim actually true, so no doc edit is needed (same-line change, no line-number drift).

**Flagged, not fixed (out of scope — doc cleanup follow-up):** `docs/SLSA_L3_AUDIT.md` refers to `needs.gate.outputs.should-release`, but the workflows use `needs.prep.outputs.should-release`. Pre-existing stale ref, unrelated to this fix.

Unblocks the zizmor 1.26.1 bump (#654).

Fixes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


---

**Merge as a merge commit, not squash** — this branch carries self-ref pin-convergence commits (`tools/converge_action_pins.sh`); squashing would re-orphan the intermediate `build/actions/*@<sha>` pins.
