### PR TITLE
claude: fix(dependency-review): best-effort markdown render (#697)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      uses: TomHennen/wrangle/build/actions/container@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      uses: TomHennen/wrangle/build/actions/container@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      uses: TomHennen/wrangle/build/actions/container@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      uses: TomHennen/wrangle/build/actions/container@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/build@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/build@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/build@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/build@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/npm@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/npm@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/npm@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/npm@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/python@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/python@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/python@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/python@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+        uses: TomHennen/wrangle/build/actions/shell@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+        uses: TomHennen/wrangle/build/actions/shell@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+        uses: TomHennen/wrangle/build/actions/shell@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+        uses: TomHennen/wrangle/build/actions/shell@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+        uses: TomHennen/wrangle/actions/scan@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+        uses: TomHennen/wrangle/actions/scan@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+        uses: TomHennen/wrangle/actions/scan@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+        uses: TomHennen/wrangle/actions/scan@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      uses: TomHennen/wrangle/tools/scorecard@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+      uses: TomHennen/wrangle/tools/dependency-review@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      uses: TomHennen/wrangle/tools/scorecard@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+      uses: TomHennen/wrangle/tools/dependency-review@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      uses: TomHennen/wrangle/tools/scorecard@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      uses: TomHennen/wrangle/tools/dependency-review@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      uses: TomHennen/wrangle/tools/scorecard@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+      uses: TomHennen/wrangle/tools/dependency-review@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@ef6df5b6bf93265c84f42424e5a28ac345e073d1 # fix/build-robustness-697 2026-07-04
+    - uses: TomHennen/wrangle/actions/verify@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+    - uses: TomHennen/wrangle/actions/verify@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@ce7f455ccd3b5fcf8999f89d5dbe54bdb951e620 # fix/depreview-md-best-effort 2026-07-04
+    - uses: TomHennen/wrangle/actions/verify@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@0ede59c821e2609a5594bc5cf3699f7b3e926ba2 # fix/depreview-md-best-effort 2026-07-04
+    - uses: TomHennen/wrangle/actions/verify@e43570933a553529f7da39a676ee2c003e5c0d91 # fix/depreview-md-best-effort 2026-07-04
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/tools/dependency-review/collect_outputs.sh
+++ b/tools/dependency-review/collect_outputs.sh
@@ -52,4 +52,7 @@ fi
 mv "$SARIF_TMP" "$SARIF_DST"
 
 # Human-readable markdown for the step summary details section.
-"$SCRIPT_DIR/../../lib/sarif_to_md.sh" "$SARIF_DST" > "$MD_DST"
+# Best-effort (matching osv): a render failure loses the summary but must
+# not fail the scan — the SARIF the gating check consults is already written.
+"$SCRIPT_DIR/../../lib/sarif_to_md.sh" "$SARIF_DST" > "$MD_DST" 2>/dev/null || \
+    printf 'wrangle/dependency-review: failed to render markdown summary (SARIF still valid)\n' > "$MD_DST"

--- a/tools/dependency-review/test.bats
+++ b/tools/dependency-review/test.bats
@@ -504,6 +504,22 @@ EOF
     [ ! -f "$META/output.sarif" ]
 }
 
+@test "collect_outputs: a broken markdown renderer does not fail the step (SARIF already written)" {
+    # sarif_to_md.sh is resolved relative to the script, so run a copy of the
+    # tool against a stub lib whose renderer always fails.
+    local root="$TMP_DIR/stubtree"
+    mkdir -p "$root/tools/depreview" "$root/lib"
+    cp "$TOOL_DIR/collect_outputs.sh" "$TOOL_DIR/vulnerable_changes_to_sarif.sh" "$root/tools/depreview/"
+    printf '#!/bin/bash\nexit 1\n' > "$root/lib/sarif_to_md.sh"
+    chmod +x "$root/lib/sarif_to_md.sh"
+
+    META="$TMP_DIR/meta-mdfail"
+    VULNERABLE_CHANGES='' run "$root/tools/depreview/collect_outputs.sh" "$META"
+    [ "$status" -eq 0 ]
+    [ -f "$META/output.sarif" ]
+    grep -q "failed to render markdown summary" "$META/output.md"
+}
+
 @test "collect_outputs: usage error when metadata dir arg missing" {
     run "$TOOL_DIR/collect_outputs.sh"
     [ "$status" -eq 1 ]


### PR DESCRIPTION
claude: One #697 item — the fatal-vs-best-effort markdown asymmetry.

## Problem
`tools/dependency-review/collect_outputs.sh` ran `sarif_to_md.sh` under `set -e` after `output.sarif` was already written, so a markdown-renderer bug aborted the whole tool step even though the SARIF the gating check consults was intact. osv already treats MD rendering as best-effort (`tools/osv/adapter.sh:73-74`); dependency-review did not.

## Change
Match osv: on a render failure, write a placeholder summary and keep the successful scan (`... 2>/dev/null || printf ... > "$MD_DST"`). New test runs a copy of the tool against a stub `lib/sarif_to_md.sh` that always fails and asserts exit 0, a present `output.sarif`, and the placeholder `output.md`.

## Pins
`actions/scan` pins `tools/dependency-review`, so the converge bumped the nested chain (**2 commits** — land as a **merge commit, not a squash**). `check_pin_ancestry` + `check_pin_freshness` both green locally.

## Tests
`bats tools/dependency-review/test.bats` all pass; shellcheck clean.

Refs #697.