### PR TITLE
claude: pluggable BYO SBOM — add-only custom tools (#673)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/prep@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/scan@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      uses: TomHennen/wrangle/build/actions/container@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/verify_release@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      uses: TomHennen/wrangle/build/actions/container@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      uses: TomHennen/wrangle/build/actions/container@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      uses: TomHennen/wrangle/build/actions/container@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/go/checks@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/go/build@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_provenance@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -125,7 +125,7 @@ on:
         type: string
         default: policies/wrangle-default-go-v1.hjson
       sbom-tool:
-        description: "SBOM tool to run: the curated `sbom` slot, or a tool you added in .wrangle/tools.json. Default sbom."
+        description: "Wrangle's default SBOM tool, or one you define yourself in `.wrangle/tools.json`."
         required: false
         type: string
         default: sbom

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -125,12 +125,12 @@ on:
         type: string
         default: policies/wrangle-default-go-v1.hjson
       sbom-tool:
-        description: "SBOM tool to run (a curated tool, or one defined in tool-overrides). Default syft."
+        description: "SBOM tool to run: the curated `sbom` slot, or a tool added via custom-tools. Default sbom."
         required: false
         type: string
-        default: syft
-      tool-overrides:
-        description: "Optional workspace path to a .wrangle/tools.json merged over wrangle's catalog (see docs/SPEC.md)."
+        default: sbom
+      custom-tools:
+        description: "Optional workspace path to a .wrangle/tools.json adding your own tools to wrangle's catalog (see docs/SPEC.md)."
         required: false
         type: string
         default: ""
@@ -296,7 +296,7 @@ jobs:
           cache: ${{ needs.prep.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
           install-zig: ${{ inputs.install-zig }}
           sbom-tool: ${{ inputs.sbom-tool }}
-          tool-overrides: ${{ inputs.tool-overrides }}
+          custom-tools: ${{ inputs.custom-tools }}
 
       # The module path is the VSA resourceUri purl namespace; read it from the
       # toolchain. head -n1 keeps a go.work workspace (multiple modules) from

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -125,15 +125,10 @@ on:
         type: string
         default: policies/wrangle-default-go-v1.hjson
       sbom-tool:
-        description: "SBOM tool to run: the curated `sbom` slot, or a tool added via custom-tools. Default sbom."
+        description: "SBOM tool to run: the curated `sbom` slot, or a tool you added in .wrangle/tools.json. Default sbom."
         required: false
         type: string
         default: sbom
-      custom-tools:
-        description: "Optional workspace path to a .wrangle/tools.json adding your own tools to wrangle's catalog (see docs/SPEC.md)."
-        required: false
-        type: string
-        default: ""
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -296,7 +291,6 @@ jobs:
           cache: ${{ needs.prep.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
           install-zig: ${{ inputs.install-zig }}
           sbom-tool: ${{ inputs.sbom-tool }}
-          custom-tools: ${{ inputs.custom-tools }}
 
       # The module path is the VSA resourceUri purl namespace; read it from the
       # toolchain. head -n1 keeps a go.work workspace (multiple modules) from

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -171,7 +171,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         id: prep
         with:
           build-type: go
@@ -190,7 +190,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -225,7 +225,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/go/checks@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -288,7 +288,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/go/build@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         id: release
         with:
           path: ${{ inputs.path }}
@@ -381,7 +381,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_provenance@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         id: attest
         with:
           build-type: go
@@ -407,7 +407,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/go/checks@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/go/build@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_provenance@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -124,6 +124,16 @@ on:
         required: false
         type: string
         default: policies/wrangle-default-go-v1.hjson
+      sbom-tool:
+        description: "SBOM tool to run (a curated tool, or one defined in tool-overrides). Default syft."
+        required: false
+        type: string
+        default: syft
+      tool-overrides:
+        description: "Optional workspace path to a .wrangle/tools.json merged over wrangle's catalog (see docs/SPEC.md)."
+        required: false
+        type: string
+        default: ""
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -285,6 +295,8 @@ jobs:
           go-version: ${{ inputs.go-version }}
           cache: ${{ needs.prep.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
           install-zig: ${{ inputs.install-zig }}
+          sbom-tool: ${{ inputs.sbom-tool }}
+          tool-overrides: ${{ inputs.tool-overrides }}
 
       # The module path is the VSA resourceUri purl namespace; read it from the
       # toolchain. head -n1 keeps a go.work workspace (multiple modules) from

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -171,7 +171,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/prep@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         id: prep
         with:
           build-type: go
@@ -190,7 +190,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/scan@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -225,7 +225,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/build/actions/go/checks@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -288,7 +288,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/build/actions/go/build@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         id: release
         with:
           path: ${{ inputs.path }}
@@ -381,7 +381,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/attest_provenance@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         id: attest
         with:
           build-type: go
@@ -407,7 +407,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/verify_release@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -105,6 +105,16 @@ on:
         required: false
         type: string
         default: policies/wrangle-default-npm-v1.hjson
+      sbom-tool:
+        description: "SBOM tool to run (a curated tool, or one defined in tool-overrides). Default syft."
+        required: false
+        type: string
+        default: syft
+      tool-overrides:
+        description: "Optional workspace path to a .wrangle/tools.json merged over wrangle's catalog (see docs/SPEC.md)."
+        required: false
+        type: string
+        default: ""
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -212,6 +222,8 @@ jobs:
           node-version: ${{ inputs.node-version }}
           run-tests: ${{ inputs.run-tests }}
           ignore-scripts: ${{ inputs.ignore-scripts }}
+          sbom-tool: ${{ inputs.sbom-tool }}
+          tool-overrides: ${{ inputs.tool-overrides }}
 
       # The npm composite doesn't emit the package name; read it from
       # package.json for the VSA resourceUri purl. Scoped names (@scope/pkg) pass through.

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/npm@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_provenance@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -159,7 +159,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/prep@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         id: prep
         with:
           build-type: npm
@@ -178,7 +178,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/scan@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/build/actions/npm@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         id: build
         with:
           path: ${{ inputs.path }}
@@ -295,7 +295,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/attest_provenance@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         id: attest
         with:
           build-type: npm
@@ -318,7 +318,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/verify_release@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -106,15 +106,10 @@ on:
         type: string
         default: policies/wrangle-default-npm-v1.hjson
       sbom-tool:
-        description: "SBOM tool to run: the curated `sbom` slot, or a tool added via custom-tools. Default sbom."
+        description: "SBOM tool to run: the curated `sbom` slot, or a tool you added in .wrangle/tools.json. Default sbom."
         required: false
         type: string
         default: sbom
-      custom-tools:
-        description: "Optional workspace path to a .wrangle/tools.json adding your own tools to wrangle's catalog (see docs/SPEC.md)."
-        required: false
-        type: string
-        default: ""
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -223,7 +218,6 @@ jobs:
           run-tests: ${{ inputs.run-tests }}
           ignore-scripts: ${{ inputs.ignore-scripts }}
           sbom-tool: ${{ inputs.sbom-tool }}
-          custom-tools: ${{ inputs.custom-tools }}
 
       # The npm composite doesn't emit the package name; read it from
       # package.json for the VSA resourceUri purl. Scoped names (@scope/pkg) pass through.

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -106,12 +106,12 @@ on:
         type: string
         default: policies/wrangle-default-npm-v1.hjson
       sbom-tool:
-        description: "SBOM tool to run (a curated tool, or one defined in tool-overrides). Default syft."
+        description: "SBOM tool to run: the curated `sbom` slot, or a tool added via custom-tools. Default sbom."
         required: false
         type: string
-        default: syft
-      tool-overrides:
-        description: "Optional workspace path to a .wrangle/tools.json merged over wrangle's catalog (see docs/SPEC.md)."
+        default: sbom
+      custom-tools:
+        description: "Optional workspace path to a .wrangle/tools.json adding your own tools to wrangle's catalog (see docs/SPEC.md)."
         required: false
         type: string
         default: ""
@@ -223,7 +223,7 @@ jobs:
           run-tests: ${{ inputs.run-tests }}
           ignore-scripts: ${{ inputs.ignore-scripts }}
           sbom-tool: ${{ inputs.sbom-tool }}
-          tool-overrides: ${{ inputs.tool-overrides }}
+          custom-tools: ${{ inputs.custom-tools }}
 
       # The npm composite doesn't emit the package name; read it from
       # package.json for the VSA resourceUri purl. Scoped names (@scope/pkg) pass through.

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/npm@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_provenance@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -106,7 +106,7 @@ on:
         type: string
         default: policies/wrangle-default-npm-v1.hjson
       sbom-tool:
-        description: "SBOM tool to run: the curated `sbom` slot, or a tool you added in .wrangle/tools.json. Default sbom."
+        description: "Wrangle's default SBOM tool, or one you define yourself in `.wrangle/tools.json`."
         required: false
         type: string
         default: sbom

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -159,7 +159,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         id: prep
         with:
           build-type: npm
@@ -178,7 +178,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/npm@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         id: build
         with:
           path: ${{ inputs.path }}
@@ -295,7 +295,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_provenance@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         id: attest
         with:
           build-type: npm
@@ -318,7 +318,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/python@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_provenance@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/python@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_provenance@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -136,7 +136,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         id: prep
         with:
           build-type: python
@@ -155,7 +155,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -190,7 +190,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/python@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_provenance@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         id: attest
         with:
           build-type: python
@@ -305,7 +305,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -85,6 +85,16 @@ on:
         required: false
         type: string
         default: policies/wrangle-default-python-v1.hjson
+      sbom-tool:
+        description: "SBOM tool to run (a curated tool, or one defined in tool-overrides). Default syft."
+        required: false
+        type: string
+        default: syft
+      tool-overrides:
+        description: "Optional workspace path to a .wrangle/tools.json merged over wrangle's catalog (see docs/SPEC.md)."
+        required: false
+        type: string
+        default: ""
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -193,6 +203,8 @@ jobs:
           # fast iteration; they produce no provenance, so cache poisoning
           # is not an L3 concern at that layer.
           cache: ${{ needs.prep.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
+          sbom-tool: ${{ inputs.sbom-tool }}
+          tool-overrides: ${{ inputs.tool-overrides }}
 
       # Compose the VSA resourceUri purl. PyPI's purl type normalizes the
       # name per PEP 503 (lowercase; runs of . _ - collapse to -), so the

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -136,7 +136,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/prep@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         id: prep
         with:
           build-type: python
@@ -155,7 +155,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/scan@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -190,7 +190,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/build/actions/python@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/attest_provenance@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         id: attest
         with:
           build-type: python
@@ -305,7 +305,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/verify_release@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -86,7 +86,7 @@ on:
         type: string
         default: policies/wrangle-default-python-v1.hjson
       sbom-tool:
-        description: "SBOM tool to run: the curated `sbom` slot, or a tool you added in .wrangle/tools.json. Default sbom."
+        description: "Wrangle's default SBOM tool, or one you define yourself in `.wrangle/tools.json`."
         required: false
         type: string
         default: sbom

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -86,15 +86,10 @@ on:
         type: string
         default: policies/wrangle-default-python-v1.hjson
       sbom-tool:
-        description: "SBOM tool to run: the curated `sbom` slot, or a tool added via custom-tools. Default sbom."
+        description: "SBOM tool to run: the curated `sbom` slot, or a tool you added in .wrangle/tools.json. Default sbom."
         required: false
         type: string
         default: sbom
-      custom-tools:
-        description: "Optional workspace path to a .wrangle/tools.json adding your own tools to wrangle's catalog (see docs/SPEC.md)."
-        required: false
-        type: string
-        default: ""
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -204,7 +199,6 @@ jobs:
           # is not an L3 concern at that layer.
           cache: ${{ needs.prep.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
           sbom-tool: ${{ inputs.sbom-tool }}
-          custom-tools: ${{ inputs.custom-tools }}
 
       # Compose the VSA resourceUri purl. PyPI's purl type normalizes the
       # name per PEP 503 (lowercase; runs of . _ - collapse to -), so the

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -86,12 +86,12 @@ on:
         type: string
         default: policies/wrangle-default-python-v1.hjson
       sbom-tool:
-        description: "SBOM tool to run (a curated tool, or one defined in tool-overrides). Default syft."
+        description: "SBOM tool to run: the curated `sbom` slot, or a tool added via custom-tools. Default sbom."
         required: false
         type: string
-        default: syft
-      tool-overrides:
-        description: "Optional workspace path to a .wrangle/tools.json merged over wrangle's catalog (see docs/SPEC.md)."
+        default: sbom
+      custom-tools:
+        description: "Optional workspace path to a .wrangle/tools.json adding your own tools to wrangle's catalog (see docs/SPEC.md)."
         required: false
         type: string
         default: ""
@@ -204,7 +204,7 @@ jobs:
           # is not an L3 concern at that layer.
           cache: ${{ needs.prep.outputs.should-release == 'true' && 'disabled' || 'enabled' }}
           sbom-tool: ${{ inputs.sbom-tool }}
-          tool-overrides: ${{ inputs.tool-overrides }}
+          custom-tools: ${{ inputs.custom-tools }}
 
       # Compose the VSA resourceUri purl. PyPI's purl type normalizes the
       # name per PEP 503 (lowercase; runs of . _ - collapse to -), so the

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+        uses: TomHennen/wrangle/build/actions/shell@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/prep@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/scan@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+        uses: TomHennen/wrangle/build/actions/shell@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+        uses: TomHennen/wrangle/build/actions/shell@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+        uses: TomHennen/wrangle/build/actions/shell@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+        uses: TomHennen/wrangle/actions/scan@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+        uses: TomHennen/wrangle/actions/scan@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      - uses: TomHennen/wrangle/actions/prep@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+        uses: TomHennen/wrangle/actions/scan@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+        uses: TomHennen/wrangle/actions/scan@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To find them in the UI: click **Actions** → your wrangle workflow → the run 
 
 ## Bring your own SBOM tool
 
-Prefer your own SBOM generator over wrangle's default (syft)? On the go, python, and npm builds, commit a `.wrangle/tools.json` and select your tool by name — wrangle discovers the file automatically, there's no workflow input to set.
+Prefer your own SBOM generator over wrangle's default (syft)? On the go, python, and npm builds, define your tool in a `.wrangle/tools.json` (wrangle discovers it automatically) and select it by name with `sbom-tool:`.
 
 1. Add `.wrangle/tools.json` at your repo root, describing your tool as a digest-pinned image:
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ To find them in the UI: click **Actions** → your wrangle workflow → the run 
 
 ## Bring your own SBOM tool
 
-Prefer your own SBOM generator over wrangle's default (syft)? On the go, python, and npm builds, add it in two steps.
+Prefer your own SBOM generator over wrangle's default (syft)? On the go, python, and npm builds, commit a `.wrangle/tools.json` and select your tool by name — wrangle discovers the file automatically, there's no workflow input to set.
 
-1. Add `.wrangle/tools.json` to your repo, describing your tool as a digest-pinned image:
+1. Add `.wrangle/tools.json` at your repo root, describing your tool as a digest-pinned image:
 
    ```json
    {
@@ -117,15 +117,16 @@ Prefer your own SBOM generator over wrangle's default (syft)? On the go, python,
    }
    ```
 
-2. Select it on the reusable workflow:
+2. Select it the same way you pick any wrangle tool — `sbom-tool: my-sbom` for the SBOM (or add the name to `tools:` for an extra scanner):
 
    ```yaml
        with:
          sbom-tool: my-sbom
-         custom-tools: .wrangle/tools.json
    ```
 
-Your image reads a read-only `/src` and writes `/output/sbom.spdx.json` — the [Adapter Script Interface](docs/SPEC.md#adapter-script-interface) is the full contract. It runs in the same sandbox as wrangle's tools (no network, dropped capabilities, non-root), but is trusted as yours: it carries no wrangle VSA, so you own its digest pin and freshness. Custom tools are add-only — you add net-new tools (a name matching a curated tool is an error) and select them; each declares its own capabilities, with an unspecified `network` or `secret` defaulting closed. Because a custom tool can grant itself network egress and a secret, keep `.wrangle/tools.json` as trusted in-repo config — don't source it from untrusted pull-request contents.
+Your image reads a read-only `/src` and writes `/output/sbom.spdx.json`, exiting 0 (ok) or 2 (tool error). It runs in the same sandbox as wrangle's tools (no network, dropped capabilities, non-root), but is trusted as yours: it carries no wrangle VSA, so you own its digest pin and freshness. Tools are add-only — a name matching a curated tool is an error, the image must be outside wrangle's namespace, and each declares its own capabilities (an unspecified `network`/`secret` defaults closed).
+
+**`.wrangle/tools.json` is trusted config.** A tool listed there can grant itself network egress and a secret, so don't run wrangle over untrusted PR content — e.g. a `pull_request_target` job that checks out the PR head — in a job that forwards secrets.
 
 ## How Wrangle Works
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,34 @@ On a **tag push**, wrangle also attaches each dist `<artifact>` and its `<artifa
 
 To find them in the UI: click **Actions** → your wrangle workflow → the run → scroll to **Artifacts**. The URL looks like `https://github.com/<owner>/<repo>/actions/runs/<id>#artifacts`. For a live example, see a run in the [wrangle-test companion repo](https://github.com/TomHennen/wrangle-test/actions). Per-ecosystem details are in the [ecosystem READMEs](#ecosystems) above.
 
+## Bring your own SBOM tool
+
+Prefer your own SBOM generator over wrangle's default (syft)? Point the build at it in two steps.
+
+1. Add `.wrangle/tools.json` to your repo, describing your tool as a digest-pinned image:
+
+   ```json
+   {
+     "tools": {
+       "my-sbom": {
+         "kind": "sbom",
+         "delivery": "image",
+         "image": "ghcr.io/myorg/my-sbom-generator@sha256:<digest>"
+       }
+     }
+   }
+   ```
+
+2. Select it on the reusable workflow:
+
+   ```yaml
+       with:
+         sbom-tool: my-sbom
+         tool-overrides: .wrangle/tools.json
+   ```
+
+Your image reads a read-only `/src` and writes `/output/sbom.spdx.json` — the [Adapter Script Interface](docs/SPEC.md#adapter-script-interface) is the full contract. It runs in the same sandbox as wrangle's tools (no network, dropped capabilities, non-root), but is trusted as yours: it carries no wrangle VSA, so you own its digest pin and freshness. Overriding a curated tool re-declares its capabilities from scratch — an unspecified `network` or `secret` defaults closed.
+
 ## How Wrangle Works
 
 Behind that one workflow call, wrangle runs your code through a pipeline of well-known security

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To find them in the UI: click **Actions** → your wrangle workflow → the run 
 
 ## Bring your own SBOM tool
 
-Prefer your own SBOM generator over wrangle's default (syft)? Point the build at it in two steps.
+Prefer your own SBOM generator over wrangle's default (syft)? On the go, python, and npm builds, add it in two steps.
 
 1. Add `.wrangle/tools.json` to your repo, describing your tool as a digest-pinned image:
 
@@ -122,10 +122,10 @@ Prefer your own SBOM generator over wrangle's default (syft)? Point the build at
    ```yaml
        with:
          sbom-tool: my-sbom
-         tool-overrides: .wrangle/tools.json
+         custom-tools: .wrangle/tools.json
    ```
 
-Your image reads a read-only `/src` and writes `/output/sbom.spdx.json` — the [Adapter Script Interface](docs/SPEC.md#adapter-script-interface) is the full contract. It runs in the same sandbox as wrangle's tools (no network, dropped capabilities, non-root), but is trusted as yours: it carries no wrangle VSA, so you own its digest pin and freshness. Overriding a curated tool re-declares its capabilities from scratch — an unspecified `network` or `secret` defaults closed.
+Your image reads a read-only `/src` and writes `/output/sbom.spdx.json` — the [Adapter Script Interface](docs/SPEC.md#adapter-script-interface) is the full contract. It runs in the same sandbox as wrangle's tools (no network, dropped capabilities, non-root), but is trusted as yours: it carries no wrangle VSA, so you own its digest pin and freshness. Custom tools are add-only — you add net-new tools (a name matching a curated tool is an error) and select them; each declares its own capabilities, with an unspecified `network` or `secret` defaulting closed. Because a custom tool can grant itself network egress and a secret, keep `.wrangle/tools.json` as trusted in-repo config — don't source it from untrusted pull-request contents.
 
 ## How Wrangle Works
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Prefer your own SBOM generator over wrangle's default (syft)? On the go, python,
 
 Your image reads a read-only `/src` and writes `/output/sbom.spdx.json`, exiting 0 (ok) or 2 (tool error). It runs in the same sandbox as wrangle's tools (no network, dropped capabilities, non-root), but is trusted as yours: it carries no wrangle VSA, so you own its digest pin and freshness. Tools are add-only — a name matching a curated tool is an error, the image must be outside wrangle's namespace, and each declares its own capabilities (an unspecified `network`/`secret` defaults closed).
 
-**`.wrangle/tools.json` is trusted config.** A tool listed there can grant itself network egress and a secret, so don't run wrangle over untrusted PR content — e.g. a `pull_request_target` job that checks out the PR head — in a job that forwards secrets.
+**`.wrangle/tools.json` is trusted config.** wrangle only runs a tool your workflow *selects* (`tools:` / `sbom-tool:`), and those inputs come from your base workflow — so a fork's PR can define an entry but can't get it run. The residual footgun is only if you hand-roll a `pull_request_target` job that checks out the PR head and forwards secrets: a tool listed there can grant itself network egress and a secret, so don't run wrangle over untrusted PR content in a secret-bearing job.
 
 ## How Wrangle Works
 

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      uses: TomHennen/wrangle/tools/scorecard@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+      uses: TomHennen/wrangle/tools/dependency-review@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      uses: TomHennen/wrangle/tools/scorecard@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+      uses: TomHennen/wrangle/tools/dependency-review@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      uses: TomHennen/wrangle/tools/scorecard@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+      uses: TomHennen/wrangle/tools/dependency-review@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      uses: TomHennen/wrangle/tools/scorecard@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+      uses: TomHennen/wrangle/tools/dependency-review@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
+    - uses: TomHennen/wrangle/actions/verify@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@e341a7d35daac4240ee1ffcdc68964664ee28e54 # main 2026-07-03
+    - uses: TomHennen/wrangle/actions/verify@54c034bc61ffd4e19a03f6552d2af72e3bf350a0 # main 2026-07-03
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
+    - uses: TomHennen/wrangle/actions/verify@096882713a4018a2d7ccd61c62c489083d243189 # main 2026-07-03
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@22137c415ef6ea44fa0cfb201de487f5a921b6aa # main 2026-07-02
+    - uses: TomHennen/wrangle/actions/verify@704f4be040ce1718672064c86d11c5ddb1ec2ed1 # main 2026-07-03
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/go/build/action.yml
+++ b/build/actions/go/build/action.yml
@@ -1,7 +1,7 @@
 name: Wrangle Go Build
 description: |
   Invoke goreleaser to build a Go project (always `--skip=publish`);
-  generate the SBOM via syft; compute artifact hashes for SLSA
+  generate the SBOM (syft by default); compute artifact hashes for SLSA
   provenance. Sister composite to `build/actions/go/checks` — the
   calling reusable workflow runs both with `contents: read`, since
   goreleaser publishes nothing. See build/actions/go/SPEC.md
@@ -51,11 +51,11 @@ inputs:
     required: false
     default: "false"
   sbom-tool:
-    description: "SBOM tool to run (a curated tool, or one defined in tool-overrides). Default syft."
+    description: "SBOM tool to run: the curated `sbom` slot, or a tool added via custom-tools. Default sbom."
     required: false
-    default: "syft"
-  tool-overrides:
-    description: "Optional workspace path to a .wrangle/tools.json merged over wrangle's catalog (see docs/SPEC.md)."
+    default: "sbom"
+  custom-tools:
+    description: "Optional workspace path to a .wrangle/tools.json adding your own tools to wrangle's catalog (see docs/SPEC.md)."
     required: false
     default: ""
 
@@ -194,7 +194,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
         WRANGLE_ROOT: ${{ github.action_path }}/../../../..
         SBOM_TOOL: ${{ inputs.sbom-tool }}
-        WRANGLE_TOOL_OVERRIDES: ${{ inputs.tool-overrides }}
+        WRANGLE_CUSTOM_TOOLS: ${{ inputs.custom-tools }}
       run: |
         set -euo pipefail
         "$WRANGLE_ROOT/lib/generate_sbom.sh" "$INPUT_PATH" "$METADATA_DIR" "$SBOM_TOOL"

--- a/build/actions/go/build/action.yml
+++ b/build/actions/go/build/action.yml
@@ -51,7 +51,7 @@ inputs:
     required: false
     default: "false"
   sbom-tool:
-    description: "SBOM tool to run: the curated `sbom` slot, or a tool you added in .wrangle/tools.json. Default sbom."
+    description: "Wrangle's default SBOM tool, or one you define yourself in `.wrangle/tools.json`."
     required: false
     default: "sbom"
 

--- a/build/actions/go/build/action.yml
+++ b/build/actions/go/build/action.yml
@@ -50,6 +50,14 @@ inputs:
       See build/actions/go/README.md "Cross-compiling with cgo."
     required: false
     default: "false"
+  sbom-tool:
+    description: "SBOM tool to run (a curated tool, or one defined in tool-overrides). Default syft."
+    required: false
+    default: "syft"
+  tool-overrides:
+    description: "Optional workspace path to a .wrangle/tools.json merged over wrangle's catalog (see docs/SPEC.md)."
+    required: false
+    default: ""
 
 outputs:
   version:
@@ -185,9 +193,11 @@ runs:
         METADATA_DIR: ${{ steps.metadata.outputs.metadata-dir }}
         GH_TOKEN: ${{ github.token }}
         WRANGLE_ROOT: ${{ github.action_path }}/../../../..
+        SBOM_TOOL: ${{ inputs.sbom-tool }}
+        WRANGLE_TOOL_OVERRIDES: ${{ inputs.tool-overrides }}
       run: |
         set -euo pipefail
-        "$WRANGLE_ROOT/lib/generate_sbom.sh" "$INPUT_PATH" "$METADATA_DIR"
+        "$WRANGLE_ROOT/lib/generate_sbom.sh" "$INPUT_PATH" "$METADATA_DIR" "$SBOM_TOOL"
 
     - name: Generate summary
       if: always()

--- a/build/actions/go/build/action.yml
+++ b/build/actions/go/build/action.yml
@@ -51,13 +51,9 @@ inputs:
     required: false
     default: "false"
   sbom-tool:
-    description: "SBOM tool to run: the curated `sbom` slot, or a tool added via custom-tools. Default sbom."
+    description: "SBOM tool to run: the curated `sbom` slot, or a tool you added in .wrangle/tools.json. Default sbom."
     required: false
     default: "sbom"
-  custom-tools:
-    description: "Optional workspace path to a .wrangle/tools.json adding your own tools to wrangle's catalog (see docs/SPEC.md)."
-    required: false
-    default: ""
 
 outputs:
   version:
@@ -194,7 +190,6 @@ runs:
         GH_TOKEN: ${{ github.token }}
         WRANGLE_ROOT: ${{ github.action_path }}/../../../..
         SBOM_TOOL: ${{ inputs.sbom-tool }}
-        WRANGLE_CUSTOM_TOOLS: ${{ inputs.custom-tools }}
       run: |
         set -euo pipefail
         "$WRANGLE_ROOT/lib/generate_sbom.sh" "$INPUT_PATH" "$METADATA_DIR" "$SBOM_TOOL"

--- a/build/actions/npm/action.yml
+++ b/build/actions/npm/action.yml
@@ -37,6 +37,14 @@ inputs:
       user's build), it can be added as a separate input.
     required: false
     default: "false"
+  sbom-tool:
+    description: "SBOM tool to run (a curated tool, or one defined in tool-overrides). Default syft."
+    required: false
+    default: "syft"
+  tool-overrides:
+    description: "Optional workspace path to a .wrangle/tools.json merged over wrangle's catalog (see docs/SPEC.md)."
+    required: false
+    default: ""
 
 outputs:
   version:
@@ -168,9 +176,11 @@ runs:
         METADATA_DIR: ${{ steps.metadata.outputs.metadata-dir }}
         GH_TOKEN: ${{ github.token }}
         WRANGLE_ROOT: ${{ github.action_path }}/../../..
+        SBOM_TOOL: ${{ inputs.sbom-tool }}
+        WRANGLE_TOOL_OVERRIDES: ${{ inputs.tool-overrides }}
       run: |
         set -euo pipefail
-        "$WRANGLE_ROOT/lib/generate_sbom.sh" "$INPUT_PATH" "$METADATA_DIR"
+        "$WRANGLE_ROOT/lib/generate_sbom.sh" "$INPUT_PATH" "$METADATA_DIR" "$SBOM_TOOL"
 
     - name: Generate summary
       if: always()

--- a/build/actions/npm/action.yml
+++ b/build/actions/npm/action.yml
@@ -38,13 +38,9 @@ inputs:
     required: false
     default: "false"
   sbom-tool:
-    description: "SBOM tool to run: the curated `sbom` slot, or a tool added via custom-tools. Default sbom."
+    description: "SBOM tool to run: the curated `sbom` slot, or a tool you added in .wrangle/tools.json. Default sbom."
     required: false
     default: "sbom"
-  custom-tools:
-    description: "Optional workspace path to a .wrangle/tools.json adding your own tools to wrangle's catalog (see docs/SPEC.md)."
-    required: false
-    default: ""
 
 outputs:
   version:
@@ -177,7 +173,6 @@ runs:
         GH_TOKEN: ${{ github.token }}
         WRANGLE_ROOT: ${{ github.action_path }}/../../..
         SBOM_TOOL: ${{ inputs.sbom-tool }}
-        WRANGLE_CUSTOM_TOOLS: ${{ inputs.custom-tools }}
       run: |
         set -euo pipefail
         "$WRANGLE_ROOT/lib/generate_sbom.sh" "$INPUT_PATH" "$METADATA_DIR" "$SBOM_TOOL"

--- a/build/actions/npm/action.yml
+++ b/build/actions/npm/action.yml
@@ -38,11 +38,11 @@ inputs:
     required: false
     default: "false"
   sbom-tool:
-    description: "SBOM tool to run (a curated tool, or one defined in tool-overrides). Default syft."
+    description: "SBOM tool to run: the curated `sbom` slot, or a tool added via custom-tools. Default sbom."
     required: false
-    default: "syft"
-  tool-overrides:
-    description: "Optional workspace path to a .wrangle/tools.json merged over wrangle's catalog (see docs/SPEC.md)."
+    default: "sbom"
+  custom-tools:
+    description: "Optional workspace path to a .wrangle/tools.json adding your own tools to wrangle's catalog (see docs/SPEC.md)."
     required: false
     default: ""
 
@@ -177,7 +177,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
         WRANGLE_ROOT: ${{ github.action_path }}/../../..
         SBOM_TOOL: ${{ inputs.sbom-tool }}
-        WRANGLE_TOOL_OVERRIDES: ${{ inputs.tool-overrides }}
+        WRANGLE_CUSTOM_TOOLS: ${{ inputs.custom-tools }}
       run: |
         set -euo pipefail
         "$WRANGLE_ROOT/lib/generate_sbom.sh" "$INPUT_PATH" "$METADATA_DIR" "$SBOM_TOOL"

--- a/build/actions/npm/action.yml
+++ b/build/actions/npm/action.yml
@@ -38,7 +38,7 @@ inputs:
     required: false
     default: "false"
   sbom-tool:
-    description: "SBOM tool to run: the curated `sbom` slot, or a tool you added in .wrangle/tools.json. Default sbom."
+    description: "Wrangle's default SBOM tool, or one you define yourself in `.wrangle/tools.json`."
     required: false
     default: "sbom"
 

--- a/build/actions/python/action.yml
+++ b/build/actions/python/action.yml
@@ -45,7 +45,7 @@ inputs:
     required: false
     default: "enabled"
   sbom-tool:
-    description: "SBOM tool to run: the curated `sbom` slot, or a tool you added in .wrangle/tools.json. Default sbom."
+    description: "Wrangle's default SBOM tool, or one you define yourself in `.wrangle/tools.json`."
     required: false
     default: "sbom"
 

--- a/build/actions/python/action.yml
+++ b/build/actions/python/action.yml
@@ -45,13 +45,9 @@ inputs:
     required: false
     default: "enabled"
   sbom-tool:
-    description: "SBOM tool to run: the curated `sbom` slot, or a tool added via custom-tools. Default sbom."
+    description: "SBOM tool to run: the curated `sbom` slot, or a tool you added in .wrangle/tools.json. Default sbom."
     required: false
     default: "sbom"
-  custom-tools:
-    description: "Optional workspace path to a .wrangle/tools.json adding your own tools to wrangle's catalog (see docs/SPEC.md)."
-    required: false
-    default: ""
 
 outputs:
   name:
@@ -189,7 +185,6 @@ runs:
         GH_TOKEN: ${{ github.token }}
         WRANGLE_ROOT: ${{ github.action_path }}/../../..
         SBOM_TOOL: ${{ inputs.sbom-tool }}
-        WRANGLE_CUSTOM_TOOLS: ${{ inputs.custom-tools }}
       run: |
         set -euo pipefail
         "$WRANGLE_ROOT/lib/generate_sbom.sh" "$INPUT_PATH" "$METADATA_DIR" "$SBOM_TOOL"

--- a/build/actions/python/action.yml
+++ b/build/actions/python/action.yml
@@ -45,11 +45,11 @@ inputs:
     required: false
     default: "enabled"
   sbom-tool:
-    description: "SBOM tool to run (a curated tool, or one defined in tool-overrides). Default syft."
+    description: "SBOM tool to run: the curated `sbom` slot, or a tool added via custom-tools. Default sbom."
     required: false
-    default: "syft"
-  tool-overrides:
-    description: "Optional workspace path to a .wrangle/tools.json merged over wrangle's catalog (see docs/SPEC.md)."
+    default: "sbom"
+  custom-tools:
+    description: "Optional workspace path to a .wrangle/tools.json adding your own tools to wrangle's catalog (see docs/SPEC.md)."
     required: false
     default: ""
 
@@ -189,7 +189,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
         WRANGLE_ROOT: ${{ github.action_path }}/../../..
         SBOM_TOOL: ${{ inputs.sbom-tool }}
-        WRANGLE_TOOL_OVERRIDES: ${{ inputs.tool-overrides }}
+        WRANGLE_CUSTOM_TOOLS: ${{ inputs.custom-tools }}
       run: |
         set -euo pipefail
         "$WRANGLE_ROOT/lib/generate_sbom.sh" "$INPUT_PATH" "$METADATA_DIR" "$SBOM_TOOL"

--- a/build/actions/python/action.yml
+++ b/build/actions/python/action.yml
@@ -44,6 +44,14 @@ inputs:
       caching by default; they are not claiming L3 provenance.
     required: false
     default: "enabled"
+  sbom-tool:
+    description: "SBOM tool to run (a curated tool, or one defined in tool-overrides). Default syft."
+    required: false
+    default: "syft"
+  tool-overrides:
+    description: "Optional workspace path to a .wrangle/tools.json merged over wrangle's catalog (see docs/SPEC.md)."
+    required: false
+    default: ""
 
 outputs:
   name:
@@ -180,9 +188,11 @@ runs:
         METADATA_DIR: ${{ steps.metadata.outputs.metadata-dir }}
         GH_TOKEN: ${{ github.token }}
         WRANGLE_ROOT: ${{ github.action_path }}/../../..
+        SBOM_TOOL: ${{ inputs.sbom-tool }}
+        WRANGLE_TOOL_OVERRIDES: ${{ inputs.tool-overrides }}
       run: |
         set -euo pipefail
-        "$WRANGLE_ROOT/lib/generate_sbom.sh" "$INPUT_PATH" "$METADATA_DIR"
+        "$WRANGLE_ROOT/lib/generate_sbom.sh" "$INPUT_PATH" "$METADATA_DIR" "$SBOM_TOOL"
 
     - name: Generate summary
       if: always()

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -639,11 +639,13 @@ NOTES:
 
 ### Custom Tools (adopter catalog, add-only)
 
-An adopter may **add** their own tool images through a custom-tools file (`.wrangle/tools.json` by
-convention), selected via a build composite's `custom-tools:` input. The path MUST resolve inside the
-workspace; `run.sh` rejects a path that escapes it (traversal or symlink). The file shares the catalog's
-shape; its tools are unioned with the curated catalog into the effective catalog `run.sh` uses
-(`lib/merge_catalog.sh`).
+`run.sh` auto-discovers a `.wrangle/tools.json` at the workspace root (`$GITHUB_WORKSPACE`, else the working
+directory) and unions the adopter tools it defines into the curated catalog (`lib/merge_catalog.sh`). The
+file is optional — its absence changes nothing. Its resolved path MUST stay inside the workspace, so a
+symlink escaping it is rejected. A custom tool is *defined* by this file but only *runs* when the selection
+names it (`tools:` for scan, `sbom-tool:` for the build SBOM); an unselected entry is never dispatched.
+Because those selection inputs come from the base workflow, a fork opening a `pull_request_target` cannot
+select an injected tool.
 
 ```jsonc
 {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -568,7 +568,9 @@ BEHAVIOR:
     1. Strip :policy suffix if present (run.sh does not use the policy —
        that is handled by lib/check_results.sh in the scan action)
     2. Validate tool name matches ^[a-z][a-z0-9_-]*$ (reject otherwise)
-    3. Verify tools/<tool>/ directory exists (reject if not — unknown tool)
+    3. Verify tools/<tool>/ directory exists, OR the catalog gives the tool a
+       `delivery: image` entry (a catalog-only image tool needs no local
+       directory); reject otherwise as an unknown tool
     4. Skip if tools/<tool>/action.yml exists (action-pattern — handled by
        uses: steps in the scan action; any adapter.sh present is only the
        tool image's entrypoint). Otherwise resolve the tool's
@@ -625,6 +627,48 @@ NOTES:
   own location (using $0 / BASH_SOURCE), not the caller's working directory.
   This is critical for portability when called via github.action_path.
 ```
+
+---
+
+### Tool Overrides (adopter catalog)
+
+An adopter may extend or replace catalog entries with their own tool images through an override file
+(`.wrangle/tools.json` by convention), selected via a build composite's `tool-overrides:` input. The path
+MUST resolve inside the workspace; `run.sh` rejects a path that escapes it (traversal or symlink). The file
+shares the catalog's shape and is merged over the curated catalog into the effective catalog `run.sh` uses
+(`lib/merge_catalog.sh`).
+
+```jsonc
+{
+  "tools": {
+    "osv":     { "image": "ghcr.io/myorg/osv@sha256:<64hex>" },  // replace a curated tool's image
+    "my-sbom": {                                                 // bring a tool wrangle doesn't ship
+      "kind": "sbom",
+      "delivery": "image",
+      "image": "ghcr.io/myorg/my-sbom@sha256:<64hex>"
+    }
+  }
+}
+```
+
+**Per-entry validation** (any failure aborts the run):
+
+- tool name matches `^[a-z][a-z0-9_-]*$`; `kind` ∈ {`scan`, `sbom`, `attest`}; `network` ∈ {`none`, `egress`};
+  `secret` matches `^[a-z][a-z0-9-]*$`.
+- `image`, when present, MUST be digest-pinned (`name@sha256:<64hex>`); a net-new tool (no curated entry of
+  the same name) MUST declare a digest-pinned `image` and `delivery: image`.
+
+**Merge semantics (capability-safe).** An entry's non-capability fields deep-merge over the curated entry.
+The capability grants `network` and `secret` are the exception: they hold ONLY when the override entry
+restates them, otherwise they reset closed — an override NEVER inherits the replaced entry's `network` or
+`secret`. Overriding a curated tool therefore re-declares its capabilities from scratch (§3.7 "an
+unspecified capability defaults closed" in [tool_container_design.md](tool_container_design.md)).
+
+**Trust.** An override image outside wrangle's namespace carries no wrangle VSA, so `run.sh` skips the VSA
+gate and trusts it as the adopter's own — the adopter owns its digest pin and freshness. It still runs in
+the full contract sandbox (read-only `/src`, `--network none` unless granted, `--cap-drop ALL`,
+no-new-privileges, non-root). An override that points at a curated-namespace digest still passes the VSA
+gate, which fails closed on a digest the wrangle signer never attested.
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -660,20 +660,21 @@ shape; its tools are unioned with the curated catalog into the effective catalog
 **Add-only — collision is an error.** A custom tool name that matches a curated tool is a hard error; the
 model never overrides or field-merges a curated entry. To change how a curated tool runs, add your own tool
 under a new name and deselect the curated one via `tools:` / `sbom-tool:`. Each added tool declares its own
-capabilities standalone; nothing inherits from any curated entry, so a custom entry can never attach a
-`secret`/`network` grant to wrangle's curated, VSA-signed image.
+capabilities standalone; nothing inherits from any curated entry.
 
 **Per-entry validation** (any failure fails closed, aborting the run): tool name matches
 `^[a-z][a-z0-9_-]*$`; `kind` ∈ {`scan`, `sbom`, `attest`}; `delivery` is `image`; `image` is digest-pinned
-(`name@sha256:<64hex>`); a declared `network` ∈ {`none`, `egress`} and `secret` matches `^[a-z][a-z0-9-]*$`.
-These value rules are shared with the curated-catalog linter via `lib/catalog_rules.sh`.
+(`name@sha256:<64hex>`) **and outside the wrangle namespace** (`ghcr.io/tomhennen/wrangle/*` is rejected —
+a custom tool cannot borrow a wrangle VSA identity); a declared `network` ∈ {`none`, `egress`} and `secret`
+matches `^[a-z][a-z0-9-]*$`. The value rules are shared with the curated-catalog linter via
+`lib/catalog_rules.sh`.
 
 **Trust boundary.** The custom-tools file is trusted adopter configuration: an added tool may grant itself
 `egress` + a `secret`, so the file MUST come from the trusted repository, never from untrusted PR contents
-in a job that carries `WRANGLE_EXTRA_*` secrets. A custom image outside wrangle's namespace carries no
-wrangle VSA, so `run.sh` skips the VSA gate and trusts it as the adopter's own — the adopter owns its digest
-pin and freshness. It still runs in the full contract sandbox (read-only `/src`, `--network none` unless
-granted, `--cap-drop ALL`, no-new-privileges, non-root).
+in a job that carries `WRANGLE_EXTRA_*` secrets. Because a custom image is always off the wrangle namespace
+it carries no wrangle VSA, so `run.sh` skips the VSA gate and trusts it as the adopter's own — the adopter
+owns its digest pin and freshness. It still runs in the full contract sandbox (read-only `/src`,
+`--network none` unless granted, `--cap-drop ALL`, no-new-privileges, non-root).
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -630,19 +630,18 @@ NOTES:
 
 ---
 
-### Tool Overrides (adopter catalog)
+### Custom Tools (adopter catalog, add-only)
 
-An adopter may extend or replace catalog entries with their own tool images through an override file
-(`.wrangle/tools.json` by convention), selected via a build composite's `tool-overrides:` input. The path
-MUST resolve inside the workspace; `run.sh` rejects a path that escapes it (traversal or symlink). The file
-shares the catalog's shape and is merged over the curated catalog into the effective catalog `run.sh` uses
+An adopter may **add** their own tool images through a custom-tools file (`.wrangle/tools.json` by
+convention), selected via a build composite's `custom-tools:` input. The path MUST resolve inside the
+workspace; `run.sh` rejects a path that escapes it (traversal or symlink). The file shares the catalog's
+shape; its tools are unioned with the curated catalog into the effective catalog `run.sh` uses
 (`lib/merge_catalog.sh`).
 
 ```jsonc
 {
   "tools": {
-    "osv":     { "image": "ghcr.io/myorg/osv@sha256:<64hex>" },  // replace a curated tool's image
-    "my-sbom": {                                                 // bring a tool wrangle doesn't ship
+    "my-sbom": {                                  // a tool wrangle doesn't ship — full definition
       "kind": "sbom",
       "delivery": "image",
       "image": "ghcr.io/myorg/my-sbom@sha256:<64hex>"
@@ -651,24 +650,23 @@ shares the catalog's shape and is merged over the curated catalog into the effec
 }
 ```
 
-**Per-entry validation** (any failure aborts the run):
+**Add-only — collision is an error.** A custom tool name that matches a curated tool is a hard error; the
+model never overrides or field-merges a curated entry. To change how a curated tool runs, add your own tool
+under a new name and deselect the curated one via `tools:` / `sbom-tool:`. Each added tool declares its own
+capabilities standalone; nothing inherits from any curated entry, so a custom entry can never attach a
+`secret`/`network` grant to wrangle's curated, VSA-signed image.
 
-- tool name matches `^[a-z][a-z0-9_-]*$`; `kind` ∈ {`scan`, `sbom`, `attest`}; `network` ∈ {`none`, `egress`};
-  `secret` matches `^[a-z][a-z0-9-]*$`.
-- `image`, when present, MUST be digest-pinned (`name@sha256:<64hex>`); a net-new tool (no curated entry of
-  the same name) MUST declare a digest-pinned `image` and `delivery: image`.
+**Per-entry validation** (any failure fails closed, aborting the run): tool name matches
+`^[a-z][a-z0-9_-]*$`; `kind` ∈ {`scan`, `sbom`, `attest`}; `delivery` is `image`; `image` is digest-pinned
+(`name@sha256:<64hex>`); a declared `network` ∈ {`none`, `egress`} and `secret` matches `^[a-z][a-z0-9-]*$`.
+These value rules are shared with the curated-catalog linter via `lib/catalog_rules.sh`.
 
-**Merge semantics (capability-safe).** An entry's non-capability fields deep-merge over the curated entry.
-The capability grants `network` and `secret` are the exception: they hold ONLY when the override entry
-restates them, otherwise they reset closed — an override NEVER inherits the replaced entry's `network` or
-`secret`. Overriding a curated tool therefore re-declares its capabilities from scratch (§3.7 "an
-unspecified capability defaults closed" in [tool_container_design.md](tool_container_design.md)).
-
-**Trust.** An override image outside wrangle's namespace carries no wrangle VSA, so `run.sh` skips the VSA
-gate and trusts it as the adopter's own — the adopter owns its digest pin and freshness. It still runs in
-the full contract sandbox (read-only `/src`, `--network none` unless granted, `--cap-drop ALL`,
-no-new-privileges, non-root). An override that points at a curated-namespace digest still passes the VSA
-gate, which fails closed on a digest the wrangle signer never attested.
+**Trust boundary.** The custom-tools file is trusted adopter configuration: an added tool may grant itself
+`egress` + a `secret`, so the file MUST come from the trusted repository, never from untrusted PR contents
+in a job that carries `WRANGLE_EXTRA_*` secrets. A custom image outside wrangle's namespace carries no
+wrangle VSA, so `run.sh` skips the VSA gate and trusts it as the adopter's own — the adopter owns its digest
+pin and freshness. It still runs in the full contract sandbox (read-only `/src`, `--network none` unless
+granted, `--cap-drop ALL`, no-new-privileges, non-root).
 
 ---
 

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -172,10 +172,10 @@ thing for the pin tooling to track and for adopters to read.
   tool version. Wrangle bumps a digest when it updates a tool.
 - **Selection stays short-name + policy** — the existing `tools: "osv zizmor:info …"` interface is
   unchanged; a name resolves through the catalog to an image.
-- **Overrides** are an adopter-supplied catalog fragment — a different digest for a built-in tool, or a
-  new tool under its own name. An override is a pin the adopter now owns the freshness of; wrangle can
-  offer rails (a `docker` Dependabot entry, a lint warning on a stale override) but cannot vouch for an
-  image it does not control.
+- **Custom tools** are an adopter-supplied catalog fragment that only *adds* net-new tools under their own
+  names (a name that collides with a built-in is a hard error — add-only, never override; §3.7). A custom
+  tool is a pin the adopter now owns the freshness of; wrangle can offer rails (a `docker` Dependabot entry,
+  a lint warning on a stale pin) but cannot vouch for an image it does not control.
 
 The shipped catalog (`tools/catalog.json`) is parsed with `jq` (`lib/read_catalog.sh`) and has **two
 consumers**: the scan orchestrator dispatches entries the `tools:` selection names that carry
@@ -429,7 +429,7 @@ a full wrangle CI/CD run**. Two pieces:
   `image:` is digest-pinned (no tag, no `@latest`); every entry declares a `kind`; capabilities are
   default-closed and any `network`/`secret` grant is explicit; curated images come from the allowed
   registry namespace; and every tool named in a default selection exists in the catalog. Plus the
-  adopter-override rail (warn on a stale/unpinned override, §3.6).
+  custom-tools rail (warn on a stale/unpinned adopter pin, §3.6).
 
 ## 9. Open questions
 
@@ -438,8 +438,8 @@ deferred); amd64 is the baseline (GitHub's hosted runners default to amd64; arm6
 publish amd64+arm64 but gate nothing on arm64); the catalog (not per-tool action inputs) is the reference
 model. Still open:
 
-- **Catalog schema details** — exact field names, the catalog file's location, and whether an adopter
-  override is a file path or inline.
+- **Catalog schema details** — exact field names, the catalog file's location, and whether the adopter
+  custom-tools config is a file path or inline.
 - **Registry namespace** — the ghcr path for curated images.
 - **SPEC.md** — fold the kind-parameterized contract into the Adapter Script Interface.
 

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -233,7 +233,7 @@ Schema below is the proposed shape; exact field names and file locations are bik
       "network": "egress",
       "secret": "github-token"   // delivered as WRANGLE_EXTRA_GITHUB_TOKEN
     },
-    "sbom": {                                                  // the SBOM slot; sbom-tool: sbom selects it
+    "sbom": {                                                  // wrangle's default SBOM tool; sbom-tool: sbom selects it
       "kind": "sbom",
       "image": "ghcr.io/tomhennen/wrangle/syft@sha256:0b72…"   // network omitted → none; no secret
     },
@@ -270,7 +270,7 @@ jobs:
     uses: TomHennen/wrangle/.github/workflows/scan.yml@<wrangle-version>  # pin a wrangle release
     with:
       tools: "my-osv zizmor:info"          # scan selection + policy; deselect osv, run my own
-      sbom-tool: my-sbom                    # pick the SBOM tool (default: the curated `sbom` slot)
+      sbom-tool: my-sbom                    # pick the SBOM tool (default: sbom, wrangle's syft)
 ```
 
 **Adopter — bringing their own tools (add-only).** An adopter commits a `.wrangle/tools.json` (same

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -206,10 +206,11 @@ only explicitly — consistent with wrangle's least-privilege and input-validati
 **Custom tools are add-only, so grants never inherit.** An adopter's file may only *add* net-new tools
 (disjoint names) and *deselect* curated ones — never partially override a curated entry. Each added tool
 declares its own capabilities standalone; there is no merge with, and no inheritance from, any curated
-entry. This is strictly safer than a field-merge: because a name that collides with a curated tool is a
-hard error, an adopter can never attach a `secret`/`network` grant to wrangle's curated, VSA-signed image.
-To change how a curated tool runs, an adopter deselects it and adds their own full definition under a new
-name.
+entry. Two enforced rules make this strictly safer than a field-merge: a name that collides with a curated
+tool is a hard error, and **a custom entry's image MUST be outside the wrangle namespace**
+(`ghcr.io/tomhennen/wrangle/*` is rejected). An adopter therefore cannot attach a `secret`/`network` grant
+to any wrangle-published, VSA-signed image. To change how a curated tool runs, an adopter deselects it and
+adds their own full definition, on their own image, under a new name.
 
 ### 3.8 Configuration, illustrated
 

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -203,6 +203,14 @@ orchestrator's decision; otherwise the sandboxed tool would define its own sandb
 recorded in-repo as reviewable catalog lines, default to `network=none, secret=none`, and are relaxed
 only explicitly — consistent with wrangle's least-privilege and input-validation rules.
 
+**Custom tools are add-only, so grants never inherit.** An adopter's file may only *add* net-new tools
+(disjoint names) and *deselect* curated ones — never partially override a curated entry. Each added tool
+declares its own capabilities standalone; there is no merge with, and no inheritance from, any curated
+entry. This is strictly safer than a field-merge: because a name that collides with a curated tool is a
+hard error, an adopter can never attach a `secret`/`network` grant to wrangle's curated, VSA-signed image.
+To change how a curated tool runs, an adopter deselects it and adds their own full definition under a new
+name.
+
 ### 3.8 Configuration, illustrated
 
 Schema below is the proposed shape; exact field names and file locations are bikeshed-able (§9).
@@ -224,7 +232,7 @@ Schema below is the proposed shape; exact field names and file locations are bik
       "network": "egress",
       "secret": "github-token"   // delivered as WRANGLE_EXTRA_GITHUB_TOKEN
     },
-    "syft": {
+    "sbom": {                                                  // the SBOM slot; sbom-tool: sbom selects it
       "kind": "sbom",
       "image": "ghcr.io/tomhennen/wrangle/syft@sha256:0b72…"   // network omitted → none; no secret
     },
@@ -252,7 +260,7 @@ selected by command rather than a separate image per tool — handy for the owne
 BYO image that exposes more than one tool. The capability rules (§3.7) and least-privilege defaults still
 apply per entry; the cost is a larger per-entry surface to validate (§8).
 
-**Adopter — selecting tools** (pin wrangle, choose which to run, optionally point at an override file):
+**Adopter — selecting tools** (pin wrangle, choose which to run, optionally add your own):
 
 ```yaml
 # adopter .github/workflows/scan.yml
@@ -260,34 +268,40 @@ jobs:
   scan:
     uses: TomHennen/wrangle/.github/workflows/scan.yml@<wrangle-version>  # pin a wrangle release
     with:
-      tools: "osv zizmor:info my-sbom"     # selection + policy (unchanged from today)
-      tool-overrides: .wrangle/tools.json  # optional; overrides/extends the catalog
+      tools: "my-osv zizmor:info"          # scan selection + policy; deselect osv, run my own
+      sbom-tool: my-sbom                    # pick the SBOM tool (default: the curated `sbom` slot)
+      custom-tools: .wrangle/tools.json     # optional; adds your own tools to the catalog
 ```
 
-**Adopter — overriding an image and bringing their own tool**:
+**Adopter — bringing their own tools (add-only)**:
 
 ```jsonc
-// adopter .wrangle/tools.json  — merged over wrangle's catalog
+// adopter .wrangle/tools.json  — net-new tools added to wrangle's catalog
 {
   "tools": {
-    "osv": {                                       // override a curated default with a different digest
-      "image": "ghcr.io/myorg/osv@sha256:7c1d…"    // adopter now owns this pin's freshness
+    "my-osv": {                                    // add your own scanner, then select it instead of osv
+      "kind": "scan",
+      "delivery": "image",
+      "image": "ghcr.io/myorg/osv@sha256:7c1d…",   // adopter owns this pin's freshness
+      "network": "egress"                          // declared here; nothing inherits from curated osv
     },
-    "my-sbom": {                                   // BYO a tool wrangle doesn't ship — full definition
+    "my-sbom": {                                   // a tool wrangle doesn't ship — full definition
       "kind": "sbom",                              // emits its own sbom.<format>.json
+      "delivery": "image",
       "image": "ghcr.io/myorg/my-sbom-generator@sha256:e88f…"  // no network / no secret → strictest contract by default
     }
   }
 }
 ```
 
-What the three pieces demonstrate:
+What the pieces demonstrate:
 - **Inheritance** — an adopter who only sets `tools:` runs wrangle's curated, cooldown-vetted images and
   pins nothing of their own.
-- **Override ownership** — overriding `osv` means pinning a digest the adopter now owns the freshness of;
-  wrangle's pin tooling covers its own catalog, not this entry.
-- **Trust direction** — `my-sbom`'s capabilities are declared by the *adopter*, in the adopter's file;
-  the image grants itself nothing, and an unspecified capability defaults closed.
+- **Add-only, no override** — a custom name that collides with a curated tool is a hard error; to replace a
+  curated tool the adopter adds their own (`my-osv`) and deselects the curated one via `tools:`, owning the
+  new pin's freshness (wrangle's pin tooling covers only its own catalog).
+- **Trust direction** — every custom tool's capabilities are declared by the *adopter*, in the adopter's
+  file; the image grants itself nothing, and an unspecified capability defaults closed.
 
 ## 4. Evidence
 

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -261,7 +261,7 @@ selected by command rather than a separate image per tool — handy for the owne
 BYO image that exposes more than one tool. The capability rules (§3.7) and least-privilege defaults still
 apply per entry; the cost is a larger per-entry surface to validate (§8).
 
-**Adopter — selecting tools** (pin wrangle, choose which to run, optionally add your own):
+**Adopter — selecting tools** (pin wrangle, choose which to run):
 
 ```yaml
 # adopter .github/workflows/scan.yml
@@ -271,38 +271,23 @@ jobs:
     with:
       tools: "my-osv zizmor:info"          # scan selection + policy; deselect osv, run my own
       sbom-tool: my-sbom                    # pick the SBOM tool (default: the curated `sbom` slot)
-      custom-tools: .wrangle/tools.json     # optional; adds your own tools to the catalog
 ```
 
-**Adopter — bringing their own tools (add-only)**:
+**Adopter — bringing their own tools (add-only).** An adopter commits a `.wrangle/tools.json` (same
+`{ "tools": { … } }` shape) at the repo root; `run.sh` auto-discovers it — no workflow input — and unions
+its net-new tools into the catalog, then selection (`tools:` / `sbom-tool:`) decides which run. The model is
+add-only: a name colliding with a curated tool is a hard error, a custom image must be off the wrangle
+namespace, and each entry declares its own capabilities (nothing inherits from curated). The full schema,
+validation, and trust boundary are the **canonical contract in [SPEC.md](SPEC.md) → "Custom Tools"**.
 
-```jsonc
-// adopter .wrangle/tools.json  — net-new tools added to wrangle's catalog
-{
-  "tools": {
-    "my-osv": {                                    // add your own scanner, then select it instead of osv
-      "kind": "scan",
-      "delivery": "image",
-      "image": "ghcr.io/myorg/osv@sha256:7c1d…",   // adopter owns this pin's freshness
-      "network": "egress"                          // declared here; nothing inherits from curated osv
-    },
-    "my-sbom": {                                   // a tool wrangle doesn't ship — full definition
-      "kind": "sbom",                              // emits its own sbom.<format>.json
-      "delivery": "image",
-      "image": "ghcr.io/myorg/my-sbom-generator@sha256:e88f…"  // no network / no secret → strictest contract by default
-    }
-  }
-}
-```
-
-What the pieces demonstrate:
-- **Inheritance** — an adopter who only sets `tools:` runs wrangle's curated, cooldown-vetted images and
-  pins nothing of their own.
-- **Add-only, no override** — a custom name that collides with a curated tool is a hard error; to replace a
-  curated tool the adopter adds their own (`my-osv`) and deselects the curated one via `tools:`, owning the
-  new pin's freshness (wrangle's pin tooling covers only its own catalog).
-- **Trust direction** — every custom tool's capabilities are declared by the *adopter*, in the adopter's
-  file; the image grants itself nothing, and an unspecified capability defaults closed.
+Three properties follow:
+- **Inheritance** — an adopter who commits no `.wrangle/tools.json` runs wrangle's curated, cooldown-vetted
+  images and pins nothing of their own.
+- **Add-only, no override** — to replace a curated tool the adopter adds their own (`my-osv`) and deselects
+  the curated one via `tools:`, owning the new pin's freshness (wrangle's pin tooling covers only its own
+  catalog).
+- **Trust direction** — every custom tool's capabilities are declared by the *adopter*; the image grants
+  itself nothing, and an unspecified capability defaults closed.
 
 ## 4. Evidence
 
@@ -439,8 +424,8 @@ deferred); amd64 is the baseline (GitHub's hosted runners default to amd64; arm6
 publish amd64+arm64 but gate nothing on arm64); the catalog (not per-tool action inputs) is the reference
 model. Still open:
 
-- **Catalog schema details** — exact field names, the catalog file's location, and whether the adopter
-  custom-tools config is a file path or inline.
+- **Catalog schema details** — exact field names and the catalog file's location. (Adopter custom tools are
+  settled: an auto-discovered `.wrangle/tools.json` at the workspace root; see SPEC.md "Custom Tools".)
 - **Registry namespace** — the ghcr path for curated images.
 - **SPEC.md** — fold the kind-parameterized contract into the Adapter Script Interface.
 

--- a/lib/catalog_rules.sh
+++ b/lib/catalog_rules.sh
@@ -18,3 +18,6 @@ CATALOG_SECRET_NAME_RE='^[a-z][a-z0-9-]*$'
 CATALOG_IMAGE_DIGEST_RE='^[a-z0-9._-]+(:[0-9]+)?(/[a-z0-9._-]+)*@sha256:[0-9a-f]{64}$'
 # Namespace of wrangle-published, VSA-signed tool images.
 CATALOG_CURATED_IMAGE_PREFIX='ghcr.io/tomhennen/wrangle/'
+# Same namespace as an anchored match tolerating an explicit registry port
+# (ghcr.io:443/…), so a custom entry can't reach a wrangle image via the port form.
+CATALOG_CURATED_IMAGE_RE='^ghcr\.io(:[0-9]+)?/tomhennen/wrangle/'

--- a/lib/catalog_rules.sh
+++ b/lib/catalog_rules.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# lib/catalog_rules.sh — shared validation constants for catalog entries, so the
+# curated-catalog linter (tools/check_catalog.sh) and the custom-tools validator
+# (lib/merge_catalog.sh) enforce one set of value rules. Namespace/trust rules
+# differ between them and stay in each caller.
+
+# shellcheck disable=SC2034 # constants are consumed by the scripts that source this file
+# Tool name: the shape run.sh admits — no leading dot/dash, no path traversal.
+CATALOG_TOOL_NAME_RE='^[a-z][a-z0-9_-]*$'
+CATALOG_KIND_RE='^(scan|sbom|attest)$'
+CATALOG_NETWORK_RE='^(none|egress)$'
+CATALOG_SECRET_NAME_RE='^[a-z][a-z0-9-]*$'
+# Digest-pinned image, host-agnostic (the registry may carry a :port). Curated
+# entries additionally require the wrangle namespace; check_catalog enforces that.
+CATALOG_IMAGE_DIGEST_RE='^[a-z0-9._-]+(:[0-9]+)?(/[a-z0-9._-]+)*@sha256:[0-9a-f]{64}$'

--- a/lib/catalog_rules.sh
+++ b/lib/catalog_rules.sh
@@ -3,16 +3,18 @@
 set -euo pipefail
 set -f  # disable globbing — sourced constants, no external input
 
-# lib/catalog_rules.sh — shared validation constants for catalog entries, so the
-# curated-catalog linter (tools/check_catalog.sh) and the custom-tools validator
-# (lib/merge_catalog.sh) enforce one set of value rules. Namespace/trust rules
-# differ between them and stay in each caller.
+# lib/catalog_rules.sh — shared validation constants for catalog entries, used by
+# run.sh, the curated-catalog linter (tools/check_catalog.sh), and the
+# custom-tools validator (lib/merge_catalog.sh). The direction of the namespace
+# rule differs per caller (curated entries MUST be in the namespace; custom
+# entries MUST NOT be), so each caller applies the prefix itself.
 
 # Tool name: the shape run.sh admits — no leading dot/dash, no path traversal.
 CATALOG_TOOL_NAME_RE='^[a-z][a-z0-9_-]*$'
 CATALOG_KIND_RE='^(scan|sbom|attest)$'
 CATALOG_NETWORK_RE='^(none|egress)$'
 CATALOG_SECRET_NAME_RE='^[a-z][a-z0-9-]*$'
-# Digest-pinned image, host-agnostic (the registry may carry a :port). Curated
-# entries additionally require the wrangle namespace; check_catalog enforces that.
+# Digest-pinned image, host-agnostic (the registry may carry a :port).
 CATALOG_IMAGE_DIGEST_RE='^[a-z0-9._-]+(:[0-9]+)?(/[a-z0-9._-]+)*@sha256:[0-9a-f]{64}$'
+# Namespace of wrangle-published, VSA-signed tool images.
+CATALOG_CURATED_IMAGE_PREFIX='ghcr.io/tomhennen/wrangle/'

--- a/lib/catalog_rules.sh
+++ b/lib/catalog_rules.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
+# shellcheck disable=SC2034 # constants are consumed by the scripts that source this file
+set -euo pipefail
+set -f  # disable globbing — sourced constants, no external input
+
 # lib/catalog_rules.sh — shared validation constants for catalog entries, so the
 # curated-catalog linter (tools/check_catalog.sh) and the custom-tools validator
 # (lib/merge_catalog.sh) enforce one set of value rules. Namespace/trust rules
 # differ between them and stay in each caller.
 
-# shellcheck disable=SC2034 # constants are consumed by the scripts that source this file
 # Tool name: the shape run.sh admits — no leading dot/dash, no path traversal.
 CATALOG_TOOL_NAME_RE='^[a-z][a-z0-9_-]*$'
 CATALOG_KIND_RE='^(scan|sbom|attest)$'

--- a/lib/generate_sbom.sh
+++ b/lib/generate_sbom.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 set -f  # processes external arguments — disable globbing per CLAUDE.md
 
 # lib/generate_sbom.sh — generate an SPDX SBOM for a build-type source tree by
-# dispatching a curated SBOM tool (default: syft) through the orchestrator.
+# dispatching an SBOM tool (default: the curated `sbom` slot, syft) through the
+# orchestrator.
 #
 # Usage: generate_sbom.sh <src_dir> <metadata_dir> [<tool>]
 
@@ -14,7 +15,7 @@ fi
 
 SRC_DIR="$1"
 METADATA_DIR="$2"
-TOOL="${3:-syft}"
+TOOL="${3:-sbom}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WRANGLE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/lib/merge_catalog.sh
+++ b/lib/merge_catalog.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # disable globbing — handles external file contents
+
+# lib/merge_catalog.sh — build the effective tool catalog by merging an adopter
+# override file over wrangle's curated catalog (both share the
+# { "tools": { … } } shape). An override entry's non-capability fields deep-merge
+# over the curated entry; the capability grants network and secret hold ONLY when
+# the override entry restates them, otherwise they reset closed — an override
+# never inherits the replaced entry's network or secret.
+#
+# Usage: merge_catalog.sh <curated_catalog> <override_file>
+# Prints the effective catalog on stdout. Exits non-zero (message on stderr) when
+# the override is not valid JSON or any adopter entry fails validation.
+
+merge_catalog() {
+    local curated="$1" override="$2"
+    local curated_json='{"tools":{}}'
+    [[ -f "$curated" ]] && curated_json="$(cat "$curated")"
+
+    if ! jq -e . "$override" >/dev/null 2>&1; then
+        printf 'wrangle: tool-overrides is not valid JSON: %s\n' "$override" >&2
+        return 1
+    fi
+
+    jq -n \
+        --argjson curated "$curated_json" \
+        --slurpfile ov "$override" '
+        def digestpin: test("^[a-z0-9._-]+(:[0-9]+)?(/[a-z0-9._-]+)*@sha256:[0-9a-f]{64}$");
+        def check($cond; $msg): if $cond then . else error($msg) end;
+
+        ($ov[0]) as $o
+        | ($curated.tools // {}) as $ct
+        | check(($o | type) == "object"; "tool-overrides: top-level must be a JSON object")
+        | check(($o | has("tools")) and (($o.tools | type) == "object");
+                "tool-overrides: \"tools\" must be an object")
+        | reduce ($o.tools | to_entries[]) as $e (0;
+            ($e.key) as $t | ($e.value) as $v | ($ct | has($t)) as $known
+            | (null
+               | check(($t | test("^[a-z][a-z0-9_-]*$"));
+                       "tool-overrides: invalid tool name: \($t)")
+               | check(($v | type) == "object";
+                       "tool-overrides: \($t): entry must be an object")
+               | check(($v | has("kind") | not)
+                       or (($v.kind | type) == "string" and ($v.kind | IN("scan","sbom","attest")));
+                       "tool-overrides: \($t): kind must be one of scan, sbom, attest")
+               | check(($v | has("network") | not) or ($v.network | IN("none","egress"));
+                       "tool-overrides: \($t): network must be one of none, egress")
+               | check(($v | has("secret") | not)
+                       or (($v.secret | type) == "string" and ($v.secret | test("^[a-z][a-z0-9-]*$")));
+                       "tool-overrides: \($t): secret must match ^[a-z][a-z0-9-]*$")
+               | check(($v | has("image") | not) or ($v.image | digestpin);
+                       "tool-overrides: \($t): image must be digest-pinned (name@sha256:<64hex>)")
+               | check($known or ($v | has("image"));
+                       "tool-overrides: \($t): a new tool must declare a digest-pinned image")
+               | check($known or (($v.delivery // "") == "image");
+                       "tool-overrides: \($t): a new tool must declare delivery: image"))
+            | .)
+        | { tools: ($ct + ($o.tools
+                           | to_entries
+                           | map({ key: .key, value: (($ct[.key] // {}) + .value) })
+                           | from_entries)) }
+        | .tools |= with_entries(
+            (.key) as $t
+            | if ($o.tools | has($t)) then
+                .value |= ((if ($o.tools[$t] | has("network")) then . else del(.network) end)
+                           | (if ($o.tools[$t] | has("secret")) then . else del(.secret) end))
+              else . end)
+    '
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [[ "$#" -ne 2 ]]; then
+        printf 'Usage: %s <curated_catalog> <override_file>\n' "${0##*/}" >&2
+        exit 2
+    fi
+    merge_catalog "$1" "$2"
+fi

--- a/lib/merge_catalog.sh
+++ b/lib/merge_catalog.sh
@@ -2,76 +2,102 @@
 set -euo pipefail
 set -f  # disable globbing — handles external file contents
 
-# lib/merge_catalog.sh — build the effective tool catalog by merging an adopter
-# override file over wrangle's curated catalog (both share the
-# { "tools": { … } } shape). An override entry's non-capability fields deep-merge
-# over the curated entry; the capability grants network and secret hold ONLY when
-# the override entry restates them, otherwise they reset closed — an override
-# never inherits the replaced entry's network or secret.
+# lib/merge_catalog.sh — build the effective tool catalog by ADDING an adopter's
+# custom tools to wrangle's curated catalog (both share the { "tools": { … } }
+# shape). The model is add-only: an adopter may add net-new tools, never override
+# a curated one. A custom tool whose name collides with a curated tool is a hard
+# error — no shadowing, no field merge, so a custom entry can never attach its
+# capabilities to a curated, VSA-signed image. Each custom entry is validated
+# standalone and declares its own capabilities; there is no inheritance.
 #
-# Usage: merge_catalog.sh <curated_catalog> <override_file>
+# Usage: merge_catalog.sh <curated_catalog> <custom_tools_file>
 # Prints the effective catalog on stdout. Exits non-zero (message on stderr) when
-# the override is not valid JSON or any adopter entry fails validation.
+# the custom file is not valid JSON, collides with a curated name, or any entry
+# fails validation.
+
+# A distinct name from the caller's SCRIPT_DIR — run.sh sources this file and
+# then sources more libs relative to its own SCRIPT_DIR.
+_MERGE_CATALOG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/read_catalog.sh
+source "$_MERGE_CATALOG_DIR/read_catalog.sh"
+# shellcheck source=lib/catalog_rules.sh
+source "$_MERGE_CATALOG_DIR/catalog_rules.sh"
 
 merge_catalog() {
-    local curated="$1" override="$2"
+    local curated="$1" custom="$2"
     local curated_json='{"tools":{}}'
     [[ -f "$curated" ]] && curated_json="$(cat "$curated")"
 
-    if ! jq -e . "$override" >/dev/null 2>&1; then
-        printf 'wrangle: tool-overrides is not valid JSON: %s\n' "$override" >&2
+    if ! jq -e '(.tools // {}) | type == "object"' "$custom" >/dev/null 2>&1; then
+        printf 'wrangle: custom-tools: not a valid JSON catalog (needs an object "tools"): %s\n' "$custom" >&2
         return 1
     fi
 
-    jq -n \
-        --argjson curated "$curated_json" \
-        --slurpfile ov "$override" '
-        def digestpin: test("^[a-z0-9._-]+(:[0-9]+)?(/[a-z0-9._-]+)*@sha256:[0-9a-f]{64}$");
-        def check($cond; $msg): if $cond then . else error($msg) end;
+    # Add-only: a name shared with the curated catalog is rejected, never merged.
+    local collisions
+    collisions="$(jq -rn --argjson c "$curated_json" --slurpfile x "$custom" '
+        ($c.tools // {} | keys) as $ck
+        | ($x[0].tools // {} | keys)
+        | map(select(. as $k | $ck | index($k)))
+        | .[]')"
+    if [[ -n "$collisions" ]]; then
+        printf 'wrangle: custom-tools: name collides with a curated tool (add-only, no override): %s\n' \
+            "$(printf '%s' "$collisions" | tr '\n' ' ')" >&2
+        return 1
+    fi
 
-        ($ov[0]) as $o
-        | ($curated.tools // {}) as $ct
-        | check(($o | type) == "object"; "tool-overrides: top-level must be a JSON object")
-        | check(($o | has("tools")) and (($o.tools | type) == "object");
-                "tool-overrides: \"tools\" must be an object")
-        | reduce ($o.tools | to_entries[]) as $e (0;
-            ($e.key) as $t | ($e.value) as $v | ($ct | has($t)) as $known
-            | (null
-               | check(($t | test("^[a-z][a-z0-9_-]*$"));
-                       "tool-overrides: invalid tool name: \($t)")
-               | check(($v | type) == "object";
-                       "tool-overrides: \($t): entry must be an object")
-               | check(($v | has("kind") | not)
-                       or (($v.kind | type) == "string" and ($v.kind | IN("scan","sbom","attest")));
-                       "tool-overrides: \($t): kind must be one of scan, sbom, attest")
-               | check(($v | has("network") | not) or ($v.network | IN("none","egress"));
-                       "tool-overrides: \($t): network must be one of none, egress")
-               | check(($v | has("secret") | not)
-                       or (($v.secret | type) == "string" and ($v.secret | test("^[a-z][a-z0-9-]*$")));
-                       "tool-overrides: \($t): secret must match ^[a-z][a-z0-9-]*$")
-               | check(($v | has("image") | not) or ($v.image | digestpin);
-                       "tool-overrides: \($t): image must be digest-pinned (name@sha256:<64hex>)")
-               | check($known or ($v | has("image"));
-                       "tool-overrides: \($t): a new tool must declare a digest-pinned image")
-               | check($known or (($v.delivery // "") == "image");
-                       "tool-overrides: \($t): a new tool must declare delivery: image"))
-            | .)
-        | { tools: ($ct + ($o.tools
-                           | to_entries
-                           | map({ key: .key, value: (($ct[.key] // {}) + .value) })
-                           | from_entries)) }
-        | .tools |= with_entries(
-            (.key) as $t
-            | if ($o.tools | has($t)) then
-                .value |= ((if ($o.tools[$t] | has("network")) then . else del(.network) end)
-                           | (if ($o.tools[$t] | has("secret")) then . else del(.secret) end))
-              else . end)
-    '
+    local rc=0 tool kind delivery image network secret
+    while IFS= read -r tool; do
+        [[ -z "$tool" ]] && continue
+        if [[ ! "$tool" =~ $CATALOG_TOOL_NAME_RE ]]; then
+            printf 'wrangle: custom-tools: invalid tool name: %s\n' "$tool" >&2
+            rc=1; continue
+        fi
+
+        kind="$(read_catalog_field "$custom" "$tool" kind)"
+        if [[ ! "$kind" =~ $CATALOG_KIND_RE ]]; then
+            printf 'wrangle: custom-tools: %s: kind must be one of scan, sbom, attest\n' "$tool" >&2
+            rc=1
+        fi
+
+        network="$(read_catalog_field "$custom" "$tool" network)"
+        if [[ -n "$network" ]] && [[ ! "$network" =~ $CATALOG_NETWORK_RE ]]; then
+            printf 'wrangle: custom-tools: %s: network must be one of none, egress\n' "$tool" >&2
+            rc=1
+        fi
+
+        secret="$(read_catalog_field "$custom" "$tool" secret)"
+        if [[ -n "$secret" ]] && [[ ! "$secret" =~ $CATALOG_SECRET_NAME_RE ]]; then
+            printf 'wrangle: custom-tools: %s: invalid secret name: %s\n' "$tool" "$secret" >&2
+            rc=1
+        fi
+
+        # A custom tool is always net-new and image-delivered.
+        delivery="$(read_catalog_field "$custom" "$tool" delivery)"
+        if [[ "$delivery" != "image" ]]; then
+            printf 'wrangle: custom-tools: %s: must declare delivery: image\n' "$tool" >&2
+            rc=1
+        fi
+
+        image="$(read_catalog_field "$custom" "$tool" image)"
+        if [[ -z "$image" ]]; then
+            printf 'wrangle: custom-tools: %s: must declare a digest-pinned image\n' "$tool" >&2
+            rc=1
+        elif [[ ! "$image" =~ $CATALOG_IMAGE_DIGEST_RE ]]; then
+            printf 'wrangle: custom-tools: %s: image must be digest-pinned (name@sha256:<64hex>): %s\n' "$tool" "$image" >&2
+            rc=1
+        fi
+    done < <(jq -r '.tools // {} | keys[]' "$custom")
+
+    [[ "$rc" -ne 0 ]] && return 1
+
+    jq -n --argjson c "$curated_json" --slurpfile x "$custom" \
+        '{ tools: (($c.tools // {}) + ($x[0].tools // {})) }'
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     if [[ "$#" -ne 2 ]]; then
-        printf 'Usage: %s <curated_catalog> <override_file>\n' "${0##*/}" >&2
+        printf 'Usage: %s <curated_catalog> <custom_tools_file>\n' "${0##*/}" >&2
         exit 2
     fi
     merge_catalog "$1" "$2"

--- a/lib/merge_catalog.sh
+++ b/lib/merge_catalog.sh
@@ -87,7 +87,7 @@ merge_catalog() {
         elif [[ ! "$image" =~ $CATALOG_IMAGE_DIGEST_RE ]]; then
             printf 'wrangle: custom-tools: %s: image must be digest-pinned (name@sha256:<64hex>): %s\n' "$tool" "$image" >&2
             rc=1
-        elif [[ "$image" == "$CATALOG_CURATED_IMAGE_PREFIX"* ]]; then
+        elif [[ "$image" =~ $CATALOG_CURATED_IMAGE_RE ]]; then
             printf 'wrangle: custom-tools: %s: image must not be in the wrangle namespace (%s): %s\n' \
                 "$tool" "$CATALOG_CURATED_IMAGE_PREFIX" "$image" >&2
             rc=1

--- a/lib/merge_catalog.sh
+++ b/lib/merge_catalog.sh
@@ -3,20 +3,15 @@ set -euo pipefail
 set -f  # disable globbing — handles external file contents
 
 # lib/merge_catalog.sh — build the effective tool catalog by ADDING an adopter's
-# custom tools to wrangle's curated catalog (both share the { "tools": { … } }
-# shape). The model is add-only: an adopter may add net-new tools, never override
-# a curated one. A custom tool whose name collides with a curated tool is a hard
-# error — no shadowing, no field merge, so a custom entry can never attach its
-# capabilities to a curated, VSA-signed image. Each custom entry is validated
-# standalone and declares its own capabilities; there is no inheritance.
+# custom tools (from a custom-tools file) to wrangle's curated catalog; both share
+# the { "tools": { … } } shape. Add-only: a name that collides with a curated tool
+# is a hard error, each custom entry is validated standalone (no field-merge, no
+# capability inheritance), and a custom image MUST be outside the wrangle namespace.
 #
 # Usage: merge_catalog.sh <curated_catalog> <custom_tools_file>
-# Prints the effective catalog on stdout. Exits non-zero (message on stderr) when
-# the custom file is not valid JSON, collides with a curated name, or any entry
-# fails validation.
+# Prints the effective catalog on stdout; exits non-zero (message on stderr) on
+# invalid JSON, a name collision, or any entry that fails validation.
 
-# A distinct name from the caller's SCRIPT_DIR — run.sh sources this file and
-# then sources more libs relative to its own SCRIPT_DIR.
 _MERGE_CATALOG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/read_catalog.sh
 source "$_MERGE_CATALOG_DIR/read_catalog.sh"
@@ -30,6 +25,10 @@ merge_catalog() {
 
     if ! jq -e '(.tools // {}) | type == "object"' "$custom" >/dev/null 2>&1; then
         printf 'wrangle: custom-tools: not a valid JSON catalog (needs an object "tools"): %s\n' "$custom" >&2
+        return 1
+    fi
+    if ! jq -e '(.tools // {}) | all(.[]; type == "object")' "$custom" >/dev/null 2>&1; then
+        printf 'wrangle: custom-tools: every tool entry must be an object: %s\n' "$custom" >&2
         return 1
     fi
 
@@ -79,6 +78,8 @@ merge_catalog() {
             rc=1
         fi
 
+        # The image must be digest-pinned and OUTSIDE the wrangle namespace: a
+        # custom tool is adopter-trusted and cannot borrow a wrangle VSA identity.
         image="$(read_catalog_field "$custom" "$tool" image)"
         if [[ -z "$image" ]]; then
             printf 'wrangle: custom-tools: %s: must declare a digest-pinned image\n' "$tool" >&2
@@ -86,13 +87,17 @@ merge_catalog() {
         elif [[ ! "$image" =~ $CATALOG_IMAGE_DIGEST_RE ]]; then
             printf 'wrangle: custom-tools: %s: image must be digest-pinned (name@sha256:<64hex>): %s\n' "$tool" "$image" >&2
             rc=1
+        elif [[ "$image" == "$CATALOG_CURATED_IMAGE_PREFIX"* ]]; then
+            printf 'wrangle: custom-tools: %s: image must not be in the wrangle namespace (%s): %s\n' \
+                "$tool" "$CATALOG_CURATED_IMAGE_PREFIX" "$image" >&2
+            rc=1
         fi
     done < <(jq -r '.tools // {} | keys[]' "$custom")
 
     [[ "$rc" -ne 0 ]] && return 1
 
     jq -n --argjson c "$curated_json" --slurpfile x "$custom" \
-        '{ tools: (($c.tools // {}) + ($x[0].tools // {})) }'
+        '$c + { tools: (($c.tools // {}) + ($x[0].tools // {})) }'
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/run.sh
+++ b/run.sh
@@ -53,7 +53,7 @@ CURATED_IMAGE_PREFIX="ghcr.io/tomhennen/wrangle/"
 # catalog. The path must resolve inside the workspace (no traversal or symlink
 # escape); the effective catalog is a temp file cleaned up on exit.
 if [[ -n "${WRANGLE_TOOL_OVERRIDES:-}" ]]; then
-    override_root="$(cd "${GITHUB_WORKSPACE:-.}" && pwd)"
+    override_root="$(cd "${GITHUB_WORKSPACE:-.}" && pwd -P)"
     if ! override_file="$(realpath -e -- "$WRANGLE_TOOL_OVERRIDES" 2>/dev/null)"; then
         printf 'wrangle: tool-overrides file not found: %s\n' "$WRANGLE_TOOL_OVERRIDES" >&2
         exit 2

--- a/run.sh
+++ b/run.sh
@@ -24,7 +24,7 @@ source "$SCRIPT_DIR/lib/env.sh"
 source "$SCRIPT_DIR/lib/read_catalog.sh"
 
 # Catalog merger: merge_catalog builds the effective catalog when an adopter
-# supplies a tool-overrides file.
+# supplies a custom-tools file.
 # shellcheck source=lib/merge_catalog.sh
 source "$SCRIPT_DIR/lib/merge_catalog.sh"
 
@@ -46,25 +46,25 @@ CATALOG="${WRANGLE_CATALOG:-${TOOLS_DIR}/catalog.json}"
 
 # Namespace prefix of wrangle-published tool images. Only these carry wrangle's
 # VSA identity, so only these get the wrangle-signer attestation gate; an
-# adopter-override image (other namespace) is trusted under its own identity.
+# adopter custom-tool image (other namespace) is trusted under its own identity.
 CURATED_IMAGE_PREFIX="ghcr.io/tomhennen/wrangle/"
 
-# WRANGLE_TOOL_OVERRIDES points at an adopter tools.json merged over the curated
-# catalog. The path must resolve inside the workspace (no traversal or symlink
-# escape); the effective catalog is a temp file cleaned up on exit.
-if [[ -n "${WRANGLE_TOOL_OVERRIDES:-}" ]]; then
-    override_root="$(cd "${GITHUB_WORKSPACE:-.}" && pwd -P)"
-    if ! override_file="$(realpath -e -- "$WRANGLE_TOOL_OVERRIDES" 2>/dev/null)"; then
-        printf 'wrangle: tool-overrides file not found: %s\n' "$WRANGLE_TOOL_OVERRIDES" >&2
+# WRANGLE_CUSTOM_TOOLS points at an adopter tools.json whose net-new tools are
+# added to the curated catalog. The path must resolve inside the workspace (no
+# traversal or symlink escape); the effective catalog is a temp file removed on exit.
+if [[ -n "${WRANGLE_CUSTOM_TOOLS:-}" ]]; then
+    custom_root="$(cd "${GITHUB_WORKSPACE:-.}" && pwd -P)"
+    if ! custom_file="$(realpath -e -- "$WRANGLE_CUSTOM_TOOLS" 2>/dev/null)"; then
+        printf 'wrangle: custom-tools file not found: %s\n' "$WRANGLE_CUSTOM_TOOLS" >&2
         exit 2
     fi
-    if [[ "$override_file" != "$override_root" && "$override_file" != "$override_root"/* ]]; then
-        printf 'wrangle: tool-overrides path escapes the workspace: %s\n' "$WRANGLE_TOOL_OVERRIDES" >&2
+    if [[ "$custom_file" != "$custom_root" && "$custom_file" != "$custom_root"/* ]]; then
+        printf 'wrangle: custom-tools path escapes the workspace: %s\n' "$WRANGLE_CUSTOM_TOOLS" >&2
         exit 2
     fi
     effective_catalog="$(mktemp "${TMPDIR:-/tmp}/wrangle-catalog-XXXXXX.json")"
     trap 'rm -f "$effective_catalog"' EXIT
-    if ! merge_catalog "$CATALOG" "$override_file" > "$effective_catalog"; then
+    if ! merge_catalog "$CATALOG" "$custom_file" > "$effective_catalog"; then
         exit 2
     fi
     CATALOG="$effective_catalog"

--- a/run.sh
+++ b/run.sh
@@ -23,6 +23,11 @@ source "$SCRIPT_DIR/lib/env.sh"
 # shellcheck source=lib/read_catalog.sh
 source "$SCRIPT_DIR/lib/read_catalog.sh"
 
+# Catalog merger: merge_catalog builds the effective catalog when an adopter
+# supplies a tool-overrides file.
+# shellcheck source=lib/merge_catalog.sh
+source "$SCRIPT_DIR/lib/merge_catalog.sh"
+
 # Pull-time VSA verification primitive: verify_image_vsa runs the fail-closed
 # attestation gate the curated-image policy below applies.
 # shellcheck source=lib/verify_image_vsa.sh
@@ -43,6 +48,27 @@ CATALOG="${WRANGLE_CATALOG:-${TOOLS_DIR}/catalog.json}"
 # VSA identity, so only these get the wrangle-signer attestation gate; an
 # adopter-override image (other namespace) is trusted under its own identity.
 CURATED_IMAGE_PREFIX="ghcr.io/tomhennen/wrangle/"
+
+# WRANGLE_TOOL_OVERRIDES points at an adopter tools.json merged over the curated
+# catalog. The path must resolve inside the workspace (no traversal or symlink
+# escape); the effective catalog is a temp file cleaned up on exit.
+if [[ -n "${WRANGLE_TOOL_OVERRIDES:-}" ]]; then
+    override_root="$(cd "${GITHUB_WORKSPACE:-.}" && pwd)"
+    if ! override_file="$(realpath -e -- "$WRANGLE_TOOL_OVERRIDES" 2>/dev/null)"; then
+        printf 'wrangle: tool-overrides file not found: %s\n' "$WRANGLE_TOOL_OVERRIDES" >&2
+        exit 2
+    fi
+    if [[ "$override_file" != "$override_root" && "$override_file" != "$override_root"/* ]]; then
+        printf 'wrangle: tool-overrides path escapes the workspace: %s\n' "$WRANGLE_TOOL_OVERRIDES" >&2
+        exit 2
+    fi
+    effective_catalog="$(mktemp "${TMPDIR:-/tmp}/wrangle-catalog-XXXXXX.json")"
+    trap 'rm -f "$effective_catalog"' EXIT
+    if ! merge_catalog "$CATALOG" "$override_file" > "$effective_catalog"; then
+        exit 2
+    fi
+    CATALOG="$effective_catalog"
+fi
 
 # is_image[$tool]=1 marks a catalog tool with delivery: image (the docker-run
 # path); absence means the adapter path. Resolved once per tool in the parse
@@ -82,15 +108,6 @@ for spec in "$@"; do
         printf 'wrangle: invalid tool name: %s (must match %s)\n' "$tool" "$TOOL_NAME_RE" >&2
         exit 2
     fi
-    if [[ ! -d "${TOOLS_DIR}/${tool}" ]]; then
-        printf 'wrangle: unknown tool: %s (no directory at %s/%s/)\n' "$tool" "$TOOLS_DIR" "$tool" >&2
-        exit 2
-    fi
-    # An action.yml means the tool runs via its uses: step; skip it here even if
-    # an adapter.sh exists (it is only the tool image's contract entrypoint).
-    if [[ -f "${TOOLS_DIR}/${tool}/action.yml" ]]; then
-        continue
-    fi
     # Resolve delivery once. Empty -> adapter path; "image" -> docker path; any
     # other non-empty value is a catalog typo, not a silent adapter fallthrough.
     delivery="$(read_catalog_field "$CATALOG" "$tool" delivery)"
@@ -101,6 +118,18 @@ for spec in "$@"; do
             printf 'wrangle: %s: unrecognized catalog delivery: %s\n' "$tool" "$delivery" >&2
             exit 2 ;;
     esac
+    if [[ -d "${TOOLS_DIR}/${tool}" ]]; then
+        # An action.yml means the tool runs via its uses: step; skip it here even
+        # if an adapter.sh exists (it is only the tool image's contract entrypoint).
+        if [[ -f "${TOOLS_DIR}/${tool}/action.yml" ]]; then
+            continue
+        fi
+    elif [[ -z "${is_image[$tool]:-}" ]]; then
+        # A catalog delivery: image tool is dispatched from its image, so it needs
+        # no local directory; anything else with no directory is unknown.
+        printf 'wrangle: unknown tool: %s (no directory at %s/%s/ and no catalog image entry)\n' "$tool" "$TOOLS_DIR" "$tool" >&2
+        exit 2
+    fi
     if [[ -n "${is_image[$tool]:-}" ]] || [[ -f "${TOOLS_DIR}/${tool}/adapter.sh" ]]; then
         run_tools+=("$tool")
     fi

--- a/run.sh
+++ b/run.sh
@@ -23,6 +23,10 @@ source "$SCRIPT_DIR/lib/env.sh"
 # shellcheck source=lib/read_catalog.sh
 source "$SCRIPT_DIR/lib/read_catalog.sh"
 
+# Shared catalog validation constants (tool-name, image-digest, namespace).
+# shellcheck source=lib/catalog_rules.sh
+source "$SCRIPT_DIR/lib/catalog_rules.sh"
+
 # Catalog merger: merge_catalog builds the effective catalog when an adopter
 # supplies a custom-tools file.
 # shellcheck source=lib/merge_catalog.sh
@@ -44,10 +48,10 @@ TOOLS_DIR="${WRANGLE_TOOLS_DIR:-${SCRIPT_DIR}/tools}"
 # which case every tool runs the adapter path.
 CATALOG="${WRANGLE_CATALOG:-${TOOLS_DIR}/catalog.json}"
 
-# Namespace prefix of wrangle-published tool images. Only these carry wrangle's
-# VSA identity, so only these get the wrangle-signer attestation gate; an
-# adopter custom-tool image (other namespace) is trusted under its own identity.
-CURATED_IMAGE_PREFIX="ghcr.io/tomhennen/wrangle/"
+# Only wrangle-namespace images carry wrangle's VSA identity, so only these get
+# the wrangle-signer attestation gate; an adopter custom-tool image (other
+# namespace) is trusted under its own identity.
+CURATED_IMAGE_PREFIX="$CATALOG_CURATED_IMAGE_PREFIX"
 
 # WRANGLE_CUSTOM_TOOLS points at an adopter tools.json whose net-new tools are
 # added to the curated catalog. The path must resolve inside the workspace (no
@@ -100,12 +104,11 @@ fi
 # (run via docker run). Action-pattern tools (have an action.yml) are invoked
 # via their uses: step, so run.sh skips them even when an adapter.sh is present
 # only as their image entrypoint. Unknown tools (no directory) are rejected.
-TOOL_NAME_RE='^[a-z][a-z0-9_-]*$'
 declare -a run_tools=()
 for spec in "$@"; do
     tool="${spec%%:*}"
-    if [[ ! "$tool" =~ $TOOL_NAME_RE ]]; then
-        printf 'wrangle: invalid tool name: %s (must match %s)\n' "$tool" "$TOOL_NAME_RE" >&2
+    if [[ ! "$tool" =~ $CATALOG_TOOL_NAME_RE ]]; then
+        printf 'wrangle: invalid tool name: %s (must match %s)\n' "$tool" "$CATALOG_TOOL_NAME_RE" >&2
         exit 2
     fi
     # Resolve delivery once. Empty -> adapter path; "image" -> docker path; any
@@ -261,9 +264,9 @@ run_one_tool() {
             printf '::endgroup::\n'
             return
         fi
-        # Require an @sha256 digest pin (a tag alone is mutable); the registry
-        # host may carry a :port (e.g. registry.internal:5000/osv@sha256:...).
-        if [[ ! "$image" =~ ^[a-z0-9._-]+(:[0-9]+)?(/[a-z0-9._-]+)*@sha256:[0-9a-f]{64}$ ]]; then
+        # Require an @sha256 digest pin (a tag alone is mutable); re-checked here
+        # even though merge_catalog validated custom entries, as defense in depth.
+        if [[ ! "$image" =~ $CATALOG_IMAGE_DIGEST_RE ]]; then
             printf 'wrangle: %s: image not digest-pinned: %s\n' "$tool" "$image" >&2
             tool_status="error"
             overall_status=2

--- a/run.sh
+++ b/run.sh
@@ -53,17 +53,19 @@ CATALOG="${WRANGLE_CATALOG:-${TOOLS_DIR}/catalog.json}"
 # namespace) is trusted under its own identity.
 CURATED_IMAGE_PREFIX="$CATALOG_CURATED_IMAGE_PREFIX"
 
-# WRANGLE_CUSTOM_TOOLS points at an adopter tools.json whose net-new tools are
-# added to the curated catalog. The path must resolve inside the workspace (no
-# traversal or symlink escape); the effective catalog is a temp file removed on exit.
-if [[ -n "${WRANGLE_CUSTOM_TOOLS:-}" ]]; then
-    custom_root="$(cd "${GITHUB_WORKSPACE:-.}" && pwd -P)"
-    if ! custom_file="$(realpath -e -- "$WRANGLE_CUSTOM_TOOLS" 2>/dev/null)"; then
-        printf 'wrangle: custom-tools file not found: %s\n' "$WRANGLE_CUSTOM_TOOLS" >&2
+# Auto-discover a conventional .wrangle/tools.json at the workspace root and add
+# its net-new tools to the catalog. Absent -> the curated catalog, unchanged. The
+# resolved file must stay inside the workspace, so a symlink escaping it is
+# rejected; the effective catalog is a temp file removed on exit.
+custom_root="$(cd "${GITHUB_WORKSPACE:-$PWD}" 2>/dev/null && pwd -P)" || custom_root=""
+custom_tools="${custom_root:+${custom_root}/.wrangle/tools.json}"
+if [[ -n "$custom_tools" ]] && [[ -e "$custom_tools" ]]; then
+    if ! custom_file="$(realpath -e -- "$custom_tools" 2>/dev/null)"; then
+        printf 'wrangle: .wrangle/tools.json is unreadable: %s\n' "$custom_tools" >&2
         exit 2
     fi
-    if [[ "$custom_file" != "$custom_root" && "$custom_file" != "$custom_root"/* ]]; then
-        printf 'wrangle: custom-tools path escapes the workspace: %s\n' "$WRANGLE_CUSTOM_TOOLS" >&2
+    if [[ "$custom_file" != "$custom_root"/* ]]; then
+        printf 'wrangle: .wrangle/tools.json resolves outside the workspace: %s\n' "$custom_file" >&2
         exit 2
     fi
     effective_catalog="$(mktemp "${TMPDIR:-/tmp}/wrangle-catalog-XXXXXX.json")"

--- a/test/fixtures/image-contract/entrypoint.sh
+++ b/test/fixtures/image-contract/entrypoint.sh
@@ -40,6 +40,12 @@ case "$mode" in
         printf '%s' "${WRANGLE_KIND:-}" > "$out/kind_seen"
         printf '{"spdxVersion":"SPDX-2.3","name":"mock"}\n' > "$out/sbom.spdx.json"
         exit 0 ;;
+    sbom-real)
+        # A non-empty SPDX inventorying one real package, so a BYO-tool test can
+        # assert a valid, populated SBOM rather than the valid-but-empty trap.
+        printf '%s' "${WRANGLE_KIND:-}" > "$out/kind_seen"
+        printf '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"mock-byo","packages":[{"SPDXID":"SPDXRef-Package-example","name":"example-lib","versionInfo":"1.2.3"}]}\n' > "$out/sbom.spdx.json"
+        exit 0 ;;
     sbom-error)
         printf 'mock: simulated sbom tool error\n' >&2
         exit 2 ;;

--- a/test/image/test_byo_sbom.bats
+++ b/test/image/test_byo_sbom.bats
@@ -3,8 +3,8 @@
 # Proves the sbom kind is tool-agnostic: a NON-wrangle, off-namespace image that
 # honors the sbom contract (/src ro -> /output/sbom.spdx.json, exit 0/2) is
 # plugged in as an adopter's SBOM tool through the real BYO path — a
-# .wrangle/tools.json added to the catalog (lib/merge_catalog.sh) and selected
-# via WRANGLE_CUSTOM_TOOLS. One run exercises the whole seam: the dir-gate
+# .wrangle/tools.json auto-discovered at the workspace root (lib/merge_catalog.sh)
+# and selected via sbom-tool. One run exercises the whole seam: the dir-gate
 # relaxation (no local tools/my-sbom/), the custom-tools union, the VSA gate
 # skipping an off-namespace image, the contract sandbox, and a real (non-empty) SBOM.
 #
@@ -59,7 +59,7 @@ setup() {
     RUN_SH="$ORIG_DIR/run.sh"
     TMP_DIR="$(mktemp -d "${BATS_TMPDIR:-/tmp}/wrangle-byo.XXXXXX")"
     # WS is the adopter workspace: it holds the source tree and the override file,
-    # and is the containment root run.sh validates the custom-tools path against.
+    # and is the workspace root run.sh auto-discovers .wrangle/tools.json under.
     WS="$TMP_DIR/ws"
     SRC="$WS/src"
     OUT="$TMP_DIR/out"
@@ -79,11 +79,10 @@ teardown() {
 
 _run_byo() {
     WRANGLE_TOOLS_DIR="$TOOLS" GITHUB_WORKSPACE="$WS" \
-        WRANGLE_CUSTOM_TOOLS="$WS/.wrangle/tools.json" \
         run "$RUN_SH" -s "$SRC" -o "$OUT" my-sbom
 }
 
-@test "byo sbom: adopter image plugs in via custom-tools, no local tool dir" {
+@test "byo sbom: adopter image plugs in via auto-discovered .wrangle/tools.json, no local tool dir" {
     _run_byo
     [ "$status" -eq 0 ]
     [ -f "$OUT/my-sbom/sbom.spdx.json" ]
@@ -123,7 +122,6 @@ _run_byo() {
 @test "byo sbom: end-to-end through generate_sbom lands the SBOM at the metadata root" {
     local meta="$TMP_DIR/meta"
     WRANGLE_TOOLS_DIR="$TOOLS" GITHUB_WORKSPACE="$WS" \
-        WRANGLE_CUSTOM_TOOLS="$WS/.wrangle/tools.json" \
         run "$ORIG_DIR/lib/generate_sbom.sh" "$SRC" "$meta" my-sbom
     [ "$status" -eq 0 ]
     [ -f "$meta/sbom.spdx.json" ]

--- a/test/image/test_byo_sbom.bats
+++ b/test/image/test_byo_sbom.bats
@@ -3,10 +3,10 @@
 # Proves the sbom kind is tool-agnostic: a NON-wrangle, off-namespace image that
 # honors the sbom contract (/src ro -> /output/sbom.spdx.json, exit 0/2) is
 # plugged in as an adopter's SBOM tool through the real BYO path — a
-# .wrangle/tools.json merged over the catalog (lib/merge_catalog.sh) and selected
-# via WRANGLE_TOOL_OVERRIDES. One run exercises the whole seam: the dir-gate
-# relaxation (no local tools/my-sbom/), the override merge, the VSA gate skipping
-# an off-namespace image, the contract sandbox, and a real (non-empty) SBOM.
+# .wrangle/tools.json added to the catalog (lib/merge_catalog.sh) and selected
+# via WRANGLE_CUSTOM_TOOLS. One run exercises the whole seam: the dir-gate
+# relaxation (no local tools/my-sbom/), the custom-tools union, the VSA gate
+# skipping an off-namespace image, the contract sandbox, and a real (non-empty) SBOM.
 #
 # Needs docker + a throwaway registry (run.sh requires a registry digest pin), so
 # it lives under test/image/ (outside the Makefile's unit bats glob) and runs in
@@ -59,7 +59,7 @@ setup() {
     RUN_SH="$ORIG_DIR/run.sh"
     TMP_DIR="$(mktemp -d "${BATS_TMPDIR:-/tmp}/wrangle-byo.XXXXXX")"
     # WS is the adopter workspace: it holds the source tree and the override file,
-    # and is the containment root run.sh validates the override path against.
+    # and is the containment root run.sh validates the custom-tools path against.
     WS="$TMP_DIR/ws"
     SRC="$WS/src"
     OUT="$TMP_DIR/out"
@@ -79,11 +79,11 @@ teardown() {
 
 _run_byo() {
     WRANGLE_TOOLS_DIR="$TOOLS" GITHUB_WORKSPACE="$WS" \
-        WRANGLE_TOOL_OVERRIDES="$WS/.wrangle/tools.json" \
+        WRANGLE_CUSTOM_TOOLS="$WS/.wrangle/tools.json" \
         run "$RUN_SH" -s "$SRC" -o "$OUT" my-sbom
 }
 
-@test "byo sbom: adopter image plugs in via overrides, no local tool dir" {
+@test "byo sbom: adopter image plugs in via custom-tools, no local tool dir" {
     _run_byo
     [ "$status" -eq 0 ]
     [ -f "$OUT/my-sbom/sbom.spdx.json" ]
@@ -123,7 +123,7 @@ _run_byo() {
 @test "byo sbom: end-to-end through generate_sbom lands the SBOM at the metadata root" {
     local meta="$TMP_DIR/meta"
     WRANGLE_TOOLS_DIR="$TOOLS" GITHUB_WORKSPACE="$WS" \
-        WRANGLE_TOOL_OVERRIDES="$WS/.wrangle/tools.json" \
+        WRANGLE_CUSTOM_TOOLS="$WS/.wrangle/tools.json" \
         run "$ORIG_DIR/lib/generate_sbom.sh" "$SRC" "$meta" my-sbom
     [ "$status" -eq 0 ]
     [ -f "$meta/sbom.spdx.json" ]

--- a/test/image/test_byo_sbom.bats
+++ b/test/image/test_byo_sbom.bats
@@ -12,8 +12,10 @@
 # it lives under test/image/ (outside the Makefile's unit bats glob) and runs in
 # the dogfooded shell build on a docker-capable runner.
 
+# A distinct host port from the other test/image registry sidecar
+# (test_run_image_dispatch.bats uses 5000); bats runs files in parallel.
 REGISTRY_IMAGE="registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373"
-REGISTRY_PORT=5000
+REGISTRY_PORT=5001
 REGISTRY_HOST="localhost:${REGISTRY_PORT}"
 
 _push_for_digest() {

--- a/test/image/test_byo_sbom.bats
+++ b/test/image/test_byo_sbom.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+
+# Proves the sbom kind is tool-agnostic: a NON-wrangle, off-namespace image that
+# honors the sbom contract (/src ro -> /output/sbom.spdx.json, exit 0/2) is
+# plugged in as an adopter's SBOM tool through the real BYO path — a
+# .wrangle/tools.json merged over the catalog (lib/merge_catalog.sh) and selected
+# via WRANGLE_TOOL_OVERRIDES. One run exercises the whole seam: the dir-gate
+# relaxation (no local tools/my-sbom/), the override merge, the VSA gate skipping
+# an off-namespace image, the contract sandbox, and a real (non-empty) SBOM.
+#
+# Needs docker + a throwaway registry (run.sh requires a registry digest pin), so
+# it lives under test/image/ (outside the Makefile's unit bats glob) and runs in
+# the dogfooded shell build on a docker-capable runner.
+
+REGISTRY_IMAGE="registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373"
+REGISTRY_PORT=5000
+REGISTRY_HOST="localhost:${REGISTRY_PORT}"
+
+_push_for_digest() {
+    local local_tag="$1" ref="${REGISTRY_HOST}/$2:test"
+    docker tag "$local_tag" "$ref" >/dev/null
+    docker push -q "$ref" >/dev/null
+    docker inspect --format '{{index .RepoDigests 0}}' "$ref"
+}
+
+setup_file() {
+    load "../lib/bats_helpers"
+    command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1 || return 0
+    local root
+    root="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+    REGISTRY_CONTAINER="wrangle-test-byo-registry-$$"
+    docker run -d -p "${REGISTRY_PORT}:5000" --name "$REGISTRY_CONTAINER" \
+        "$REGISTRY_IMAGE" >/dev/null
+    export REGISTRY_CONTAINER
+
+    # An off-namespace contract-conforming image standing in for an adopter's own
+    # SBOM tool; <src>/MODE selects sbom-real (a populated SPDX).
+    docker build -q -t wrangle-mock-tool:test \
+        "$root/test/fixtures/image-contract" >/dev/null
+    BYO_IMAGE="$(_push_for_digest wrangle-mock-tool:test wrangle-byo-sbom)"
+    export BYO_IMAGE
+}
+
+teardown_file() {
+    if [[ -n "${REGISTRY_CONTAINER:-}" ]]; then
+        docker rm -f "$REGISTRY_CONTAINER" >/dev/null 2>&1 || true
+    fi
+}
+
+setup() {
+    load "../lib/bats_helpers"
+    load "../lib/image_test_harness.sh"
+    wrangle_require_docker
+
+    ORIG_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    RUN_SH="$ORIG_DIR/run.sh"
+    TMP_DIR="$(mktemp -d "${BATS_TMPDIR:-/tmp}/wrangle-byo.XXXXXX")"
+    # WS is the adopter workspace: it holds the source tree and the override file,
+    # and is the containment root run.sh validates the override path against.
+    WS="$TMP_DIR/ws"
+    SRC="$WS/src"
+    OUT="$TMP_DIR/out"
+    TOOLS="$TMP_DIR/tools"      # no my-sbom/ dir — the tool is catalog-only
+    mkdir -p "$SRC" "$OUT" "$TOOLS" "$WS/.wrangle"
+    printf 'sbom-real' > "$SRC/MODE"
+
+    cat > "$WS/.wrangle/tools.json" <<JSON
+{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"$BYO_IMAGE"}}}
+JSON
+    export ORIG_DIR RUN_SH TMP_DIR WS SRC OUT TOOLS
+}
+
+teardown() {
+    [[ -n "${TMP_DIR:-}" ]] && rm -rf "$TMP_DIR"
+}
+
+_run_byo() {
+    WRANGLE_TOOLS_DIR="$TOOLS" GITHUB_WORKSPACE="$WS" \
+        WRANGLE_TOOL_OVERRIDES="$WS/.wrangle/tools.json" \
+        run "$RUN_SH" -s "$SRC" -o "$OUT" my-sbom
+}
+
+@test "byo sbom: adopter image plugs in via overrides, no local tool dir" {
+    _run_byo
+    [ "$status" -eq 0 ]
+    [ -f "$OUT/my-sbom/sbom.spdx.json" ]
+    run jq empty "$OUT/my-sbom/sbom.spdx.json"
+    [ "$status" -eq 0 ]
+    [[ "$(jq -r '.spdxVersion' "$OUT/my-sbom/sbom.spdx.json")" == SPDX-* ]]
+    # Real inventory: at least one named package (not the valid-but-empty trap).
+    [ "$(jq '.packages | length' "$OUT/my-sbom/sbom.spdx.json")" -gt 0 ]
+    [ "$(jq '[.packages[] | select((.name // "") == "")] | length' "$OUT/my-sbom/sbom.spdx.json")" -eq 0 ]
+}
+
+@test "byo sbom: the sbom kind reaches the adopter image and drives its manifest" {
+    _run_byo
+    [ "$status" -eq 0 ]
+    [ "$(cat "$OUT/my-sbom/kind_seen")" = "sbom" ]
+    [ "$(jq -r '."predicate-type"' "$OUT/my-sbom/wrangle_attestation_metadata.json")" = "https://spdx.dev/Document" ]
+    [ "$(jq -r '."result-file"' "$OUT/my-sbom/wrangle_attestation_metadata.json")" = "sbom.spdx.json" ]
+}
+
+@test "byo sbom: an off-namespace image skips the wrangle VSA gate (adopter-trusted)" {
+    _run_byo
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"non-wrangle image, not wrangle-identity-verified"* ]]
+    [[ "$output" != *"VSA verified PASSED"* ]]
+}
+
+@test "byo sbom: the adopter image runs under the contract sandbox (src read-only)" {
+    local before
+    before="$(find "$SRC" -type f | wc -l | tr -d ' ')"
+    _run_byo
+    [ "$status" -eq 0 ]
+    wrangle_assert_src_unchanged "$SRC" "$before"
+    # Output is owned by the runner UID, not root — the sandbox's -u mapping.
+    [ "$(stat -c '%u' "$OUT/my-sbom/sbom.spdx.json")" -eq "$(id -u)" ]
+}
+
+@test "byo sbom: end-to-end through generate_sbom lands the SBOM at the metadata root" {
+    local meta="$TMP_DIR/meta"
+    WRANGLE_TOOLS_DIR="$TOOLS" GITHUB_WORKSPACE="$WS" \
+        WRANGLE_TOOL_OVERRIDES="$WS/.wrangle/tools.json" \
+        run "$ORIG_DIR/lib/generate_sbom.sh" "$SRC" "$meta" my-sbom
+    [ "$status" -eq 0 ]
+    [ -f "$meta/sbom.spdx.json" ]
+    [ "$(jq '.packages | length' "$meta/sbom.spdx.json")" -gt 0 ]
+    [ ! -d "$meta/my-sbom" ]
+}

--- a/test/test_generate_sbom.bats
+++ b/test/test_generate_sbom.bats
@@ -59,14 +59,14 @@ _run_gen() {
     [ "$(jq -r '."result-file"' "$META/wrangle_attestation_metadata.json")" = "sbom.spdx.json" ]
 }
 
-@test "generate_sbom: defaults the tool to syft when none is given" {
-    # No catalog in the mock tools dir, so a stub syft/ dir dispatches via the
-    # adapter path — exercising the ${3:-syft} default without docker.
-    cp -r "$TOOLS/stubsbom" "$TOOLS/syft"
+@test "generate_sbom: defaults the tool to the sbom slot when none is given" {
+    # No catalog in the mock tools dir, so a stub sbom/ dir dispatches via the
+    # adapter path — exercising the ${3:-sbom} default without docker.
+    cp -r "$TOOLS/stubsbom" "$TOOLS/sbom"
     _run_gen "$SRC" "$META"
     [ "$status" -eq 0 ]
     [ -f "$META/sbom.spdx.json" ]
-    [ ! -d "$META/syft" ]
+    [ ! -d "$META/sbom" ]
 }
 
 @test "generate_sbom: fails closed when the dispatched tool errors" {

--- a/test/test_merge_catalog.bats
+++ b/test/test_merge_catalog.bats
@@ -152,6 +152,15 @@ JSON
     [[ "$output" == *"must not be in the wrangle namespace"* ]]
 }
 
+@test "merge: rejects a wrangle-namespace image via the registry-port form" {
+    cat > "$CUSTOM" <<JSON
+{"tools":{"my-osv":{"kind":"scan","delivery":"image","image":"ghcr.io:443/tomhennen/wrangle/osv@$DIGEST"}}}
+JSON
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"must not be in the wrangle namespace"* ]]
+}
+
 @test "merge: rejects an array-valued tool entry (clean error, not a raw jq failure)" {
     printf '{"tools":{"t":["x"]}}' > "$CUSTOM"
     _merge

--- a/test/test_merge_catalog.bats
+++ b/test/test_merge_catalog.bats
@@ -4,7 +4,7 @@
 # effective catalog = curated tools ∪ adopter-added tools. A custom tool whose
 # name collides with a curated tool is a hard error (no override, no field
 # merge); each added tool declares its own capabilities with no inheritance from
-# curated (docs/tool_container_design.md §3.7).
+# curated, and its image must be outside the wrangle namespace.
 
 setup() {
     ORIG_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
@@ -134,13 +134,39 @@ JSON
     [[ "$output" == *"must declare delivery: image"* ]]
 }
 
-@test "merge: an off-namespace custom image is allowed (adopter-trusted, VSA gate handles trust)" {
+@test "merge: an off-namespace custom image is allowed (adopter-trusted)" {
     cat > "$CUSTOM" <<JSON
 {"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
 JSON
     _merge
     [ "$status" -eq 0 ]
     [ "$(jq -r '.tools["my-sbom"].image' <<<"$output")" = "ghcr.io/myorg/my-sbom@$DIGEST" ]
+}
+
+@test "merge: rejects a custom image in the wrangle namespace (no borrowing a VSA identity)" {
+    cat > "$CUSTOM" <<JSON
+{"tools":{"my-osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@$DIGEST"}}}
+JSON
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"must not be in the wrangle namespace"* ]]
+}
+
+@test "merge: rejects an array-valued tool entry (clean error, not a raw jq failure)" {
+    printf '{"tools":{"t":["x"]}}' > "$CUSTOM"
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"every tool entry must be an object"* ]]
+}
+
+@test "merge: preserves curated top-level siblings such as _comment" {
+    printf '{"_comment":"keep me","tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@%s"}}}' "$DIGEST" > "$CURATED"
+    cat > "$CUSTOM" <<JSON
+{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
+JSON
+    _merge
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '._comment' <<<"$output")" = "keep me" ]
 }
 
 @test "merge: rejects a non-object tools envelope" {

--- a/test/test_merge_catalog.bats
+++ b/test/test_merge_catalog.bats
@@ -1,9 +1,10 @@
 #!/usr/bin/env bats
 
-# Tests for lib/merge_catalog.sh — the adopter tool-overrides merge. The security
-# rule under test: an override entry's non-capability fields deep-merge over the
-# curated entry, but network and secret hold ONLY when the override restates
-# them, else they reset closed (docs/tool_container_design.md §3.7).
+# Tests for lib/merge_catalog.sh — the add-only custom-tools union. The model:
+# effective catalog = curated tools ∪ adopter-added tools. A custom tool whose
+# name collides with a curated tool is a hard error (no override, no field
+# merge); each added tool declares its own capabilities with no inheritance from
+# curated (docs/tool_container_design.md §3.7).
 
 setup() {
     ORIG_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
@@ -12,11 +13,11 @@ setup() {
     DIGEST="sha256:$(printf 'a%.0s' {1..64})"
     DIGEST2="sha256:$(printf 'b%.0s' {1..64})"
     CURATED="$TEST_DIR/curated.json"
-    OVERRIDE="$TEST_DIR/override.json"
+    CUSTOM="$TEST_DIR/custom.json"
     cat > "$CURATED" <<JSON
 {"tools":{
   "osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@$DIGEST","network":"egress","secret":"github-token"},
-  "syft":{"kind":"sbom","delivery":"image","image":"ghcr.io/tomhennen/wrangle/syft@$DIGEST","network":"none"}
+  "sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/tomhennen/wrangle/syft@$DIGEST","network":"none"}
 }}
 JSON
 }
@@ -25,53 +26,53 @@ teardown() {
     [[ -n "${TEST_DIR:-}" ]] && rm -rf "$TEST_DIR"
 }
 
-_merge() { run "$MERGE" "$CURATED" "$OVERRIDE"; }
+_merge() { run "$MERGE" "$CURATED" "$CUSTOM"; }
 
-@test "merge: override of a curated tool image only RESETS network and secret closed" {
-    cat > "$OVERRIDE" <<JSON
-{"tools":{"osv":{"image":"ghcr.io/myorg/osv@$DIGEST2"}}}
-JSON
-    _merge
-    [ "$status" -eq 0 ]
-    [ "$(jq -r '.tools.osv.image' <<<"$output")" = "ghcr.io/myorg/osv@$DIGEST2" ]
-    [ "$(jq -r '.tools.osv.kind' <<<"$output")" = "scan" ]
-    [ "$(jq '.tools.osv | has("network")' <<<"$output")" = "false" ]
-    [ "$(jq '.tools.osv | has("secret")' <<<"$output")" = "false" ]
-}
-
-@test "merge: override restating network keeps it; an unrestated secret still resets" {
-    cat > "$OVERRIDE" <<JSON
-{"tools":{"osv":{"image":"ghcr.io/myorg/osv@$DIGEST2","network":"egress"}}}
-JSON
-    _merge
-    [ "$status" -eq 0 ]
-    [ "$(jq -r '.tools.osv.network' <<<"$output")" = "egress" ]
-    [ "$(jq '.tools.osv | has("secret")' <<<"$output")" = "false" ]
-}
-
-@test "merge: a new BYO tool is added with its declared fields" {
-    cat > "$OVERRIDE" <<JSON
+@test "merge: a net-new custom tool is unioned in; curated tools survive" {
+    cat > "$CUSTOM" <<JSON
 {"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
 JSON
     _merge
     [ "$status" -eq 0 ]
-    [ "$(jq -r '.tools["my-sbom"].kind' <<<"$output")" = "sbom" ]
     [ "$(jq -r '.tools["my-sbom"].image' <<<"$output")" = "ghcr.io/myorg/my-sbom@$DIGEST" ]
-    # Curated tools survive the merge.
-    [ "$(jq -r '.tools.syft.kind' <<<"$output")" = "sbom" ]
+    [ "$(jq -r '.tools.sbom.kind' <<<"$output")" = "sbom" ]
+    [ "$(jq -r '.tools.osv.kind' <<<"$output")" = "scan" ]
 }
 
-@test "merge: curated-namespace override image is allowed (VSA gate handles trust)" {
-    cat > "$OVERRIDE" <<JSON
-{"tools":{"osv":{"image":"ghcr.io/tomhennen/wrangle/osv@$DIGEST2"}}}
+@test "merge: a name colliding with a curated tool is REJECTED (add-only, no override)" {
+    cat > "$CUSTOM" <<JSON
+{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/myorg/osv@$DIGEST2"}}}
+JSON
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"collides with a curated tool"* ]]
+    [[ "$output" == *"osv"* ]]
+}
+
+@test "merge: an added tool gets exactly the grants it declares (no curated inheritance)" {
+    cat > "$CUSTOM" <<JSON
+{"tools":{"my-scan":{"kind":"scan","delivery":"image","image":"ghcr.io/myorg/s@$DIGEST","network":"egress","secret":"my-token"}}}
 JSON
     _merge
     [ "$status" -eq 0 ]
-    [ "$(jq -r '.tools.osv.image' <<<"$output")" = "ghcr.io/tomhennen/wrangle/osv@$DIGEST2" ]
+    [ "$(jq -r '.tools["my-scan"].network' <<<"$output")" = "egress" ]
+    [ "$(jq -r '.tools["my-scan"].secret' <<<"$output")" = "my-token" ]
+    # A curated tool the adopter did not touch is unchanged.
+    [ "$(jq -r '.tools.osv.secret' <<<"$output")" = "github-token" ]
+}
+
+@test "merge: an added tool with no network/secret declares neither" {
+    cat > "$CUSTOM" <<JSON
+{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
+JSON
+    _merge
+    [ "$status" -eq 0 ]
+    [ "$(jq '.tools["my-sbom"] | has("network")' <<<"$output")" = "false" ]
+    [ "$(jq '.tools["my-sbom"] | has("secret")' <<<"$output")" = "false" ]
 }
 
 @test "merge: rejects an invalid tool name" {
-    cat > "$OVERRIDE" <<JSON
+    cat > "$CUSTOM" <<JSON
 {"tools":{"BadName":{"kind":"sbom","delivery":"image","image":"ghcr.io/x@$DIGEST"}}}
 JSON
     _merge
@@ -80,7 +81,7 @@ JSON
 }
 
 @test "merge: rejects an out-of-allowlist kind" {
-    cat > "$OVERRIDE" <<JSON
+    cat > "$CUSTOM" <<JSON
 {"tools":{"my-sbom":{"kind":"exfiltrate","delivery":"image","image":"ghcr.io/x@$DIGEST"}}}
 JSON
     _merge
@@ -89,7 +90,7 @@ JSON
 }
 
 @test "merge: rejects an out-of-allowlist network" {
-    cat > "$OVERRIDE" <<JSON
+    cat > "$CUSTOM" <<JSON
 {"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/x@$DIGEST","network":"host"}}}
 JSON
     _merge
@@ -98,16 +99,16 @@ JSON
 }
 
 @test "merge: rejects an invalid secret name" {
-    cat > "$OVERRIDE" <<JSON
+    cat > "$CUSTOM" <<JSON
 {"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/x@$DIGEST","secret":"BAD_NAME"}}}
 JSON
     _merge
     [ "$status" -ne 0 ]
-    [[ "$output" == *"secret must match"* ]]
+    [[ "$output" == *"invalid secret name"* ]]
 }
 
 @test "merge: rejects a non-digest-pinned image" {
-    cat > "$OVERRIDE" <<JSON
+    cat > "$CUSTOM" <<JSON
 {"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/x:latest"}}}
 JSON
     _merge
@@ -115,43 +116,52 @@ JSON
     [[ "$output" == *"digest-pinned"* ]]
 }
 
-@test "merge: rejects a new tool with no image" {
-    cat > "$OVERRIDE" <<JSON
-{"tools":{"new-tool":{"kind":"sbom","delivery":"image"}}}
+@test "merge: rejects a tool with no image" {
+    cat > "$CUSTOM" <<JSON
+{"tools":{"my-sbom":{"kind":"sbom","delivery":"image"}}}
 JSON
     _merge
     [ "$status" -ne 0 ]
     [[ "$output" == *"must declare a digest-pinned image"* ]]
 }
 
-@test "merge: rejects a new tool that is not delivery: image" {
-    cat > "$OVERRIDE" <<JSON
-{"tools":{"new-tool":{"kind":"sbom","image":"ghcr.io/x@$DIGEST"}}}
+@test "merge: rejects a tool that is not delivery: image" {
+    cat > "$CUSTOM" <<JSON
+{"tools":{"my-sbom":{"kind":"sbom","image":"ghcr.io/x@$DIGEST"}}}
 JSON
     _merge
     [ "$status" -ne 0 ]
     [[ "$output" == *"must declare delivery: image"* ]]
 }
 
+@test "merge: an off-namespace custom image is allowed (adopter-trusted, VSA gate handles trust)" {
+    cat > "$CUSTOM" <<JSON
+{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
+JSON
+    _merge
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.tools["my-sbom"].image' <<<"$output")" = "ghcr.io/myorg/my-sbom@$DIGEST" ]
+}
+
 @test "merge: rejects a non-object tools envelope" {
-    printf '{"tools":[]}' > "$OVERRIDE"
+    printf '{"tools":[]}' > "$CUSTOM"
     _merge
     [ "$status" -ne 0 ]
-    [[ "$output" == *"\"tools\" must be an object"* ]]
+    [[ "$output" == *"not a valid JSON catalog"* ]]
 }
 
 @test "merge: rejects malformed JSON" {
-    printf 'not json{' > "$OVERRIDE"
+    printf 'not json{' > "$CUSTOM"
     _merge
     [ "$status" -ne 0 ]
-    [[ "$output" == *"not valid JSON"* ]]
+    [[ "$output" == *"not a valid JSON catalog"* ]]
 }
 
 @test "merge: tolerates a missing curated catalog (adopter-only tools)" {
-    cat > "$OVERRIDE" <<JSON
+    cat > "$CUSTOM" <<JSON
 {"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
 JSON
-    run "$MERGE" "$TEST_DIR/does-not-exist.json" "$OVERRIDE"
+    run "$MERGE" "$TEST_DIR/does-not-exist.json" "$CUSTOM"
     [ "$status" -eq 0 ]
     [ "$(jq -r '.tools["my-sbom"].kind' <<<"$output")" = "sbom" ]
 }

--- a/test/test_merge_catalog.bats
+++ b/test/test_merge_catalog.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+
+# Tests for lib/merge_catalog.sh — the adopter tool-overrides merge. The security
+# rule under test: an override entry's non-capability fields deep-merge over the
+# curated entry, but network and secret hold ONLY when the override restates
+# them, else they reset closed (docs/tool_container_design.md §3.7).
+
+setup() {
+    ORIG_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    MERGE="$ORIG_DIR/lib/merge_catalog.sh"
+    TEST_DIR="$(mktemp -d)"
+    DIGEST="sha256:$(printf 'a%.0s' {1..64})"
+    DIGEST2="sha256:$(printf 'b%.0s' {1..64})"
+    CURATED="$TEST_DIR/curated.json"
+    OVERRIDE="$TEST_DIR/override.json"
+    cat > "$CURATED" <<JSON
+{"tools":{
+  "osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@$DIGEST","network":"egress","secret":"github-token"},
+  "syft":{"kind":"sbom","delivery":"image","image":"ghcr.io/tomhennen/wrangle/syft@$DIGEST","network":"none"}
+}}
+JSON
+}
+
+teardown() {
+    [[ -n "${TEST_DIR:-}" ]] && rm -rf "$TEST_DIR"
+}
+
+_merge() { run "$MERGE" "$CURATED" "$OVERRIDE"; }
+
+@test "merge: override of a curated tool image only RESETS network and secret closed" {
+    cat > "$OVERRIDE" <<JSON
+{"tools":{"osv":{"image":"ghcr.io/myorg/osv@$DIGEST2"}}}
+JSON
+    _merge
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.tools.osv.image' <<<"$output")" = "ghcr.io/myorg/osv@$DIGEST2" ]
+    [ "$(jq -r '.tools.osv.kind' <<<"$output")" = "scan" ]
+    [ "$(jq '.tools.osv | has("network")' <<<"$output")" = "false" ]
+    [ "$(jq '.tools.osv | has("secret")' <<<"$output")" = "false" ]
+}
+
+@test "merge: override restating network keeps it; an unrestated secret still resets" {
+    cat > "$OVERRIDE" <<JSON
+{"tools":{"osv":{"image":"ghcr.io/myorg/osv@$DIGEST2","network":"egress"}}}
+JSON
+    _merge
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.tools.osv.network' <<<"$output")" = "egress" ]
+    [ "$(jq '.tools.osv | has("secret")' <<<"$output")" = "false" ]
+}
+
+@test "merge: a new BYO tool is added with its declared fields" {
+    cat > "$OVERRIDE" <<JSON
+{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
+JSON
+    _merge
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.tools["my-sbom"].kind' <<<"$output")" = "sbom" ]
+    [ "$(jq -r '.tools["my-sbom"].image' <<<"$output")" = "ghcr.io/myorg/my-sbom@$DIGEST" ]
+    # Curated tools survive the merge.
+    [ "$(jq -r '.tools.syft.kind' <<<"$output")" = "sbom" ]
+}
+
+@test "merge: curated-namespace override image is allowed (VSA gate handles trust)" {
+    cat > "$OVERRIDE" <<JSON
+{"tools":{"osv":{"image":"ghcr.io/tomhennen/wrangle/osv@$DIGEST2"}}}
+JSON
+    _merge
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.tools.osv.image' <<<"$output")" = "ghcr.io/tomhennen/wrangle/osv@$DIGEST2" ]
+}
+
+@test "merge: rejects an invalid tool name" {
+    cat > "$OVERRIDE" <<JSON
+{"tools":{"BadName":{"kind":"sbom","delivery":"image","image":"ghcr.io/x@$DIGEST"}}}
+JSON
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"invalid tool name"* ]]
+}
+
+@test "merge: rejects an out-of-allowlist kind" {
+    cat > "$OVERRIDE" <<JSON
+{"tools":{"my-sbom":{"kind":"exfiltrate","delivery":"image","image":"ghcr.io/x@$DIGEST"}}}
+JSON
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"kind must be one of"* ]]
+}
+
+@test "merge: rejects an out-of-allowlist network" {
+    cat > "$OVERRIDE" <<JSON
+{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/x@$DIGEST","network":"host"}}}
+JSON
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"network must be one of"* ]]
+}
+
+@test "merge: rejects an invalid secret name" {
+    cat > "$OVERRIDE" <<JSON
+{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/x@$DIGEST","secret":"BAD_NAME"}}}
+JSON
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"secret must match"* ]]
+}
+
+@test "merge: rejects a non-digest-pinned image" {
+    cat > "$OVERRIDE" <<JSON
+{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/x:latest"}}}
+JSON
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"digest-pinned"* ]]
+}
+
+@test "merge: rejects a new tool with no image" {
+    cat > "$OVERRIDE" <<JSON
+{"tools":{"new-tool":{"kind":"sbom","delivery":"image"}}}
+JSON
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"must declare a digest-pinned image"* ]]
+}
+
+@test "merge: rejects a new tool that is not delivery: image" {
+    cat > "$OVERRIDE" <<JSON
+{"tools":{"new-tool":{"kind":"sbom","image":"ghcr.io/x@$DIGEST"}}}
+JSON
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"must declare delivery: image"* ]]
+}
+
+@test "merge: rejects a non-object tools envelope" {
+    printf '{"tools":[]}' > "$OVERRIDE"
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"\"tools\" must be an object"* ]]
+}
+
+@test "merge: rejects malformed JSON" {
+    printf 'not json{' > "$OVERRIDE"
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not valid JSON"* ]]
+}
+
+@test "merge: tolerates a missing curated catalog (adopter-only tools)" {
+    cat > "$OVERRIDE" <<JSON
+{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
+JSON
+    run "$MERGE" "$TEST_DIR/does-not-exist.json" "$OVERRIDE"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.tools["my-sbom"].kind' <<<"$output")" = "sbom" ]
+}

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -637,60 +637,57 @@ JSON
     [[ "$output" == *"running sbom (image)"* ]]
 }
 
-# --- custom-tools: path validation ---
+# --- custom tools: auto-discovered .wrangle/tools.json at the workspace root ---
 
-@test "orchestrator: custom-tools path escaping the workspace is rejected" {
-    mkdir -p "$TEST_DIR/ws"
-    printf '{"tools":{}}' > "$TEST_DIR/outside.json"
-    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_CUSTOM_TOOLS="$TEST_DIR/outside.json" \
-        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"escapes the workspace"* ]]
+_byo_digest="sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+_write_custom_tools() {
+    mkdir -p "$TEST_DIR/ws/.wrangle" "$TEST_DIR/src"
+    printf '%s' "$1" > "$TEST_DIR/ws/.wrangle/tools.json"
 }
 
-@test "orchestrator: a missing custom-tools file is rejected" {
-    mkdir -p "$TEST_DIR/ws"
-    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_CUSTOM_TOOLS="$TEST_DIR/ws/nope.json" \
-        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"not found"* ]]
-}
-
-@test "orchestrator: an in-workspace custom-tools file merges and admits a new tool" {
-    digest="sha256:0000000000000000000000000000000000000000000000000000000000000000"
-    mkdir -p "$TEST_DIR/ws" "$TEST_DIR/src"
-    cat > "$TEST_DIR/ws/tools.json" <<JSON
-{"tools":{"byotool":{"kind":"sbom","delivery":"image","image":"registry.internal:5000/byo@$digest"}}}
-JSON
-    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_CUSTOM_TOOLS="$TEST_DIR/ws/tools.json" \
+@test "orchestrator: auto-discovers .wrangle/tools.json and admits a selected new tool" {
+    _write_custom_tools "{\"tools\":{\"byotool\":{\"kind\":\"sbom\",\"delivery\":\"image\",\"image\":\"registry.internal:5000/byo@$_byo_digest\"}}}"
+    GITHUB_WORKSPACE="$TEST_DIR/ws" \
         run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
     [[ "$output" != *"unknown tool"* ]]
     [[ "$output" == *"running byotool (image)"* ]]
 }
 
-@test "orchestrator: a workspace-relative custom-tools path resolves (the composite seam)" {
-    # The composites pass a workspace-relative path (.wrangle/tools.json) with cwd
-    # = GITHUB_WORKSPACE; assert that resolves rather than being read as an escape.
-    digest="sha256:0000000000000000000000000000000000000000000000000000000000000000"
-    mkdir -p "$TEST_DIR/ws/.wrangle" "$TEST_DIR/src"
-    cat > "$TEST_DIR/ws/.wrangle/tools.json" <<JSON
-{"tools":{"byotool":{"kind":"sbom","delivery":"image","image":"registry.internal:5000/byo@$digest"}}}
-JSON
-    cd "$TEST_DIR/ws"
-    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_CUSTOM_TOOLS=".wrangle/tools.json" \
-        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
-    [[ "$output" != *"escapes the workspace"* ]]
-    [[ "$output" != *"not found"* ]]
-    [[ "$output" == *"running byotool (image)"* ]]
+@test "orchestrator: no .wrangle/tools.json leaves the default catalog untouched" {
+    mkdir -p "$TEST_DIR/ws" "$TEST_DIR/src"
+    GITHUB_WORKSPACE="$TEST_DIR/ws" \
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_DIR/output/clean-tool/output.sarif" ]
 }
 
-@test "orchestrator: an invalid custom-tools entry aborts the run" {
-    mkdir -p "$TEST_DIR/ws" "$TEST_DIR/src"
-    cat > "$TEST_DIR/ws/tools.json" <<'JSON'
-{"tools":{"byotool":{"kind":"sbom","delivery":"image","image":"ghcr.io/x:latest"}}}
-JSON
-    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_CUSTOM_TOOLS="$TEST_DIR/ws/tools.json" \
+@test "orchestrator: a .wrangle/tools.json symlink resolving outside the workspace is rejected" {
+    mkdir -p "$TEST_DIR/ws/.wrangle" "$TEST_DIR/src"
+    printf '{"tools":{}}' > "$TEST_DIR/outside.json"
+    ln -s "$TEST_DIR/outside.json" "$TEST_DIR/ws/.wrangle/tools.json"
+    GITHUB_WORKSPACE="$TEST_DIR/ws" \
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"resolves outside the workspace"* ]]
+}
+
+@test "orchestrator: an invalid .wrangle/tools.json entry aborts the run" {
+    _write_custom_tools '{"tools":{"byotool":{"kind":"sbom","delivery":"image","image":"ghcr.io/x:latest"}}}'
+    GITHUB_WORKSPACE="$TEST_DIR/ws" \
         run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
     [ "$status" -eq 2 ]
     [[ "$output" == *"digest-pinned"* ]]
+}
+
+@test "orchestrator: a custom tool defined but NOT selected is never dispatched" {
+    # Selection gates execution: an injected .wrangle/tools.json entry that the
+    # selection does not name must stay defined-but-never-run (the property that
+    # makes auto-discovery safe under pull_request_target).
+    _write_custom_tools "{\"tools\":{\"injected\":{\"kind\":\"sbom\",\"delivery\":\"image\",\"image\":\"registry.internal:5000/evil@$_byo_digest\"}}}"
+    GITHUB_WORKSPACE="$TEST_DIR/ws" \
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"injected"* ]]
+    [ ! -d "$TEST_DIR/output/injected" ]
 }

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -626,6 +626,17 @@ JSON
     [[ "$output" == *"unknown tool"* ]]
 }
 
+@test "orchestrator: the curated sbom key dispatches as a catalog-only image tool" {
+    # The default SBOM path (sbom-tool: sbom) has no tools/sbom/ dir, so it relies
+    # on the dir-gate resolving the real catalog's sbom entry to the image path.
+    [ ! -d "$ORIG_DIR/tools/sbom" ]
+    mkdir -p "$TEST_DIR/src"
+    WRANGLE_TOOLS_DIR="$ORIG_DIR/tools" WRANGLE_VERIFY_TOOL_IMAGES=0 \
+        run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" sbom
+    [[ "$output" != *"unknown tool"* ]]
+    [[ "$output" == *"running sbom (image)"* ]]
+}
+
 # --- custom-tools: path validation ---
 
 @test "orchestrator: custom-tools path escaping the workspace is rejected" {

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -657,6 +657,22 @@ JSON
     [[ "$output" == *"running byotool (image)"* ]]
 }
 
+@test "orchestrator: a workspace-relative tool-overrides path resolves (the composite seam)" {
+    # The composites pass a workspace-relative path (.wrangle/tools.json) with cwd
+    # = GITHUB_WORKSPACE; assert that resolves rather than being read as an escape.
+    digest="sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    mkdir -p "$TEST_DIR/ws/.wrangle" "$TEST_DIR/src"
+    cat > "$TEST_DIR/ws/.wrangle/tools.json" <<JSON
+{"tools":{"byotool":{"kind":"sbom","delivery":"image","image":"registry.internal:5000/byo@$digest"}}}
+JSON
+    cd "$TEST_DIR/ws"
+    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_TOOL_OVERRIDES=".wrangle/tools.json" \
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
+    [[ "$output" != *"escapes the workspace"* ]]
+    [[ "$output" != *"not found"* ]]
+    [[ "$output" == *"running byotool (image)"* ]]
+}
+
 @test "orchestrator: an invalid tool-overrides entry aborts the run" {
     mkdir -p "$TEST_DIR/ws" "$TEST_DIR/src"
     cat > "$TEST_DIR/ws/tools.json" <<'JSON'

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -626,38 +626,38 @@ JSON
     [[ "$output" == *"unknown tool"* ]]
 }
 
-# --- tool-overrides: path validation ---
+# --- custom-tools: path validation ---
 
-@test "orchestrator: tool-overrides path escaping the workspace is rejected" {
+@test "orchestrator: custom-tools path escaping the workspace is rejected" {
     mkdir -p "$TEST_DIR/ws"
     printf '{"tools":{}}' > "$TEST_DIR/outside.json"
-    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_TOOL_OVERRIDES="$TEST_DIR/outside.json" \
+    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_CUSTOM_TOOLS="$TEST_DIR/outside.json" \
         run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
     [ "$status" -eq 2 ]
     [[ "$output" == *"escapes the workspace"* ]]
 }
 
-@test "orchestrator: a missing tool-overrides file is rejected" {
+@test "orchestrator: a missing custom-tools file is rejected" {
     mkdir -p "$TEST_DIR/ws"
-    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_TOOL_OVERRIDES="$TEST_DIR/ws/nope.json" \
+    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_CUSTOM_TOOLS="$TEST_DIR/ws/nope.json" \
         run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
     [ "$status" -eq 2 ]
     [[ "$output" == *"not found"* ]]
 }
 
-@test "orchestrator: an in-workspace tool-overrides file merges and admits a new tool" {
+@test "orchestrator: an in-workspace custom-tools file merges and admits a new tool" {
     digest="sha256:0000000000000000000000000000000000000000000000000000000000000000"
     mkdir -p "$TEST_DIR/ws" "$TEST_DIR/src"
     cat > "$TEST_DIR/ws/tools.json" <<JSON
 {"tools":{"byotool":{"kind":"sbom","delivery":"image","image":"registry.internal:5000/byo@$digest"}}}
 JSON
-    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_TOOL_OVERRIDES="$TEST_DIR/ws/tools.json" \
+    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_CUSTOM_TOOLS="$TEST_DIR/ws/tools.json" \
         run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
     [[ "$output" != *"unknown tool"* ]]
     [[ "$output" == *"running byotool (image)"* ]]
 }
 
-@test "orchestrator: a workspace-relative tool-overrides path resolves (the composite seam)" {
+@test "orchestrator: a workspace-relative custom-tools path resolves (the composite seam)" {
     # The composites pass a workspace-relative path (.wrangle/tools.json) with cwd
     # = GITHUB_WORKSPACE; assert that resolves rather than being read as an escape.
     digest="sha256:0000000000000000000000000000000000000000000000000000000000000000"
@@ -666,19 +666,19 @@ JSON
 {"tools":{"byotool":{"kind":"sbom","delivery":"image","image":"registry.internal:5000/byo@$digest"}}}
 JSON
     cd "$TEST_DIR/ws"
-    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_TOOL_OVERRIDES=".wrangle/tools.json" \
+    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_CUSTOM_TOOLS=".wrangle/tools.json" \
         run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
     [[ "$output" != *"escapes the workspace"* ]]
     [[ "$output" != *"not found"* ]]
     [[ "$output" == *"running byotool (image)"* ]]
 }
 
-@test "orchestrator: an invalid tool-overrides entry aborts the run" {
+@test "orchestrator: an invalid custom-tools entry aborts the run" {
     mkdir -p "$TEST_DIR/ws" "$TEST_DIR/src"
     cat > "$TEST_DIR/ws/tools.json" <<'JSON'
 {"tools":{"byotool":{"kind":"sbom","delivery":"image","image":"ghcr.io/x:latest"}}}
 JSON
-    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_TOOL_OVERRIDES="$TEST_DIR/ws/tools.json" \
+    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_CUSTOM_TOOLS="$TEST_DIR/ws/tools.json" \
         run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
     [ "$status" -eq 2 ]
     [[ "$output" == *"digest-pinned"* ]]

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -603,3 +603,67 @@ JSON
     # then fails at docker (image absent / docker may be unavailable here).
     [[ "$output" != *"not digest-pinned"* ]]
 }
+
+# --- catalog-only image tool: admitted with no local tools/<name>/ dir ---
+
+@test "orchestrator: a delivery: image tool with no directory is admitted (not unknown)" {
+    digest="sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    mkdir -p "$TEST_DIR/src"
+    # No $MOCK_TOOLS/byotool directory; the catalog alone defines it.
+    cat > "$MOCK_TOOLS/catalog.json" <<JSON
+{"tools":{"byotool":{"kind":"sbom","delivery":"image","image":"registry.internal:5000/byo@$digest"}}}
+JSON
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
+    # Reaches the image path rather than the "unknown tool" gate; docker then
+    # fails (image absent / docker may be unavailable), which is not our concern.
+    [[ "$output" != *"unknown tool"* ]]
+    [[ "$output" == *"running byotool (image)"* ]]
+}
+
+@test "orchestrator: a tool with no directory and no catalog image entry is unknown" {
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "nodir"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"unknown tool"* ]]
+}
+
+# --- tool-overrides: path validation ---
+
+@test "orchestrator: tool-overrides path escaping the workspace is rejected" {
+    mkdir -p "$TEST_DIR/ws"
+    printf '{"tools":{}}' > "$TEST_DIR/outside.json"
+    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_TOOL_OVERRIDES="$TEST_DIR/outside.json" \
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"escapes the workspace"* ]]
+}
+
+@test "orchestrator: a missing tool-overrides file is rejected" {
+    mkdir -p "$TEST_DIR/ws"
+    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_TOOL_OVERRIDES="$TEST_DIR/ws/nope.json" \
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not found"* ]]
+}
+
+@test "orchestrator: an in-workspace tool-overrides file merges and admits a new tool" {
+    digest="sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    mkdir -p "$TEST_DIR/ws" "$TEST_DIR/src"
+    cat > "$TEST_DIR/ws/tools.json" <<JSON
+{"tools":{"byotool":{"kind":"sbom","delivery":"image","image":"registry.internal:5000/byo@$digest"}}}
+JSON
+    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_TOOL_OVERRIDES="$TEST_DIR/ws/tools.json" \
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
+    [[ "$output" != *"unknown tool"* ]]
+    [[ "$output" == *"running byotool (image)"* ]]
+}
+
+@test "orchestrator: an invalid tool-overrides entry aborts the run" {
+    mkdir -p "$TEST_DIR/ws" "$TEST_DIR/src"
+    cat > "$TEST_DIR/ws/tools.json" <<'JSON'
+{"tools":{"byotool":{"kind":"sbom","delivery":"image","image":"ghcr.io/x:latest"}}}
+JSON
+    GITHUB_WORKSPACE="$TEST_DIR/ws" WRANGLE_TOOL_OVERRIDES="$TEST_DIR/ws/tools.json" \
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"digest-pinned"* ]]
+}

--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -20,7 +20,7 @@
       "image": "ghcr.io/tomhennen/wrangle/wrangle-lint@sha256:6d7c6ff05f45411e5b1bc4c1d239e258f5885f913dca8a16222369ed2eacf9e3",
       "network": "none"
     },
-    "syft": {
+    "sbom": {
       "kind": "sbom",
       "delivery": "image",
       "image": "ghcr.io/tomhennen/wrangle/syft@sha256:a8c074e45182fb2b51935f5947e92d95e40154e22295144552297b72fd6eb386",

--- a/tools/check_catalog.sh
+++ b/tools/check_catalog.sh
@@ -22,9 +22,9 @@ set -f  # disable globbing — handles external tool/field names
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/read_catalog.sh
 source "$SCRIPT_DIR/../lib/read_catalog.sh"
+# shellcheck source=../lib/catalog_rules.sh
+source "$SCRIPT_DIR/../lib/catalog_rules.sh"
 
-NETWORK_ALLOWED_RE='^(none|egress)$'
-SECRET_NAME_RE='^[a-z][a-z0-9-]*$'
 # Tool segment matches run.sh's tool-name shape, so no leading dot/dash or `..`
 # can survive into a registry path.
 CURATED_PREFIX='ghcr.io/tomhennen/wrangle/'
@@ -56,13 +56,13 @@ validate_catalog() {
         fi
 
         network="$(read_catalog_field "$file" "$tool" network)"
-        if [[ -n "$network" ]] && [[ ! "$network" =~ $NETWORK_ALLOWED_RE ]]; then
+        if [[ -n "$network" ]] && [[ ! "$network" =~ $CATALOG_NETWORK_RE ]]; then
             printf 'check_catalog: %s: invalid network value: %s\n' "$tool" "$network" >&2
             rc=1
         fi
 
         secret="$(read_catalog_field "$file" "$tool" secret)"
-        if [[ -n "$secret" ]] && [[ ! "$secret" =~ $SECRET_NAME_RE ]]; then
+        if [[ -n "$secret" ]] && [[ ! "$secret" =~ $CATALOG_SECRET_NAME_RE ]]; then
             printf 'check_catalog: %s: invalid secret name: %s\n' "$tool" "$secret" >&2
             rc=1
         fi

--- a/tools/check_catalog.sh
+++ b/tools/check_catalog.sh
@@ -27,7 +27,7 @@ source "$SCRIPT_DIR/../lib/catalog_rules.sh"
 
 # Tool segment matches run.sh's tool-name shape, so no leading dot/dash or `..`
 # can survive into a registry path.
-CURATED_PREFIX='ghcr.io/tomhennen/wrangle/'
+CURATED_PREFIX="$CATALOG_CURATED_IMAGE_PREFIX"
 IMAGE_STRICT_RE='^ghcr\.io/tomhennen/wrangle/[a-z][a-z0-9_-]*@sha256:[0-9a-f]{64}$'
 
 # validate_catalog <catalog_file> — print one line per violation to stderr.
@@ -52,6 +52,9 @@ validate_catalog() {
         kind="$(read_catalog_field "$file" "$tool" kind)"
         if [[ -z "$kind" ]]; then
             printf 'check_catalog: %s: missing kind\n' "$tool" >&2
+            rc=1
+        elif [[ ! "$kind" =~ $CATALOG_KIND_RE ]]; then
+            printf 'check_catalog: %s: invalid kind: %s\n' "$tool" "$kind" >&2
             rc=1
         fi
 


### PR DESCRIPTION
claude: Pluggable BYO SBOM — add-only custom tools (#673)

## Model (owner-decided, add-only)

Adopters may **add** their own net-new tools and **deselect** curated ones — never partially override/replace a curated entry. This is strictly safer than a field-merge and needs no capability-reset.

- `lib/merge_catalog.sh` is a **disjoint union**: effective catalog = curated tools ∪ adopter-added tools. A custom tool name that **collides** with a curated name is a **hard error** (fail closed) — no shadowing, no field merge. So a custom entry can never attach its own `secret`/`network` grant onto wrangle's curated, VSA-signed image.
- Each added tool is validated **standalone** and declares its own capabilities; there is no inheritance, so there is nothing to "reset."

Adopter flow (go / python / npm builds) — commit a `.wrangle/tools.json`, select by name. `run.sh` **auto-discovers** the file at the workspace root; there is no workflow input.

```jsonc
// .wrangle/tools.json  — net-new tools added to wrangle's catalog
{ "tools": { "my-sbom": { "kind": "sbom", "delivery": "image",
  "image": "ghcr.io/myorg/my-sbom@sha256:<digest>" } } }
```
```yaml
    with:
      sbom-tool: my-sbom        # the only knob; no path/opt-in input
```

## Interface: auto-discovery + selection gates execution

`run.sh` reads `.wrangle/tools.json` at the workspace root (`$GITHUB_WORKSPACE`, else cwd) on every run — the shared path for **both** scan and the build composites, so scan + SBOM BYO unify for free. The old `custom-tools` input and `WRANGLE_CUSTOM_TOOLS` plumbing are removed from all three composites and reusable workflows.

This is safe because **selection gates execution**: a custom tool is *defined* by the file but *runs* only when named in `tools:` (scan) or `sbom-tool:` (build), both of which are `workflow_call` inputs from the base workflow — verified: the scan action reads `inputs.tools` (explicitly not attacker-controllable) and the `pull_request_target` startup-block (`actions/prep/preflight_guard.sh`) is intact. This is also *why* wrangle deliberately does **not** auto-select the SBOM tool from `.wrangle/tools.json`: auto-selecting would run a file-defined entry with no base-controlled gate, breaking the exact property that makes auto-discovery safe. So define-in-file + select-by-input is a security boundary, not redundancy. A unit test asserts a custom tool present in `.wrangle/tools.json` but absent from the selection is never dispatched. Absent file → no-op (default path pays nothing). A symlinked `.wrangle/tools.json` resolving outside the workspace is still rejected.

## Union + collision implementation

`merge_catalog.sh`: a jq intersection of curated∩custom keys → any non-empty result is a hard error before the union; otherwise `curated.tools + custom.tools`. Each custom entry is validated (name `^[a-z][a-z0-9_-]*$`, `kind`∈{scan,sbom,attest}, `delivery: image`, digest-pinned `image` **that MUST be outside the wrangle namespace `ghcr.io/tomhennen/wrangle/*`**, and — if present — `network`∈{none,egress} / `secret` regex). The namespace ban is the security invariant: an adopter genuinely cannot attach capabilities to a wrangle VSA-signed image (not merely fail the VSA gate at dispatch). The match is anchored and tolerates an explicit registry port, so the `ghcr.io:443/...` form can't slip a wrangle image past it.

## Shared validation (drift fix)

The value rules (name/kind/network/secret/digest-pin) are factored into **`lib/catalog_rules.sh`**, sourced by both the custom-tools validator and the curated-catalog linter `tools/check_catalog.sh`, so the two can't silently diverge.

## Renames

- The adopter file is the conventional **`.wrangle/tools.json`** (auto-discovered); no input to name (earlier `tool-overrides`/`custom-tools` inputs are gone).
- Curated catalog **key `syft` → `sbom`** (the role slot; the image stays `ghcr.io/tomhennen/wrangle/syft`). `generate_sbom.sh` and the `sbom-tool` input default to `sbom`. `sbom-tool` is the selector (default `sbom`; BYO = `sbom-tool: my-sbom`).

## run.sh

Foundational dir-gate relaxation kept: a `delivery: image` catalog tool is admitted with no local `tools/<name>/` dir (BYO tools are catalog-only). The auto-discovered `.wrangle/tools.json` is `realpath`-resolved and must stay within the workspace root (symlink escape rejected). Fixed a sourcing bug where `merge_catalog.sh`'s file-scope `SCRIPT_DIR` clobbered run.sh's.

## Trust boundary (review finding)

Layered controls: base-controlled selection + the `pull_request_target` startup-block + GitHub withholding secrets from fork `pull_request` runs are the primary defenses; the trusted-config note (an added tool can grant itself `egress` + a `secret`) is defense-in-depth for adopters who hand-roll a PRT workflow around the raw composites. Custom images are additionally forced off the wrangle namespace, so they can never carry a wrangle VSA identity.

## Docs

`docs/tool_container_design.md` §3.7–3.8 rewritten to add-only (no inheritance, collision-is-error, `my-osv` add-and-select example); `docs/SPEC.md` "Tool Overrides" → "Custom Tools" (union, collision, standalone validation, containment, trust boundary; stale dir-gate step fixed); README quickstart scoped to go/python/npm.

## Contract test (the artifact puerco reviews)

`test/image/test_byo_sbom.bats` drives the **real custom-tools path**: a `.wrangle/tools.json` adding a NON-wrangle, off-namespace contract image (pushed to a `registry:2` sidecar for a real digest), selected via `WRANGLE_CUSTOM_TOOLS`. One run exercises the dir-gate relaxation, the union, the VSA-skip (off-namespace warning), the sandbox, and a **real, non-empty** SPDX (≥1 named package — not the #641 empty trap). Integration job, `wrangle_require_docker`/`skip_or_fail` (never skips in CI).

## Tests

- Unit (docker-free): `test/test_merge_catalog.bats` — collision-rejected, added-tool-gets-exactly-its-declared-grants (no inheritance), standalone-validation rejections; `run.sh` cases in `test/test_orchestrator.bats` (dir-gate, path traversal, workspace-relative path, union-and-admit).
- Integration: `test/image/test_byo_sbom.bats` (5, passing locally with real docker).
- Rebased on current `origin/main` (#671/#675/#677); reconciled the overlapping files (`entrypoint.sh` keeps both `source-name` and `sbom-real` arms; `run_tool_image.sh` keeps `WRANGLE_SOURCE_NAME`; the `sbom` catalog key carries main's syft digest).
- `./test.sh quick`: green (1378 tests, 0 failures). zizmor runs in CI; inputs are threaded through `env:`, no injection.

## Notes for reviewers

- Self-ref pins converged to the PR head so CI runs the new composites. **Post-merge:** land as a merge commit (not squash) and run `bump_action_pins` to the merge commit.

Links: builds on #674 (SBOM seam), #596 (catalog image dispatch); guards the #641 valid-but-empty-SBOM trap.

Fixes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)
