### PR TITLE
claude: fix(build): surface pip fallback failures + refuse null SBOM manifest (#697)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      uses: TomHennen/wrangle/build/actions/container@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/build@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/npm@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/python@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+        uses: TomHennen/wrangle/build/actions/shell@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+        uses: TomHennen/wrangle/actions/scan@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      uses: TomHennen/wrangle/tools/scorecard@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      uses: TomHennen/wrangle/tools/dependency-review@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+    - uses: TomHennen/wrangle/actions/verify@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/container/extract_sbom.sh
+++ b/build/actions/container/extract_sbom.sh
@@ -21,6 +21,12 @@ main() {
     local sbom_path="${metadata_dir}/sbom.spdx.json"
 
     docker buildx imagetools inspect "$image_ref" --format "{{ json .SBOM.SPDX }}" > "$sbom_path"
+    # The format yields literal `null` when the image carries no SBOM; refuse
+    # to manifest a non-SBOM for attestation.
+    if ! jq -e 'type == "object" and has("spdxVersion")' "$sbom_path" >/dev/null 2>&1; then
+        printf 'extract_sbom: no SPDX SBOM attached to %s (sbom: true missing from the build?)\n' "$image_ref" >&2
+        return 1
+    fi
     "$WRANGLE_ROOT/lib/write_attest_manifest.sh" \
         "$metadata_dir" "https://spdx.dev/Document" "sbom.spdx.json"
     printf 'sbom=%s\n' "$sbom_path" >> "$github_output"

--- a/build/actions/container/test.bats
+++ b/build/actions/container/test.bats
@@ -398,6 +398,24 @@ FAKE
     rm -rf "$fakebin" "$meta" "$out"
 }
 
+@test "container: extract_sbom.sh fails when the image carries no SBOM (null) and writes no manifest" {
+    # buildx's --format yields literal `null` for an SBOM-less image.
+    fakebin="$(mktemp -d)"
+    cat > "$fakebin/docker" << 'FAKE'
+#!/usr/bin/env bash
+printf 'null\n'
+FAKE
+    chmod +x "$fakebin/docker"
+    meta="$(mktemp -d)"
+    out="$(mktemp)"
+    PATH="$fakebin:$PATH" run "$ACTION_DIR/extract_sbom.sh" "img@sha256:abc" "$meta" "$out"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"no SPDX SBOM attached"* ]]
+    [[ ! -f "$meta/wrangle_attestation_metadata.json" ]]
+    [[ ! -s "$out" ]]
+    rm -rf "$fakebin" "$meta" "$out"
+}
+
 @test "container: extract_sbom.sh usage error on wrong arg count" {
     run "$ACTION_DIR/extract_sbom.sh" "img@sha256:abc"
     [[ "$status" -eq 2 ]]

--- a/build/actions/python/install_deps.sh
+++ b/build/actions/python/install_deps.sh
@@ -26,12 +26,19 @@ if [[ "$USE_UV" == "true" ]]; then
     exit 0
 fi
 
+# Fallthrough is announced and stderr is never suppressed: a real install
+# failure (network, resolution) must be visible, not reclassified as a
+# missing extra.
 python -m pip install --upgrade pip
-if python -m pip install -e ".[test]" 2>/dev/null; then
+if python -m pip install -e ".[test]"; then
     printf 'Installed with [test] extra\n'
-elif python -m pip install -e ".[dev]" 2>/dev/null; then
-    printf 'Installed with [dev] extra\n'
 else
-    python -m pip install -e .
-    printf 'Installed without test extras\n'
+    printf 'WARNING: install with [test] extra failed; trying [dev]\n' >&2
+    if python -m pip install -e ".[dev]"; then
+        printf 'Installed with [dev] extra\n'
+    else
+        printf 'WARNING: install with [dev] extra failed; trying bare install\n' >&2
+        python -m pip install -e .
+        printf 'Installed without test extras\n'
+    fi
 fi

--- a/build/actions/python/test.bats
+++ b/build/actions/python/test.bats
@@ -39,7 +39,10 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" ]]; then
         n=$(($(cat "$counter" 2>/dev/null || echo 0) + 1))
         printf '%d' "$n" > "$counter" 2>/dev/null || true
         fails=",${WRANGLE_TEST_PIP_FAILS:-},"
-        if [[ "$fails" == *",$n,"* ]]; then exit 1; fi
+        if [[ "$fails" == *",$n,"* ]]; then
+            printf 'pip-shim: simulated failure of install %d\n' "$n" >&2
+            exit 1
+        fi
     fi
 fi
 exit 0
@@ -362,6 +365,9 @@ write_pyproject() {
     grep -qE '^python -m pip install -e \.\[dev\]$' <<<"$output"
     [[ "$output" == *"Installed with [dev] extra"* ]]
     ! grep -qE '^python -m pip install -e \.$' <<<"$output"
+    # The fallthrough is announced and the failing install's stderr surfaces.
+    [[ "$output" == *"WARNING: install with [test] extra failed"* ]]
+    [[ "$output" == *"pip-shim: simulated failure of install 1"* ]]
 }
 
 @test "python: install_deps.sh falls all the way through to bare install when both extras fail" {
@@ -378,6 +384,8 @@ write_pyproject() {
     grep -qE '^python -m pip install -e \.\[dev\]$' <<<"$output"
     grep -qE '^python -m pip install -e \.$' <<<"$output"
     [[ "$output" == *"Installed without test extras"* ]]
+    [[ "$output" == *"WARNING: install with [dev] extra failed"* ]]
+    [[ "$output" == *"pip-shim: simulated failure of install 2"* ]]
 }
 
 @test "python: install_deps.sh usage error with wrong arg count" {


### PR DESCRIPTION
claude: Two of the #697 items (the build-action pair, combined to share one pin-converge cycle).

## 1. `build/actions/python/install_deps.sh` — stderr no longer swallowed
The `[test]` -> `[dev]` -> bare pip chain ran the first two attempts under `2>/dev/null`, so a genuine failure (network, broken transitive dep, resolution conflict) was silently reclassified as "no such extra" and the suite ran without its declared test deps. The chain semantics are unchanged, but each fallthrough is now announced on stderr and pip's own stderr flows to the log. Tests: the pip shim now emits stderr on simulated failure, and both fallback tests assert the warning **and** the shim's stderr surface in the output.

## 2. `build/actions/container/extract_sbom.sh` — fail closed on a missing SBOM
`docker buildx imagetools inspect --format "{{ json .SBOM.SPDX }}"` yields literal `null` when the image carries no SBOM (e.g. `sbom: true` dropped from the build), and the script unconditionally manifested it for attestation — an SBOM attestation pointing at a non-SBOM. Now guarded with `jq -e 'type == "object" and has("spdxVersion")'`; on failure it exits nonzero with a pointed message, writes no attest manifest, and records no output. New test covers the `null` case end-to-end (no manifest, no output, nonzero exit).

## Pins
Both scripts live in pinned composite trees, so the converge commit bumps the self-ref pins to this branch (bootstrap pin) — `check_pin_ancestry` + `check_pin_freshness` both pass locally. **Land as a merge commit, not a squash** (docs/e2e_testing.md §Bootstrap).

## Tests
`bats build/actions/python/test.bats` 76/76; `bats build/actions/container/test.bats` 76/76; shellcheck clean.

Refs #697 (two checklist items; the remaining items stay open).