### PR TITLE
docs(verify): remove the stale gh --predicate-type caveat

### DIFF
--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -135,12 +135,6 @@ ampel verify --subject sha256:<digest> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>
 ```
 
-The `gh attestation verify --predicate-type` filter does **not** accept the VSA
-predicate URI (`https://slsa.dev/verification_summary/v1`) — GitHub returns HTTP
-422 from its filter allowlist — so use ampel (recommended) or an unfiltered `gh
-attestation verify`. The filter only blocks the query; storing and unfiltered
-fetch work.
-
 Pin the policy locator to any wrangle `v*` release tag — it does **not**
 need to match the wrangle version the adopter builds with. The `-v1` in the
 policy filename is the contract version; any release tag carrying that file


### PR DESCRIPTION
claude: Gate-3 finding from v0.3.1 release prep. `docs/verifying_artifacts.md` carried a note warning that `gh attestation verify --predicate-type <VSA URI>` is rejected (HTTP 422). That's stale — current gh filters client-side and the flag works — so the note's only job (steer consumers away from a broken flag) no longer exists. Rather than reword internal-API trivia a consumer can't act on, drop it: the recommended ampel and cosign paths already verify the VSA. Empirically checked against a real showcase artifact during release prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)