### PR TITLE
claude: fix(ci): gate keyless-attest off fork PRs (#697)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,11 @@ jobs:
   # produces a valid Fulcio/Rekor-backed Sigstore bundle with ambient GitHub
   # OIDC. Tag-gated so it never runs in the hermetic unit suite.
   keyless-attest:
+    # Fork-PR runs are never issued OIDC tokens, and the test hard-fails
+    # (not skips) without one — so gate to contexts that can mint the token.
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
claude: One #697 item — the fork-PR guaranteed-red check.

## Problem
`test.yml`'s `keyless-attest` job requests `id-token: write` and runs on `pull_request: branches: ["**"]` with no same-repo gate. GitHub never issues OIDC tokens to fork-PR runs, and `sign_keyless_integration_test.go` deliberately hard-fails (not skips) when `ACTIONS_ID_TOKEN_REQUEST_URL` is unset — right for contexts where OIDC is guaranteed, but this trigger context structurally cannot provide it. Every fork contributor gets an unfixable red check.

## Change
Gate the job with `github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository` — push-to-main and same-repo PRs still run it (this PR itself proves the same-repo path); fork PRs skip it. Same pattern as `integration-test.yml`'s existing gate.

## Checks
wrangle-workflow-lint clean; the trigger-model guard bats (`test_refuse_pull_request_target.bats`) all pass. `test.yml` is not a self-ref pin target, so no converge needed — squashable.

Refs #697.