### PR TITLE
claude: fix(gen_policies): splice scorecard tenet literally, not via awk gsub (Fixes #696)

### DIFF
--- a/tools/gen_policies/gen.sh
+++ b/tools/gen_policies/gen.sh
@@ -24,21 +24,36 @@ ECOS=(go npm python container)
 # for strict, and write policies/wrangle-<tier>-<eco>-v1.hjson.
 emit() {
     local tier="$1" eco="$2"
-    local scorecard_tenet="" strict_doc="" strict_desc=""
+    local scorecard_file="" strict_doc="" strict_desc=""
     if [[ "$tier" == "strict" ]]; then
-        scorecard_tenet="$(cat "$SCORECARD")"
+        scorecard_file="$SCORECARD"
         strict_doc=" It also requires an OpenSSF Scorecard aggregate score >= 7.0."
         strict_desc=" plus OpenSSF Scorecard >= 7.0"
     fi
+    # The scorecard tenet is spliced literally (getline + index/substr), never via
+    # gsub — CEL `&&` and `\.`-escaped regexes would otherwise be reinterpreted as
+    # gsub replacement metacharacters. The other tokens are fixed and gsub-safe.
     awk -v tier="$tier" -v eco="$eco" \
-        -v scorecard="$scorecard_tenet" \
+        -v scorecard_file="$scorecard_file" \
         -v strict_doc="$strict_doc" -v strict_desc="$strict_desc" '
+        BEGIN {
+            scorecard = ""
+            first = 1
+            while (scorecard_file != "" && (getline line < scorecard_file) > 0) {
+                if (first) { scorecard = line; first = 0 }
+                else { scorecard = scorecard "\n" line }
+            }
+            if (scorecard_file != "") close(scorecard_file)
+            tok = "@SCORECARD_TENET@"
+        }
         {
             gsub(/@TIER@/, tier)
             gsub(/@ECO@/, eco)
             gsub(/@STRICT_DOC@/, strict_doc)
             gsub(/@STRICT_DESC@/, strict_desc)
-            gsub(/@SCORECARD_TENET@/, scorecard)
+            while ((p = index($0, tok)) > 0) {
+                $0 = substr($0, 1, p - 1) scorecard substr($0, p + length(tok))
+            }
             print
         }
     ' "$TEMPLATE" > "$OUT_DIR/wrangle-$tier-$eco-v1.hjson"

--- a/tools/gen_policies/test.bats
+++ b/tools/gen_policies/test.bats
@@ -46,6 +46,22 @@ setup() {
     [ "$status" -ne 0 ]
 }
 
+@test "gen_policies: scorecard tenet is spliced literally (CEL && and \\. survive)" {
+    # A gsub-based splice would reinterpret & (whole-match) and backslashes in
+    # the tenet; run a copy of the generator against a fixture carrying both.
+    local gendir="$BATS_TEST_TMPDIR/gendir" out="$BATS_TEST_TMPDIR/out"
+    mkdir -p "$gendir" "$out"
+    cp "$GEN_DIR/gen.sh" "$GEN_DIR/policy.hjson.in" "$gendir/"
+    printf '%s\n' \
+        '        {' \
+        '            code: "score >= 7.0 && matches(id, \"v[0-9]\\.[0-9]\")"' \
+        '        }' > "$gendir/scorecard-tenet.hjson.in"
+    "$gendir/gen.sh" "$out"
+    run grep -F 'code: "score >= 7.0 && matches(id, \"v[0-9]\\.[0-9]\")"' \
+        "$out/wrangle-strict-go-v1.hjson"
+    [ "$status" -eq 0 ]
+}
+
 @test "gen_policies: every generated PolicySet keeps the identity-binding markers" {
     "$GEN_DIR/gen.sh" "$BATS_TEST_TMPDIR"
     for eco in "${ECOS[@]}"; do


### PR DESCRIPTION
claude: Fixes #696.

## Problem
`tools/gen_policies/gen.sh` spliced the strict-tier scorecard tenet with `gsub(/@SCORECARD_TENET@/, scorecard)` and passed it via `awk -v scorecard=...`. Both reinterpret metacharacters: `gsub`'s replacement treats `&` as the whole match and processes `\`, and `awk -v` processes backslash escapes in the value. Today's `scorecard-tenet.hjson.in` contains neither, so it's latent — but a CEL `&&` or a `\.`-escaped identity regex (both idiomatic here; `policy.hjson.in` already uses `\\.` escapes) would silently corrupt the generated strict PolicySets, and the drift detector **cannot** catch it because the committed files are produced by the same mangling.

## Change
- Read the tenet via `getline` from the file (no `-v` backslash processing) and splice it with `index`/`substr` — verbatim, no metachar reinterpretation. The other tokens (`@TIER@`, `@ECO@`, `@STRICT_DOC@`, `@STRICT_DESC@`) are fixed strings and stay on `gsub`.
- Regression test runs a **copy** of the generator against a fixture tenet containing `score >= 7.0 && matches(id, "v[0-9]\.[0-9]")` and asserts it survives verbatim (hermetic; no production test hook).

## Verification
- All 8 committed PolicySets regenerate **byte-identical** (`diff` clean) — behavior-preserving.
- New test passes on the fix and **fails on the pre-fix generator** (old `gsub` renders `&&` as `@SCORECARD_TENET@@SCORECARD_TENET@` and drops the escaped quotes), confirming it guards the right thing.
- `bats tools/gen_policies/test.bats` 6/6; shellcheck clean.

See #698 (structural item 3: parsers/literal handling over metachar-reinterpreting text tools).