### PR TITLE
claude: feat(catalog): add token grant to catalog schema + validator (#619 Phase 3 Tranche A1)

### DIFF
--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -197,11 +197,10 @@ Two distinct layers:
 - **Definition** (static, per tool): the catalog entry — `{image digest, kind, network, secret, token,
   output}`.
 
-`token: sigstore` grants the host permission to mint an `aud=sigstore` `SIGSTORE_ID_TOKEN` into the
-container — the OIDC-token analogue of `secret: github-token`. Default-closed and from the trusting party
-like every grant; `check_catalog` permits it only on the curated `attest-toolbox` (a `kind: attest`
-entry), never on a scan/sbom tool or a custom adopter entry. The field is validated today but not yet
-consumed; a later Phase 3 PR wires the minting.
+`token: sigstore` lets wrangle mint a short-lived Sigstore signing token (`SIGSTORE_ID_TOKEN`) into the
+tool's container — the signing-token counterpart of `secret: github-token`. It is off by default, and
+`check_catalog` allows it only on wrangle's own `attest-toolbox` image, never on a scan/sbom tool or an
+adopter's custom tool. The field is validated today, but nothing reads it yet.
 
 **A capability grant comes from the trusting party — wrangle, or the adopter for their own tool — never
 from the image itself.** An image may *request* a capability (e.g. an OCI label), but granting it is the

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -194,8 +194,13 @@ from osv.dev.
 Two distinct layers:
 
 - **Selection** (per run, adopter-facing): which tools to run and at what policy — the `tools:` string.
-- **Definition** (static, per tool): the catalog entry — `{image digest, kind, network, secret,
+- **Definition** (static, per tool): the catalog entry — `{image digest, kind, network, secret, token,
   output}`.
+
+`token: sigstore` grants the host permission to mint an `aud=sigstore` `SIGSTORE_ID_TOKEN` into the
+container — the OIDC-token analogue of `secret: github-token`. Default-closed and from the trusting party
+like every grant; `check_catalog` permits it only on the curated `attest-toolbox` (a `kind: attest`
+entry), never on a scan/sbom tool or a custom adopter entry.
 
 **A capability grant comes from the trusting party — wrangle, or the adopter for their own tool — never
 from the image itself.** An image may *request* a capability (e.g. an OCI label), but granting it is the

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -200,7 +200,8 @@ Two distinct layers:
 `token: sigstore` grants the host permission to mint an `aud=sigstore` `SIGSTORE_ID_TOKEN` into the
 container — the OIDC-token analogue of `secret: github-token`. Default-closed and from the trusting party
 like every grant; `check_catalog` permits it only on the curated `attest-toolbox` (a `kind: attest`
-entry), never on a scan/sbom tool or a custom adopter entry.
+entry), never on a scan/sbom tool or a custom adopter entry. The field is validated today but not yet
+consumed; a later Phase 3 PR wires the minting.
 
 **A capability grant comes from the trusting party — wrangle, or the adopter for their own tool — never
 from the image itself.** An image may *request* a capability (e.g. an OCI label), but granting it is the

--- a/lib/catalog_rules.sh
+++ b/lib/catalog_rules.sh
@@ -14,6 +14,8 @@ CATALOG_TOOL_NAME_RE='^[a-z][a-z0-9_-]*$'
 CATALOG_KIND_RE='^(scan|sbom|attest)$'
 CATALOG_NETWORK_RE='^(none|egress)$'
 CATALOG_SECRET_NAME_RE='^[a-z][a-z0-9-]*$'
+# OIDC-token grant: only sigstore, and only on the curated attest toolbox.
+CATALOG_TOKEN_RE='^(sigstore)$'
 # Digest-pinned image, host-agnostic (the registry may carry a :port).
 CATALOG_IMAGE_DIGEST_RE='^[a-z0-9._-]+(:[0-9]+)?(/[a-z0-9._-]+)*@sha256:[0-9a-f]{64}$'
 # Namespace of wrangle-published, VSA-signed tool images.

--- a/lib/merge_catalog.sh
+++ b/lib/merge_catalog.sh
@@ -45,7 +45,7 @@ merge_catalog() {
         return 1
     fi
 
-    local rc=0 tool kind delivery image network secret
+    local rc=0 tool kind delivery image network secret token
     while IFS= read -r tool; do
         [[ -z "$tool" ]] && continue
         if [[ ! "$tool" =~ $CATALOG_TOOL_NAME_RE ]]; then
@@ -68,6 +68,14 @@ merge_catalog() {
         secret="$(read_catalog_field "$custom" "$tool" secret)"
         if [[ -n "$secret" ]] && [[ ! "$secret" =~ $CATALOG_SECRET_NAME_RE ]]; then
             printf 'wrangle: custom-tools: %s: invalid secret name: %s\n' "$tool" "$secret" >&2
+            rc=1
+        fi
+
+        # The token grant is confined to the curated attest toolbox; an adopter's
+        # image can never carry it.
+        token="$(read_catalog_field "$custom" "$tool" token)"
+        if [[ -n "$token" ]]; then
+            printf 'wrangle: custom-tools: %s: token grant is not allowed on custom tools\n' "$tool" >&2
             rc=1
         fi
 

--- a/test/test_check_catalog.bats
+++ b/test/test_check_catalog.bats
@@ -107,6 +107,33 @@ write_catalog() { printf '%s\n' "$1" > "$CATALOG"; }
     [[ "$output" == *"curated namespace"* ]]
 }
 
+@test "check_catalog: token: sigstore on the attest toolbox passes" {
+    write_catalog '{"tools":{"attest-toolbox":{"kind":"attest","image":"ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:'"$(printf 'a%.0s' {1..64})"'","network":"egress","token":"sigstore"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "check_catalog: an unrecognized token value fails" {
+    write_catalog '{"tools":{"attest-toolbox":{"kind":"attest","image":"ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:'"$(printf 'a%.0s' {1..64})"'","token":"github"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"invalid token value"* ]]
+}
+
+@test "check_catalog: token grant on a scan entry is forbidden" {
+    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'","token":"sigstore"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"token grant forbidden"* ]]
+}
+
+@test "check_catalog: token grant on an sbom entry is forbidden" {
+    write_catalog '{"tools":{"sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/tomhennen/wrangle/syft@sha256:'"$(printf 'a%.0s' {1..64})"'","token":"sigstore"}}}'
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"token grant forbidden"* ]]
+}
+
 @test "check_catalog: extra argument is a usage error (exit 2)" {
     write_catalog '{"tools":{}}'
     run "$SCRIPT" unexpected

--- a/test/test_merge_catalog.bats
+++ b/test/test_merge_catalog.bats
@@ -134,6 +134,15 @@ JSON
     [[ "$output" == *"must declare delivery: image"* ]]
 }
 
+@test "merge: rejects a custom tool carrying a token grant (curated toolbox only)" {
+    cat > "$CUSTOM" <<JSON
+{"tools":{"my-attest":{"kind":"attest","delivery":"image","image":"ghcr.io/myorg/my-attest@$DIGEST","token":"sigstore"}}}
+JSON
+    _merge
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"token grant is not allowed on custom tools"* ]]
+}
+
 @test "merge: an off-namespace custom image is allowed (adopter-trusted)" {
     cat > "$CUSTOM" <<JSON
 {"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}

--- a/tools/check_catalog.sh
+++ b/tools/check_catalog.sh
@@ -8,8 +8,9 @@ set -f  # disable globbing — handles external tool/field names
 # off-namespace image reference can't pass CI green.
 #
 # For every tool it asserts: the file is valid JSON, a `kind` is declared, the
-# `delivery` (if set) is one run.sh recognizes, and a declared `network`/`secret`
-# is from the allowed, default-closed set. A `delivery: image` entry must also name
+# `delivery` (if set) is one run.sh recognizes, a declared `network`/`secret`
+# is from the allowed, default-closed set, and a `token` grant is `sigstore` and
+# only on a `kind: attest` entry. A `delivery: image` entry must also name
 # an image. Any entry naming an `image` (image-delivery or not) must be digest-pinned
 # (@sha256: + 64 hex, never a bare tag / :latest / @latest) on the curated namespace
 # ghcr.io/tomhennen/wrangle/<tool> — adopter overrides never live in this in-repo
@@ -45,7 +46,7 @@ validate_catalog() {
         return 1
     fi
 
-    local tool kind delivery image network secret
+    local tool kind delivery image network secret token
     while IFS= read -r tool; do
         [[ -z "$tool" ]] && continue
 
@@ -68,6 +69,20 @@ validate_catalog() {
         if [[ -n "$secret" ]] && [[ ! "$secret" =~ $CATALOG_SECRET_NAME_RE ]]; then
             printf 'check_catalog: %s: invalid secret name: %s\n' "$tool" "$secret" >&2
             rc=1
+        fi
+
+        # The token grant lets the host mint an OIDC token into the container, so
+        # it is confined to the curated attest toolbox — never a scan/sbom tool.
+        token="$(read_catalog_field "$file" "$tool" token)"
+        if [[ -n "$token" ]]; then
+            if [[ ! "$token" =~ $CATALOG_TOKEN_RE ]]; then
+                printf 'check_catalog: %s: invalid token value: %s\n' "$tool" "$token" >&2
+                rc=1
+            fi
+            if [[ "$kind" != "attest" ]]; then
+                printf 'check_catalog: %s: token grant forbidden on kind %s (attest only)\n' "$tool" "$kind" >&2
+                rc=1
+            fi
         fi
 
         # Same allowlist run.sh enforces: empty/adapter/image. A typo'd value must

--- a/tools/check_catalog.sh
+++ b/tools/check_catalog.sh
@@ -71,8 +71,8 @@ validate_catalog() {
             rc=1
         fi
 
-        # The token grant lets the host mint an OIDC token into the container, so
-        # it is confined to the curated attest toolbox — never a scan/sbom tool.
+        # A token grant is confined to the curated attest toolbox (kind: attest) —
+        # never a scan/sbom tool.
         token="$(read_catalog_field "$file" "$tool" token)"
         if [[ -n "$token" ]]; then
             if [[ ! "$token" =~ $CATALOG_TOKEN_RE ]]; then


### PR DESCRIPTION
claude: Phase 3 Tranche A1 for #619 — the decision-independent precondition that adds the `token` capability to the catalog schema and validators, with **no production behavior change**.

## What this adds
A catalog capability grant `token: sigstore`, meaning "the host may mint an `aud=sigstore` `SIGSTORE_ID_TOKEN` into this container" — the OIDC-token analogue of the existing `secret: github-token` grant. Schema + validators only; **nothing consumes the grant yet** (Tranche B/D will).

- `lib/catalog_rules.sh`: `CATALOG_TOKEN_RE` (value ∈ {`sigstore`}).
- `tools/check_catalog.sh`: validates a `token` field and **forbids it on any non-`attest` entry** — a `kind: scan` or `kind: sbom` entry carrying `token:` fails the catalog check (security-critical: only the curated attest toolbox may mint an OIDC token into its container).
- `lib/merge_catalog.sh`: **forbids `token` on any custom adopter tool** — an out-of-namespace entry can never carry it.
- `docs/tool_container_design.md` §3.7: documents the grant (default-closed, from the trusting party, curated-attest-only).

## Production behavior unchanged
- **`tools/catalog.json` is untouched** — the live `attest-toolbox` entry does NOT gain `token: sigstore`. Adding the live grant is Tranche D's job.
- **No activation logic touched** — `actions/verify/run_verify.sh` and `WRANGLE_VERIFY_AMPEL_TOOLBOX` are byte-for-byte unchanged. The production release path signs+verifies in-job exactly as before.

## A2 deferred pending an owner activation-mechanism decision
Tranche A2 (refactor toolbox activation from the env var to catalog-driven) is **not** in this PR. A2's production default stays OFF under any grant-keyed model, because the live `attest-toolbox` entry carries **no `token` grant** (A1 deliberately did not add one) — so activation resolves to in-job in production regardless. What needs an owner call is the *mechanism*, because the two viable models diverge once Tranche D flips the grant on:

- **Pure grant-driven** (env `WRANGLE_VERIFY_AMPEL_TOOLBOX` demoted to a `=0` break-glass disable): grant present ⇒ containerize. Post-D this containerizes even when the env is unset, which **contradicts** `docs/tool_container_design.md` §~386 ("`WRANGLE_VERIFY_AMPEL_TOOLBOX` unset falls back to in-job").
- **Grant + explicit opt-in** (grant present AND env explicitly set; unset/`=0` ⇒ in-job): matches §386's documented break-glass, at the cost of a second gate.

Both are a pure mechanism refactor for A2 (production stays in-job either way); they differ only on the post-D containerized-default semantics. That choice is the owner's, so A2 is deferred rather than guessed.

## Tests
- `test/test_check_catalog.bats`: 19 ok (added: token on attest passes; invalid token value fails; token on scan forbidden; token on sbom forbidden).
- `test/test_merge_catalog.bats`: 20 ok (added: custom tool carrying a token grant is rejected).
- shellcheck + wrangle-shell-lint clean; live `tools/catalog.json` still validates.

Refs #619