### PR TITLE
claude: fix(scorecard): keep check reasons on one table row (#697)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      uses: TomHennen/wrangle/build/actions/container@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      uses: TomHennen/wrangle/build/actions/container@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      uses: TomHennen/wrangle/build/actions/container@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      uses: TomHennen/wrangle/build/actions/container@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/build@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/build@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/build@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/build@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/npm@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/npm@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/npm@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/npm@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/python@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/python@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/python@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/python@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+        uses: TomHennen/wrangle/build/actions/shell@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+        uses: TomHennen/wrangle/build/actions/shell@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+        uses: TomHennen/wrangle/build/actions/shell@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+        uses: TomHennen/wrangle/build/actions/shell@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+        uses: TomHennen/wrangle/actions/scan@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+        uses: TomHennen/wrangle/actions/scan@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+        uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+        uses: TomHennen/wrangle/actions/scan@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      uses: TomHennen/wrangle/tools/scorecard@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+      uses: TomHennen/wrangle/tools/dependency-review@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      uses: TomHennen/wrangle/tools/scorecard@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+      uses: TomHennen/wrangle/tools/dependency-review@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      uses: TomHennen/wrangle/tools/scorecard@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+      uses: TomHennen/wrangle/tools/dependency-review@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -142,7 +142,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      uses: TomHennen/wrangle/tools/scorecard@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -154,7 +154,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+      uses: TomHennen/wrangle/tools/dependency-review@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@dcaadd074114a4f1c34bc36a92d866e9734e1017 # fix/container-imagename-uppercase 2026-07-04
+    - uses: TomHennen/wrangle/actions/verify@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
+    - uses: TomHennen/wrangle/actions/verify@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@33e3707ecf524a37a6bf2be8b2b40dd490b1c78f # fix/scorecard-table-safety-697 2026-07-04
+    - uses: TomHennen/wrangle/actions/verify@1ac1f364072045a90e3dc54a45a27b943a099c39 # fix/scorecard-table-safety-697 2026-07-04
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@466bfa17dc07de6a78cbd5d4a047e8dcbf37b46f # fix/depreview-md-best-effort 2026-07-04
+    - uses: TomHennen/wrangle/actions/verify@c7c0bd5441277d2f15de0ea25871c8d1661d5a8f # fix/scorecard-table-safety-697 2026-07-04
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/tools/scorecard/json_to_markdown.sh
+++ b/tools/scorecard/json_to_markdown.sh
@@ -35,11 +35,12 @@ printf 'Aggregate score: %s / 10\n\n' "$score"
 printf '%s\n' 'Check | Score | Reason'
 printf '%s\n' '----- | ----- | ------'
 
-# Per-check rows; strip HTML and collapse newlines so each check stays on one row.
-# Capture, then cap with a substring instead of piping into head: a pipe into
-# head closes at the byte cap, SIGPIPEs the producer, and pipefail turns a valid
-# truncation into a false error.
-if ! checks="$(jq -r '(.checks // [])[] | "\(.name) | \(.score) | \(.reason)"' "$JSON_FILE" 2>/dev/null | sed 's/<[^>]*>//g')"; then
+# Per-check rows; escape table-breaking pipes and collapse newlines per field so
+# each check stays on one row, then strip HTML. Capture, then cap with a substring
+# instead of piping into head: a pipe into head closes at the byte cap, SIGPIPEs
+# the producer, and pipefail turns a valid truncation into a false error.
+row_field='gsub("[|]";"\\|") | gsub("[\r\n]+";" ")'
+if ! checks="$(jq -r "(.checks // [])[] | \"\(.name | ${row_field}) | \(.score) | \(.reason | ${row_field})\"" "$JSON_FILE" 2>/dev/null | sed 's/<[^>]*>//g')"; then
     printf 'Error: failed to parse Scorecard checks\n' >&2
     exit 2
 fi

--- a/tools/scorecard/test.bats
+++ b/tools/scorecard/test.bats
@@ -119,6 +119,18 @@ JSON
     [[ "$output" == *"see docs"* ]]
 }
 
+@test "json_to_markdown: pipes and newlines in a reason stay on one escaped row" {
+    cat > "$TMP_DIR/in.json" <<'JSON'
+{"score":1,"checks":[{"name":"R","score":0,"reason":"a | b\nc"}]}
+JSON
+    run "$SCRIPT" "$TMP_DIR/in.json"
+    [ "$status" -eq 0 ]
+    # One row, pipe escaped, newline collapsed to a space.
+    [[ "$output" == *"R | 0 | a \\| b c"* ]]
+    # The reason's newline did not create a second table line.
+    [[ "$(grep -c '^R ' <<<"$output")" -eq 1 ]]
+}
+
 @test "json_to_markdown: truncates checks at WRANGLE_MAX_SUMMARY bytes, exit 0" {
     # Many checks with long reasons so output far exceeds the cap and jq/sed
     # are still streaming when head closes the pipe — the case that SIGPIPEs a


### PR DESCRIPTION
claude: The remaining #697 items, on close inspection, were not the clean mechanical fixes the earlier ones were — so this PR ships the one that is, and I am documenting why the other two are not included (rather than force them).

## Shipped: scorecard renderer table-safety
A Scorecard `reason` containing a `|` or a newline broke the markdown table (an unescaped `|` adds phantom columns; a newline starts a spurious row). `json_to_markdown.sh` now escapes `|` and collapses newlines per field in jq before rendering. The deliberate SIGPIPE-safe capture-and-substring cap path is preserved (see the comment there — piping into `head` under `pipefail` turns a valid truncation into a false error, which is why this does **not** route through `lib/sanitize.sh`). New test covers a pipe+newline reason staying on one escaped row. 19/19 pass, shellcheck clean.

## Deliberately not included (with reasons)
- **scorecard error-marker** — dependency-review gates its marker on `steps.<id>.outcome == 'failure'` because its failures are genuine. Scorecard **commonly fails on PR events by design** (token scopes / default-branch-only — see `tools/scorecard/action.yml:24-27`), so an outcome-gated marker would flag every PR run as an error. Distinguishing "expected PR failure" from "genuinely broken" is a design decision, not a mechanical mirror — leaving it for an owner call.
- **scan `contains()` -> exact-token** — the substring match is **load-bearing**: tools carry `:policy` suffixes (`wrangle-lint:info`), so a word-boundary match (`' osv '`) would break gating for any suffixed tool. The substring is correct given tool names are regex-validated; "exact-token" as suggested would be a regression.
- **route scorecard through the shared sanitizer** — would reintroduce the SIGPIPE-under-pipefail false error scorecard deliberately avoids (test `truncates checks at WRANGLE_MAX_SUMMARY` guards it). The shared-sanitizer consolidation belongs with the #692 redesign.

## Pins
`actions/scan` pins `tools/scorecard`, so the converge bumped the nested chain (**2 commits** — land as a **merge commit, not a squash**). `check_pin_ancestry` + `check_pin_freshness` green locally.

Refs #697.