### PR TITLE
claude: fix(syft): exact version match in idempotency check (addresses one item in #697)

### DIFF
--- a/tools/syft/install.sh
+++ b/tools/syft/install.sh
@@ -26,8 +26,8 @@ BIN_DIR="${WRANGLE_BIN_DIR:-${RUNNER_TEMP:-.}/.wrangle/bin}"
 
 # Idempotency: skip if the requested version is already on disk.
 if [[ -x "${BIN_DIR}/${TOOL_NAME}" ]]; then
-    installed_version="$("${BIN_DIR}/${TOOL_NAME}" version --output json 2>/dev/null | grep -o '"version":"[^"]*"' | head -1 || true)"
-    if [[ "$installed_version" == *"${VERSION}"* ]]; then
+    installed_version="$("${BIN_DIR}/${TOOL_NAME}" version --output json 2>/dev/null | grep -o '"version":"[^"]*"' | head -1 | sed 's/^"version":"//; s/"$//' || true)"
+    if [[ "$installed_version" == "${VERSION}" ]]; then
         printf 'wrangle: %s %s already installed\n' "$TOOL_NAME" "$VERSION"
         exit 0
     fi

--- a/tools/syft/test.bats
+++ b/tools/syft/test.bats
@@ -34,6 +34,18 @@ MOCK
     [[ "$output" == *"already installed"* ]]
 }
 
+@test "syft install: a version that only shares a prefix is not treated as installed" {
+    # 1.42.40 must not satisfy a request for 1.42.4 (substring match bug).
+    cat > "$WRANGLE_BIN_DIR/syft" << 'MOCK'
+#!/bin/bash
+printf '{"application":"syft","version":"1.42.40","buildDate":""}'
+MOCK
+    chmod +x "$WRANGLE_BIN_DIR/syft"
+
+    run "$ORIG_DIR/tools/syft/install.sh" "1.42.4"
+    [[ "$output" != *"already installed"* ]]
+}
+
 @test "syft install: fails fast if cosign is not on PATH" {
     # Mock curl to return any content (so download succeeds), then ensure
     # cosign is not findable. install.sh must abort before tarball download.


### PR DESCRIPTION
claude: Addresses the syft item in #697.

## Problem
`tools/syft/install.sh` idempotency used `[[ "$installed_version" == *"${VERSION}"* ]]` — a substring match. An installed `1.42.40` satisfies a request for `1.42.4`, so install is skipped with the wrong binary in place.

## Change
Extract the version value from the `--output json` blob and compare it exactly (`==`). Added a regression test: an installed `1.42.40` must not be treated as satisfying `1.42.4` (it proceeds past the idempotency gate rather than printing "already installed").

## Test
`bats tools/syft/test.bats` — all pass, including the existing exact-match skip and the new prefix-mismatch case. shellcheck clean (the SC1091 is the pre-existing lib-source info).