### PR TITLE
claude: post-publish catalog auto-bump + first-party cooldown exemption (#619)

### DIFF
--- a/.github/workflows/local_publish_images.yml
+++ b/.github/workflows/local_publish_images.yml
@@ -14,8 +14,9 @@ on:
     paths:
       - tools/**
       - lib/**
-      # A catalog-only push is a digest bump, not a source change: it must not
-      # re-trigger a rebuild (which would loop the auto-bump below).
+      # A catalog-only push is a digest bump, not a source change: excluding it
+      # keeps the auto-bump below from looping. Must stay after `tools/**` —
+      # last matching pattern wins, so reordering silently reopens the loop.
       - "!tools/catalog.json"
 
 permissions: {}
@@ -64,11 +65,8 @@ jobs:
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # After a publish, repoint the curated catalog to the freshly published
-  # `:latest` digests and OPEN (never auto-merge) a bump PR for review. First-
-  # party rebuilds are cooldown-exempt (docs/tool_container_design.md §11), so the
-  # maintainer merges it on review latency. Runs only on main, off the trusted
-  # push trigger (no pull_request_target, no untrusted-tree checkout).
+  # Open (never auto-merge) a catalog bump PR for the just-published digests.
+  # main-only, on the trusted push trigger (no pull_request_target).
   bump-catalog:
     needs: [publish]
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/local_publish_images.yml
+++ b/.github/workflows/local_publish_images.yml
@@ -14,8 +14,17 @@ on:
     paths:
       - tools/**
       - lib/**
+      # A catalog-only push is a digest bump, not a source change: it must not
+      # re-trigger a rebuild (which would loop the auto-bump below).
+      - "!tools/catalog.json"
 
 permissions: {}
+
+# Serialize publishes so two runs cannot race the shared `:latest` tag the
+# auto-bump resolves.
+concurrency:
+  group: publish-tool-images
+  cancel-in-progress: false
 
 jobs:
   publish:
@@ -54,3 +63,42 @@ jobs:
       release-events: main-and-tags
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # After a publish, repoint the curated catalog to the freshly published
+  # `:latest` digests and OPEN (never auto-merge) a bump PR for review. First-
+  # party rebuilds are cooldown-exempt (docs/tool_container_design.md §11), so the
+  # maintainer merges it on review latency. Runs only on main, off the trusted
+  # push trigger (no pull_request_target, no untrusted-tree checkout).
+  bump-catalog:
+    needs: [publish]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write        # push the bump branch
+      pull-requests: write   # open the bump PR
+    steps:
+      # persist-credentials: false — the push authenticates with GH_TOKEN via an
+      # explicit push URL (open_catalog_bump_pr.sh), so no git credential is left
+      # on disk for a later step to exfiltrate.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Resolve each curated `:latest` and rewrite drifted catalog entries. A
+      # registry backend error (exit 2) is advisory — any resolvable entry is
+      # still bumped and the PR opened for it.
+      - name: Bump catalog to published :latest digests
+        run: |
+          set +e
+          ./tools/bump_catalog_to_latest.sh
+          rc=$?
+          if [[ "$rc" -eq 2 ]]; then
+            printf '::warning::a curated image could not be resolved; its digest was left as-is\n'
+          fi
+
+      - name: Open the catalog bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WRANGLE_AUTOBUMP_GH_REPO: ${{ github.repository }}
+        run: ./tools/open_catalog_bump_pr.sh

--- a/DEP_MGMT.md
+++ b/DEP_MGMT.md
@@ -128,7 +128,15 @@ whatever is already set.
   reads each pinned digest's signed SLSA provenance, takes the build commit, and
   fails if any image build input (`tools/` + `lib/`, the publish trigger's paths,
   excluding the catalog file) changed between that commit and HEAD (also a release
-  gate, needs full git history). A digest cooldown remains deferred (#623).
+  gate, needs full git history). After a publish, `local_publish_images.yml`
+  auto-**opens** (never auto-merges) a bump PR — `tools/bump_catalog_to_latest.sh`
+  repoints each drifted `ghcr.io/tomhennen/wrangle/*` entry to its new `:latest`,
+  `tools/open_catalog_bump_pr.sh` opens the PR (requires the repo setting *"Allow
+  GitHub Actions to create and approve pull requests"*). First-party curated-image
+  bumps are **cooldown-exempt** — a rebuild of wrangle's own reviewed source is not
+  a third-party update — so they merge on review latency; an adopter override is
+  not exempt. A digest cooldown remains deferred (#623); when it lands it keys on
+  the `ghcr.io/tomhennen/wrangle/*` namespace so only third-party overrides wait.
 - **Manual today:** the binary+provenance installs (branch 2) and the base-image
   digest. Automating that surface — ideally one mechanism that also covers
   wrangle's own self-references — is #264.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test lint shellcheck shellstyle workflowstyle gotest bats zizmor integration bump-action-pins converge-action-pins check-catalog check-catalog-freshness check-catalog-provenance-freshness bump-catalog-digest
+.PHONY: all test lint shellcheck shellstyle workflowstyle gotest bats zizmor integration bump-action-pins converge-action-pins check-catalog check-catalog-freshness check-catalog-provenance-freshness bump-catalog-digest bump-catalog-to-latest
 
 # bash, not the default sh: the integration recipe sources lib/env.sh,
 # whose `set -o pipefail` dash doesn't reliably support.
@@ -105,3 +105,8 @@ check-catalog-provenance-freshness:
 # Usage: make bump-catalog-digest TOOL=osv DIGEST=sha256:<64hex>
 bump-catalog-digest:
 	@./tools/bump_catalog_digest.sh $(TOOL) $(DIGEST)
+
+# Repoint every curated entry to its current registry :latest digest (the batch
+# driver the post-publish auto-bump runs). See tools/bump_catalog_to_latest.sh.
+bump-catalog-to-latest:
+	@./tools/bump_catalog_to_latest.sh

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -348,8 +348,8 @@ not a meaningful per-delivery signal.)
   stays a narrow, wrangle-internal task, required only before *production consumption*, not before
   prototyping. Source-freshness (`check_catalog_provenance_freshness.sh`) runs release-blocking and as a
   weekly advisory — **not** per run: a stale-but-attested image passes the pull-time VSA gate and is
-  consumed like any pinned dependency (the consume-the-pin model, §7/§11), with a planned auto-bump PR
-  (§11) keeping the pinned digest current. Still open (#623): a digest cooldown and the adoption-lag check's
+  consumed like any pinned dependency (the consume-the-pin model, §7/§11), with the post-publish auto-bump
+  PR (§11) keeping the pinned digest current. Still open (#623): a digest cooldown and the adoption-lag check's
   advisory→blocking promotion.
 - **Pull-time consumer VSA gate.** Before a curated image runs, the orchestrator verifies it carries a
   PASSED, SLSA-Build-L3 wrangle verification-summary attestation signed by the container build+publish
@@ -375,8 +375,8 @@ not a meaningful per-delivery signal.)
   (`lib/verify_image_vsa.sh`, Phase 1) — a stale pinned toolbox is consumed like any pinned dependency,
   **not** gated per run. This dissolves the self-signing concern: `attest-toolbox@NEW` is signed by the
   pinned `attest-toolbox@OLD`, which is attested and passes verify-before-run — no circularity, no
-  self-build exemption. Source-freshness stays a release/weekly check (§6, §11), with a planned auto-bump
-  PR (§11) keeping the pinned digest current; there is **no per-signing-run freshness gate**. Containerizing the
+  self-build exemption. Source-freshness stays a release/weekly check (§6, §11), with the post-publish
+  auto-bump PR (§11) keeping the pinned digest current; there is **no per-signing-run freshness gate**. Containerizing the
   verify path also unlocks **VSA-verified caching** of all tool images — the L3-safe replacement for the
   build cache wrangle disables today.
   **Token delivery.** The host mints an `aud=sigstore` `SIGSTORE_ID_TOKEN` and passes it plus the
@@ -393,8 +393,8 @@ not a meaningful per-delivery signal.)
   provenance-verified host-side (`verify_image_vsa`) before it runs. Off by default, byte-identical when
   unset, and not on the L3 release path; supported for the go/python/npm build types only (the container
   build type's `oci:` collector needs in-container registry auth, fail-closed and deferred). Containerizing
-  the signing steps (bnd/cosign, which need the OIDC token), the OCI-collector verify path, and the
-  catalog auto-bump PR (§11) are the remaining Phase-3 work.
+  the signing steps (bnd/cosign, which need the OIDC token) and the OCI-collector verify path are the
+  remaining Phase-3 work. (The catalog auto-bump PR, §11, has shipped.)
 - **Separate feature:** emitting an attested container of an adopter's own Go app (the "free container"
   value-add via goreleaser/ko). It reuses some machinery but serves adopter UX, not the goals here.
 - **Left as-is:** tools with official GitHub Actions that gain nothing from containerization stay
@@ -459,13 +459,15 @@ digest *is* its version — and a wrangle release references a consistent set of
 release does not rebuild or re-tag tool images.**
 
 - **Tool change** — a PR edits `tools/<tool>/Dockerfile` or its go.mod; on merge to main, CI builds and
-  publishes the image (with provenance) → a new digest, and an **auto-bump PR** (to be built, #619;
-  today `tools/bump_catalog_digest.sh` does this by hand) updates the catalog entry to it. First-party
+  publishes the image (with provenance) → a new digest, and the **post-publish auto-bump PR**
+  (`local_publish_images.yml`'s `bump-catalog` job → `tools/bump_catalog_to_latest.sh` +
+  `tools/open_catalog_bump_pr.sh`) updates the catalog entry to it. First-party
   rebuilds (wrangle's own `ghcr.io/tomhennen/wrangle/*`) are **exempt from the 7-day community-vetting
   cooldown** — that delay exists to let the community vet *third-party* updates for supply-chain attacks,
   which a rebuild of wrangle's own reviewed source is not — so the bump merges on CI/review latency and
-  keeps the catalog current. One source PR + one bump PR — not a manual double-bump. A catalog-only digest
-  change touches no Dockerfile, so it triggers no rebuild (no loop).
+  keeps the catalog current. One source PR + one bump PR — not a manual double-bump. The publish trigger is
+  a path glob that matches `tools/catalog.json`, so a catalog-only digest change would re-trigger a rebuild;
+  the trigger excludes `tools/catalog.json`, which is what keeps the bump from looping.
 - **Release tag** — precondition: the catalog is fresh. `check_catalog_freshness.sh` proves the shipped
   half — no digest is behind its published `:latest` (adoption lag); `check_catalog_provenance_freshness.sh`
   proves the stronger half — every digest is the image built from the current tool source, read from each

--- a/lib/registry.sh
+++ b/lib/registry.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# lib/registry.sh — shared GHCR helpers for the curated tool catalog.
+#
+# Provides:
+#   resolve_latest_digest — anonymous GHCR digest of an <image>:latest tag
+# plus the two regexes its callers share:
+#   CURATED_PREFIX_RE     — wrangle's own image namespace (adopter overrides excluded)
+#   DIGEST_RE             — a well-formed sha256 image digest
+
+set -euo pipefail
+set -f  # disable globbing — handles external image names
+
+# Tool segment matches run.sh's tool-name shape, so a crafted `..` segment can't
+# turn curl's path into a cross-repo query.
+CURATED_PREFIX_RE='^ghcr\.io/tomhennen/wrangle/[a-z][a-z0-9_-]*$'
+DIGEST_RE='^sha256:[0-9a-f]{64}$'
+
+# is_curated_image <imagename> — true if <imagename> is on wrangle's own curated
+# namespace. An adopter-override image (a foreign namespace) is not, so callers
+# skip it: wrangle vouches only for the images it publishes.
+is_curated_image() {
+    [[ "$1" =~ $CURATED_PREFIX_RE ]]
+}
+
+# resolve_latest_digest <imagename> — anonymous GHCR digest of <imagename>:latest
+# via the registry API. Prints the index digest on success; non-zero on any
+# backend failure (token fetch, registry read, or a missing/malformed digest).
+# The index media types in Accept return the same multi-arch index digest the
+# catalog pins.
+resolve_latest_digest() {
+    local imagename="$1" registry repo token digest
+    registry="${imagename%%/*}"
+    repo="${imagename#*/}"
+
+    token="$(curl -fsSL --connect-timeout 10 --max-time 30 "https://${registry}/token?scope=repository:${repo}:pull" 2>/dev/null \
+        | jq -r '.token // empty' 2>/dev/null)" || return 1
+    [[ -n "$token" ]] || return 1
+
+    digest="$(curl -fsS -I -X GET --connect-timeout 10 --max-time 30 \
+        -H "Authorization: Bearer ${token}" \
+        -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json' \
+        "https://${registry}/v2/${repo}/manifests/latest" 2>/dev/null \
+        | tr -d '\r' | sed -n 's/^[Dd]ocker-[Cc]ontent-[Dd]igest:[[:space:]]*//p')" || return 1
+    [[ "$digest" =~ $DIGEST_RE ]] || return 1
+    printf '%s' "$digest"
+}

--- a/test/test_bump_catalog_to_latest.bats
+++ b/test/test_bump_catalog_to_latest.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+# Unit tests for tools/bump_catalog_to_latest.sh — the batch driver behind the
+# post-publish auto-bump. Digest resolution is curl-only, so a fake `curl` on
+# PATH stands in for the GHCR registry API (same shim shape as the freshness
+# test); the write path runs the real bump_catalog_digest.sh, no network.
+
+DIGEST_A="sha256:$(printf 'a%.0s' {1..64})"
+DIGEST_B="sha256:$(printf 'b%.0s' {1..64})"
+
+setup() {
+    SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/tools/bump_catalog_to_latest.sh"
+    CATALOG="$BATS_TEST_TMPDIR/catalog.json"
+    BIN_DIR="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$BIN_DIR"
+    export WRANGLE_CATALOG="$CATALOG" PATH="$BIN_DIR:$PATH"
+    command -v jq >/dev/null 2>&1 || { printf 'jq not on PATH\n' >&2; return 1; }
+
+    printf '%s\n' \
+        '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@'"$DIGEST_A"'","network":"egress"}}}' \
+        > "$CATALOG"
+}
+
+image_of() { jq -r --arg t "$1" '.tools[$t].image' "$CATALOG"; }
+
+# install_curl — a fake `curl` reading $SHIM_DIGEST / $SHIM_TOKEN_FAIL at run time.
+install_curl() {
+    cat >"$BIN_DIR/curl" <<'SHIM'
+#!/usr/bin/env bash
+for a in "$@"; do
+  case "$a" in
+    */token\?*)
+      [[ -n "${SHIM_TOKEN_FAIL:-}" ]] && exit 22
+      printf '{"token":"t"}\n'; exit 0 ;;
+    *manifests/*)
+      printf 'HTTP/2 200\r\ndocker-content-digest: %s\r\n\r\n' "${SHIM_DIGEST}"; exit 0 ;;
+  esac
+done
+exit 0
+SHIM
+    chmod +x "$BIN_DIR/curl"
+}
+
+# install_curl_per_image — toola resolves a drifted digest; toolb's lookup fails.
+install_curl_per_image() {
+    cat >"$BIN_DIR/curl" <<SHIM
+#!/usr/bin/env bash
+for a in "\$@"; do
+  case "\$a" in
+    *toolb*) exit 22 ;;
+    *token\?*) printf '{"token":"t"}\n'; exit 0 ;;
+    *toola/manifests*) printf 'HTTP/2 200\r\ndocker-content-digest: $DIGEST_B\r\n\r\n'; exit 0 ;;
+  esac
+done
+exit 0
+SHIM
+    chmod +x "$BIN_DIR/curl"
+}
+
+@test "bump_catalog_to_latest: drifted digest is bumped to :latest (exit 0)" {
+    install_curl
+    SHIM_DIGEST="$DIGEST_B" run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(image_of osv)" = "ghcr.io/tomhennen/wrangle/osv@$DIGEST_B" ]
+    [[ "$output" == *"bumped 1 of 1"* ]]
+}
+
+@test "bump_catalog_to_latest: in-sync digest is a no-op (exit 0)" {
+    install_curl
+    SHIM_DIGEST="$DIGEST_A" run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(image_of osv)" = "ghcr.io/tomhennen/wrangle/osv@$DIGEST_A" ]
+    [[ "$output" == *"bumped 0 of 1"* ]]
+}
+
+@test "bump_catalog_to_latest: adopter-override entry is skipped" {
+    # Token-fail shim: a resolved non-curated entry would surface as exit 2.
+    install_curl
+    printf '%s\n' \
+        '{"tools":{"adopter":{"kind":"scan","delivery":"image","image":"registry.example.com/x/y@'"$DIGEST_A"'"}}}' \
+        > "$CATALOG"
+    SHIM_TOKEN_FAIL=1 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"bumped 0 of 0"* ]]
+}
+
+# A resolvable entry is still bumped even when a sibling's registry lookup fails,
+# and the overall run reports the backend error (exit 2).
+@test "bump_catalog_to_latest: resolvable entry bumped despite a sibling backend error (exit 2)" {
+    install_curl_per_image
+    printf '%s\n' \
+        '{"tools":{"toola":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toola@'"$DIGEST_A"'"},"toolb":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toolb@'"$DIGEST_A"'"}}}' \
+        > "$CATALOG"
+    run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [ "$(image_of toola)" = "ghcr.io/tomhennen/wrangle/toola@$DIGEST_B" ]
+    [ "$(image_of toolb)" = "ghcr.io/tomhennen/wrangle/toolb@$DIGEST_A" ]
+    [[ "$output" == *"could not resolve"* ]]
+}
+
+@test "bump_catalog_to_latest: malformed catalog is an error (exit 2)" {
+    printf '{ not json\n' > "$CATALOG"
+    run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not valid JSON"* ]]
+}

--- a/test/test_open_catalog_bump_pr.bats
+++ b/test/test_open_catalog_bump_pr.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+# Unit tests for tools/open_catalog_bump_pr.sh. git runs for real against a
+# throwaway repo with a local bare "origin" (no network, faithful to the real
+# push); only `gh` is shimmed, recording its argv so we can assert the PR-open
+# path without touching GitHub. The shim reports "PR already open" via
+# $SHIM_PR_EXISTS so both the create and the update branches are covered.
+
+setup() {
+    SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/tools/open_catalog_bump_pr.sh"
+    BIN_DIR="$BATS_TEST_TMPDIR/bin"
+    WORK="$BATS_TEST_TMPDIR/work"
+    REMOTE="$BATS_TEST_TMPDIR/remote.git"
+    GH_LOG="$BATS_TEST_TMPDIR/gh.log"
+    mkdir -p "$BIN_DIR"
+    export PATH="$BIN_DIR:$PATH"
+    export WRANGLE_AUTOBUMP_GH_REPO="tomhennen/wrangle"
+    export GH_LOG
+    # Local bare "origin" is a filesystem path — keep the token push path (https
+    # only) out of these tests so the push is deterministic.
+    unset GH_TOKEN
+
+    command -v git >/dev/null 2>&1 || { printf 'git not on PATH\n' >&2; return 1; }
+
+    git init --bare -q "$REMOTE"
+    git init -q "$WORK"
+    git -C "$WORK" config user.name t
+    git -C "$WORK" config user.email t@example.com
+    git -C "$WORK" config commit.gpgsign false
+    mkdir -p "$WORK/tools"
+    printf '{"tools":{}}\n' > "$WORK/tools/catalog.json"
+    git -C "$WORK" add -A
+    git -C "$WORK" commit -qm init
+    git -C "$WORK" branch -M main
+    git -C "$WORK" remote add origin "$REMOTE"
+    git -C "$WORK" push -q origin main
+
+    cat >"$BIN_DIR/gh" <<'SHIM'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+case "$*" in
+  *"pr list"*) [[ -n "${SHIM_PR_EXISTS:-}" ]] && printf '1\n' || printf '0\n' ;;
+  *"pr create"*) printf 'https://github.com/tomhennen/wrangle/pull/1\n' ;;
+esac
+exit 0
+SHIM
+    chmod +x "$BIN_DIR/gh"
+
+    cd "$WORK" || return 1
+}
+
+@test "open_catalog_bump_pr: unchanged catalog is a no-op (no branch, no gh)" {
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"nothing to open"* ]]
+    [ ! -f "$GH_LOG" ]
+    run git -C "$REMOTE" rev-parse --verify bot/catalog-autobump
+    [ "$status" -ne 0 ]
+}
+
+@test "open_catalog_bump_pr: a bumped catalog is committed, pushed, and a PR opened" {
+    printf '{"tools":{"osv":{"image":"x"}}}\n' > "$WORK/tools/catalog.json"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    # Branch pushed to origin with the catalog change.
+    git -C "$REMOTE" rev-parse --verify bot/catalog-autobump
+    run git -C "$REMOTE" show bot/catalog-autobump:tools/catalog.json
+    [[ "$output" == *'"osv"'* ]]
+    # gh opened the PR against main.
+    grep -q 'pr create' "$GH_LOG"
+    grep -q -- '--base main' "$GH_LOG"
+    grep -q -- '--head bot/catalog-autobump' "$GH_LOG"
+}
+
+@test "open_catalog_bump_pr: an already-open PR is refreshed, not recreated" {
+    printf '{"tools":{"osv":{"image":"x"}}}\n' > "$WORK/tools/catalog.json"
+    SHIM_PR_EXISTS=1 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already open"* ]]
+    grep -q 'pr list' "$GH_LOG"
+    ! grep -q 'pr create' "$GH_LOG"
+    # The force-push still landed the refreshed catalog on the branch.
+    git -C "$REMOTE" rev-parse --verify bot/catalog-autobump
+}
+
+@test "open_catalog_bump_pr: a second run force-updates the same branch (one rolling PR)" {
+    printf '{"tools":{"osv":{"image":"x1"}}}\n' > "$WORK/tools/catalog.json"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    # Next publish: back on main, catalog re-bumped, PR already open.
+    git checkout -q main
+    printf '{"tools":{"osv":{"image":"x2"}}}\n' > "$WORK/tools/catalog.json"
+    SHIM_PR_EXISTS=1 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    run git -C "$REMOTE" show bot/catalog-autobump:tools/catalog.json
+    [[ "$output" == *'x2'* ]]
+}

--- a/tools/bump_catalog_to_latest.sh
+++ b/tools/bump_catalog_to_latest.sh
@@ -16,15 +16,13 @@ set -f  # disable globbing — handles external tool names
 #         any resolvable entry is still bumped).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../lib/read_catalog.sh
-source "$SCRIPT_DIR/../lib/read_catalog.sh"
 # shellcheck source=../lib/registry.sh
 source "$SCRIPT_DIR/../lib/registry.sh"
 
 # bump_catalog_to_latest <catalog_file> — 0 done, 2 a backend error.
 bump_catalog_to_latest() {
     local file="$1" backend_err=0 bumped=0 checked=0
-    local tool delivery image imagename pinned resolved
+    local tool image imagename pinned resolved
 
     if [[ ! -f "$file" ]]; then
         printf 'bump_catalog_to_latest: catalog not found: %s\n' "$file" >&2
@@ -35,11 +33,8 @@ bump_catalog_to_latest() {
         return 2
     fi
 
-    while IFS= read -r tool; do
+    while IFS=$'\t' read -r tool image; do
         [[ -z "$tool" ]] && continue
-        delivery="$(read_catalog_field "$file" "$tool" delivery)"
-        [[ "$delivery" == "image" ]] || continue
-        image="$(read_catalog_field "$file" "$tool" image)"
         imagename="${image%@sha256:*}"
         pinned="${image##*@}"
 
@@ -59,7 +54,9 @@ bump_catalog_to_latest() {
             continue
         fi
         bumped=$((bumped + 1))
-    done < <(jq -r '.tools // {} | keys[]' "$file")
+    done < <(jq -r '.tools // {} | to_entries[]
+        | select(.value.delivery == "image")
+        | [.key, .value.image] | @tsv' "$file")
 
     printf 'bump_catalog_to_latest: bumped %d of %d curated image digest(s)\n' "$bumped" "$checked"
     [[ "$backend_err" -eq 1 ]] && return 2

--- a/tools/bump_catalog_to_latest.sh
+++ b/tools/bump_catalog_to_latest.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — handles external tool names
+
+# tools/bump_catalog_to_latest.sh — repoint every curated first-party catalog
+# entry to its current registry `:latest` digest. The batch driver behind the
+# post-publish auto-bump (docs/tool_container_design.md §11): it resolves
+# `:latest` for each ghcr.io/tomhennen/wrangle/* `delivery: image` entry and
+# applies bump_catalog_digest.sh to any that drifted. Adopter-override entries
+# (a foreign namespace) are skipped — wrangle owns only its own images.
+#
+# Catalog path: $WRANGLE_CATALOG, else the catalog beside this script.
+#
+# Exit: 0 done (catalog updated in place, or already current — idempotent),
+#       2 a registry backend failure for some entry (that entry left unchanged;
+#         any resolvable entry is still bumped).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/read_catalog.sh
+source "$SCRIPT_DIR/../lib/read_catalog.sh"
+# shellcheck source=../lib/registry.sh
+source "$SCRIPT_DIR/../lib/registry.sh"
+
+# bump_catalog_to_latest <catalog_file> — 0 done, 2 a backend error.
+bump_catalog_to_latest() {
+    local file="$1" backend_err=0 bumped=0 checked=0
+    local tool delivery image imagename pinned resolved
+
+    if [[ ! -f "$file" ]]; then
+        printf 'bump_catalog_to_latest: catalog not found: %s\n' "$file" >&2
+        return 2
+    fi
+    if ! jq -e . "$file" >/dev/null 2>&1; then
+        printf 'bump_catalog_to_latest: %s is not valid JSON\n' "$file" >&2
+        return 2
+    fi
+
+    while IFS= read -r tool; do
+        [[ -z "$tool" ]] && continue
+        delivery="$(read_catalog_field "$file" "$tool" delivery)"
+        [[ "$delivery" == "image" ]] || continue
+        image="$(read_catalog_field "$file" "$tool" image)"
+        imagename="${image%@sha256:*}"
+        pinned="${image##*@}"
+
+        # Skip adopter-override entries: wrangle bumps only its own namespace.
+        is_curated_image "$imagename" || continue
+        checked=$((checked + 1))
+
+        if ! resolved="$(resolve_latest_digest "$imagename")"; then
+            printf 'bump_catalog_to_latest: %s: could not resolve %s:latest\n' "$tool" "$imagename" >&2
+            backend_err=1
+            continue
+        fi
+        [[ "$resolved" == "$pinned" ]] && continue
+
+        if ! WRANGLE_CATALOG="$file" "$SCRIPT_DIR/bump_catalog_digest.sh" "$tool" "$resolved"; then
+            printf 'bump_catalog_to_latest: %s: bump to %s failed\n' "$tool" "$resolved" >&2
+            backend_err=1
+            continue
+        fi
+        bumped=$((bumped + 1))
+    done < <(jq -r '.tools // {} | keys[]' "$file")
+
+    printf 'bump_catalog_to_latest: bumped %d of %d curated image digest(s)\n' "$bumped" "$checked"
+    [[ "$backend_err" -eq 1 ]] && return 2
+    return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [[ "$#" -gt 0 ]]; then
+        printf 'Usage: %s   (catalog: WRANGLE_CATALOG env, else %s/catalog.json)\n' "${0##*/}" "$SCRIPT_DIR" >&2
+        exit 2
+    fi
+    bump_catalog_to_latest "${WRANGLE_CATALOG:-$SCRIPT_DIR/catalog.json}"
+fi

--- a/tools/bump_catalog_to_latest.sh
+++ b/tools/bump_catalog_to_latest.sh
@@ -43,7 +43,6 @@ bump_catalog_to_latest() {
         imagename="${image%@sha256:*}"
         pinned="${image##*@}"
 
-        # Skip adopter-override entries: wrangle bumps only its own namespace.
         is_curated_image "$imagename" || continue
         checked=$((checked + 1))
 

--- a/tools/check_catalog_freshness.sh
+++ b/tools/check_catalog_freshness.sh
@@ -37,32 +37,8 @@ set -f  # disable globbing — handles external tool names
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/read_catalog.sh
 source "$SCRIPT_DIR/../lib/read_catalog.sh"
-
-# Tool segment matches run.sh's tool-name shape, so a crafted `..` segment can't
-# turn curl's path into a cross-repo query.
-CURATED_PREFIX_RE='^ghcr\.io/tomhennen/wrangle/[a-z][a-z0-9_-]*$'
-DIGEST_RE='^sha256:[0-9a-f]{64}$'
-
-# resolve_latest_digest <imagename> — anonymous GHCR digest of <imagename>:latest
-# via the registry API. Prints the index digest on success; non-zero on any
-# backend failure (token fetch, registry read, or a missing/malformed digest).
-resolve_latest_digest() {
-    local imagename="$1" registry repo token digest
-    registry="${imagename%%/*}"
-    repo="${imagename#*/}"
-
-    token="$(curl -fsSL --connect-timeout 10 --max-time 30 "https://${registry}/token?scope=repository:${repo}:pull" 2>/dev/null \
-        | jq -r '.token // empty' 2>/dev/null)" || return 1
-    [[ -n "$token" ]] || return 1
-
-    digest="$(curl -fsS -I -X GET --connect-timeout 10 --max-time 30 \
-        -H "Authorization: Bearer ${token}" \
-        -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json' \
-        "https://${registry}/v2/${repo}/manifests/latest" 2>/dev/null \
-        | tr -d '\r' | sed -n 's/^[Dd]ocker-[Cc]ontent-[Dd]igest:[[:space:]]*//p')" || return 1
-    [[ "$digest" =~ $DIGEST_RE ]] || return 1
-    printf '%s' "$digest"
-}
+# shellcheck source=../lib/registry.sh
+source "$SCRIPT_DIR/../lib/registry.sh"
 
 # check_freshness <catalog_file> — returns 0 in sync, 1 drift, 2 backend error.
 check_freshness() {
@@ -87,7 +63,7 @@ check_freshness() {
         pinned="${image##*@}"
 
         # Skip non-curated/adopter-override entries: their tag scheme is unknown.
-        [[ "$imagename" =~ $CURATED_PREFIX_RE ]] || continue
+        is_curated_image "$imagename" || continue
         checked=$((checked + 1))
 
         if ! resolved="$(resolve_latest_digest "$imagename")"; then

--- a/tools/check_catalog_provenance_freshness.sh
+++ b/tools/check_catalog_provenance_freshness.sh
@@ -16,11 +16,12 @@ set -f  # disable globbing — handles external tool names
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/read_catalog.sh
 source "$SCRIPT_DIR/../lib/read_catalog.sh"
+# shellcheck source=../lib/registry.sh
+source "$SCRIPT_DIR/../lib/registry.sh"
 # shellcheck source=../lib/verify_image_vsa.sh
 source "$SCRIPT_DIR/../lib/verify_image_vsa.sh"
 
 PROVENANCE_PREDICATE_TYPE='https://slsa.dev/provenance/v1'
-CURATED_PREFIX_RE='^ghcr\.io/tomhennen/wrangle/[a-z][a-z0-9_-]*$'
 COMMIT_RE='^[0-9a-f]{40}$'
 # A build commit is trusted only from a resolvedDependency on wrangle's own repo.
 WRANGLE_SOURCE_URI_PREFIX='git+https://github.com/tomhennen/wrangle@'
@@ -93,7 +94,7 @@ check_provenance_freshness() {
         imagename="${image%@sha256:*}"
 
         # Skip adopter-override entries — not wrangle-signed.
-        [[ "$imagename" =~ $CURATED_PREFIX_RE ]] || continue
+        is_curated_image "$imagename" || continue
         checked=$((checked + 1))
 
         local prov_rc=0

--- a/tools/open_catalog_bump_pr.sh
+++ b/tools/open_catalog_bump_pr.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# tools/open_catalog_bump_pr.sh — open (or refresh) the catalog auto-bump PR.
+#
+# Runs after bump_catalog_to_latest.sh in the post-publish workflow: it takes the
+# already-modified tools/catalog.json in the working tree, commits it to a
+# dedicated bot branch, and opens a PR (or force-updates the existing one, so a
+# rolling publish keeps a single PR rather than piling up). No-op when the catalog
+# is unchanged. First-party rebuilds are cooldown-exempt (§11), so the PR is
+# meant to be reviewed and merged on CI/review latency, not held for the 7-day
+# community-vetting delay. Uses git + the gh CLI with the ambient GITHUB_TOKEN.
+#
+# Setup requirement: the repository must have "Allow GitHub Actions to create and
+# approve pull requests" enabled, or `gh pr create` with GITHUB_TOKEN fails.
+#
+# Exit: 0 PR opened/updated, or nothing to do; 2 git/gh failure.
+
+BRANCH="${WRANGLE_AUTOBUMP_BRANCH:-bot/catalog-autobump}"
+REMOTE="${WRANGLE_AUTOBUMP_REMOTE:-origin}"
+BASE="${WRANGLE_AUTOBUMP_BASE:-main}"
+CATALOG_REL="tools/catalog.json"
+BOT_NAME="github-actions[bot]"
+BOT_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+
+pr_title() {
+    printf 'chore(catalog): bump curated tool-image digests to :latest'
+}
+
+# pr_body — the PR description. States the first-party cooldown exemption and the
+# required repository setting; links the design and issues.
+pr_body() {
+    cat <<'BODY'
+Automated by the post-publish auto-bump (docs/tool_container_design.md §11).
+
+`local_publish_images.yml` republished wrangle's curated tool images, so their
+`:latest` digests moved ahead of the pins in `tools/catalog.json`. This PR
+repoints each drifted first-party entry to the digest just published.
+
+**First-party, cooldown-exempt.** These are rebuilds of wrangle's own reviewed
+source under `ghcr.io/tomhennen/wrangle/*`, not third-party updates — the 7-day
+community-vetting cooldown does not apply. Review the digests and merge on
+CI/review latency to keep the catalog current.
+
+Adopter-override entries (a foreign namespace) are never touched here; those
+pins stay adopter-owned.
+
+Refs #619, #596.
+BODY
+}
+
+# push_branch — force-push $BRANCH to $REMOTE. When GH_TOKEN is set and the
+# remote is https (the CI path, run with persist-credentials: false), it pushes
+# to a token-authenticated URL so no credential is persisted on disk; a local
+# remote (the test path) pushes as-is.
+push_branch() {
+    local target="$REMOTE" url
+    if [[ -n "${GH_TOKEN:-}" ]]; then
+        url="$(git remote get-url "$REMOTE")"
+        [[ "$url" == https://* ]] && target="https://x-access-token:${GH_TOKEN}@${url#https://}"
+    fi
+    git push --force "$target" "$BRANCH"
+}
+
+# open_or_update_pr — open a PR from $BRANCH, or leave the existing open one (the
+# force-push already refreshed it). Returns non-zero on a gh failure.
+open_or_update_pr() {
+    local existing
+    existing="$(gh pr list --repo "$WRANGLE_AUTOBUMP_GH_REPO" --head "$BRANCH" --base "$BASE" --state open --json number --jq 'length')" || return 1
+    if [[ "$existing" != "0" ]]; then
+        printf 'open_catalog_bump_pr: PR from %s already open; force-push refreshed it\n' "$BRANCH"
+        return 0
+    fi
+    gh pr create --repo "$WRANGLE_AUTOBUMP_GH_REPO" \
+        --base "$BASE" --head "$BRANCH" \
+        --title "$(pr_title)" --body "$(pr_body)"
+}
+
+main() {
+    local repo_root
+    repo_root="$(git rev-parse --show-toplevel)" || return 2
+    cd "$repo_root" || return 2
+
+    if git diff --quiet -- "$CATALOG_REL"; then
+        printf 'open_catalog_bump_pr: catalog unchanged; nothing to open\n'
+        return 0
+    fi
+    : "${WRANGLE_AUTOBUMP_GH_REPO:?set WRANGLE_AUTOBUMP_GH_REPO (owner/repo)}"
+
+    git switch -C "$BRANCH" >/dev/null 2>&1 || { printf 'open_catalog_bump_pr: could not create branch %s\n' "$BRANCH" >&2; return 2; }
+    git add "$CATALOG_REL"
+    git -c "user.name=$BOT_NAME" -c "user.email=$BOT_EMAIL" \
+        commit -m "$(pr_title)" >/dev/null || { printf 'open_catalog_bump_pr: commit failed\n' >&2; return 2; }
+    push_branch || { printf 'open_catalog_bump_pr: push failed\n' >&2; return 2; }
+    open_or_update_pr || { printf 'open_catalog_bump_pr: gh pr open failed\n' >&2; return 2; }
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tools/open_catalog_bump_pr.sh
+++ b/tools/open_catalog_bump_pr.sh
@@ -28,8 +28,6 @@ pr_title() {
     printf 'chore(catalog): bump curated tool-image digests to :latest'
 }
 
-# pr_body — the PR description. States the first-party cooldown exemption and the
-# required repository setting; links the design and issues.
 pr_body() {
     cat <<'BODY'
 Automated by the post-publish auto-bump (docs/tool_container_design.md §11).
@@ -50,17 +48,22 @@ Refs #619, #596.
 BODY
 }
 
-# push_branch — force-push $BRANCH to $REMOTE. When GH_TOKEN is set and the
-# remote is https (the CI path, run with persist-credentials: false), it pushes
-# to a token-authenticated URL so no credential is persisted on disk; a local
-# remote (the test path) pushes as-is.
+# push_branch — force-with-lease $BRANCH to $REMOTE. The lease is an explicit
+# expected value from ls-remote (empty when the branch is new), so it works for
+# both the first push and a rolling update without a remote-tracking ref. When
+# GH_TOKEN is set on an https remote (the CI path, run with
+# persist-credentials: false), auth is an http.extraheader carried in the
+# environment, never in argv or on-disk config.
 push_branch() {
-    local target="$REMOTE" url
-    if [[ -n "${GH_TOKEN:-}" ]]; then
-        url="$(git remote get-url "$REMOTE")"
-        [[ "$url" == https://* ]] && target="https://x-access-token:${GH_TOKEN}@${url#https://}"
+    local -a auth=()
+    if [[ -n "${GH_TOKEN:-}" && "$(git remote get-url "$REMOTE")" == https://* ]]; then
+        local hdr
+        hdr="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+        auth=(env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=http.extraheader "GIT_CONFIG_VALUE_0=Authorization: Basic ${hdr}")
     fi
-    git push --force "$target" "$BRANCH"
+    local expected
+    expected="$("${auth[@]}" git ls-remote "$REMOTE" "refs/heads/$BRANCH" | cut -f1)" || return 1
+    "${auth[@]}" git push --force-with-lease="refs/heads/$BRANCH:${expected}" "$REMOTE" "$BRANCH"
 }
 
 # open_or_update_pr — open a PR from $BRANCH, or leave the existing open one (the


### PR DESCRIPTION
claude: Phase 3 step 1 (non-token-bearing) — the freshness lifecycle that keeps the curated catalog current after a tool-image publish, per `docs/tool_container_design.md` §11. No signing, no tokens beyond a PR-open grant.

## What this does
After `local_publish_images.yml` republishes wrangle's tool images on push-to-main, a new `bump-catalog` job repoints each drifted curated digest to the freshly published `:latest` and **auto-OPENs** (never auto-merges) a PR for review. The maintainer reviews + fast-merges it — fast because first-party rebuilds are cooldown-exempt.

## Pieces
- `lib/registry.sh` — extracts the shared `resolve_latest_digest` (GHCR `:latest` resolver) and the curated-namespace predicate `is_curated_image`, now single-sourced by both freshness checks and the new driver (was duplicated).
- `tools/bump_catalog_to_latest.sh` — resolves `:latest` for each `ghcr.io/tomhennen/wrangle/*` `delivery: image` entry and applies `bump_catalog_digest.sh` to any that drifted (exit 0 done/no-op, 2 registry backend error; a resolvable entry is still bumped).
- `tools/open_catalog_bump_pr.sh` — commits the bump to a rolling bot branch and opens/refreshes the PR via `gh` (one rolling PR, not N). No-op when the catalog is unchanged.
- `bump-catalog` job wired into `local_publish_images.yml`: `needs: [publish]`, `if: github.ref == 'refs/heads/main'`, least-privilege `contents: write` + `pull-requests: write`, `persist-credentials: false` (the push authenticates via an explicit `GH_TOKEN` URL, no credential left on disk).

## Design decisions (owner-approved)
1. **Resolve `:latest` post-publish**, not matrix outputs — a matrix reusable-workflow call collides its outputs, and the broad trigger rebuilds all images, so "bump every drifted curated entry" is exactly the freshness loop.
2. **Auto-OPEN only, never auto-merge** — no bot commit to main; matches wrangle's no-auto-merge posture.
3. **Least-privilege + injection-safe** — trusted push-to-main only; no `pull_request_target`, no untrusted-tree checkout. Digests are registry-resolved and validated (`^sha256:[0-9a-f]{64}$`); tool names are catalog keys; nothing attacker-controllable reaches a shell.
4. **First-party cooldown exemption** — mechanically this is namespace scoping (`is_curated_image` restricts auto-bump to wrangle's own images; adopter overrides are never in the path) + a policy line, not a code gate (WL005 is Dependabot-only; #623's digest cooldown is deferred and, when it lands, keys on this namespace). Documented in `DEP_MGMT.md` + this PR.
5. **`gh pr create` + `GITHUB_TOKEN`**, not peter-evans — avoids a new pinned+cooldowned third-party action.
6. **Skipped VSA-re-verify-before-bump** — the `verify` leg already passed for every image in the same run, and the new `concurrency:` group closes the `:latest` race, so re-verify would be redundant.

## Trigger-loop fix (folded in)
`local_publish_images.yml` triggered on `paths: [tools/**, lib/**]`, and `tools/catalog.json` matches `tools/**` — so a merged bump would re-trigger publish → new digests → another bump PR (a human-gated treadmill; GITHUB_TOKEN's event-suppression doesn't cover the human merge). This PR excludes `tools/catalog.json` from the trigger (Dockerfile/go.mod changes still fire) and adds a `concurrency:` group, making §11's no-loop claim actually true (the doc reasoned about Dockerfiles, but the real trigger is the path glob the catalog matches).

## Required repo setting
The auto-bump PR-open needs **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** enabled, or `gh pr create` with `GITHUB_TOKEN` fails. Documented in `DEP_MGMT.md` and `tools/open_catalog_bump_pr.sh`.

## Tests
- `test/test_bump_catalog_to_latest.bats` — drift bumps, no-op when current, adopter override skipped, resolvable-despite-sibling-error (exit 2), malformed catalog. `curl` shimmed like the existing freshness test; write path runs the real `bump_catalog_digest.sh`.
- `test/test_open_catalog_bump_pr.bats` — real throwaway git repo with a local bare origin (no network), only `gh` shimmed: no-op on clean catalog, commit+push+PR-open, already-open refresh, rolling force-update.
- Full `make test` green (bats, shellcheck, wrangle-shell-lint, wrangle-workflow-lint, zizmor, go). No suppressions.

Refs #619, #596.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Reviewer notes
- **Design doc now trails reality.** §11 still calls the auto-bump "to be built, #619" and §7 lists "the catalog auto-bump PR (§11)" under *remaining* Phase-3 work. This PR builds it. I did not rewrite the design-of-record unilaterally — flagging so §11/§7 (and the §11 "Doc follow-ups when this lands" note) get reconciled at merge.
- **Failure semantics are deliberate, and asymmetric.** The bump step is advisory (registry error -> `::warning::`, run stays green, resolvable entries still bumped); the PR-open step is fatal (non-zero -> red publish run). Rationale: a failed PR-open is a total failure of the job's purpose (e.g. the repo setting is off), which should be loud rather than silently never opening bump PRs — the published images themselves already succeeded upstream of it. A transient `gh`/network blip reddening a publish run is the accepted, rare cost. If you'd prefer advisory-on-open, say so and I'll flip it.
