### PR TITLE
claude: fix(sanitize): strip HTML tags across line boundaries (partially addresses #692)

### DIFF
--- a/lib/sanitize.sh
+++ b/lib/sanitize.sh
@@ -16,6 +16,7 @@ MAX_SUMMARY_LENGTH="${WRANGLE_MAX_SUMMARY:-65536}"
 # Strip HTML tags from input to prevent markdown/HTML injection.
 # Uses printf '%s' for untrusted content per CLAUDE.md.
 wrangle_sanitize_output() {
-    # Remove HTML tags, then truncate
-    sed 's/<[^>]*>//g' | head -c "$MAX_SUMMARY_LENGTH"
+    # Slurp the whole stream before stripping so a tag split across lines
+    # (<img src=x\nonerror=...>) can't survive a line-by-line pass, then truncate.
+    sed ':a;$!{N;ba};s/<[^>]*>//g' | head -c "$MAX_SUMMARY_LENGTH"
 }

--- a/test/test_sanitize.bats
+++ b/test/test_sanitize.bats
@@ -30,6 +30,16 @@ setup() {
     [[ "$result" == "bold" ]]
 }
 
+@test "sanitize: strips a tag split across lines" {
+    # A line-by-line strip leaves a newline-spanning tag intact; the whole
+    # stream must be considered.
+    result="$(printf '<img src=x\nonerror=alert(1)>hello' | wrangle_sanitize_output)"
+
+    [[ "$result" == "hello" ]]
+    [[ "$result" != *"onerror"* ]]
+    [[ "$result" != *"<img"* ]]
+}
+
 @test "sanitize: passes plain text through unchanged" {
     result="$(printf 'No HTML here, just text.' | wrangle_sanitize_output)"
 


### PR DESCRIPTION
claude: Partially addresses #692 (the multi-line-tag half).

## Problem
`lib/sanitize.sh`'s `sed 's/<[^>]*>//g'` is line-based, so a tag split across two lines survives into `GITHUB_STEP_SUMMARY`. Verified:
```
$ printf '<img src=x\nonerror=x>hello\n' | wrangle_sanitize_output
<img src=x
onerror=x>hello
```
(Impact is spoofed summary content, not XSS — GitHub blocks scripts — and the pass/fail gate is unaffected; but summary integrity is the control's job.)

## Change
Slurp the whole stream before stripping (`sed ':a;$!{N;ba};s/<[^>]*>//g'`) so a newline-spanning tag is removed. Chose the `$!{N;ba}` form deliberately: the more common `:a;N;$!ba` idiom skips the substitution on single-line input (GNU sed's `N` prints-and-exits at EOF), which would regress the existing single-line tag tests. Single-line, plain, and empty input are unchanged; truncation still applies.

## Test
New `strips a tag split across lines` case; `bats test/test_sanitize.bats` 7/7, and the four consumer suites (`test_sanitized_summary`, `test_sarif_to_md`, `test_log_findings`, `test_check_results`) all pass — 71 ok, no failures. shellcheck clean.

## Deliberately NOT in this PR (kept #692 open)
The **backtick / code-fence-escape** bypass (untrusted content closing the ``` fence in `format_sarif_summary.sh` to inject fake markdown) can't be fixed in this shared function without breaking the consumer that renders `output.md` as intended markdown (where backticks are legitimate). That needs a fence-vs-markdown split — an architectural call for the owner. Details in #692 / #698 (structural item 3).