### PR TITLE
claude: fix(container): accept mixed-case imagename so it normalizes (Fixes #687)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      uses: TomHennen/wrangle/build/actions/container@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/go/checks@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/go/build@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_provenance@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/npm@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_provenance@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/build/actions/python@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/attest_provenance@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+        uses: TomHennen/wrangle/build/actions/shell@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+        uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      uses: TomHennen/wrangle/tools/scorecard@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+      uses: TomHennen/wrangle/tools/dependency-review@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@b722f88b7856286407c63e964cc680fc1bb5f075 # worktree-issue424-ampel-bump 2026-07-03
+    - uses: TomHennen/wrangle/actions/verify@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -63,6 +63,14 @@ teardown() {
     grep -q '^shortname=pkg_foo$' "$GITHUB_OUTPUT"
 }
 
+@test "container: validate_inputs.sh accepts a mixed-case owner and lowercases it" {
+    # github.repository preserves owner case; the example passes
+    # ghcr.io/${{ github.repository }}/img, so TomHennen/... must be accepted.
+    run "$ACTION_DIR/validate_inputs.sh" "pkg/foo" "ghcr.io" "ghcr.io/TomHennen/Img" "enabled"
+    [[ "$status" -eq 0 ]]
+    grep -q '^imagename=ghcr.io/tomhennen/img$' "$GITHUB_OUTPUT"
+}
+
 @test "container: validate_inputs.sh at root '.' emits an empty shortname (clean names)" {
     run "$ACTION_DIR/validate_inputs.sh" "." "ghcr.io" "ghcr.io/owner/img" "enabled"
     [[ "$status" -eq 0 ]]

--- a/build/actions/container/validate_inputs.sh
+++ b/build/actions/container/validate_inputs.sh
@@ -56,7 +56,9 @@ if [[ ! "$INPUT_REGISTRY" =~ ^[a-z0-9.-]+$ ]]; then
     printf 'Error: invalid registry: %s\n' "$INPUT_REGISTRY" >&2
     exit 1
 fi
-if [[ ! "$INPUT_IMAGENAME" =~ ^[a-z0-9./:_-]+$ ]]; then
+# Uppercase is accepted and lowercased below: `github.repository` preserves
+# owner case, so an owner like `TomHennen` must normalize, not be rejected.
+if [[ ! "$INPUT_IMAGENAME" =~ ^[a-zA-Z0-9./:_-]+$ ]]; then
     printf 'Error: invalid image name: %s\n' "$INPUT_IMAGENAME" >&2
     exit 1
 fi


### PR DESCRIPTION
claude: Fixes #687.

## Problem
`build/actions/container/validate_inputs.sh` validated the imagename against `^[a-z0-9./:_-]+$` — no `A-Z` — **before** the `${INPUT_IMAGENAME,,}` lowercasing, making the normalization dead code. Because `github.repository` preserves owner case and the recommended example passes `imagename: ghcr.io/${{ github.repository }}/...`, any adopter whose owner has an uppercase letter (e.g. `TomHennen`) was rejected at validation with `invalid image name`. `docs/SPEC.md` says the imagename output "matches the imagename input except for case", so accept-then-normalize is the intended contract. Dogfooding never caught it because `local_publish_images.yml` only ever passes lowercase `ghcr.io/tomhennen/...`.

## Change
- Add `A-Z` to the imagename character class; the existing `,,` normalizes.
- Add a spec-derived bats test: a mixed-case owner/name is accepted and lowercased in the output. (The `rejects bad imagename` test still passes — a space is still rejected.)

## Test
`bats build/actions/container/test.bats` — 75/75 pass, including the new `accepts a mixed-case owner and lowercases it`.

Surfaced in a whole-repo review; see #698 (structural item 2: derive a validation test from the spec sentence).