### PR TITLE
fix(sbom): restore meaningful SBOM source name (follow-up to #674)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -390,6 +390,13 @@ PRECONDITIONS:
   jq is available
 
 ENVIRONMENT:
+  The orchestrator sets these WRANGLE_* variables for every tool image:
+    WRANGLE_KIND         the tool's kind (input/stage; see TOOL KIND above)
+    WRANGLE_SOURCE_NAME  basename of the scanned source dir (the /src mount
+                         hides its real path)
+    WRANGLE_EXTRA_<VAR>  the runner's WRANGLE_EXTRA_<VAR> reaches the tool as
+                         <VAR>, prefix stripped (see the WRANGLE_EXTRA_ rule below)
+
   Adapters run with a restricted environment. Only the following variables
   are passed through from the runner:
     PATH, HOME, TMPDIR, RUNNER_TEMP, GITHUB_WORKSPACE, GITHUB_STEP_SUMMARY

--- a/lib/run_tool_image.sh
+++ b/lib/run_tool_image.sh
@@ -15,10 +15,16 @@ run_tool_image() {
     net="none"
     [[ "$(read_catalog_field "$catalog" "$tool" network)" == "egress" ]] && net="bridge"
 
-    # WRANGLE_KIND carries the tool's input/stage to its entrypoint.
+    # docker -v needs absolute paths.
+    src_abs="$(cd "$src_dir" && pwd)"
+    out_abs="$(cd "$tool_out" && pwd)"
+
+    # WRANGLE_KIND carries the tool's input/stage; WRANGLE_SOURCE_NAME the source
+    # dir name, which the fixed /src mount otherwise hides.
     local -a docker_env=()
     kind="$(read_catalog_field "$catalog" "$tool" kind)"
     [[ -n "$kind" ]] && docker_env+=(-e "WRANGLE_KIND=$kind")
+    docker_env+=(-e "WRANGLE_SOURCE_NAME=$(basename "$src_abs")")
 
     secret="$(read_catalog_field "$catalog" "$tool" secret)"
     if [[ -n "$secret" ]]; then
@@ -30,13 +36,6 @@ run_tool_image() {
             docker_env+=(-e "${secret_var}")
         fi
     fi
-
-    # docker -v needs absolute paths.
-    src_abs="$(cd "$src_dir" && pwd)"
-    out_abs="$(cd "$tool_out" && pwd)"
-
-    # sbom names the document after the source dir, which the /src mount hides.
-    [[ "$kind" == "sbom" ]] && docker_env+=(-e "WRANGLE_SOURCE_NAME=$(basename "$src_abs")")
 
     local rc=0
     timeout "$timeout_s" docker run --rm --network "$net" \

--- a/lib/run_tool_image.sh
+++ b/lib/run_tool_image.sh
@@ -35,8 +35,7 @@ run_tool_image() {
     src_abs="$(cd "$src_dir" && pwd)"
     out_abs="$(cd "$tool_out" && pwd)"
 
-    # sbom-only: name the SBOM after the source directory, since the scan runs
-    # against the fixed /src mount rather than the real path.
+    # sbom names the document after the source dir, which the /src mount hides.
     [[ "$kind" == "sbom" ]] && docker_env+=(-e "WRANGLE_SOURCE_NAME=$(basename "$src_abs")")
 
     local rc=0

--- a/lib/run_tool_image.sh
+++ b/lib/run_tool_image.sh
@@ -35,6 +35,10 @@ run_tool_image() {
     src_abs="$(cd "$src_dir" && pwd)"
     out_abs="$(cd "$tool_out" && pwd)"
 
+    # sbom-only: name the SBOM after the source directory, since the scan runs
+    # against the fixed /src mount rather than the real path.
+    [[ "$kind" == "sbom" ]] && docker_env+=(-e "WRANGLE_SOURCE_NAME=$(basename "$src_abs")")
+
     local rc=0
     timeout "$timeout_s" docker run --rm --network "$net" \
         --cap-drop ALL --security-opt no-new-privileges \

--- a/test/fixtures/image-contract/entrypoint.sh
+++ b/test/fixtures/image-contract/entrypoint.sh
@@ -35,9 +35,15 @@ case "$mode" in
         (ls /sys/class/net 2>/dev/null || printf '') > "$out/net_ifaces"
         printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"mock"}},"results":[]}]}\n' > "$out/output.sarif"
         exit 0 ;;
+    source-name)
+        # Record WRANGLE_SOURCE_NAME so a scan-kind test can assert it is empty.
+        printf '%s' "${WRANGLE_SOURCE_NAME:-}" > "$out/source_name_seen"
+        printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"mock"}},"results":[]}]}\n' > "$out/output.sarif"
+        exit 0 ;;
     sbom)
-        # Record WRANGLE_KIND so a test can assert the stage signal arrived.
+        # Record WRANGLE_KIND and WRANGLE_SOURCE_NAME so a test can assert both signals arrived.
         printf '%s' "${WRANGLE_KIND:-}" > "$out/kind_seen"
+        printf '%s' "${WRANGLE_SOURCE_NAME:-}" > "$out/source_name_seen"
         printf '{"spdxVersion":"SPDX-2.3","name":"mock"}\n' > "$out/sbom.spdx.json"
         exit 0 ;;
     sbom-error)

--- a/test/fixtures/image-contract/entrypoint.sh
+++ b/test/fixtures/image-contract/entrypoint.sh
@@ -36,7 +36,7 @@ case "$mode" in
         printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"mock"}},"results":[]}]}\n' > "$out/output.sarif"
         exit 0 ;;
     source-name)
-        # Record WRANGLE_SOURCE_NAME so a scan-kind test can assert it is empty.
+        # Record WRANGLE_SOURCE_NAME so a scan-kind test can assert it arrived.
         printf '%s' "${WRANGLE_SOURCE_NAME:-}" > "$out/source_name_seen"
         printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"mock"}},"results":[]}]}\n' > "$out/output.sarif"
         exit 0 ;;

--- a/test/image/test_run_image_dispatch.bats
+++ b/test/image/test_run_image_dispatch.bats
@@ -288,6 +288,21 @@ JSON
     [ "$(cat "$OUT/mocktool/kind_seen")" = "sbom" ]
 }
 
+@test "run.sh sbom dispatch: WRANGLE_SOURCE_NAME is the source dir basename" {
+    _sbom_catalog
+    printf 'sbom' > "$SRC/MODE"
+    _run_orch mocktool
+    [ "$status" -eq 0 ]
+    [ "$(cat "$OUT/mocktool/source_name_seen")" = "$(basename "$SRC")" ]
+}
+
+@test "run.sh scan dispatch: no WRANGLE_SOURCE_NAME reaches a scan-kind container" {
+    printf 'source-name' > "$SRC/MODE"
+    _run_orch mocktool
+    [ "$status" -eq 0 ]
+    [ -z "$(cat "$OUT/mocktool/source_name_seen")" ]
+}
+
 @test "run.sh sbom dispatch: tool error -> exit 2" {
     _sbom_catalog
     printf 'sbom-error' > "$SRC/MODE"

--- a/test/image/test_run_image_dispatch.bats
+++ b/test/image/test_run_image_dispatch.bats
@@ -296,11 +296,11 @@ JSON
     [ "$(cat "$OUT/mocktool/source_name_seen")" = "$(basename "$SRC")" ]
 }
 
-@test "run.sh scan dispatch: no WRANGLE_SOURCE_NAME reaches a scan-kind container" {
+@test "run.sh scan dispatch: WRANGLE_SOURCE_NAME is the source dir basename" {
     printf 'source-name' > "$SRC/MODE"
     _run_orch mocktool
     [ "$status" -eq 0 ]
-    [ -z "$(cat "$OUT/mocktool/source_name_seen")" ]
+    [ "$(cat "$OUT/mocktool/source_name_seen")" = "$(basename "$SRC")" ]
 }
 
 @test "run.sh sbom dispatch: tool error -> exit 2" {

--- a/tools/syft/adapter.sh
+++ b/tools/syft/adapter.sh
@@ -31,8 +31,11 @@ OUT_FILE="${OUTPUT_DIR}/sbom.spdx.json"
 ERR_FILE="$(mktemp "${TMPDIR:-/tmp}/wrangle-syft-err-XXXXXX")"
 trap 'rm -f "$ERR_FILE"' EXIT
 
+declare -a name_args=()
+[[ -n "${WRANGLE_SOURCE_NAME:-}" ]] && name_args=(--source-name "$WRANGLE_SOURCE_NAME")
+
 syft_exit=0
-syft dir:"$SRC_DIR" -o spdx-json > "$OUT_FILE" 2> "$ERR_FILE" || syft_exit=$?
+syft dir:"$SRC_DIR" -o spdx-json "${name_args[@]}" > "$OUT_FILE" 2> "$ERR_FILE" || syft_exit=$?
 if [[ "$syft_exit" -ne 0 ]]; then
     printf 'wrangle/syft: syft exited with code %d\n' "$syft_exit" >&2
     cat "$ERR_FILE" >&2

--- a/tools/syft/test.bats
+++ b/tools/syft/test.bats
@@ -148,6 +148,34 @@ MOCK
     [ "$status" -eq 0 ]
 }
 
+# A syft shim records its argv and emits a valid empty SBOM: the real syft needs
+# network and a package ecosystem, but the adapter's flag wiring is what's tested.
+_syft_shim() {
+    cat > "$TEST_DIR/bin/syft" << MOCK
+#!/bin/bash
+printf '%s\n' "\$*" > "$TEST_DIR/syft_argv"
+printf '{}'
+MOCK
+    chmod +x "$TEST_DIR/bin/syft"
+}
+
+@test "syft adapter: passes --source-name when WRANGLE_SOURCE_NAME is set" {
+    _syft_shim
+    mkdir -p "$TEST_DIR/src" "$TEST_DIR/out"
+    PATH="$TEST_DIR/bin:$PATH" WRANGLE_SOURCE_NAME="my-project" \
+        run "$ORIG_DIR/tools/syft/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/out"
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$TEST_DIR/syft_argv")" == *"--source-name my-project"* ]]
+}
+
+@test "syft adapter: omits --source-name when WRANGLE_SOURCE_NAME is unset" {
+    _syft_shim
+    mkdir -p "$TEST_DIR/src" "$TEST_DIR/out"
+    PATH="$TEST_DIR/bin:$PATH" run "$ORIG_DIR/tools/syft/adapter.sh" "$TEST_DIR/src" "$TEST_DIR/out"
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$TEST_DIR/syft_argv")" != *"--source-name"* ]]
+}
+
 @test "install: cosign verification retries once and surfaces cosign stderr on final failure" {
     # A cosign shim is required: real verify-blob needs network and the real
     # syft release blobs; the retry/diagnostic contract is what's under test.


### PR DESCRIPTION
claude: Follow-up to #674. When #674 moved SBOM generation to the containerized syft image, syft began scanning the fixed container mount `/src`, so every project's SPDX document `.name` (and DocumentRoot SPDXID) became the literal string `/src` instead of the source directory name that the pre-#674 inline `syft dir:<real-path>` produced. This restores a meaningful source name.

## What changed
- `lib/run_tool_image.sh`: dispatch a `WRANGLE_SOURCE_NAME` env (the source directory basename, from the resolved absolute path) into the container's explicit `docker run` env list for **every** tool image — the same mechanism as `WRANGLE_KIND`. The basename is generic, non-sensitive context any source-scanning tool can use (label findings, name an SBOM), so it is unconditional rather than sbom-gated. The sandbox posture (`--network none`, cap-drop ALL, no-new-privileges) is unchanged since it is one more entry in the explicit env list, not a broad passthrough.
- `tools/syft/adapter.sh`: when `WRANGLE_SOURCE_NAME` is set and non-empty, pass `--source-name "$WRANGLE_SOURCE_NAME"` to the `syft dir:/src` invocation; when unset it behaves exactly as before (no regression for direct/other callers). A tool that doesn't read the env simply ignores it. Exit-code and invalid-JSON handling are preserved.
- `docs/SPEC.md` §Adapter Script Interface: enumerate the `WRANGLE_*` env vars the orchestrator sets for every tool image (`WRANGLE_KIND`, `WRANGLE_SOURCE_NAME`, the `WRANGLE_EXTRA_*` prefix-strip rule) in one authoritative place.

## Upstream flag confirmed
Verified against syft v1.42.4 source (`cmd/syft/internal/options/catalog.go`): `--source-name` is registered as `flags.StringVarP(&cfg.Source.Name, "source-name", ...)` — "set the name of the target being analyzed". Chosen over the `SYFT_SOURCE_NAME` env form because the explicit flag is unambiguous at the call site. A single flag fixes both symptoms: in `syft/format/common/spdxhelpers/to_format_model.go` the document `.name` and the root package's name + `SPDXRef-DocumentRoot-Directory-<name>` SPDXID both derive from `source.Name`.

## Package content is unchanged
A real e2e run (owner-validated for #674) confirmed the containerized SBOM is byte-identical to the pre-#674 one EXCEPT the document name (`sample-npm` → `/src`); the package set (purls) is identical. This change touches only the document `.name`, restoring it to the source basename.

## Rollout note
The Dockerfile bakes `tools/syft/adapter.sh` into the syft image and `catalog.json` pins it by digest, so this fix takes effect in builds only after the syft image is republished and its catalog digest bumped (`bump_catalog_digest.sh`). Not live from merge alone. At rebuild, confirm on a real SBOM that both `.name` and the `SPDXRef-DocumentRoot-Directory-*` SPDXID pick up the source-dir name (the unit/dispatch tests here prove the flag wiring, not syft's output — real syft lives only in the image, so an in-suite assertion would be a CI skip).

## Tests + hygiene
- Adapter unit tests (`tools/syft/test.bats`) with a `syft` argv-recording shim: `--source-name` present when the env is set, absent when unset (docker-free).
- Dispatch tests (`test/image/test_run_image_dispatch.bats`): `WRANGLE_SOURCE_NAME` equals the source dir basename in both a sbom-kind and a scan-kind container. The mock contract fixture records `source_name_seen`.
- Pin freshness: my edits did not re-stale any self-ref pins (`check_pin_freshness` green, all 17 resolve to HEAD), so no converge/`bump_action_pins` is required.
- `./test.sh quick`: all 1340 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
