### PR TITLE
claude: #619 Phase 3 — containerized signing (all 3 sign sites)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      uses: TomHennen/wrangle/build/actions/container@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -90,16 +90,6 @@ on:
         required: false
         type: string
         default: policies/wrangle-default-container-v1.hjson
-      verify-in-container:
-        description: |
-          Run the attest/verify signing (bnd/cosign/wrangle-attest/ampel) inside
-          the curated, VSA-verified attest-toolbox image instead of in-job
-          from-source binaries. Default false (in-job). Requires the catalog's
-          attest-toolbox token: sigstore grant; set WRANGLE_VERIFY_AMPEL_TOOLBOX=0
-          in the environment to force in-job as a break-glass.
-        required: false
-        type: boolean
-        default: false
     secrets:
       gh_token:
         description: "GitHub token with write access"
@@ -238,9 +228,6 @@ jobs:
       attestations: write   # write the attestations to GitHub's store
       packages: write       # push the provenance + metadata referrers to ghcr
       contents: read
-    env:
-      # Opt into containerized signing; the composite action's steps inherit this.
-      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     steps:
       # push-to-registry / cosign attach authenticate to ghcr with the job's
       # GITHUB_TOKEN, like the build and verify jobs. Same pin as the verify
@@ -285,9 +272,6 @@ jobs:
       id-token: write       # bnd keyless-signs the VSA via this workflow's OIDC identity
       attestations: write   # post the VSA to the GitHub attestation store
       packages: write       # push the VSA referrer to ghcr
-    env:
-      # Opt into containerized signing; the composite action's steps inherit this.
-      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     steps:
       # Pushing the VSA referrer to ghcr needs registry auth. Same pin as
       # the attest job's cosign-installer — bump in lockstep.

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      uses: TomHennen/wrangle/build/actions/container@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      uses: TomHennen/wrangle/build/actions/container@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -90,6 +90,16 @@ on:
         required: false
         type: string
         default: policies/wrangle-default-container-v1.hjson
+      verify-in-container:
+        description: |
+          Run the attest/verify signing (bnd/cosign/wrangle-attest/ampel) inside
+          the curated, VSA-verified attest-toolbox image instead of in-job
+          from-source binaries. Default false (in-job). Requires the catalog's
+          attest-toolbox token: sigstore grant; set WRANGLE_VERIFY_AMPEL_TOOLBOX=0
+          in the environment to force in-job as a break-glass.
+        required: false
+        type: boolean
+        default: false
     secrets:
       gh_token:
         description: "GitHub token with write access"
@@ -228,6 +238,9 @@ jobs:
       attestations: write   # write the attestations to GitHub's store
       packages: write       # push the provenance + metadata referrers to ghcr
       contents: read
+    env:
+      # Opt into containerized signing; the composite action's steps inherit this.
+      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     steps:
       # push-to-registry / cosign attach authenticate to ghcr with the job's
       # GITHUB_TOKEN, like the build and verify jobs. Same pin as the verify
@@ -272,6 +285,9 @@ jobs:
       id-token: write       # bnd keyless-signs the VSA via this workflow's OIDC identity
       attestations: write   # post the VSA to the GitHub attestation store
       packages: write       # push the VSA referrer to ghcr
+    env:
+      # Opt into containerized signing; the composite action's steps inherit this.
+      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     steps:
       # Pushing the VSA referrer to ghcr needs registry auth. Same pin as
       # the attest job's cosign-installer — bump in lockstep.

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -129,6 +129,16 @@ on:
         required: false
         type: string
         default: sbom
+      verify-in-container:
+        description: |
+          Run the attest/verify signing (bnd/cosign/wrangle-attest/ampel) inside
+          the curated, VSA-verified attest-toolbox image instead of in-job
+          from-source binaries. Default false (in-job). Requires the catalog's
+          attest-toolbox token: sigstore grant; set WRANGLE_VERIFY_AMPEL_TOOLBOX=0
+          in the environment to force in-job as a break-glass.
+        required: false
+        type: boolean
+        default: false
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -368,6 +378,9 @@ jobs:
       id-token: write       # OIDC for Sigstore keyless signing
       attestations: write   # write the attestation to GitHub's store
       contents: read        # download-artifact reads the same-run dist
+    env:
+      # Opt into containerized signing; the composite action's steps inherit this.
+      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     outputs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
@@ -399,6 +412,9 @@ jobs:
       id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
       attestations: write   # post each VSA to the GitHub attestation store
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
+    env:
+      # Opt into containerized signing; the composite action's steps inherit this.
+      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -129,16 +129,6 @@ on:
         required: false
         type: string
         default: sbom
-      verify-in-container:
-        description: |
-          Run the attest/verify signing (bnd/cosign/wrangle-attest/ampel) inside
-          the curated, VSA-verified attest-toolbox image instead of in-job
-          from-source binaries. Default false (in-job). Requires the catalog's
-          attest-toolbox token: sigstore grant; set WRANGLE_VERIFY_AMPEL_TOOLBOX=0
-          in the environment to force in-job as a break-glass.
-        required: false
-        type: boolean
-        default: false
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -378,9 +368,6 @@ jobs:
       id-token: write       # OIDC for Sigstore keyless signing
       attestations: write   # write the attestation to GitHub's store
       contents: read        # download-artifact reads the same-run dist
-    env:
-      # Opt into containerized signing; the composite action's steps inherit this.
-      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     outputs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
@@ -412,9 +399,6 @@ jobs:
       id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
       attestations: write   # post each VSA to the GitHub attestation store
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
-    env:
-      # Opt into containerized signing; the composite action's steps inherit this.
-      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/build@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/build@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/build@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -110,6 +110,16 @@ on:
         required: false
         type: string
         default: sbom
+      verify-in-container:
+        description: |
+          Run the attest/verify signing (bnd/cosign/wrangle-attest/ampel) inside
+          the curated, VSA-verified attest-toolbox image instead of in-job
+          from-source binaries. Default false (in-job). Requires the catalog's
+          attest-toolbox token: sigstore grant; set WRANGLE_VERIFY_AMPEL_TOOLBOX=0
+          in the environment to force in-job as a break-glass.
+        required: false
+        type: boolean
+        default: false
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -285,6 +295,9 @@ jobs:
       id-token: write       # OIDC for Sigstore keyless signing
       attestations: write   # write the attestation to GitHub's store
       contents: read        # download-artifact reads the same-run dist
+    env:
+      # Opt into containerized signing; the composite action's steps inherit this.
+      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     outputs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
@@ -310,6 +323,9 @@ jobs:
       id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
       attestations: write   # post each VSA to the GitHub attestation store
       contents: write       # create the release if absent and attach the bundle on tag pushes
+    env:
+      # Opt into containerized signing; the composite action's steps inherit this.
+      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/npm@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/npm@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/npm@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -110,16 +110,6 @@ on:
         required: false
         type: string
         default: sbom
-      verify-in-container:
-        description: |
-          Run the attest/verify signing (bnd/cosign/wrangle-attest/ampel) inside
-          the curated, VSA-verified attest-toolbox image instead of in-job
-          from-source binaries. Default false (in-job). Requires the catalog's
-          attest-toolbox token: sigstore grant; set WRANGLE_VERIFY_AMPEL_TOOLBOX=0
-          in the environment to force in-job as a break-glass.
-        required: false
-        type: boolean
-        default: false
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -295,9 +285,6 @@ jobs:
       id-token: write       # OIDC for Sigstore keyless signing
       attestations: write   # write the attestation to GitHub's store
       contents: read        # download-artifact reads the same-run dist
-    env:
-      # Opt into containerized signing; the composite action's steps inherit this.
-      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     outputs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
@@ -323,9 +310,6 @@ jobs:
       id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
       attestations: write   # post each VSA to the GitHub attestation store
       contents: write       # create the release if absent and attach the bundle on tag pushes
-    env:
-      # Opt into containerized signing; the composite action's steps inherit this.
-      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -90,16 +90,6 @@ on:
         required: false
         type: string
         default: sbom
-      verify-in-container:
-        description: |
-          Run the attest/verify signing (bnd/cosign/wrangle-attest/ampel) inside
-          the curated, VSA-verified attest-toolbox image instead of in-job
-          from-source binaries. Default false (in-job). Requires the catalog's
-          attest-toolbox token: sigstore grant; set WRANGLE_VERIFY_AMPEL_TOOLBOX=0
-          in the environment to force in-job as a break-glass.
-        required: false
-        type: boolean
-        default: false
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -282,9 +272,6 @@ jobs:
       id-token: write       # OIDC for Sigstore keyless signing
       attestations: write   # write the attestation to GitHub's store
       contents: read        # download-artifact reads the same-run dist
-    env:
-      # Opt into containerized signing; the composite action's steps inherit this.
-      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     outputs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
@@ -310,9 +297,6 @@ jobs:
       id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
       attestations: write   # post each VSA to the GitHub attestation store
       contents: write       # create the release if absent and attach the bundle on tag pushes
-    env:
-      # Opt into containerized signing; the composite action's steps inherit this.
-      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -90,6 +90,16 @@ on:
         required: false
         type: string
         default: sbom
+      verify-in-container:
+        description: |
+          Run the attest/verify signing (bnd/cosign/wrangle-attest/ampel) inside
+          the curated, VSA-verified attest-toolbox image instead of in-job
+          from-source binaries. Default false (in-job). Requires the catalog's
+          attest-toolbox token: sigstore grant; set WRANGLE_VERIFY_AMPEL_TOOLBOX=0
+          in the environment to force in-job as a break-glass.
+        required: false
+        type: boolean
+        default: false
     outputs:
       hashes:
         description: "Base64-encoded SHA-256 hashes of built artifacts (for SLSA provenance)"
@@ -272,6 +282,9 @@ jobs:
       id-token: write       # OIDC for Sigstore keyless signing
       attestations: write   # write the attestation to GitHub's store
       contents: read        # download-artifact reads the same-run dist
+    env:
+      # Opt into containerized signing; the composite action's steps inherit this.
+      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     outputs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
@@ -297,6 +310,9 @@ jobs:
       id-token: write       # bnd keyless-signs each VSA via this workflow's OIDC identity
       attestations: write   # post each VSA to the GitHub attestation store
       contents: write       # create the release if absent and attach the bundle on tag pushes
+    env:
+      # Opt into containerized signing; the composite action's steps inherit this.
+      WRANGLE_VERIFY_AMPEL_TOOLBOX: ${{ inputs.verify-in-container }}
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
       - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/python@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/python@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/python@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+        uses: TomHennen/wrangle/build/actions/shell@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+        uses: TomHennen/wrangle/build/actions/shell@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+        uses: TomHennen/wrangle/build/actions/shell@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+        uses: TomHennen/wrangle/actions/scan@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+        uses: TomHennen/wrangle/actions/scan@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+        uses: TomHennen/wrangle/actions/scan@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/local_publish_images.yml
+++ b/.github/workflows/local_publish_images.yml
@@ -43,10 +43,9 @@ jobs:
           - path: tools/osv
             imagename: ghcr.io/tomhennen/wrangle/osv
           # The attest/verify toolbox (ampel + bnd + cosign + wrangle-attest in
-          # one image). Built like the scan images, but it is not a sandboxed
-          # adapter — it is the SLSA-L3 signing path that needs network + the
-          # OIDC token at run time, consumed under the pinned catalog digest by
-          # the containerized signing above (verify-in-container).
+          # one image). Built like the scan images, but it is the SLSA-L3 signing
+          # path that needs network + the OIDC token at run time, consumed under
+          # the pinned catalog digest by the containerized signing.
           - path: tools/attest-toolbox
             imagename: ghcr.io/tomhennen/wrangle/attest-toolbox
           - path: tools/wrangle-lint
@@ -62,9 +61,6 @@ jobs:
       imagename: ${{ matrix.imagename }}
       registry: ghcr.io
       release-events: main-and-tags
-      # Dogfood containerized signing: sign each image's VSA inside the curated,
-      # VSA-verified attest-toolbox (consume-the-pin, #619). Break-glass: set false.
-      verify-in-container: true
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/local_publish_images.yml
+++ b/.github/workflows/local_publish_images.yml
@@ -45,8 +45,8 @@ jobs:
           # The attest/verify toolbox (ampel + bnd + cosign + wrangle-attest in
           # one image). Built like the scan images, but it is not a sandboxed
           # adapter — it is the SLSA-L3 signing path that needs network + the
-          # OIDC token at run time. Publishing the image here is inert; wiring a
-          # signing job to RUN it is a separate, flagged step (#596).
+          # OIDC token at run time, consumed under the pinned catalog digest by
+          # the containerized signing above (verify-in-container).
           - path: tools/attest-toolbox
             imagename: ghcr.io/tomhennen/wrangle/attest-toolbox
           - path: tools/wrangle-lint
@@ -62,6 +62,9 @@ jobs:
       imagename: ${{ matrix.imagename }}
       registry: ghcr.io
       release-events: main-and-tags
+      # Dogfood containerized signing: sign each image's VSA inside the curated,
+      # VSA-verified attest-toolbox (consume-the-pin, #619). Break-glass: set false.
+      verify-in-container: true
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/actions/attest_metadata_oci/test_sign_metadata.bats
+++ b/actions/attest_metadata_oci/test_sign_metadata.bats
@@ -31,6 +31,10 @@ setup() {
 
     ATTEST_BIN="$(command -v wrangle-attest || echo "${WRANGLE_BIN_DIR}/wrangle-attest")"
     export ATTEST_BIN
+
+    # Signing always containerizes; make the toolbox path transparent so the
+    # tool stubs run. Written after META so its stubs sit on PATH for $SIGN.
+    wrangle_stub_toolbox_transparent
 }
 
 teardown() {

--- a/actions/attest_provenance/test_sign_metadata.bats
+++ b/actions/attest_provenance/test_sign_metadata.bats
@@ -39,6 +39,10 @@ setup() {
 
     ATTEST_BIN="$(command -v wrangle-attest || echo "${WRANGLE_BIN_DIR}/wrangle-attest")"
     export ATTEST_BIN
+
+    # Signing always containerizes; make the toolbox path transparent so the
+    # tool stubs run. Recording-docker/fail-closed tests override.
+    wrangle_stub_toolbox_transparent
 }
 
 teardown() {

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      uses: TomHennen/wrangle/tools/scorecard@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+      uses: TomHennen/wrangle/tools/dependency-review@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      uses: TomHennen/wrangle/tools/scorecard@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      uses: TomHennen/wrangle/tools/dependency-review@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      uses: TomHennen/wrangle/tools/scorecard@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+      uses: TomHennen/wrangle/tools/dependency-review@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
 
     - name: Generate step summary
       if: always()

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -112,22 +112,21 @@ wrangle_bnd_sign_args() {
 # job's registry login and GITHUB_TOKEN to read attestations from ghcr.
 wrangle_ampel() {
     wrangle_toolbox_optin || { ampel "$@"; return; }
-    local results_dir policy
-    results_dir="$(cd "$(dirname "${WRANGLE_AMPEL_RESULTS:?wrangle_ampel needs WRANGLE_AMPEL_RESULTS set}")" && pwd)"
-    # Mount the resolved policy's actual parent, not a hardcoded policies/: a
-    # relative policy resolves to $REPO_ROOT/<policy>, which may sit elsewhere. A
-    # network locator (*://*) is fetched, not read from disk, so it needs no mount.
+    # The bundle, results path, and (relative) BUNDLE_OUT ride the workspace/temp
+    # mounts wrangle_toolbox_exec sets up. Only the policy dir needs an extra
+    # mount: a disk policy resolves under the action checkout, outside the
+    # workspace; a network locator (*://*) is fetched, not read from disk.
+    local policy
     policy="$(wrangle_resolve_policy "$POLICY")"
-    local -a m=()
-    wrangle_toolbox_add_mount m "$BUNDLE_OUT" ro
+    local -a extra=()
     case "$policy" in
         *://*) ;;
-        *)     wrangle_toolbox_add_mount m "$(dirname "$policy")" ro ;;
+        *)     extra+=(--mount "$(dirname "$policy")") ;;
     esac
-    wrangle_toolbox_add_mount m "$results_dir" rw
-    local -a extra=()
-    [[ -n "${COLLECTOR:-}" ]] && extra=(--docker-config --env GITHUB_TOKEN)
-    wrangle_toolbox_exec "${m[@]}" "${extra[@]}" -- ampel "$@"
+    # An oci: collector reads attestations from ghcr; give it the job's registry
+    # login and GITHUB_TOKEN. No signing token — verify never signs.
+    [[ -n "${COLLECTOR:-}" ]] && extra+=(--docker-config --env GITHUB_TOKEN)
+    wrangle_toolbox_exec "${extra[@]}" -- ampel "$@"
 }
 
 # ampel verify one subject -> unsigned VSA at $2, streaming the report to the
@@ -148,8 +147,6 @@ wrangle_verify_emit_vsa() {
     # the policy verdict, and piping straight into the truncating sanitizer could
     # SIGPIPE ampel and flip a PASS into a blocked release.
     report="$(mktemp)"
-    # The container ampel path (opt-in) mounts the dir holding the unsigned VSA.
-    local WRANGLE_AMPEL_RESULTS="$results_path"
     wrangle_retry_once "$report" wrangle_ampel "${args[@]}" || rc=$?
     wrangle_sanitize_output < "$report" >> "$GITHUB_STEP_SUMMARY"
     # The step summary is easy to miss, so echo a failed report to the job log.
@@ -172,11 +169,11 @@ wrangle_sign_vsa() {
     mv "$vsa" "$vsa.unsigned"
     local rc=0
     if wrangle_toolbox_signing_enabled; then
+        # The unsigned VSA rides the workspace/temp mounts; fail closed on a mint
+        # failure rather than leaking the request vars to an in-job fallback.
         if wrangle_mint_sigstore_token; then
-            local -a m=()
-            wrangle_toolbox_add_mount m "$(dirname "$vsa")" ro
             wrangle_retry_once "$vsa" wrangle_toolbox_exec \
-                "${m[@]}" --env SIGSTORE_ID_TOKEN -- bnd "${args[@]}" || rc=$?
+                --env SIGSTORE_ID_TOKEN -- bnd "${args[@]}" || rc=$?
         else
             rc=1
         fi

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -105,17 +105,12 @@ wrangle_bnd_sign_args() {
     printf '%s\n' statement "$1"
 }
 
-# Dispatch ampel: the in-job binary, or — under the WRANGLE_VERIFY_AMPEL_TOOLBOX
-# opt-in — the catalog's attest-toolbox image, VSA-verified host-side before it
-# runs (the host is the verifier, never the container). Verify never signs, so no
-# signing token enters the container; an oci: collector additionally gets the
-# job's registry login and GITHUB_TOKEN to read attestations from ghcr.
+# Run ampel verify in the VSA-gated toolbox image. The bundle, results path, and
+# (relative) BUNDLE_OUT ride the workspace/temp mounts; only the policy dir needs
+# an extra mount — a disk policy resolves under the action checkout, outside the
+# workspace (a *://* locator is fetched, not read). An oci: collector reads
+# attestations from ghcr, so it also gets the job's registry login and token.
 wrangle_ampel() {
-    wrangle_toolbox_optin || { ampel "$@"; return; }
-    # The bundle, results path, and (relative) BUNDLE_OUT ride the workspace/temp
-    # mounts wrangle_toolbox_exec sets up. Only the policy dir needs an extra
-    # mount: a disk policy resolves under the action checkout, outside the
-    # workspace; a network locator (*://*) is fetched, not read from disk.
     local policy
     policy="$(wrangle_resolve_policy "$POLICY")"
     local -a extra=()
@@ -123,8 +118,6 @@ wrangle_ampel() {
         *://*) ;;
         *)     extra+=(--mount "$(dirname "$policy")") ;;
     esac
-    # An oci: collector reads attestations from ghcr; give it the job's registry
-    # login and GITHUB_TOKEN. No signing token — verify never signs.
     [[ -n "${COLLECTOR:-}" ]] && extra+=(--docker-config --env GITHUB_TOKEN)
     wrangle_toolbox_exec "${extra[@]}" -- ampel "$@"
 }
@@ -158,27 +151,19 @@ wrangle_verify_emit_vsa() {
     return "$rc"
 }
 
-# bnd-sign the unsigned VSA at $1 in place; the signed statement lands at $1.
-# Under the grant + opt-in the sign runs in the toolbox container (minting a
-# step-local SIGSTORE_ID_TOKEN, threaded by name); otherwise the in-job bnd signs
-# byte-for-byte (the break-glass revert).
+# bnd-sign the unsigned VSA at $1 in place (in the toolbox container, minting a
+# step-local SIGSTORE_ID_TOKEN threaded by name); the signed statement lands at $1.
 wrangle_sign_vsa() {
     local vsa="$1"
     local args
     mapfile -t args < <(wrangle_bnd_sign_args "$vsa.unsigned")
     mv "$vsa" "$vsa.unsigned"
     local rc=0
-    if wrangle_toolbox_signing_enabled; then
-        # The unsigned VSA rides the workspace/temp mounts; fail closed on a mint
-        # failure rather than leaking the request vars to an in-job fallback.
-        if wrangle_mint_sigstore_token; then
-            wrangle_retry_once "$vsa" wrangle_toolbox_exec \
-                --env SIGSTORE_ID_TOKEN -- bnd "${args[@]}" || rc=$?
-        else
-            rc=1
-        fi
+    if wrangle_mint_sigstore_token; then
+        wrangle_retry_once "$vsa" wrangle_toolbox_exec \
+            --env SIGSTORE_ID_TOKEN -- bnd "${args[@]}" || rc=$?
     else
-        wrangle_retry_once "$vsa" bnd "${args[@]}" || rc=$?
+        rc=1
     fi
     rm -f "$vsa.unsigned"
     return "$rc"

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -48,9 +48,12 @@ source "$LIB_DIR/sign_metadata.sh"
 source "$LIB_DIR/read_catalog.sh"
 # shellcheck source=../../lib/verify_image_vsa.sh
 source "$LIB_DIR/verify_image_vsa.sh"
+# Toolbox dispatch (image resolution + VSA gate + hardened docker run + token
+# mint), shared with the attest job's signer helpers.
+# shellcheck source=../../lib/toolbox_run.sh
+source "$LIB_DIR/toolbox_run.sh"
 
 WRANGLE_CATALOG="${WRANGLE_CATALOG:-$REPO_ROOT/tools/catalog.json}"
-WRANGLE_VERIFY_TOOLBOX_TOOL="attest-toolbox"
 
 # Emit the ampel subject flag for one subject, one arg per line. A digest-form
 # subject (algo:hex, e.g. a container) passes through; a file subject is hashed
@@ -102,65 +105,29 @@ wrangle_bnd_sign_args() {
     printf '%s\n' statement "$1"
 }
 
-# "egress" -> docker's default bridge; anything else -> no network.
-wrangle_toolbox_network() {
-    case "$(read_catalog_field "$WRANGLE_CATALOG" "$WRANGLE_VERIFY_TOOLBOX_TOOL" network)" in
-        egress) printf 'bridge\n' ;;
-        *)      printf 'none\n' ;;
-    esac
-}
-
-# Dispatch ampel: the in-job binary, or — when WRANGLE_VERIFY_AMPEL_TOOLBOX is
-# 1/true — the catalog's attest-toolbox image, verified host-side before it runs
-# (the host is the verifier, never the container). No token enters the container.
+# Dispatch ampel: the in-job binary, or — under the WRANGLE_VERIFY_AMPEL_TOOLBOX
+# opt-in — the catalog's attest-toolbox image, VSA-verified host-side before it
+# runs (the host is the verifier, never the container). Verify never signs, so no
+# signing token enters the container; an oci: collector additionally gets the
+# job's registry login and GITHUB_TOKEN to read attestations from ghcr.
 wrangle_ampel() {
-    case "${WRANGLE_VERIFY_AMPEL_TOOLBOX:-}" in
-        1|true) ;;
-        *) ampel "$@"; return ;;
-    esac
-    # An oci: collector needs in-container registry auth, which is deferred.
-    if [[ -n "${COLLECTOR:-}" ]]; then
-        printf 'wrangle: in-container ampel verify does not support an oci collector (%s); leave WRANGLE_VERIFY_AMPEL_TOOLBOX unset for the container build type\n' "$COLLECTOR" >&2
-        return 2
-    fi
-    local image
-    image="$(read_catalog_field "$WRANGLE_CATALOG" "$WRANGLE_VERIFY_TOOLBOX_TOOL" image)"
-    if [[ -z "$image" ]]; then
-        printf 'wrangle: WRANGLE_VERIFY_AMPEL_TOOLBOX set but catalog %s has no %s image\n' "$WRANGLE_CATALOG" "$WRANGLE_VERIFY_TOOLBOX_TOOL" >&2
-        return 2
-    fi
-    if [[ ! "$image" =~ @sha256:[0-9a-f]{64}$ ]]; then
-        printf 'wrangle: toolbox image must be @sha256:-digest-pinned (got %s)\n' "$image" >&2
-        return 2
-    fi
-    # WRANGLE_VERIFY_TOOL_IMAGES=0 is the break-glass for a sustained Sigstore outage.
-    if [[ "${WRANGLE_VERIFY_TOOL_IMAGES:-1}" == "0" ]]; then
-        printf 'wrangle: toolbox-image VSA verification disabled by configuration\n' >&2
-    elif verify_image_vsa "$image"; then
-        printf 'wrangle: toolbox-image VSA verified PASSED\n' >&2
-    else
-        printf 'wrangle: toolbox-image VSA verification failed (image not provably PASSED)\n' >&2
-        return 2
-    fi
-    local results_dir policy policy_mount net
+    wrangle_toolbox_optin || { ampel "$@"; return; }
+    local results_dir policy
     results_dir="$(cd "$(dirname "${WRANGLE_AMPEL_RESULTS:?wrangle_ampel needs WRANGLE_AMPEL_RESULTS set}")" && pwd)"
     # Mount the resolved policy's actual parent, not a hardcoded policies/: a
     # relative policy resolves to $REPO_ROOT/<policy>, which may sit elsewhere. A
     # network locator (*://*) is fetched, not read from disk, so it needs no mount.
     policy="$(wrangle_resolve_policy "$POLICY")"
+    local -a m=()
+    wrangle_toolbox_add_mount m "$BUNDLE_OUT" ro
     case "$policy" in
-        *://*) policy_mount=() ;;
-        *)     policy_mount=(-v "$(dirname "$policy")":"$(dirname "$policy")":ro) ;;
+        *://*) ;;
+        *)     wrangle_toolbox_add_mount m "$(dirname "$policy")" ro ;;
     esac
-    net="$(wrangle_toolbox_network)"
-    # No token env; non-root so the in-job step can read the VSA; no dist mount
-    # (subjects are pre-hashed in-job).
-    docker run --rm --network "$net" -u "$(id -u):$(id -g)" \
-        -v "$BUNDLE_OUT":"$BUNDLE_OUT":ro \
-        "${policy_mount[@]}" \
-        -v "$results_dir":"$results_dir" \
-        -e HOME=/tmp \
-        "$image" ampel "$@"
+    wrangle_toolbox_add_mount m "$results_dir" rw
+    local -a extra=()
+    [[ -n "${COLLECTOR:-}" ]] && extra=(--docker-config --env GITHUB_TOKEN)
+    wrangle_toolbox_exec "${m[@]}" "${extra[@]}" -- ampel "$@"
 }
 
 # ampel verify one subject -> unsigned VSA at $2, streaming the report to the
@@ -195,13 +162,29 @@ wrangle_verify_emit_vsa() {
 }
 
 # bnd-sign the unsigned VSA at $1 in place; the signed statement lands at $1.
+# Under the grant + opt-in the sign runs in the toolbox container (minting a
+# step-local SIGSTORE_ID_TOKEN, threaded by name); otherwise the in-job bnd signs
+# byte-for-byte (the break-glass revert).
 wrangle_sign_vsa() {
     local vsa="$1"
     local args
     mapfile -t args < <(wrangle_bnd_sign_args "$vsa.unsigned")
     mv "$vsa" "$vsa.unsigned"
-    wrangle_retry_once "$vsa" bnd "${args[@]}"
+    local rc=0
+    if wrangle_toolbox_signing_enabled; then
+        if wrangle_mint_sigstore_token; then
+            local -a m=()
+            wrangle_toolbox_add_mount m "$(dirname "$vsa")" ro
+            wrangle_retry_once "$vsa" wrangle_toolbox_exec \
+                "${m[@]}" --env SIGSTORE_ID_TOKEN -- bnd "${args[@]}" || rc=$?
+        else
+            rc=1
+        fi
+    else
+        wrangle_retry_once "$vsa" bnd "${args[@]}" || rc=$?
+    fi
     rm -f "$vsa.unsigned"
+    return "$rc"
 }
 
 # Push the signed VSA at $1 as its own OCI referrer (container only). Fails

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -159,12 +159,8 @@ wrangle_sign_vsa() {
     mapfile -t args < <(wrangle_bnd_sign_args "$vsa.unsigned")
     mv "$vsa" "$vsa.unsigned"
     local rc=0
-    if wrangle_mint_sigstore_token; then
-        wrangle_retry_once "$vsa" wrangle_toolbox_exec \
-            --env SIGSTORE_ID_TOKEN -- bnd "${args[@]}" || rc=$?
-    else
-        rc=1
-    fi
+    wrangle_retry_once "$vsa" wrangle_toolbox_exec \
+        --sigstore -- bnd "${args[@]}" || rc=$?
     rm -f "$vsa.unsigned"
     return "$rc"
 }

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -53,6 +53,9 @@ setup() {
     # at runtime; load it here so the direct-call emit tests have it too.
     # shellcheck source=../../lib/sanitize.sh
     source "$(cd "$(dirname "$BATS_TEST_FILENAME")/../../lib" && pwd)/sanitize.sh"
+    # Signing/verify always containerizes; make the toolbox path transparent so
+    # orchestration tests exercise their tool stubs. Recording-docker tests override.
+    wrangle_stub_toolbox_transparent
 }
 
 teardown() {
@@ -972,70 +975,39 @@ EOF
     chmod +x "$TEST_DIR/gh"
 }
 
-@test "wrangle_ampel: toggle off runs the in-job ampel binary unchanged" {
-    # Shim ampel to record it was the binary invoked, with the args passed through.
-    cat > "$TEST_DIR/ampel" <<EOF
-#!/bin/bash
-printf '%s\n' "\$@" > "$TEST_DIR/ampel.args"
-EOF
-    chmod +x "$TEST_DIR/ampel"
-    PATH="$TEST_DIR:$PATH" run wrangle_ampel verify --policy=p
-    [ "$status" -eq 0 ]
-    grep -q -- '--policy=p' "$TEST_DIR/ampel.args"
-    # No docker on the default path.
-    [ ! -f "$TEST_DIR/docker.args" ]
-}
-
-@test "wrangle_ampel: WRANGLE_VERIFY_AMPEL_TOOLBOX=0 stays on the in-job binary (no footgun)" {
-    cat > "$TEST_DIR/ampel" <<EOF
-#!/bin/bash
-printf '%s\n' "\$@" > "$TEST_DIR/ampel.args"
-EOF
-    chmod +x "$TEST_DIR/ampel"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=0 run wrangle_ampel verify --policy=p
-    [ "$status" -eq 0 ]
-    grep -q -- '--policy=p' "$TEST_DIR/ampel.args"
-    [ ! -f "$TEST_DIR/docker.args" ]
-}
-
-@test "wrangle_ampel: toggle on resolves the catalog image, verifies it, runs it on the egress bridge" {
+@test "wrangle_ampel: runs ampel verify in the VSA-gated toolbox image on the egress bridge" {
     _install_toolbox_shims
     _stub_toolbox_catalog
-    export WRANGLE_AMPEL_RESULTS="$TEST_DIR/results/vsa.json"
-    mkdir -p "$TEST_DIR/results" "$BUNDLE_OUT"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 run wrangle_ampel verify --policy=p
+    PATH="$TEST_DIR:$PATH" run wrangle_ampel verify --policy=p
     [ "$status" -eq 0 ]
     grep -q "toolbox-image VSA verified PASSED" <<< "$output"
-    # The catalog image ran, on the bridge (egress) network — not host.
     grep -q -- "--network bridge" "$TEST_DIR/docker.args"
     grep -q -- "$_toolbox_image ampel verify" "$TEST_DIR/docker.args"
 }
 
-@test "wrangle_ampel: toggle on but a non-PASSED VSA fails closed (no docker)" {
+@test "wrangle_ampel: a non-PASSED toolbox VSA fails closed (no docker)" {
     _install_toolbox_shims
     _stub_toolbox_catalog
-    export WRANGLE_AMPEL_RESULTS="$TEST_DIR/results/vsa.json"
-    mkdir -p "$TEST_DIR/results"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 GH_FAIL=1 run wrangle_ampel verify
+    PATH="$TEST_DIR:$PATH" GH_FAIL=1 run wrangle_ampel verify
     [ "$status" -eq 2 ]
     grep -q "verification failed" <<< "$output"
     [ ! -f "$TEST_DIR/docker.args" ]
 }
 
-@test "wrangle_ampel: toggle on but no catalog toolbox entry fails closed (no docker)" {
+@test "wrangle_ampel: a missing catalog toolbox image fails closed (no docker)" {
     _install_toolbox_shims
     echo '{"tools":{}}' > "$TEST_DIR/catalog.json"
     export WRANGLE_CATALOG="$TEST_DIR/catalog.json"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 run wrangle_ampel verify
+    PATH="$TEST_DIR:$PATH" run wrangle_ampel verify
     [ "$status" -eq 2 ]
     grep -q "no attest-toolbox image" <<< "$output"
     [ ! -f "$TEST_DIR/docker.args" ]
 }
 
-@test "wrangle_ampel: toggle on but a non-digest-pinned catalog image is rejected (no docker)" {
+@test "wrangle_ampel: a non-digest-pinned catalog image is rejected (no docker)" {
     _install_toolbox_shims
     _stub_toolbox_catalog "ghcr.io/tomhennen/wrangle/attest-toolbox:latest"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 run wrangle_ampel verify
+    PATH="$TEST_DIR:$PATH" run wrangle_ampel verify
     [ "$status" -eq 2 ]
     grep -q "digest-pinned" <<< "$output"
     [ ! -f "$TEST_DIR/docker.args" ]
@@ -1044,10 +1016,9 @@ EOF
 @test "wrangle_ampel: an OCI collector runs in-container with the job's registry auth" {
     _install_toolbox_shims
     _stub_toolbox_catalog
-    export WRANGLE_AMPEL_RESULTS="$TEST_DIR/results/vsa.json"
     export GITHUB_TOKEN="registry-token" HOME="$TEST_DIR"
-    mkdir -p "$TEST_DIR/results" "$BUNDLE_OUT" "$TEST_DIR/.docker"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 COLLECTOR="oci:ghcr.io/x@sha256:abc" \
+    mkdir -p "$TEST_DIR/.docker"
+    PATH="$TEST_DIR:$PATH" COLLECTOR="oci:ghcr.io/x@sha256:abc" \
         run wrangle_ampel verify --policy=p
     [ "$status" -eq 0 ]
     grep -q -- "$_toolbox_image ampel verify" "$TEST_DIR/docker.args"
@@ -1057,7 +1028,7 @@ EOF
     ! grep -q -- "-e SIGSTORE_ID_TOKEN" "$TEST_DIR/docker.args"
 }
 
-@test "wrangle_ampel: WRANGLE_VERIFY_TOOL_IMAGES=0 break-glass skips verify and still runs" {
+@test "wrangle_ampel: WRANGLE_VERIFY_TOOL_IMAGES=0 skips the VSA gate for a Sigstore outage" {
     # The sole path that dispatches without verifying — gh must never be consulted.
     cat > "$TEST_DIR/gh" <<EOF
 #!/bin/bash
@@ -1070,62 +1041,26 @@ printf '%s\n' "\$*" > "$TEST_DIR/docker.args"
 EOF
     chmod +x "$TEST_DIR/docker"
     _stub_toolbox_catalog
-    export WRANGLE_AMPEL_RESULTS="$TEST_DIR/results/vsa.json"
-    mkdir -p "$TEST_DIR/results" "$BUNDLE_OUT"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 WRANGLE_VERIFY_TOOL_IMAGES=0 \
-        run wrangle_ampel verify --policy=p
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_TOOL_IMAGES=0 run wrangle_ampel verify --policy=p
     [ "$status" -eq 0 ]
     grep -q "verification disabled by configuration" <<< "$output"
     [ ! -f "$TEST_DIR/gh.called" ]
     grep -q -- "$_toolbox_image ampel verify" "$TEST_DIR/docker.args"
 }
 
-@test "retry: ampel and bnd invocations both route through wrangle_retry_once" {
-    # ampel runs via the wrangle_ampel dispatcher (in-job binary or, opt-in, the
-    # toolbox image) — still through the retry helper.
+@test "retry: ampel and the VSA sign both route through wrangle_retry_once" {
     grep -q 'wrangle_retry_once "$report" wrangle_ampel' "$SCRIPT"
-    grep -q 'wrangle_retry_once "$vsa" bnd' "$SCRIPT"
+    grep -q 'wrangle_retry_once "$vsa" wrangle_toolbox_exec' "$SCRIPT"
 }
 
 # ---- containerized VSA signing (bnd statement) ----
 
-# The in-job bnd arg vector today, preserved byte-for-byte on the break-glass path.
-@test "wrangle_sign_vsa: break-glass (opt-in off) signs with the in-job bnd, unchanged" {
-    cat > "$TEST_DIR/bnd" <<EOF
-#!/bin/bash
-printf '%s\n' "\$*" > "$TEST_DIR/bnd.args"
-EOF
-    chmod +x "$TEST_DIR/bnd"
-    printf 'unsigned-vsa\n' > "$VSA"
-    PATH="$TEST_DIR:$PATH" run wrangle_sign_vsa "$VSA"
-    [ "$status" -eq 0 ]
-    grep -qx -- "statement $VSA.unsigned" "$TEST_DIR/bnd.args"
-    [ ! -f "$TEST_DIR/docker.args" ]
-}
-
-# The token grant, not just the opt-in, is what moves signing into the container.
-@test "wrangle_sign_vsa: opt-in on but no token grant stays on the in-job bnd" {
-    _install_toolbox_shims
-    _stub_toolbox_catalog
-    cat > "$TEST_DIR/bnd" <<EOF
-#!/bin/bash
-printf '%s\n' "\$*" > "$TEST_DIR/bnd.args"
-EOF
-    chmod +x "$TEST_DIR/bnd"
-    printf 'unsigned-vsa\n' > "$VSA"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 run wrangle_sign_vsa "$VSA"
-    [ "$status" -eq 0 ]
-    grep -qx -- "statement $VSA.unsigned" "$TEST_DIR/bnd.args"
-    [ ! -f "$TEST_DIR/docker.args" ]
-}
-
-@test "wrangle_sign_vsa: grant + opt-in signs in-container with a minted, name-threaded token" {
+@test "wrangle_sign_vsa: signs in-container with a minted, name-threaded token" {
     _install_toolbox_shims
     _stub_toolbox_catalog "$_toolbox_image" sigstore
     _stub_mint_curl
     printf 'unsigned-vsa\n' > "$VSA"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 GITHUB_TOKEN=registry-token \
-        run wrangle_sign_vsa "$VSA"
+    PATH="$TEST_DIR:$PATH" GITHUB_TOKEN=registry-token run wrangle_sign_vsa "$VSA"
     [ "$status" -eq 0 ]
     # The VSA gate ran, then bnd statement inside the toolbox image.
     grep -q "toolbox-image VSA verified PASSED" <<< "$output"
@@ -1139,21 +1074,37 @@ EOF
     ! grep -q -- "-e GITHUB_TOKEN" "$TEST_DIR/docker.args"
 }
 
-@test "wrangle_sign_vsa: grant + opt-in but a non-PASSED toolbox VSA fails closed (no docker)" {
+@test "wrangle_sign_vsa: a missing token: sigstore grant fails closed (no docker, no in-job bnd)" {
+    _install_toolbox_shims
+    _stub_toolbox_catalog   # no token grant
+    _stub_mint_curl
+    cat > "$TEST_DIR/bnd" <<EOF
+#!/bin/bash
+touch "$TEST_DIR/bnd.called"
+EOF
+    chmod +x "$TEST_DIR/bnd"
+    printf 'unsigned-vsa\n' > "$VSA"
+    PATH="$TEST_DIR:$PATH" GITHUB_TOKEN=registry-token run wrangle_sign_vsa "$VSA"
+    [ "$status" -ne 0 ]
+    grep -q "lacks the token: sigstore grant" <<< "$output"
+    [ ! -f "$TEST_DIR/docker.args" ]
+    [ ! -f "$TEST_DIR/bnd.called" ]
+}
+
+@test "wrangle_sign_vsa: a non-PASSED toolbox VSA fails closed (no docker)" {
     _install_toolbox_shims
     _stub_toolbox_catalog "$_toolbox_image" sigstore
     _stub_mint_curl
     printf 'unsigned-vsa\n' > "$VSA"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 GH_FAIL=1 GITHUB_TOKEN=registry-token \
-        run wrangle_sign_vsa "$VSA"
+    PATH="$TEST_DIR:$PATH" GH_FAIL=1 GITHUB_TOKEN=registry-token run wrangle_sign_vsa "$VSA"
     [ "$status" -ne 0 ]
     [ ! -f "$TEST_DIR/docker.args" ]
 }
 
-@test "wrangle_sign_vsa: grant + opt-in but a failed token mint fails closed (no docker, no in-job bnd)" {
+@test "wrangle_sign_vsa: a failed token mint fails closed (no docker, no in-job bnd)" {
     _install_toolbox_shims
     _stub_toolbox_catalog "$_toolbox_image" sigstore
-    # No mint curl and no request vars -> the mint fails; must not fall back in-job.
+    # Grant present but the ambient OIDC request vars absent -> mint fails.
     unset ACTIONS_ID_TOKEN_REQUEST_URL ACTIONS_ID_TOKEN_REQUEST_TOKEN SIGSTORE_ID_TOKEN
     cat > "$TEST_DIR/bnd" <<EOF
 #!/bin/bash
@@ -1161,9 +1112,9 @@ touch "$TEST_DIR/bnd.called"
 EOF
     chmod +x "$TEST_DIR/bnd"
     printf 'unsigned-vsa\n' > "$VSA"
-    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 GITHUB_TOKEN=registry-token \
-        run wrangle_sign_vsa "$VSA"
+    PATH="$TEST_DIR:$PATH" GITHUB_TOKEN=registry-token run wrangle_sign_vsa "$VSA"
     [ "$status" -ne 0 ]
+    grep -q "lacks id-token: write" <<< "$output"
     [ ! -f "$TEST_DIR/docker.args" ]
     [ ! -f "$TEST_DIR/bnd.called" ]
 }

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -1149,3 +1149,21 @@ EOF
     [ "$status" -ne 0 ]
     [ ! -f "$TEST_DIR/docker.args" ]
 }
+
+@test "wrangle_sign_vsa: grant + opt-in but a failed token mint fails closed (no docker, no in-job bnd)" {
+    _install_toolbox_shims
+    _stub_toolbox_catalog "$_toolbox_image" sigstore
+    # No mint curl and no request vars -> the mint fails; must not fall back in-job.
+    unset ACTIONS_ID_TOKEN_REQUEST_URL ACTIONS_ID_TOKEN_REQUEST_TOKEN SIGSTORE_ID_TOKEN
+    cat > "$TEST_DIR/bnd" <<EOF
+#!/bin/bash
+touch "$TEST_DIR/bnd.called"
+EOF
+    chmod +x "$TEST_DIR/bnd"
+    printf 'unsigned-vsa\n' > "$VSA"
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 GITHUB_TOKEN=registry-token \
+        run wrangle_sign_vsa "$VSA"
+    [ "$status" -ne 0 ]
+    [ ! -f "$TEST_DIR/docker.args" ]
+    [ ! -f "$TEST_DIR/bnd.called" ]
+}

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -1086,7 +1086,7 @@ EOF
     printf 'unsigned-vsa\n' > "$VSA"
     PATH="$TEST_DIR:$PATH" GITHUB_TOKEN=registry-token run wrangle_sign_vsa "$VSA"
     [ "$status" -ne 0 ]
-    grep -q "lacks the token: sigstore grant" <<< "$output"
+    grep -q "capability required to sign" <<< "$output"
     [ ! -f "$TEST_DIR/docker.args" ]
     [ ! -f "$TEST_DIR/bnd.called" ]
 }

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -931,13 +931,26 @@ SHIM
 _toolbox_image="ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:0000000000000000000000000000000000000000000000000000000000000000"
 
 # Write a stub catalog with the attest-toolbox grant ($1 = image; default the
-# pinned curated image) and export WRANGLE_CATALOG at it.
+# pinned curated image; $2 = token grant, e.g. sigstore, when set) and export
+# WRANGLE_CATALOG at it.
 _stub_toolbox_catalog() {
-    local image="${1:-$_toolbox_image}"
+    local image="${1:-$_toolbox_image}" token="${2:-}" token_field=""
+    [[ -n "$token" ]] && token_field=",\"token\":\"$token\""
     cat > "$TEST_DIR/catalog.json" <<JSON
-{"tools":{"attest-toolbox":{"kind":"attest","image":"$image","network":"egress"}}}
+{"tools":{"attest-toolbox":{"kind":"attest","image":"$image","network":"egress"$token_field}}}
 JSON
     export WRANGLE_CATALOG="$TEST_DIR/catalog.json"
+}
+
+# Shim curl so the sigstore-token mint returns a fixed JWT value without network.
+_stub_mint_curl() {
+    cat > "$TEST_DIR/curl" <<'EOF'
+#!/bin/bash
+printf '{"value":"MINTED-SIGSTORE-JWT"}\n'
+EOF
+    chmod +x "$TEST_DIR/curl"
+    export ACTIONS_ID_TOKEN_REQUEST_URL="https://oidc.example/token"
+    export ACTIONS_ID_TOKEN_REQUEST_TOKEN="request-bearer-secret"
 }
 
 # Install a docker shim that records its argv, and a gh shim whose attestation
@@ -1028,14 +1041,20 @@ EOF
     [ ! -f "$TEST_DIR/docker.args" ]
 }
 
-@test "wrangle_ampel: container path refuses an OCI collector (fail-closed, no docker)" {
+@test "wrangle_ampel: an OCI collector runs in-container with the job's registry auth" {
     _install_toolbox_shims
     _stub_toolbox_catalog
+    export WRANGLE_AMPEL_RESULTS="$TEST_DIR/results/vsa.json"
+    export GITHUB_TOKEN="registry-token" HOME="$TEST_DIR"
+    mkdir -p "$TEST_DIR/results" "$BUNDLE_OUT" "$TEST_DIR/.docker"
     PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 COLLECTOR="oci:ghcr.io/x@sha256:abc" \
-        run wrangle_ampel verify
-    [ "$status" -eq 2 ]
-    grep -q "oci collector" <<< "$output"
-    [ ! -f "$TEST_DIR/docker.args" ]
+        run wrangle_ampel verify --policy=p
+    [ "$status" -eq 0 ]
+    grep -q -- "$_toolbox_image ampel verify" "$TEST_DIR/docker.args"
+    # Registry read needs the job's ghcr login and token, no signing token.
+    grep -q -- "-e GITHUB_TOKEN" "$TEST_DIR/docker.args"
+    grep -q -- "-e DOCKER_CONFIG=/wrangle/docker-config" "$TEST_DIR/docker.args"
+    ! grep -q -- "-e SIGSTORE_ID_TOKEN" "$TEST_DIR/docker.args"
 }
 
 @test "wrangle_ampel: WRANGLE_VERIFY_TOOL_IMAGES=0 break-glass skips verify and still runs" {
@@ -1066,4 +1085,67 @@ EOF
     # toolbox image) — still through the retry helper.
     grep -q 'wrangle_retry_once "$report" wrangle_ampel' "$SCRIPT"
     grep -q 'wrangle_retry_once "$vsa" bnd' "$SCRIPT"
+}
+
+# ---- containerized VSA signing (bnd statement) ----
+
+# The in-job bnd arg vector today, preserved byte-for-byte on the break-glass path.
+@test "wrangle_sign_vsa: break-glass (opt-in off) signs with the in-job bnd, unchanged" {
+    cat > "$TEST_DIR/bnd" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" > "$TEST_DIR/bnd.args"
+EOF
+    chmod +x "$TEST_DIR/bnd"
+    printf 'unsigned-vsa\n' > "$VSA"
+    PATH="$TEST_DIR:$PATH" run wrangle_sign_vsa "$VSA"
+    [ "$status" -eq 0 ]
+    grep -qx -- "statement $VSA.unsigned" "$TEST_DIR/bnd.args"
+    [ ! -f "$TEST_DIR/docker.args" ]
+}
+
+# The token grant, not just the opt-in, is what moves signing into the container.
+@test "wrangle_sign_vsa: opt-in on but no token grant stays on the in-job bnd" {
+    _install_toolbox_shims
+    _stub_toolbox_catalog
+    cat > "$TEST_DIR/bnd" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" > "$TEST_DIR/bnd.args"
+EOF
+    chmod +x "$TEST_DIR/bnd"
+    printf 'unsigned-vsa\n' > "$VSA"
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 run wrangle_sign_vsa "$VSA"
+    [ "$status" -eq 0 ]
+    grep -qx -- "statement $VSA.unsigned" "$TEST_DIR/bnd.args"
+    [ ! -f "$TEST_DIR/docker.args" ]
+}
+
+@test "wrangle_sign_vsa: grant + opt-in signs in-container with a minted, name-threaded token" {
+    _install_toolbox_shims
+    _stub_toolbox_catalog "$_toolbox_image" sigstore
+    _stub_mint_curl
+    printf 'unsigned-vsa\n' > "$VSA"
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 GITHUB_TOKEN=registry-token \
+        run wrangle_sign_vsa "$VSA"
+    [ "$status" -eq 0 ]
+    # The VSA gate ran, then bnd statement inside the toolbox image.
+    grep -q "toolbox-image VSA verified PASSED" <<< "$output"
+    grep -q -- "$_toolbox_image bnd statement" "$TEST_DIR/docker.args"
+    # The sigstore token is threaded by NAME only; its value is never on argv.
+    grep -q -- "-e SIGSTORE_ID_TOKEN" "$TEST_DIR/docker.args"
+    ! grep -q "MINTED-SIGSTORE-JWT" "$TEST_DIR/docker.args"
+    # The mint-anything request vars NEVER enter the container.
+    ! grep -q "ACTIONS_ID_TOKEN_REQUEST" "$TEST_DIR/docker.args"
+    # Signing needs no registry login token.
+    ! grep -q -- "-e GITHUB_TOKEN" "$TEST_DIR/docker.args"
+}
+
+@test "wrangle_sign_vsa: grant + opt-in but a non-PASSED toolbox VSA fails closed (no docker)" {
+    _install_toolbox_shims
+    _stub_toolbox_catalog "$_toolbox_image" sigstore
+    _stub_mint_curl
+    printf 'unsigned-vsa\n' > "$VSA"
+    PATH="$TEST_DIR:$PATH" WRANGLE_VERIFY_AMPEL_TOOLBOX=1 GH_FAIL=1 GITHUB_TOKEN=registry-token \
+        run wrangle_sign_vsa "$VSA"
+    [ "$status" -ne 0 ]
+    [ ! -f "$TEST_DIR/docker.args" ]
 }

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@ad159e9af4ea588258d6fe7020f05478f8d73613 # feat/phase3-container-signing 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+    - uses: TomHennen/wrangle/actions/verify@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
+    - uses: TomHennen/wrangle/actions/verify@f91ac884ca8037fec70c470ce8705533cebefaca # feat/phase3-container-signing 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@4984c487f00095b51a9a0c9b6743f58dd25c0125 # main 2026-07-04
+    - uses: TomHennen/wrangle/actions/verify@e9f68cfa979e6eae1243a708e4c6d9c36a49ee24 # main 2026-07-04
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -388,18 +388,19 @@ not a meaningful per-delivery signal.)
   job-scoped `GITHUB_TOKEN` into the container (Option A: sign+push in-container); the
   `ACTIONS_ID_TOKEN_REQUEST_*` vars never enter it — a security improvement over today's in-job binary,
   which can mint a token for any audience.
-  **Break-glass.** Once signing is containerized, `WRANGLE_VERIFY_AMPEL_TOOLBOX` unset falls back to
-  in-job, from-source signing — the outage escape hatch; no automatic staleness fallback. (Today the same
-  toggle gates only the verify step; see Status.)
+  **Break-glass.** `WRANGLE_VERIFY_AMPEL_TOOLBOX` unset (or `0`) falls back to in-job, from-source
+  signing — the outage escape hatch; no automatic staleness fallback.
   **Status (#596 Track 2):** the toolbox image (`tools/attest-toolbox/`, all four binaries from
-  `tools/go.mod`) is built and published like the scan images, and `actions/verify`'s opt-in
-  `WRANGLE_VERIFY_AMPEL_TOOLBOX` toggle runs *ampel verify only* (no signing token) via it — resolved from
-  the curated catalog's `attest-toolbox` grant (digest-pinned, `network: egress`, no token) and
-  provenance-verified host-side (`verify_image_vsa`) before it runs. Off by default, byte-identical when
-  unset, and not on the L3 release path; supported for the go/python/npm build types only (the container
-  build type's `oci:` collector needs in-container registry auth, fail-closed and deferred). Containerizing
-  the signing steps (bnd/cosign, which need the OIDC token) and the OCI-collector verify path are the
-  remaining Phase-3 work. (The catalog auto-bump PR, §11, has shipped.)
+  `tools/go.mod`) is built and published like the scan images. Under the curated catalog's
+  `attest-toolbox` grant (`delivery: image`, digest-pinned, `network: egress`, `token: sigstore`) plus
+  the `WRANGLE_VERIFY_AMPEL_TOOLBOX` opt-in, all three sign sites run in it: the verify job's VSA sign
+  (`bnd statement`) and referrer pushes, `attest_provenance`'s `wrangle-attest --sign` + store push, and
+  `attest_metadata_oci`'s sign + `cosign` OCI push/download — plus the `oci:` collector verify path
+  (registry auth threaded in-container). The host mints the step-local `SIGSTORE_ID_TOKEN` and threads it
+  (signing) or `GITHUB_TOKEN` (registry) by name only; each token-bearing `docker run` is fronted by the
+  fail-closed `verify_image_vsa` gate (`lib/toolbox_run.sh`). Off by default and byte-identical when
+  unset; wrangle dogfoods it when publishing its own tool images (`local_publish_images.yml`,
+  `verify-in-container: true`). Reusable callers opt in via the `verify-in-container` input.
 - **Separate feature:** emitting an attested container of an adopter's own Go app (the "free container"
   value-add via goreleaser/ko). It reuses some machinery but serves adopter UX, not the goals here.
 - **Left as-is:** tools with official GitHub Actions that gain nothing from containerization stay

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -198,11 +198,10 @@ Two distinct layers:
   output}`.
 
 `token: sigstore` lets wrangle mint a short-lived Sigstore signing token (`SIGSTORE_ID_TOKEN`) into the
-tool's container — the signing-token counterpart of `secret: github-token`. It is off by default, and
-`check_catalog` allows it only on wrangle's own `attest-toolbox` image, never on a scan/sbom tool or an
-adopter's custom tool. The signing path reads it (`lib/toolbox_run.sh`): under the grant plus the
-`WRANGLE_VERIFY_AMPEL_TOOLBOX` opt-in, the host mints the token and threads it, by name, into the
-toolbox container (§7 Status).
+tool's container — the signing-token counterpart of `secret: github-token`. `check_catalog` allows it
+only on wrangle's own `attest-toolbox` image, never on a scan/sbom tool or an adopter's custom tool. The
+signing path reads it (`lib/toolbox_run.sh`) and authorizes the mint on it: the host mints the token and
+threads it, by name, into the toolbox container; a missing grant fails signing closed (§7 Status).
 
 **A capability grant comes from the trusting party — wrangle, or the adopter for their own tool — never
 from the image itself.** An image may *request* a capability (e.g. an OCI label), but granting it is the
@@ -386,23 +385,22 @@ not a meaningful per-delivery signal.)
   auto-bump PR (§11) keeping the pinned digest current; there is **no per-signing-run freshness gate**. Containerizing the
   verify path also unlocks **VSA-verified caching** of all tool images — the L3-safe replacement for the
   build cache wrangle disables today.
-  **Token delivery.** The host mints an `aud=sigstore` `SIGSTORE_ID_TOKEN` and passes it plus the
-  job-scoped `GITHUB_TOKEN` into the container (Option A: sign+push in-container); the
-  `ACTIONS_ID_TOKEN_REQUEST_*` vars never enter it — a security improvement over today's in-job binary,
-  which can mint a token for any audience.
-  **Break-glass.** `WRANGLE_VERIFY_AMPEL_TOOLBOX` unset (or `0`) falls back to in-job, from-source
-  signing — the outage escape hatch; no automatic staleness fallback.
+  **Token delivery.** The host mints an `aud=sigstore` `SIGSTORE_ID_TOKEN` and passes it (signing) or the
+  job-scoped `GITHUB_TOKEN` (registry) into the container by name; the `ACTIONS_ID_TOKEN_REQUEST_*` vars
+  never enter it — a security improvement over an in-job binary, which can mint a token for any audience.
+  **Recovery.** Signing always runs in-container — adopters already run scan/sbom/syft as containers, so
+  this adds no new dependency class and there is no in-job fallback. A Sigstore-TUF outage that the
+  pull-time VSA gate hard-depends on is ridden out with `WRANGLE_VERIFY_TOOL_IMAGES=0` (skip the gate); a
+  mechanism regression is recovered by pinning an earlier wrangle version.
   **Status (#596 Track 2):** the toolbox image (`tools/attest-toolbox/`, all four binaries from
   `tools/go.mod`) is built and published like the scan images. Under the curated catalog's
-  `attest-toolbox` grant (`delivery: image`, digest-pinned, `network: egress`, `token: sigstore`) plus
-  the `WRANGLE_VERIFY_AMPEL_TOOLBOX` opt-in, all three sign sites run in it: the verify job's VSA sign
-  (`bnd statement`) and referrer pushes, `attest_provenance`'s `wrangle-attest --sign` + store push, and
-  `attest_metadata_oci`'s sign + `cosign` OCI push/download — plus the `oci:` collector verify path
-  (registry auth threaded in-container). The host mints the step-local `SIGSTORE_ID_TOKEN` and threads it
-  (signing) or `GITHUB_TOKEN` (registry) by name only; each token-bearing `docker run` is fronted by the
-  fail-closed `verify_image_vsa` gate (`lib/toolbox_run.sh`). Off by default and byte-identical when
-  unset; wrangle dogfoods it when publishing its own tool images (`local_publish_images.yml`,
-  `verify-in-container: true`). Reusable callers opt in via the `verify-in-container` input.
+  `attest-toolbox` grant (`delivery: image`, digest-pinned, `network: egress`, `token: sigstore`) all
+  three sign sites run in it: the verify job's VSA sign (`bnd statement`) and referrer pushes,
+  `attest_provenance`'s `wrangle-attest --sign` + store push, and `attest_metadata_oci`'s sign + `cosign`
+  OCI push/download — plus the `oci:` collector verify path (registry auth threaded in-container). The
+  host mints the step-local `SIGSTORE_ID_TOKEN` and threads it (signing) or `GITHUB_TOKEN` (registry) by
+  name only; the mint is authorized by the `token: sigstore` grant and each token-bearing `docker run` is
+  fronted by the fail-closed `verify_image_vsa` gate (`lib/toolbox_run.sh`).
 - **Separate feature:** emitting an attested container of an adopter's own Go app (the "free container"
   value-add via goreleaser/ko). It reuses some machinery but serves adopter UX, not the goals here.
 - **Left as-is:** tools with official GitHub Actions that gain nothing from containerization stay

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -200,7 +200,9 @@ Two distinct layers:
 `token: sigstore` lets wrangle mint a short-lived Sigstore signing token (`SIGSTORE_ID_TOKEN`) into the
 tool's container — the signing-token counterpart of `secret: github-token`. It is off by default, and
 `check_catalog` allows it only on wrangle's own `attest-toolbox` image, never on a scan/sbom tool or an
-adopter's custom tool. The field is validated today, but nothing reads it yet.
+adopter's custom tool. The signing path reads it (`lib/toolbox_run.sh`): under the grant plus the
+`WRANGLE_VERIFY_AMPEL_TOOLBOX` opt-in, the host mints the token and threads it, by name, into the
+toolbox container (§7 Status).
 
 **A capability grant comes from the trusting party — wrangle, or the adopter for their own tool — never
 from the image itself.** An image may *request* a capability (e.g. an OCI label), but granting it is the

--- a/lib/read_catalog.sh
+++ b/lib/read_catalog.sh
@@ -23,6 +23,16 @@ read_catalog_field() {
         '.tools[$t][$f] // empty' "$file"
 }
 
+# catalog_docker_network <catalog_file> <tool> — echo the tool's catalog network
+# as a docker --network value: "egress" gets the default bridge; anything else,
+# including an absent field, gets none (a closed network).
+catalog_docker_network() {
+    case "$(read_catalog_field "$1" "$2" network)" in
+        egress) printf 'bridge\n' ;;
+        *)      printf 'none\n' ;;
+    esac
+}
+
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     if [[ "$#" -ne 3 ]]; then
         printf 'Usage: %s <catalog_file> <tool> <field>\n' "${0##*/}" >&2

--- a/lib/run_tool_image.sh
+++ b/lib/run_tool_image.sh
@@ -11,9 +11,7 @@ run_tool_image() {
     local tool="$1" image="$2" tool_out="$3" src_dir="$4" catalog="$5" timeout_s="$6"
     local net kind secret secret_var extra_var src_abs out_abs
 
-    # egress -> docker's default bridge network; absent -> none (closed).
-    net="none"
-    [[ "$(read_catalog_field "$catalog" "$tool" network)" == "egress" ]] && net="bridge"
+    net="$(catalog_docker_network "$catalog" "$tool")"
 
     # docker -v needs absolute paths.
     src_abs="$(cd "$src_dir" && pwd)"

--- a/lib/sign_metadata.sh
+++ b/lib/sign_metadata.sh
@@ -57,14 +57,11 @@ wrangle_sign_metadata_statements() {
     local args
     mapfile -t args < <(wrangle_attest_args "$subject_arg" "$stmts")
     if wrangle_toolbox_signing_enabled; then
-        wrangle_mint_sigstore_token
-        local -a m=()
-        wrangle_toolbox_add_mount m "$METADATA_ROOT" ro
-        wrangle_toolbox_add_mount m "$(dirname "$stmts")" rw
-        [[ "$subject_arg" == --artifact=* ]] &&
-            wrangle_toolbox_add_mount m "$(dirname "$subject")" ro
+        # A mint failure fails closed under the grant+opt-in — never falls back to
+        # an in-job sign that would leak the request vars to the from-source binary.
+        wrangle_mint_sigstore_token || return 1
         wrangle_retry_once /dev/null wrangle_toolbox_exec \
-            "${m[@]}" --env SIGSTORE_ID_TOKEN -- wrangle-attest "${args[@]}"
+            --env SIGSTORE_ID_TOKEN -- wrangle-attest "${args[@]}"
     else
         wrangle_retry_once /dev/null wrangle-attest "${args[@]}"
     fi
@@ -76,10 +73,8 @@ wrangle_push_store() {
     local args
     mapfile -t args < <(wrangle_bnd_push_args "$GITHUB_REPOSITORY" "$1")
     if wrangle_toolbox_signing_enabled; then
-        local -a m=()
-        wrangle_toolbox_add_mount m "$(dirname "$1")" ro
         wrangle_retry_once /dev/null wrangle_toolbox_exec \
-            "${m[@]}" --env GITHUB_TOKEN -- bnd "${args[@]}"
+            --env GITHUB_TOKEN -- bnd "${args[@]}"
     else
         wrangle_retry_once /dev/null bnd "${args[@]}"
     fi
@@ -103,10 +98,8 @@ wrangle_push_oci_referrer() {
     local args
     mapfile -t args < <(wrangle_cosign_attach_args "$1" "$OCI_TARGET")
     if wrangle_toolbox_signing_enabled; then
-        local -a m=()
-        wrangle_toolbox_add_mount m "$(dirname "$1")" ro
         wrangle_retry_once /dev/null wrangle_toolbox_exec \
-            "${m[@]}" --docker-config --env GITHUB_TOKEN -- cosign "${args[@]}"
+            --docker-config --env GITHUB_TOKEN -- cosign "${args[@]}"
     else
         wrangle_retry_once /dev/null cosign "${args[@]}"
     fi

--- a/lib/sign_metadata.sh
+++ b/lib/sign_metadata.sh
@@ -5,6 +5,8 @@ set -f
 _SIGN_METADATA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/retry.sh
 source "$_SIGN_METADATA_DIR/retry.sh"
+# shellcheck source=lib/toolbox_run.sh
+source "$_SIGN_METADATA_DIR/toolbox_run.sh"
 
 # lib/sign_metadata.sh — Shared build-metadata signing primitives.
 #
@@ -54,7 +56,18 @@ wrangle_sign_metadata_statements() {
     fi
     local args
     mapfile -t args < <(wrangle_attest_args "$subject_arg" "$stmts")
-    wrangle_retry_once /dev/null wrangle-attest "${args[@]}"
+    if wrangle_toolbox_signing_enabled; then
+        wrangle_mint_sigstore_token
+        local -a m=()
+        wrangle_toolbox_add_mount m "$METADATA_ROOT" ro
+        wrangle_toolbox_add_mount m "$(dirname "$stmts")" rw
+        [[ "$subject_arg" == --artifact=* ]] &&
+            wrangle_toolbox_add_mount m "$(dirname "$subject")" ro
+        wrangle_retry_once /dev/null wrangle_toolbox_exec \
+            "${m[@]}" --env SIGSTORE_ID_TOKEN -- wrangle-attest "${args[@]}"
+    else
+        wrangle_retry_once /dev/null wrangle-attest "${args[@]}"
+    fi
 }
 
 # Post the signed statement at $1 to the GitHub attestation store. Fails closed:
@@ -62,7 +75,14 @@ wrangle_sign_metadata_statements() {
 wrangle_push_store() {
     local args
     mapfile -t args < <(wrangle_bnd_push_args "$GITHUB_REPOSITORY" "$1")
-    wrangle_retry_once /dev/null bnd "${args[@]}"
+    if wrangle_toolbox_signing_enabled; then
+        local -a m=()
+        wrangle_toolbox_add_mount m "$(dirname "$1")" ro
+        wrangle_retry_once /dev/null wrangle_toolbox_exec \
+            "${m[@]}" --env GITHUB_TOKEN -- bnd "${args[@]}"
+    else
+        wrangle_retry_once /dev/null bnd "${args[@]}"
+    fi
 }
 
 # Build the cosign arg vector that pushes a single signed statement as an OCI
@@ -82,7 +102,14 @@ wrangle_push_oci_referrer() {
     [[ -z "${OCI_TARGET:-}" ]] && return 0
     local args
     mapfile -t args < <(wrangle_cosign_attach_args "$1" "$OCI_TARGET")
-    wrangle_retry_once /dev/null cosign "${args[@]}"
+    if wrangle_toolbox_signing_enabled; then
+        local -a m=()
+        wrangle_toolbox_add_mount m "$(dirname "$1")" ro
+        wrangle_retry_once /dev/null wrangle_toolbox_exec \
+            "${m[@]}" --docker-config --env GITHUB_TOKEN -- cosign "${args[@]}"
+    else
+        wrangle_retry_once /dev/null cosign "${args[@]}"
+    fi
 }
 
 # Build the cosign arg vector that downloads an image's attestation referrers as
@@ -106,7 +133,11 @@ wrangle_seed_bundle() {
         # Keep only the SLSA provenance envelopes (download emits all referrers,
         # including prior VSAs); a jq decode failure must fail, not seed empty.
         downloaded="$(mktemp "${RUNNER_TEMP:-/tmp}/seed.XXXXXX")"
-        cosign "${args[@]}" > "$downloaded"
+        if wrangle_toolbox_signing_enabled; then
+            wrangle_toolbox_exec --docker-config --env GITHUB_TOKEN -- cosign "${args[@]}" > "$downloaded"
+        else
+            cosign "${args[@]}" > "$downloaded"
+        fi
         if ! jq -ce "select((.dsseEnvelope.payload | @base64d | fromjson | .predicateType) == \"$WRANGLE_PROVENANCE_PREDICATE\")" \
             "$downloaded" > "$seed"; then
             rm -f "$downloaded"

--- a/lib/sign_metadata.sh
+++ b/lib/sign_metadata.sh
@@ -56,15 +56,9 @@ wrangle_sign_metadata_statements() {
     fi
     local args
     mapfile -t args < <(wrangle_attest_args "$subject_arg" "$stmts")
-    if wrangle_toolbox_signing_enabled; then
-        # A mint failure fails closed under the grant+opt-in — never falls back to
-        # an in-job sign that would leak the request vars to the from-source binary.
-        wrangle_mint_sigstore_token || return 1
-        wrangle_retry_once /dev/null wrangle_toolbox_exec \
-            --env SIGSTORE_ID_TOKEN -- wrangle-attest "${args[@]}"
-    else
-        wrangle_retry_once /dev/null wrangle-attest "${args[@]}"
-    fi
+    wrangle_mint_sigstore_token || return 1
+    wrangle_retry_once /dev/null wrangle_toolbox_exec \
+        --env SIGSTORE_ID_TOKEN -- wrangle-attest "${args[@]}"
 }
 
 # Post the signed statement at $1 to the GitHub attestation store. Fails closed:
@@ -72,12 +66,8 @@ wrangle_sign_metadata_statements() {
 wrangle_push_store() {
     local args
     mapfile -t args < <(wrangle_bnd_push_args "$GITHUB_REPOSITORY" "$1")
-    if wrangle_toolbox_signing_enabled; then
-        wrangle_retry_once /dev/null wrangle_toolbox_exec \
-            --env GITHUB_TOKEN -- bnd "${args[@]}"
-    else
-        wrangle_retry_once /dev/null bnd "${args[@]}"
-    fi
+    wrangle_retry_once /dev/null wrangle_toolbox_exec \
+        --env GITHUB_TOKEN -- bnd "${args[@]}"
 }
 
 # Build the cosign arg vector that pushes a single signed statement as an OCI
@@ -97,12 +87,8 @@ wrangle_push_oci_referrer() {
     [[ -z "${OCI_TARGET:-}" ]] && return 0
     local args
     mapfile -t args < <(wrangle_cosign_attach_args "$1" "$OCI_TARGET")
-    if wrangle_toolbox_signing_enabled; then
-        wrangle_retry_once /dev/null wrangle_toolbox_exec \
-            --docker-config --env GITHUB_TOKEN -- cosign "${args[@]}"
-    else
-        wrangle_retry_once /dev/null cosign "${args[@]}"
-    fi
+    wrangle_retry_once /dev/null wrangle_toolbox_exec \
+        --docker-config --env GITHUB_TOKEN -- cosign "${args[@]}"
 }
 
 # Build the cosign arg vector that downloads an image's attestation referrers as
@@ -126,11 +112,7 @@ wrangle_seed_bundle() {
         # Keep only the SLSA provenance envelopes (download emits all referrers,
         # including prior VSAs); a jq decode failure must fail, not seed empty.
         downloaded="$(mktemp "${RUNNER_TEMP:-/tmp}/seed.XXXXXX")"
-        if wrangle_toolbox_signing_enabled; then
-            wrangle_toolbox_exec --docker-config --env GITHUB_TOKEN -- cosign "${args[@]}" > "$downloaded"
-        else
-            cosign "${args[@]}" > "$downloaded"
-        fi
+        wrangle_toolbox_exec --docker-config --env GITHUB_TOKEN -- cosign "${args[@]}" > "$downloaded"
         if ! jq -ce "select((.dsseEnvelope.payload | @base64d | fromjson | .predicateType) == \"$WRANGLE_PROVENANCE_PREDICATE\")" \
             "$downloaded" > "$seed"; then
             rm -f "$downloaded"

--- a/lib/sign_metadata.sh
+++ b/lib/sign_metadata.sh
@@ -56,9 +56,8 @@ wrangle_sign_metadata_statements() {
     fi
     local args
     mapfile -t args < <(wrangle_attest_args "$subject_arg" "$stmts")
-    wrangle_mint_sigstore_token || return 1
     wrangle_retry_once /dev/null wrangle_toolbox_exec \
-        --env SIGSTORE_ID_TOKEN -- wrangle-attest "${args[@]}"
+        --sigstore -- wrangle-attest "${args[@]}"
 }
 
 # Post the signed statement at $1 to the GitHub attestation store. Fails closed:

--- a/lib/toolbox_run.sh
+++ b/lib/toolbox_run.sh
@@ -1,17 +1,13 @@
 #!/bin/bash
-# lib/toolbox_run.sh — shared primitives for running wrangle's signing/verify
-# toolbox (cosign, ampel, bnd, wrangle-attest) inside the curated attest-toolbox
-# image. Sourced by actions/verify/run_verify.sh and lib/sign_metadata.sh; each
-# signer helper containerizes only when the grant + opt-in are present, and runs
-# the in-job binary byte-for-byte otherwise (the break-glass revert).
+# lib/toolbox_run.sh — run wrangle's signing/verify toolbox (cosign, ampel, bnd,
+# wrangle-attest) inside the curated attest-toolbox image. Sourced by
+# actions/verify/run_verify.sh and lib/sign_metadata.sh.
 #
 # Provides:
-#   wrangle_toolbox_optin            — the WRANGLE_VERIFY_AMPEL_TOOLBOX toggle
-#   wrangle_toolbox_signing_enabled  — optin AND the catalog token: sigstore grant
-#   wrangle_toolbox_image            — resolve, digest-pin-check, VSA-gate (memoized)
-#   wrangle_toolbox_network          — the catalog network as a docker --network
-#   wrangle_mint_sigstore_token      — mint aud=sigstore SIGSTORE_ID_TOKEN, step-local
-#   wrangle_toolbox_exec             — one hardened docker run of the toolbox image
+#   wrangle_toolbox_image        — resolve, digest-pin-check, VSA-gate (memoized)
+#   wrangle_toolbox_network      — the catalog network as a docker --network
+#   wrangle_mint_sigstore_token  — mint aud=sigstore SIGSTORE_ID_TOKEN, step-local
+#   wrangle_toolbox_exec         — one hardened docker run of the toolbox image
 
 set -euo pipefail
 set -f
@@ -29,29 +25,10 @@ _wrangle_toolbox_catalog() {
     printf '%s\n' "${WRANGLE_CATALOG:-$_TOOLBOX_RUN_DIR/../tools/catalog.json}"
 }
 
-# True when the opt-in toggle selects the toolbox image over the in-job binary.
-wrangle_toolbox_optin() {
-    case "${WRANGLE_VERIFY_AMPEL_TOOLBOX:-}" in
-        1|true) return 0 ;;
-        *)      return 1 ;;
-    esac
-}
-
-# True when signing may run in-container: the opt-in AND the catalog's
-# attest-toolbox carrying the token: sigstore grant. Absent grant keeps signing
-# in-job even under the opt-in, so a container never signs without a declared
-# token grant.
-wrangle_toolbox_signing_enabled() {
-    wrangle_toolbox_optin || return 1
-    [[ "$(read_catalog_field "$(_wrangle_toolbox_catalog)" "$WRANGLE_TOOLBOX_TOOL" token)" == "sigstore" ]]
-}
-
 # Resolve the toolbox image, assert it is @sha256:-digest-pinned, and VSA-gate it
-# fail-closed before any container consumes it. Memoized: the digest is immutable
-# within a step, so the gate's network verify runs once and every later docker run
-# reuses the verdict. Echoes the image on success; returns 2 (no docker) on a
-# missing/unpinned image or a non-PASSED VSA. WRANGLE_VERIFY_TOOL_IMAGES=0 is the
-# sustained-Sigstore-outage break-glass that skips the gate.
+# before any container consumes it. Memoized so the network verify runs once per
+# step. Echoes the image; returns 2 (no docker) on a missing/unpinned image or a
+# non-PASSED VSA. WRANGLE_VERIFY_TOOL_IMAGES=0 skips the gate for a Sigstore outage.
 _WRANGLE_TOOLBOX_IMAGE_VERIFIED=""
 wrangle_toolbox_image() {
     if [[ -n "$_WRANGLE_TOOLBOX_IMAGE_VERIFIED" ]]; then
@@ -89,21 +66,23 @@ wrangle_toolbox_network() {
     esac
 }
 
-# Mint an aud=sigstore SIGSTORE_ID_TOKEN from the ambient GitHub OIDC request vars
-# into this process's env only — never GITHUB_ENV, so it stays step-local. The
-# in-container gitlab provider of carabiner-dev/signer redeems it verbatim; the
-# request-URL vars stay on the host, so the container cannot mint a token for any
-# other audience. Idempotent within a step. Returns 2 when the request vars are
-# absent (the job lacks id-token: write).
+# Mint an aud=sigstore SIGSTORE_ID_TOKEN into this process's env only (never
+# GITHUB_ENV, so it stays step-local); the in-container gitlab provider redeems it
+# verbatim while the request-URL vars stay on the host. Idempotent within a step.
+# Fails closed (2) if the catalog lacks the token: sigstore grant or the job lacks
+# id-token: write — there is no in-job fallback.
 wrangle_mint_sigstore_token() {
     [[ -n "${SIGSTORE_ID_TOKEN:-}" ]] && return 0
-    local url="${ACTIONS_ID_TOKEN_REQUEST_URL:-}" reqtok="${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
-    if [[ -z "$url" || -z "$reqtok" ]]; then
-        printf 'wrangle: cannot mint SIGSTORE_ID_TOKEN — ambient OIDC request vars absent (job needs id-token: write)\n' >&2
+    if [[ "$(read_catalog_field "$(_wrangle_toolbox_catalog)" "$WRANGLE_TOOLBOX_TOOL" token)" != "sigstore" ]]; then
+        printf 'wrangle: %s lacks the token: sigstore grant — cannot mint a signing token\n' "$WRANGLE_TOOLBOX_TOOL" >&2
         return 2
     fi
-    # Pass the bearer via stdin (-H @-), never on curl's argv, so it never lands
-    # on /proc/<pid>/cmdline — the in-job signer reads it from env, not argv.
+    local url="${ACTIONS_ID_TOKEN_REQUEST_URL:-}" reqtok="${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+    if [[ -z "$url" || -z "$reqtok" ]]; then
+        printf 'wrangle: signing requires a Sigstore OIDC token but the job lacks id-token: write\n' >&2
+        return 2
+    fi
+    # Bearer on stdin (-H @-), never argv, so it never lands on /proc/<pid>/cmdline.
     local resp token
     if ! resp="$(printf 'Authorization: bearer %s\n' "$reqtok" \
         | curl -sSf --retry 2 -H @- "${url}&audience=sigstore")"; then
@@ -131,21 +110,14 @@ wrangle_toolbox_add_mount() {
 }
 
 # One hardened docker run of the VSA-gated toolbox image. The workspace ($PWD) and
-# RUNNER_TEMP are bind-mounted at their own paths and the container working dir is
-# set to $PWD, so the SAME relative METADATA_ROOT/SUBJECTS and relative command
-# args wrangle passes resolve exactly as the in-job binary's do — no argv
-# divergence, and docker's absolute-path requirement for -v is met by the process
-# cwd. Flags precede a `--` separator, then the in-container command:
-#   --mount <dir>      add an extra read-only bind (e.g. the policy dir, which
-#                      ships in the action checkout outside the workspace)
-#   --env <NAME>       thread the host env var NAME by name only, never by value
-#                      (its value never lands on docker's argv)
-#   --docker-config    mount the runner's registry credentials read-only so
-#                      cosign/ampel reach ghcr with the job's login
-#   --                 end of flags; the rest is the command run in the image
-# The token-minting request vars are never threaded; callers pass only
-# SIGSTORE_ID_TOKEN and/or GITHUB_TOKEN via --env. No retry/capture here — callers
-# wrap this in wrangle_retry_once exactly where they wrap the in-job binary.
+# RUNNER_TEMP are bind-mounted at their own paths and the working dir is set to
+# $PWD, so wrangle's relative METADATA_ROOT/SUBJECTS/command args resolve exactly
+# as in-job (docker -v needs absolute paths; wrangle passes relative). Flags
+# precede a `--`, then the in-container command:
+#   --mount <dir>      extra read-only bind (e.g. the policy dir, outside $PWD)
+#   --env <NAME>       thread host var NAME by name only, never its value on argv
+#   --docker-config    mount the runner's registry credentials read-only
+#   --                 end of flags
 wrangle_toolbox_exec() {
     local -a mounts=() env_flags=(-e HOME=/tmp)
     local workdir="$PWD"

--- a/lib/toolbox_run.sh
+++ b/lib/toolbox_run.sh
@@ -5,7 +5,6 @@
 #
 # Provides:
 #   wrangle_toolbox_image        — resolve, digest-pin-check, VSA-gate (memoized)
-#   wrangle_toolbox_network      — the catalog network as a docker --network
 #   wrangle_mint_sigstore_token  — mint aud=sigstore SIGSTORE_ID_TOKEN, step-local
 #   wrangle_toolbox_exec         — one hardened docker run of the toolbox image
 
@@ -20,14 +19,16 @@ source "$_TOOLBOX_RUN_DIR/verify_image_vsa.sh"
 
 WRANGLE_TOOLBOX_TOOL="attest-toolbox"
 
-# The catalog the grant is read from; a test/adopter run may override it.
+# Echo the catalog path: WRANGLE_CATALOG if a test/adopter set it, else the
+# in-repo default. Takes no arguments.
 _wrangle_toolbox_catalog() {
     printf '%s\n' "${WRANGLE_CATALOG:-$_TOOLBOX_RUN_DIR/../tools/catalog.json}"
 }
 
 # Resolve the toolbox image, assert it is @sha256:-digest-pinned, and VSA-gate it
-# before any container consumes it. Memoized so the network verify runs once per
-# step. Echoes the image; returns 2 (no docker) on a missing/unpinned image or a
+# before any container consumes it. Takes no arguments; reads the catalog and
+# WRANGLE_VERIFY_TOOL_IMAGES. Memoized so the network verify runs once per step.
+# Echoes the image; returns 2 (no docker) on a missing/unpinned image or a
 # non-PASSED VSA. WRANGLE_VERIFY_TOOL_IMAGES=0 skips the gate for a Sigstore outage.
 _WRANGLE_TOOLBOX_IMAGE_VERIFIED=""
 wrangle_toolbox_image() {
@@ -58,22 +59,15 @@ wrangle_toolbox_image() {
     printf '%s\n' "$image"
 }
 
-# "egress" -> docker's default bridge; anything else -> no network.
-wrangle_toolbox_network() {
-    case "$(read_catalog_field "$(_wrangle_toolbox_catalog)" "$WRANGLE_TOOLBOX_TOOL" network)" in
-        egress) printf 'bridge\n' ;;
-        *)      printf 'none\n' ;;
-    esac
-}
-
 # Mint an aud=sigstore SIGSTORE_ID_TOKEN into this process's env only (never
 # GITHUB_ENV, so it stays step-local); the in-container gitlab provider redeems it
 # verbatim while the request-URL vars stay on the host. Fails closed (2) if the
 # catalog lacks the token: sigstore grant or the job lacks id-token: write — there
 # is no in-job fallback.
 #
-# Cached for the step: once minted, SIGSTORE_ID_TOKEN is reused rather than
-# re-requested.
+# Takes no arguments; reads the ambient ACTIONS_ID_TOKEN_REQUEST_{URL,TOKEN} and
+# the catalog grant, and exports SIGSTORE_ID_TOKEN. Cached for the step: once
+# minted, SIGSTORE_ID_TOKEN is reused rather than re-requested.
 wrangle_mint_sigstore_token() {
     [[ -n "${SIGSTORE_ID_TOKEN:-}" ]] && return 0
     if [[ "$(read_catalog_field "$(_wrangle_toolbox_catalog)" "$WRANGLE_TOOLBOX_TOOL" token)" != "sigstore" ]]; then
@@ -122,8 +116,9 @@ wrangle_toolbox_add_mount() {
 # One hardened docker run of the VSA-gated toolbox image. The workspace ($PWD) and
 # RUNNER_TEMP are bind-mounted at their own paths and the working dir is set to
 # $PWD, so wrangle's relative METADATA_ROOT/SUBJECTS/command args resolve exactly
-# as in-job (bind mounts need absolute paths; wrangle passes relative). Flags
-# precede a `--`, then the in-container command:
+# as in-job (bind mounts need absolute paths; wrangle passes relative). The args
+# are the flags below, a `--`, then the in-container command (the tool and its
+# arguments):
 #   --sigstore         mint + thread a step-local SIGSTORE_ID_TOKEN by name (the
 #                      keyless signing token); fails closed if it cannot be minted
 #   --env <NAME>       thread host var NAME by name only, never its value on argv
@@ -153,7 +148,7 @@ wrangle_toolbox_exec() {
     done
     local image net
     image="$(wrangle_toolbox_image)" || return 2
-    net="$(wrangle_toolbox_network)"
+    net="$(catalog_docker_network "$(_wrangle_toolbox_catalog)" "$WRANGLE_TOOLBOX_TOOL")"
     docker run --rm --network "$net" \
         --cap-drop ALL --security-opt no-new-privileges \
         -u "$(id -u):$(id -g)" -w "$workdir" \

--- a/lib/toolbox_run.sh
+++ b/lib/toolbox_run.sh
@@ -68,13 +68,17 @@ wrangle_toolbox_network() {
 
 # Mint an aud=sigstore SIGSTORE_ID_TOKEN into this process's env only (never
 # GITHUB_ENV, so it stays step-local); the in-container gitlab provider redeems it
-# verbatim while the request-URL vars stay on the host. Idempotent within a step.
-# Fails closed (2) if the catalog lacks the token: sigstore grant or the job lacks
-# id-token: write — there is no in-job fallback.
+# verbatim while the request-URL vars stay on the host. Fails closed (2) if the
+# catalog lacks the token: sigstore grant or the job lacks id-token: write — there
+# is no in-job fallback.
+#
+# Cached for the step: once minted, SIGSTORE_ID_TOKEN is reused rather than
+# re-requested.
 wrangle_mint_sigstore_token() {
     [[ -n "${SIGSTORE_ID_TOKEN:-}" ]] && return 0
     if [[ "$(read_catalog_field "$(_wrangle_toolbox_catalog)" "$WRANGLE_TOOLBOX_TOOL" token)" != "sigstore" ]]; then
-        printf 'wrangle: %s lacks the token: sigstore grant — cannot mint a signing token\n' "$WRANGLE_TOOLBOX_TOOL" >&2
+        printf 'wrangle: catalog %s does not grant %s the "token: sigstore" capability required to sign\n' \
+            "$(_wrangle_toolbox_catalog)" "$WRANGLE_TOOLBOX_TOOL" >&2
         return 2
     fi
     local url="${ACTIONS_ID_TOKEN_REQUEST_URL:-}" reqtok="${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
@@ -82,10 +86,14 @@ wrangle_mint_sigstore_token() {
         printf 'wrangle: signing requires a Sigstore OIDC token but the job lacks id-token: write\n' >&2
         return 2
     fi
+    # &audience= vs ?audience=: append with whichever separator the request URL
+    # still needs (GitHub supplies ?api-version=, but don't assume a query exists).
+    local sep='&'
+    [[ "$url" == *'?'* ]] || sep='?'
     # Bearer on stdin (-H @-), never argv, so it never lands on /proc/<pid>/cmdline.
     local resp token
     if ! resp="$(printf 'Authorization: bearer %s\n' "$reqtok" \
-        | curl -sSf --retry 2 -H @- "${url}&audience=sigstore")"; then
+        | curl -sSf --retry 2 -H @- "${url}${sep}audience=sigstore")"; then
         printf 'wrangle: failed to mint SIGSTORE_ID_TOKEN from the OIDC request endpoint\n' >&2
         return 1
     fi
@@ -98,25 +106,29 @@ wrangle_mint_sigstore_token() {
 }
 
 # Append a bind mount (host path == container path) to the caller's mount-flags
-# array, deduped by path. $1 = array name, $2 = path, $3 = ro|rw.
+# array, deduped by source path. --mount (not -v) so a path containing a colon
+# parses correctly. $1 = array name, $2 = path, $3 = ro|rw.
 wrangle_toolbox_add_mount() {
     local -n _arr="$1"
-    local path="$2" mode="$3" flag i
+    local path="$2" mode="$3" spec i
     for ((i = 0; i < ${#_arr[@]}; i++)); do
-        [[ "${_arr[i]}" == "-v" && "${_arr[i + 1]%%:*}" == "$path" ]] && return 0
+        [[ "${_arr[i]}" == "--mount" && "${_arr[i + 1]}" == *"source=$path,"* ]] && return 0
     done
-    if [[ "$mode" == "ro" ]]; then flag="$path:$path:ro"; else flag="$path:$path"; fi
-    _arr+=(-v "$flag")
+    spec="type=bind,source=$path,target=$path"
+    [[ "$mode" == "ro" ]] && spec="$spec,readonly"
+    _arr+=(--mount "$spec")
 }
 
 # One hardened docker run of the VSA-gated toolbox image. The workspace ($PWD) and
 # RUNNER_TEMP are bind-mounted at their own paths and the working dir is set to
 # $PWD, so wrangle's relative METADATA_ROOT/SUBJECTS/command args resolve exactly
-# as in-job (docker -v needs absolute paths; wrangle passes relative). Flags
+# as in-job (bind mounts need absolute paths; wrangle passes relative). Flags
 # precede a `--`, then the in-container command:
-#   --mount <dir>      extra read-only bind (e.g. the policy dir, outside $PWD)
+#   --sigstore         mint + thread a step-local SIGSTORE_ID_TOKEN by name (the
+#                      keyless signing token); fails closed if it cannot be minted
 #   --env <NAME>       thread host var NAME by name only, never its value on argv
 #   --docker-config    mount the runner's registry credentials read-only
+#   --mount <dir>      extra read-only bind (e.g. the policy dir, outside $PWD)
 #   --                 end of flags
 wrangle_toolbox_exec() {
     local -a mounts=() env_flags=(-e HOME=/tmp)
@@ -126,13 +138,15 @@ wrangle_toolbox_exec() {
         wrangle_toolbox_add_mount mounts "$RUNNER_TEMP" rw
     while [[ "$#" -gt 0 ]]; do
         case "$1" in
-            --mount)        wrangle_toolbox_add_mount mounts "$2" ro; shift 2 ;;
+            --sigstore)     wrangle_mint_sigstore_token || return $?
+                            env_flags+=(-e SIGSTORE_ID_TOKEN); shift ;;
             --env)          env_flags+=(-e "$2"); shift 2 ;;
             --docker-config)
                 local cfg="${DOCKER_CONFIG:-$HOME/.docker}"
-                mounts+=(-v "$cfg":/wrangle/docker-config:ro)
+                mounts+=(--mount "type=bind,source=$cfg,target=/wrangle/docker-config,readonly")
                 env_flags+=(-e DOCKER_CONFIG=/wrangle/docker-config)
                 shift ;;
+            --mount)        wrangle_toolbox_add_mount mounts "$2" ro; shift 2 ;;
             --)             shift; break ;;
             *)              printf 'wrangle_toolbox_exec: unexpected flag %s\n' "$1" >&2; return 2 ;;
         esac

--- a/lib/toolbox_run.sh
+++ b/lib/toolbox_run.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# lib/toolbox_run.sh — shared primitives for running wrangle's signing/verify
+# toolbox (cosign, ampel, bnd, wrangle-attest) inside the curated attest-toolbox
+# image. Sourced by actions/verify/run_verify.sh and lib/sign_metadata.sh; each
+# signer helper containerizes only when the grant + opt-in are present, and runs
+# the in-job binary byte-for-byte otherwise (the break-glass revert).
+#
+# Provides:
+#   wrangle_toolbox_optin            — the WRANGLE_VERIFY_AMPEL_TOOLBOX toggle
+#   wrangle_toolbox_signing_enabled  — optin AND the catalog token: sigstore grant
+#   wrangle_toolbox_image            — resolve, digest-pin-check, VSA-gate (memoized)
+#   wrangle_toolbox_network          — the catalog network as a docker --network
+#   wrangle_mint_sigstore_token      — mint aud=sigstore SIGSTORE_ID_TOKEN, step-local
+#   wrangle_toolbox_exec             — one hardened docker run of the toolbox image
+
+set -euo pipefail
+set -f
+
+_TOOLBOX_RUN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/read_catalog.sh
+source "$_TOOLBOX_RUN_DIR/read_catalog.sh"
+# shellcheck source=lib/verify_image_vsa.sh
+source "$_TOOLBOX_RUN_DIR/verify_image_vsa.sh"
+
+WRANGLE_TOOLBOX_TOOL="attest-toolbox"
+
+# The catalog the grant is read from; a test/adopter run may override it.
+_wrangle_toolbox_catalog() {
+    printf '%s\n' "${WRANGLE_CATALOG:-$_TOOLBOX_RUN_DIR/../tools/catalog.json}"
+}
+
+# True when the opt-in toggle selects the toolbox image over the in-job binary.
+wrangle_toolbox_optin() {
+    case "${WRANGLE_VERIFY_AMPEL_TOOLBOX:-}" in
+        1|true) return 0 ;;
+        *)      return 1 ;;
+    esac
+}
+
+# True when signing may run in-container: the opt-in AND the catalog's
+# attest-toolbox carrying the token: sigstore grant. Absent grant keeps signing
+# in-job even under the opt-in, so a container never signs without a declared
+# token grant.
+wrangle_toolbox_signing_enabled() {
+    wrangle_toolbox_optin || return 1
+    [[ "$(read_catalog_field "$(_wrangle_toolbox_catalog)" "$WRANGLE_TOOLBOX_TOOL" token)" == "sigstore" ]]
+}
+
+# Resolve the toolbox image, assert it is @sha256:-digest-pinned, and VSA-gate it
+# fail-closed before any container consumes it. Memoized: the digest is immutable
+# within a step, so the gate's network verify runs once and every later docker run
+# reuses the verdict. Echoes the image on success; returns 2 (no docker) on a
+# missing/unpinned image or a non-PASSED VSA. WRANGLE_VERIFY_TOOL_IMAGES=0 is the
+# sustained-Sigstore-outage break-glass that skips the gate.
+_WRANGLE_TOOLBOX_IMAGE_VERIFIED=""
+wrangle_toolbox_image() {
+    if [[ -n "$_WRANGLE_TOOLBOX_IMAGE_VERIFIED" ]]; then
+        printf '%s\n' "$_WRANGLE_TOOLBOX_IMAGE_VERIFIED"
+        return 0
+    fi
+    local catalog image
+    catalog="$(_wrangle_toolbox_catalog)"
+    image="$(read_catalog_field "$catalog" "$WRANGLE_TOOLBOX_TOOL" image)"
+    if [[ -z "$image" ]]; then
+        printf 'wrangle: catalog %s has no %s image\n' "$catalog" "$WRANGLE_TOOLBOX_TOOL" >&2
+        return 2
+    fi
+    if [[ ! "$image" =~ @sha256:[0-9a-f]{64}$ ]]; then
+        printf 'wrangle: toolbox image must be @sha256:-digest-pinned (got %s)\n' "$image" >&2
+        return 2
+    fi
+    if [[ "${WRANGLE_VERIFY_TOOL_IMAGES:-1}" == "0" ]]; then
+        printf 'wrangle: toolbox-image VSA verification disabled by configuration\n' >&2
+    elif verify_image_vsa "$image"; then
+        printf 'wrangle: toolbox-image VSA verified PASSED\n' >&2
+    else
+        printf 'wrangle: toolbox-image VSA verification failed (image not provably PASSED)\n' >&2
+        return 2
+    fi
+    _WRANGLE_TOOLBOX_IMAGE_VERIFIED="$image"
+    printf '%s\n' "$image"
+}
+
+# "egress" -> docker's default bridge; anything else -> no network.
+wrangle_toolbox_network() {
+    case "$(read_catalog_field "$(_wrangle_toolbox_catalog)" "$WRANGLE_TOOLBOX_TOOL" network)" in
+        egress) printf 'bridge\n' ;;
+        *)      printf 'none\n' ;;
+    esac
+}
+
+# Mint an aud=sigstore SIGSTORE_ID_TOKEN from the ambient GitHub OIDC request vars
+# into this process's env only — never GITHUB_ENV, so it stays step-local. The
+# in-container gitlab provider of carabiner-dev/signer redeems it verbatim; the
+# request-URL vars stay on the host, so the container cannot mint a token for any
+# other audience. Idempotent within a step. Returns 2 when the request vars are
+# absent (the job lacks id-token: write).
+wrangle_mint_sigstore_token() {
+    [[ -n "${SIGSTORE_ID_TOKEN:-}" ]] && return 0
+    local url="${ACTIONS_ID_TOKEN_REQUEST_URL:-}" reqtok="${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+    if [[ -z "$url" || -z "$reqtok" ]]; then
+        printf 'wrangle: cannot mint SIGSTORE_ID_TOKEN — ambient OIDC request vars absent (job needs id-token: write)\n' >&2
+        return 2
+    fi
+    local resp token
+    if ! resp="$(curl -sSf --retry 2 -H "Authorization: bearer $reqtok" "${url}&audience=sigstore")"; then
+        printf 'wrangle: failed to mint SIGSTORE_ID_TOKEN from the OIDC request endpoint\n' >&2
+        return 1
+    fi
+    token="$(printf '%s' "$resp" | jq -r '.value // empty')"
+    if [[ -z "$token" ]]; then
+        printf 'wrangle: OIDC token endpoint returned no .value\n' >&2
+        return 1
+    fi
+    export SIGSTORE_ID_TOKEN="$token"
+}
+
+# Append a bind mount (host path == container path, so the in-container command
+# reads the same absolute paths the in-job binary would) to the caller's mount-
+# flags array, deduped by path. $1 = array name, $2 = path, $3 = ro|rw.
+wrangle_toolbox_add_mount() {
+    local -n _arr="$1"
+    local path="$2" mode="$3" flag i
+    for ((i = 0; i < ${#_arr[@]}; i++)); do
+        [[ "${_arr[i]}" == "-v" && "${_arr[i + 1]%%:*}" == "$path" ]] && return 0
+    done
+    if [[ "$mode" == "ro" ]]; then flag="$path:$path:ro"; else flag="$path:$path"; fi
+    _arr+=(-v "$flag")
+}
+
+# One hardened docker run of the VSA-gated toolbox image. Flags precede a `--`
+# separator, then the in-container command:
+#   -v <spec>          add a bind mount (repeatable)
+#   --env <NAME>       thread the host env var NAME by name only, never by value
+#                      (its value never lands on docker's argv)
+#   --docker-config    mount the runner's registry credentials read-only so
+#                      cosign/ampel reach ghcr with the job's login
+#   --                 end of flags; the rest is the command run in the image
+# The token-minting request vars are never threaded; callers pass only
+# SIGSTORE_ID_TOKEN and/or GITHUB_TOKEN via --env. No retry/capture here — callers
+# wrap this in wrangle_retry_once exactly where they wrap the in-job binary.
+wrangle_toolbox_exec() {
+    local -a mounts=() env_flags=(-e HOME=/tmp)
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            -v)             mounts+=(-v "$2"); shift 2 ;;
+            --env)          env_flags+=(-e "$2"); shift 2 ;;
+            --docker-config)
+                local cfg="${DOCKER_CONFIG:-$HOME/.docker}"
+                mounts+=(-v "$cfg":/wrangle/docker-config:ro)
+                env_flags+=(-e DOCKER_CONFIG=/wrangle/docker-config)
+                shift ;;
+            --)             shift; break ;;
+            *)              printf 'wrangle_toolbox_exec: unexpected flag %s\n' "$1" >&2; return 2 ;;
+        esac
+    done
+    local image net
+    image="$(wrangle_toolbox_image)" || return 2
+    net="$(wrangle_toolbox_network)"
+    docker run --rm --network "$net" \
+        --cap-drop ALL --security-opt no-new-privileges \
+        -u "$(id -u):$(id -g)" \
+        "${mounts[@]}" "${env_flags[@]}" \
+        "$image" "$@"
+}

--- a/lib/toolbox_run.sh
+++ b/lib/toolbox_run.sh
@@ -102,8 +102,11 @@ wrangle_mint_sigstore_token() {
         printf 'wrangle: cannot mint SIGSTORE_ID_TOKEN — ambient OIDC request vars absent (job needs id-token: write)\n' >&2
         return 2
     fi
+    # Pass the bearer via stdin (-H @-), never on curl's argv, so it never lands
+    # on /proc/<pid>/cmdline — the in-job signer reads it from env, not argv.
     local resp token
-    if ! resp="$(curl -sSf --retry 2 -H "Authorization: bearer $reqtok" "${url}&audience=sigstore")"; then
+    if ! resp="$(printf 'Authorization: bearer %s\n' "$reqtok" \
+        | curl -sSf --retry 2 -H @- "${url}&audience=sigstore")"; then
         printf 'wrangle: failed to mint SIGSTORE_ID_TOKEN from the OIDC request endpoint\n' >&2
         return 1
     fi
@@ -115,9 +118,8 @@ wrangle_mint_sigstore_token() {
     export SIGSTORE_ID_TOKEN="$token"
 }
 
-# Append a bind mount (host path == container path, so the in-container command
-# reads the same absolute paths the in-job binary would) to the caller's mount-
-# flags array, deduped by path. $1 = array name, $2 = path, $3 = ro|rw.
+# Append a bind mount (host path == container path) to the caller's mount-flags
+# array, deduped by path. $1 = array name, $2 = path, $3 = ro|rw.
 wrangle_toolbox_add_mount() {
     local -n _arr="$1"
     local path="$2" mode="$3" flag i
@@ -128,9 +130,14 @@ wrangle_toolbox_add_mount() {
     _arr+=(-v "$flag")
 }
 
-# One hardened docker run of the VSA-gated toolbox image. Flags precede a `--`
-# separator, then the in-container command:
-#   -v <spec>          add a bind mount (repeatable)
+# One hardened docker run of the VSA-gated toolbox image. The workspace ($PWD) and
+# RUNNER_TEMP are bind-mounted at their own paths and the container working dir is
+# set to $PWD, so the SAME relative METADATA_ROOT/SUBJECTS and relative command
+# args wrangle passes resolve exactly as the in-job binary's do — no argv
+# divergence, and docker's absolute-path requirement for -v is met by the process
+# cwd. Flags precede a `--` separator, then the in-container command:
+#   --mount <dir>      add an extra read-only bind (e.g. the policy dir, which
+#                      ships in the action checkout outside the workspace)
 #   --env <NAME>       thread the host env var NAME by name only, never by value
 #                      (its value never lands on docker's argv)
 #   --docker-config    mount the runner's registry credentials read-only so
@@ -141,9 +148,13 @@ wrangle_toolbox_add_mount() {
 # wrap this in wrangle_retry_once exactly where they wrap the in-job binary.
 wrangle_toolbox_exec() {
     local -a mounts=() env_flags=(-e HOME=/tmp)
+    local workdir="$PWD"
+    wrangle_toolbox_add_mount mounts "$workdir" rw
+    [[ -n "${RUNNER_TEMP:-}" && "$RUNNER_TEMP" != "$workdir" ]] &&
+        wrangle_toolbox_add_mount mounts "$RUNNER_TEMP" rw
     while [[ "$#" -gt 0 ]]; do
         case "$1" in
-            -v)             mounts+=(-v "$2"); shift 2 ;;
+            --mount)        wrangle_toolbox_add_mount mounts "$2" ro; shift 2 ;;
             --env)          env_flags+=(-e "$2"); shift 2 ;;
             --docker-config)
                 local cfg="${DOCKER_CONFIG:-$HOME/.docker}"
@@ -159,7 +170,7 @@ wrangle_toolbox_exec() {
     net="$(wrangle_toolbox_network)"
     docker run --rm --network "$net" \
         --cap-drop ALL --security-opt no-new-privileges \
-        -u "$(id -u):$(id -g)" \
+        -u "$(id -u):$(id -g)" -w "$workdir" \
         "${mounts[@]}" "${env_flags[@]}" \
-        "$image" "$@"
+        -- "$image" "$@"
 }

--- a/test/lib/bats_helpers.bash
+++ b/test/lib/bats_helpers.bash
@@ -20,3 +20,44 @@ skip_or_fail() {
     fi
     skip "$1"
 }
+
+# A digest-pinned curated toolbox image used across the signer tests.
+WRANGLE_TEST_TOOLBOX_IMAGE="ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+# wrangle_stub_toolbox_transparent [dir]: make the always-containerized signer
+# path transparent for orchestration tests — the token grant is present, the VSA
+# gate passes, the mint succeeds, and `docker run … -- <image> <tool> <args>`
+# execs `<tool> <args>` on the host (host==container paths), so a test's in-PATH
+# tool stub runs and its arg/IO assertions hold. Tests that inspect the docker
+# argv or exercise fail-closed paths install their own recording docker stub +
+# catalog, which override this.
+wrangle_stub_toolbox_transparent() {
+    local dir="${1:-$TEST_DIR}"
+    cat > "$dir/docker" <<'EOF'
+#!/bin/bash
+# Exec the in-container command: everything after `-- <image>`.
+args=("$@")
+i=0
+while [[ $i -lt ${#args[@]} && "${args[$i]}" != "--" ]]; do i=$((i + 1)); done
+exec "${args[@]:$((i + 2))}"
+EOF
+    cat > "$dir/gh" <<EOF
+#!/bin/bash
+cat <<JSON
+[{"verificationResult":{"statement":{"predicate":{"verificationResult":"PASSED","resourceUri":"$WRANGLE_TEST_TOOLBOX_IMAGE","verifiedLevels":["SLSA_BUILD_LEVEL_3"]}}}}]
+JSON
+EOF
+    cat > "$dir/curl" <<'EOF'
+#!/bin/bash
+printf '{"value":"MINTED-SIGSTORE-JWT"}\n'
+EOF
+    chmod +x "$dir/docker" "$dir/gh" "$dir/curl"
+    cat > "$dir/catalog.json" <<EOF
+{"tools":{"attest-toolbox":{"kind":"attest","image":"$WRANGLE_TEST_TOOLBOX_IMAGE","network":"egress","token":"sigstore"}}}
+EOF
+    export PATH="$dir:$PATH"
+    export WRANGLE_CATALOG="$dir/catalog.json"
+    export ACTIONS_ID_TOKEN_REQUEST_URL="https://oidc.example/token"
+    export ACTIONS_ID_TOKEN_REQUEST_TOKEN="request-bearer-secret"
+    export GITHUB_TOKEN="${GITHUB_TOKEN:-registry-token}"
+}

--- a/test/test_sign_metadata.bats
+++ b/test/test_sign_metadata.bats
@@ -332,7 +332,8 @@ JSON
 
 @test "sign_metadata: OCI referrer push runs in-container with the job's registry login" {
     _stub_toolbox_container
-    export OCI_TARGET="ghcr.io/o/r/img@sha256:$(printf '0%.0s' {1..64})"
+    local sha; sha="$(printf '0%.0s' {1..64})"
+    export OCI_TARGET="ghcr.io/o/r/img@sha256:$sha"
     export HOME="$TEST_DIR"; mkdir -p "$TEST_DIR/.docker"
     printf 'stmt\n' > "$TEST_DIR/line.json"
     wrangle_push_oci_referrer "$TEST_DIR/line.json"

--- a/test/test_sign_metadata.bats
+++ b/test/test_sign_metadata.bats
@@ -313,8 +313,10 @@ JSON
     ! grep -q "MINTED-SIGSTORE-JWT" "$TEST_DIR/docker.args"
     ! grep -q "ACTIONS_ID_TOKEN_REQUEST" "$TEST_DIR/docker.args"
     ! grep -q -- "-e GITHUB_TOKEN" "$TEST_DIR/docker.args"
-    # The metadata root is mounted read-only.
-    grep -q -- "-v $meta:$meta:ro" "$TEST_DIR/docker.args"
+    # The workspace and RUNNER_TEMP are mounted and the working dir is set, so the
+    # same (relative-in-prod) metadata/subject/out paths resolve as they do in-job.
+    grep -q -- "-w $PWD" "$TEST_DIR/docker.args"
+    grep -q -- "-v $RUNNER_TEMP:$RUNNER_TEMP" "$TEST_DIR/docker.args"
 }
 
 @test "sign_metadata: store push runs in-container with the registry token, no sigstore token" {
@@ -360,4 +362,39 @@ STUB
     grep -qx -- "--subject=sha256:$sha" "$TEST_DIR/attest.args"
     grep -qx -- "--sign" "$TEST_DIR/attest.args"
     [ ! -f "$TEST_DIR/docker.args" ]
+}
+
+@test "sign_metadata: relative METADATA_ROOT never becomes an invalid relative -v (blocker guard)" {
+    _stub_toolbox_container
+    # wrangle sets METADATA_ROOT/SUBJECTS relative; docker -v requires absolute, so
+    # the signer must mount the workspace + set -w, never a relative -v.
+    cd "$TEST_DIR"
+    mkdir -p metadata; printf '{}' > metadata/wrangle_attestation_metadata.json
+    export METADATA_ROOT="metadata" COMMIT="abc123"
+    local sha; sha="$(printf '0%.0s' {1..64})"
+    wrangle_sign_metadata_statements "sha256:$sha" "out.jsonl"
+    # Every -v is an absolute host path (starts with /); none is relative.
+    ! grep -qE -- '-v [^/]' "$TEST_DIR/docker.args"
+    # The workspace is mounted and set as the container working dir instead.
+    grep -q -- "-w $TEST_DIR" "$TEST_DIR/docker.args"
+    grep -q -- "-v $TEST_DIR:$TEST_DIR" "$TEST_DIR/docker.args"
+}
+
+@test "sign_metadata: metadata signing fails closed on a token-mint failure (no docker, no in-job fallback)" {
+    _stub_toolbox_container
+    # Mint fails when the ambient OIDC request vars are absent; the grant+opt-in
+    # path must NOT fall back to an in-job wrangle-attest.
+    unset ACTIONS_ID_TOKEN_REQUEST_URL ACTIONS_ID_TOKEN_REQUEST_TOKEN
+    cat > "$TEST_DIR/wrangle-attest" <<EOF
+#!/bin/bash
+touch "$TEST_DIR/attest.called"
+EOF
+    chmod +x "$TEST_DIR/wrangle-attest"
+    local meta="$TEST_DIR/meta"; mkdir -p "$meta"; printf '{}' > "$meta/wrangle_attestation_metadata.json"
+    export METADATA_ROOT="$meta" COMMIT="abc123"
+    local sha; sha="$(printf '0%.0s' {1..64})"
+    run wrangle_sign_metadata_statements "sha256:$sha" "$TEST_DIR/out.jsonl"
+    [ "$status" -ne 0 ]
+    [ ! -f "$TEST_DIR/docker.args" ]
+    [ ! -f "$TEST_DIR/attest.called" ]
 }

--- a/test/test_sign_metadata.bats
+++ b/test/test_sign_metadata.bats
@@ -263,3 +263,100 @@ STUB
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"no signed metadata"* ]]
 }
+
+# --- containerized signing (the attest-toolbox image under the grant + opt-in) ---
+
+_toolbox_image="ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+# docker records its argv; gh returns a PASSED L3 VSA for the toolbox image; curl
+# mints a fixed sigstore JWT; the catalog carries the token: sigstore grant.
+_stub_toolbox_container() {
+    cat > "$TEST_DIR/docker" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" > "$TEST_DIR/docker.args"
+EOF
+    cat > "$TEST_DIR/gh" <<EOF
+#!/bin/bash
+cat <<JSON
+[{"verificationResult":{"statement":{"predicate":{"verificationResult":"PASSED","resourceUri":"$_toolbox_image","verifiedLevels":["SLSA_BUILD_LEVEL_3"]}}}}]
+JSON
+EOF
+    cat > "$TEST_DIR/curl" <<'EOF'
+#!/bin/bash
+printf '{"value":"MINTED-SIGSTORE-JWT"}\n'
+EOF
+    chmod +x "$TEST_DIR/docker" "$TEST_DIR/gh" "$TEST_DIR/curl"
+    cat > "$TEST_DIR/catalog.json" <<JSON
+{"tools":{"attest-toolbox":{"kind":"attest","image":"$_toolbox_image","network":"egress","token":"sigstore"}}}
+JSON
+    export PATH="$TEST_DIR:$PATH"
+    export WRANGLE_CATALOG="$TEST_DIR/catalog.json"
+    export WRANGLE_VERIFY_AMPEL_TOOLBOX=1
+    export ACTIONS_ID_TOKEN_REQUEST_URL="https://oidc.example/token"
+    export ACTIONS_ID_TOKEN_REQUEST_TOKEN="request-bearer-secret"
+    export GITHUB_TOKEN="registry-token"
+}
+
+@test "sign_metadata: metadata signing runs in-container with a name-threaded sigstore token" {
+    _stub_toolbox_container
+    local meta="$TEST_DIR/meta"; mkdir -p "$meta"
+    printf '{}' > "$meta/wrangle_attestation_metadata.json"
+    export METADATA_ROOT="$meta" COMMIT="abc123"
+    local sha; sha="$(printf '0%.0s' {1..64})"
+    wrangle_sign_metadata_statements "sha256:$sha" "$TEST_DIR/out.jsonl"
+    # wrangle-attest --sign ran inside the VSA-gated toolbox image.
+    grep -q -- "$_toolbox_image wrangle-attest" "$TEST_DIR/docker.args"
+    grep -q -- "--sign" "$TEST_DIR/docker.args"
+    # Only the sigstore token is threaded, by name; never the request vars, never
+    # the minted value on argv, never the registry token.
+    grep -q -- "-e SIGSTORE_ID_TOKEN" "$TEST_DIR/docker.args"
+    ! grep -q "MINTED-SIGSTORE-JWT" "$TEST_DIR/docker.args"
+    ! grep -q "ACTIONS_ID_TOKEN_REQUEST" "$TEST_DIR/docker.args"
+    ! grep -q -- "-e GITHUB_TOKEN" "$TEST_DIR/docker.args"
+    # The metadata root is mounted read-only.
+    grep -q -- "-v $meta:$meta:ro" "$TEST_DIR/docker.args"
+}
+
+@test "sign_metadata: store push runs in-container with the registry token, no sigstore token" {
+    _stub_toolbox_container
+    export GITHUB_REPOSITORY="o/r"
+    printf 'stmt\n' > "$TEST_DIR/line.json"
+    wrangle_push_store "$TEST_DIR/line.json"
+    grep -q -- "$_toolbox_image bnd push github o/r" "$TEST_DIR/docker.args"
+    grep -q -- "-e GITHUB_TOKEN" "$TEST_DIR/docker.args"
+    # A store push is not a signing op — no sigstore token, and the GitHub API
+    # needs no registry-login mount.
+    ! grep -q -- "-e SIGSTORE_ID_TOKEN" "$TEST_DIR/docker.args"
+    ! grep -q -- "docker-config" "$TEST_DIR/docker.args"
+}
+
+@test "sign_metadata: OCI referrer push runs in-container with the job's registry login" {
+    _stub_toolbox_container
+    export OCI_TARGET="ghcr.io/o/r/img@sha256:$(printf '0%.0s' {1..64})"
+    export HOME="$TEST_DIR"; mkdir -p "$TEST_DIR/.docker"
+    printf 'stmt\n' > "$TEST_DIR/line.json"
+    wrangle_push_oci_referrer "$TEST_DIR/line.json"
+    grep -q -- "$_toolbox_image cosign attach attestation" "$TEST_DIR/docker.args"
+    grep -q -- "-e GITHUB_TOKEN" "$TEST_DIR/docker.args"
+    grep -q -- "-e DOCKER_CONFIG=/wrangle/docker-config" "$TEST_DIR/docker.args"
+    ! grep -q -- "-e SIGSTORE_ID_TOKEN" "$TEST_DIR/docker.args"
+}
+
+@test "sign_metadata: break-glass (opt-in off) keeps metadata signing on the in-job binary" {
+    # No container stubs: the in-job wrangle-attest arg vector is unchanged.
+    cat > "$TEST_DIR/wrangle-attest" <<STUB
+#!/bin/bash
+printf '%s\n' "\$@" > "$TEST_DIR/attest.args"
+for a in "\$@"; do case "\$a" in --out=*) printf '{}' > "\${a#--out=}";; esac; done
+STUB
+    chmod +x "$TEST_DIR/wrangle-attest"
+    export PATH="$TEST_DIR:$PATH"
+    local meta="$TEST_DIR/meta"; mkdir -p "$meta"
+    printf '{}' > "$meta/wrangle_attestation_metadata.json"
+    export METADATA_ROOT="$meta" COMMIT="abc123"
+    local sha; sha="$(printf '0%.0s' {1..64})"
+    wrangle_sign_metadata_statements "sha256:$sha" "$TEST_DIR/out.jsonl"
+    grep -qx -- "--subject=sha256:$sha" "$TEST_DIR/attest.args"
+    grep -qx -- "--sign" "$TEST_DIR/attest.args"
+    [ ! -f "$TEST_DIR/docker.args" ]
+}

--- a/test/test_sign_metadata.bats
+++ b/test/test_sign_metadata.bats
@@ -318,7 +318,7 @@ JSON
     # The workspace and RUNNER_TEMP are mounted and the working dir is set, so the
     # same (relative-in-prod) metadata/subject/out paths resolve as they do in-job.
     grep -q -- "-w $PWD" "$TEST_DIR/docker.args"
-    grep -q -- "-v $RUNNER_TEMP:$RUNNER_TEMP" "$TEST_DIR/docker.args"
+    grep -q -- "--mount type=bind,source=$RUNNER_TEMP,target=$RUNNER_TEMP" "$TEST_DIR/docker.args"
 }
 
 @test "sign_metadata: store push runs in-container with the registry token, no sigstore token" {
@@ -362,25 +362,25 @@ EOF
     local sha; sha="$(printf '0%.0s' {1..64})"
     run wrangle_sign_metadata_statements "sha256:$sha" "$TEST_DIR/out.jsonl"
     [ "$status" -ne 0 ]
-    grep -q "lacks the token: sigstore grant" <<< "$output"
+    grep -q "capability required to sign" <<< "$output"
     [ ! -f "$TEST_DIR/docker.args" ]
     [ ! -f "$TEST_DIR/attest.called" ]
 }
 
-@test "sign_metadata: relative METADATA_ROOT never becomes an invalid relative -v (blocker guard)" {
+@test "sign_metadata: relative METADATA_ROOT never becomes an invalid relative bind mount (blocker guard)" {
     _stub_toolbox_container
-    # wrangle sets METADATA_ROOT/SUBJECTS relative; docker -v requires absolute, so
-    # the signer must mount the workspace + set -w, never a relative -v.
+    # wrangle sets METADATA_ROOT/SUBJECTS relative; a bind mount source must be
+    # absolute, so the signer mounts the workspace + sets -w, never a relative source.
     cd "$TEST_DIR"
     mkdir -p metadata; printf '{}' > metadata/wrangle_attestation_metadata.json
     export METADATA_ROOT="metadata" COMMIT="abc123"
     local sha; sha="$(printf '0%.0s' {1..64})"
     wrangle_sign_metadata_statements "sha256:$sha" "out.jsonl"
-    # Every -v is an absolute host path (starts with /); none is relative.
-    ! grep -qE -- '-v [^/]' "$TEST_DIR/docker.args"
+    # Every bind mount source is an absolute host path (starts with /); none is relative.
+    ! grep -qE -- 'source=[^/]' "$TEST_DIR/docker.args"
     # The workspace is mounted and set as the container working dir instead.
     grep -q -- "-w $TEST_DIR" "$TEST_DIR/docker.args"
-    grep -q -- "-v $TEST_DIR:$TEST_DIR" "$TEST_DIR/docker.args"
+    grep -q -- "--mount type=bind,source=$TEST_DIR,target=$TEST_DIR" "$TEST_DIR/docker.args"
 }
 
 @test "sign_metadata: metadata signing fails closed on a token-mint failure (no docker, no in-job fallback)" {

--- a/test/test_sign_metadata.bats
+++ b/test/test_sign_metadata.bats
@@ -19,6 +19,9 @@ setup() {
     export WRANGLE_RETRY_DELAY=0
     # shellcheck source=../lib/sign_metadata.sh
     source "$LIB"
+    # Signing always containerizes; make the toolbox path transparent so the
+    # assemble/seed tests exercise their tool stubs. Recording-docker tests override.
+    wrangle_stub_toolbox_transparent
 }
 
 teardown() {
@@ -264,7 +267,7 @@ STUB
     [[ "$output" == *"no signed metadata"* ]]
 }
 
-# --- containerized signing (the attest-toolbox image under the grant + opt-in) ---
+# --- containerized signing (the attest-toolbox image under the token grant) ---
 
 _toolbox_image="ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:0000000000000000000000000000000000000000000000000000000000000000"
 
@@ -291,7 +294,6 @@ EOF
 JSON
     export PATH="$TEST_DIR:$PATH"
     export WRANGLE_CATALOG="$TEST_DIR/catalog.json"
-    export WRANGLE_VERIFY_AMPEL_TOOLBOX=1
     export ACTIONS_ID_TOKEN_REQUEST_URL="https://oidc.example/token"
     export ACTIONS_ID_TOKEN_REQUEST_TOKEN="request-bearer-secret"
     export GITHUB_TOKEN="registry-token"
@@ -345,23 +347,24 @@ JSON
     ! grep -q -- "-e SIGSTORE_ID_TOKEN" "$TEST_DIR/docker.args"
 }
 
-@test "sign_metadata: break-glass (opt-in off) keeps metadata signing on the in-job binary" {
-    # No container stubs: the in-job wrangle-attest arg vector is unchanged.
-    cat > "$TEST_DIR/wrangle-attest" <<STUB
+@test "sign_metadata: a missing token: sigstore grant fails closed (no docker, no in-job sign)" {
+    _stub_toolbox_container
+    # Strip the grant: signing must fail closed, never fall back to an in-job sign.
+    printf '{"tools":{"attest-toolbox":{"kind":"attest","image":"%s","network":"egress"}}}\n' \
+        "$_toolbox_image" > "$TEST_DIR/catalog.json"
+    cat > "$TEST_DIR/wrangle-attest" <<EOF
 #!/bin/bash
-printf '%s\n' "\$@" > "$TEST_DIR/attest.args"
-for a in "\$@"; do case "\$a" in --out=*) printf '{}' > "\${a#--out=}";; esac; done
-STUB
+touch "$TEST_DIR/attest.called"
+EOF
     chmod +x "$TEST_DIR/wrangle-attest"
-    export PATH="$TEST_DIR:$PATH"
-    local meta="$TEST_DIR/meta"; mkdir -p "$meta"
-    printf '{}' > "$meta/wrangle_attestation_metadata.json"
+    local meta="$TEST_DIR/meta"; mkdir -p "$meta"; printf '{}' > "$meta/wrangle_attestation_metadata.json"
     export METADATA_ROOT="$meta" COMMIT="abc123"
     local sha; sha="$(printf '0%.0s' {1..64})"
-    wrangle_sign_metadata_statements "sha256:$sha" "$TEST_DIR/out.jsonl"
-    grep -qx -- "--subject=sha256:$sha" "$TEST_DIR/attest.args"
-    grep -qx -- "--sign" "$TEST_DIR/attest.args"
+    run wrangle_sign_metadata_statements "sha256:$sha" "$TEST_DIR/out.jsonl"
+    [ "$status" -ne 0 ]
+    grep -q "lacks the token: sigstore grant" <<< "$output"
     [ ! -f "$TEST_DIR/docker.args" ]
+    [ ! -f "$TEST_DIR/attest.called" ]
 }
 
 @test "sign_metadata: relative METADATA_ROOT never becomes an invalid relative -v (blocker guard)" {

--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -29,7 +29,7 @@
     "attest-toolbox": {
       "kind": "attest",
       "delivery": "image",
-      "image": "ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:638972885a6ebb3966aaa47954bad5d10ab4bf009288818a3abd4bdb641b270b",
+      "image": "ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:3995f05ad0584c77ca5d46af64a4b6bd3728c1bd1be18963fd3d3f88844f0b8c",
       "network": "egress",
       "token": "sigstore"
     }

--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -28,8 +28,10 @@
     },
     "attest-toolbox": {
       "kind": "attest",
+      "delivery": "image",
       "image": "ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:638972885a6ebb3966aaa47954bad5d10ab4bf009288818a3abd4bdb641b270b",
-      "network": "egress"
+      "network": "egress",
+      "token": "sigstore"
     }
   }
 }


### PR DESCRIPTION
claude: **#619 Phase 3 — containerized signing, all three sign sites, in one PR.** Do NOT merge yet: this turns container-signing **ON** for wrangle's own tool-image publishing and needs independent security + architecture review **and** a playground validation (below) before LGTM.

Base: `feat/phase3-a1-token-schema` (PR #686 — the `token: sigstore` catalog capability + validator this consumes). Land as a **merge commit, not a squash** — the two `chore: converge self-ref pins` commits are a nested pin chain that re-orphans under a squash.

## What this builds (#619 items 1–8)

A shared `lib/toolbox_run.sh` factors the containerized-signer seam:
- `wrangle_toolbox_signing_enabled` — true only when the catalog `attest-toolbox` carries `token: sigstore` **AND** `WRANGLE_VERIFY_AMPEL_TOOLBOX` is set; else callers run the in-job binary byte-for-byte.
- `wrangle_toolbox_image` — resolve, assert `@sha256:` pin, and run the fail-closed `verify_image_vsa` gate **once per step** (memoized), fronting every token-bearing `docker run`.
- `wrangle_mint_sigstore_token` — mint an `aud=sigstore` `SIGSTORE_ID_TOKEN` from `ACTIONS_ID_TOKEN_REQUEST_{URL,TOKEN}` into the step's process env only (never `GITHUB_ENV`).
- `wrangle_toolbox_exec` — one hardened `docker run` (`--cap-drop ALL --security-opt no-new-privileges -u uid:gid --network bridge`, `HOME=/tmp`), threading `SIGSTORE_ID_TOKEN` **or** `GITHUB_TOKEN` **by name only** (value never on argv); the mint-request vars are never in the `-e` set.

All three sign sites route through it:
- **verify** (`run_verify.sh`): `wrangle_sign_vsa` (`bnd statement`, sigstore token), the store/OCI referrer pushes (`GITHUB_TOKEN`), and `wrangle_ampel` — whose **oci: collector** is unblocked (`--docker-config` + `GITHUB_TOKEN`, item 7).
- **attest_provenance** / **attest_metadata_oci** (shared `lib/sign_metadata.sh`): `wrangle-attest --sign` (sigstore), `bnd push` / `cosign attach` / `cosign download` (`GITHUB_TOKEN` + registry login).

Least-privilege per call: **only** `bnd statement` and `wrangle-attest --sign` receive the sigstore token; registry ops receive only `GITHUB_TOKEN`.

Catalog (`tools/catalog.json`): `attest-toolbox` gains `delivery: image` (item 6 — now covered by `check_catalog_freshness.sh`, `check_catalog_provenance_freshness.sh`, `bump_catalog_to_latest.sh`) and `token: sigstore` (item 8).

Go-live (item 8): a `verify-in-container` reusable-workflow input (default **false**, adopters stay opt-in) threaded to the attest + verify job env; set `true` only in `local_publish_images.yml`, so wrangle dogfoods container-signing publishing its own tool images (consume-the-pin: `attest-toolbox@NEW`'s VSA is signed by the pinned `attest-toolbox@OLD`).

## Security "no worse than in-job/from-source" analysis

- **Identity preserved.** Keyless subject = the workflow ref (the host mints the same OIDC identity; the in-container gitlab provider of `carabiner-dev/signer` v0.5.2 redeems `SIGSTORE_ID_TOKEN` verbatim — confirmed at the pinned source: `sts/providers/gitlab/ci.go` reads it, `github/actions.go` no-ops when the request URL is absent). So #678's `verifiedLevels`/identity policies still pass. *Control:* unchanged bnd/wrangle-attest keyless path; identity comes from the same token.
- **Mint-anything vars never enter a container.** `ACTIONS_ID_TOKEN_REQUEST_*` are never threaded; a scan/sbom container never gets a token (A1's validator forbids `token` off `kind: attest`). *Control:* unit tests assert the docker `-e` set excludes `ACTIONS_ID_TOKEN_REQUEST` and the minted value never lands on argv. This is **strictly better** than the in-job binary, which sees the request vars and can mint any audience.
- **Toolbox-image compromise bounded to ≤ from-source.** Every token-bearing `docker run` is fronted by `verify_image_vsa` (same trust anchor as `wrangle_ampel` today: a PASSED SLSA-L3 wrangle VSA whose resourceUri == the image, matching `wrangle-vsa-consumer-v1`). Non-PASSED ⇒ exit 2, no docker. *Control:* `wrangle_toolbox_image` memoized gate; unit test `non-PASSED toolbox VSA fails closed (no docker)`.
- **Break-glass = byte-identical in-job revert.** `WRANGLE_VERIFY_AMPEL_TOOLBOX` unset/`0` runs the exact in-job arg vector. *Control:* per-site unit tests assert the disabled path's arg vector is unchanged.
- **Fail-closed ≥ today.** The VSA gate, token mint, and each signer call fail closed; `wrangle_sign_vsa` propagates the signing exit explicitly (no trailing-`rm` masking).

**Known, deliberate cost (architecture reviewer):** signing runs per-binary containers (N×M `docker run`/step) rather than one long-lived container, to preserve break-glass arg-vector symmetry. The VSA gate is memoized so this is not N×M network verifies.

**Blast-radius note:** `WRANGLE_VERIFY_AMPEL_TOOLBOX` is a single toggle, so `verify-in-container: true` also moves ampel **verify** into the container (never on in prod before now), not just signing. Adopters are unaffected (default false).

## MUST be playground-validated before LGTM (I'll drive)

1. **In-container keyless redemption works with the *currently pinned* `attest-toolbox` digest.** The redemption contract is verified at `signer` v0.5.2 source, but the pinned image must be built from that (rebuild/bump if stale). **#1 linchpin.**
2. Real keyless in-container sign at **all three sites** (bnd statement, wrangle-attest --sign, cosign OCI push) produces a VSA that passes the **#678 consumer policy**.
3. Bridge egress reaches **Fulcio/Rekor/ghcr** from the container (network narrowed from `host` to `bridge`).
4. **OCI referrer auth**: the `--docker-config` mount + `GITHUB_TOKEN` let cosign/ampel reach ghcr in-container (the item-7 unblock — the one design choice not exercised offline).

## Tests / discipline
- New unit tests per site (verify + shared lib): token threaded by name, request-vars excluded, minted value off argv, VSA gate before docker, break-glass arg vector unchanged, oci-collector registry auth. `check_catalog` green with the new grant.
- Shellcheck clean; self-ref pins converged (`WRANGLE_PINS_BRANCH=main`); **post-merge pin bump** still required per the bootstrap-pin lifecycle.

Refs #619.
