### PR TITLE
claude: fix(lint): close WWL002 format()/multiline, WSL001/2 node-kind, WL003 glob bypasses (#691)

### DIFF
--- a/tools/wrangle-lint/main.go
+++ b/tools/wrangle-lint/main.go
@@ -331,8 +331,14 @@ func checkDependabot(ymlPath, uri, srcDir string) ([]finding, error) {
 		dirs := entryDirectories(entry)
 		hasGlob := false
 		for _, d := range dirs {
-			if strings.Contains(d.val, "**") {
+			// Any glob makes literal WL004 coverage comparison meaningless — a
+			// `/actions/*` is a valid covering config, so comparing its literal
+			// text against real dirs would spuriously flag every composite it
+			// covers. `**` is additionally flagged by WL003 below.
+			if strings.Contains(d.val, "*") {
 				hasGlob = true
+			}
+			if strings.Contains(d.val, "**") {
 				findings = append(findings, finding{"WL003", uri, ymlPath, d.line, fmt.Sprintf(
 					"The github-actions entry's '%s' is a `**` glob: Dependabot does not recurse "+
 						"into nested action.yml (so composite actions are never bumped) and `/**` "+
@@ -340,8 +346,8 @@ func checkDependabot(ymlPath, uri, srcDir string) ([]finding, error) {
 						"`directories: [\"/\", \"/path/to/your/action\"]`.", d.val)})
 			}
 		}
-		// A glob is already flagged (WL003); enumerating coverage on top would
-		// double-report. Only check coverage when explicit directories are used.
+		// A glob directory can't be coverage-checked literally; skip WL004 when
+		// any glob is present (a `**` is already flagged by WL003).
 		if hasGlob {
 			continue
 		}

--- a/tools/wrangle-lint/main_test.go
+++ b/tools/wrangle-lint/main_test.go
@@ -121,6 +121,33 @@ updates:
 			notWant: "WL004",
 		},
 		{
+			name: "WL004 not fired for a single-star glob covering the composite",
+			files: map[string]string{
+				".github/dependabot.yml": `version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/*"
+    cooldown:
+      default-days: 7
+`,
+				"myaction/action.yml": "name: x\nruns:\n  using: composite\n  steps: []\n",
+			},
+			notWant: "WL004",
+		},
+		{
+			name: "WL003 not fired for a single-star glob (only ** is flagged)",
+			files: map[string]string{".github/dependabot.yml": `version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/*"
+    cooldown:
+      default-days: 7
+`},
+			notWant: "WL003",
+		},
+		{
 			name: "WL005 missing cooldown",
 			files: map[string]string{".github/dependabot.yml": `version: 2
 updates:

--- a/tools/wrangle-shell-lint/rules/wsl001.yml
+++ b/tools/wrangle-shell-lint/rules/wsl001.yml
@@ -21,7 +21,9 @@
 #    `cmd1 && cmd2` / `cmd1 ; cmd2` as a `list`, and `! cmd` as a
 #    `negated_command` — none of those are `command` nodes, so omitting
 #    them would let a script silently bypass WSL001 by making its first
-#    top-level node one of those shapes.
+#    top-level node one of those shapes. `test_command` (`[[ … ]]`),
+#    `unset_command` (`unset X`), and `c_style_for_statement`
+#    (`for ((…))`) are enumerated for the same reason.
 #  - Files containing only comments (or only a shebang) produce no match
 #    and pass cleanly — there is no command to flag.
 
@@ -44,6 +46,9 @@ rule:
     - kind: pipeline
     - kind: list
     - kind: negated_command
+    - kind: test_command
+    - kind: unset_command
+    - kind: c_style_for_statement
   inside:
     kind: program
   nthChild:

--- a/tools/wrangle-shell-lint/rules/wsl002.yml
+++ b/tools/wrangle-shell-lint/rules/wsl002.yml
@@ -37,6 +37,9 @@ rule:
     - kind: pipeline
     - kind: list
     - kind: negated_command
+    - kind: test_command
+    - kind: unset_command
+    - kind: c_style_for_statement
   inside:
     kind: program
   nthChild:

--- a/tools/wrangle-shell-lint/test.bats
+++ b/tools/wrangle-shell-lint/test.bats
@@ -677,6 +677,42 @@ SCRIPT
     [[ "$output" == *"WSL002"* ]]
 }
 
+@test "WSL001: test_command as first top-level node is flagged (regression)" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\n[[ -n "${1:-}" ]] || exit 1\nset -euo pipefail\nset -f\nprintf hi\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WSL001"* ]]
+}
+
+@test "WSL001: unset_command as first top-level node is flagged (regression)" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nunset CDPATH\nset -euo pipefail\nset -f\nprintf hi\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WSL001"* ]]
+}
+
+@test "WSL001: c_style_for_statement as first top-level node is flagged (regression)" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nfor ((i=0;i<1;i++)); do :; done\nset -euo pipefail\nset -f\nprintf hi\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WSL001"* ]]
+}
+
+@test "WSL002: test_command at position 2 is flagged (regression)" {
+    tmp="$(mktemp /tmp/wsl-test-XXXXXX.sh)"
+    printf '#!/bin/bash\nset -euo pipefail\n[[ -n "${1:-}" ]] || exit 1\nset -f\nprintf hi\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WSL002"* ]]
+}
+
 # --- WSL003 regression pin: echo with literal-only args + redirect/pipe ------
 # `echo` with no variable expansion piped to another command must not be
 # flagged. A regression here would surface as a false positive that is

--- a/tools/wrangle-workflow-lint/lint.py
+++ b/tools/wrangle-workflow-lint/lint.py
@@ -53,15 +53,18 @@ MAX_RUN_LINES = 10
 
 # R2: an interpolation of a typed input or the webhook event payload. These are
 # attacker-influenced and must never be spliced into a shell command directly.
+# A full `${{ … }}` expression is matched to its `}}` terminator (not the first
+# `}`) and with DOTALL, so a root wrapped in `format('{0}', github.event.x)` or
+# split across physical lines can't slip the interior check.
+EXPR_RE = re.compile(r"\$\{\{(.*?)\}\}", re.DOTALL)
 # `inputs` / `github` are matched only as expression roots (the lookbehind
 # rejects a leading `.` or word char) so sibling contexts that merely end in
 # `inputs` — `${{ matrix.inputs }}`, `${{ steps.x.outputs.inputs }}` — are not
 # false-flagged. `inputs` must be followed by `.`/`[` (a typed-input access).
 # `github.head_ref` / `github.ref_name` are attacker-influenced refs (the
 # classic pull_request_target injection vector), so they are flagged too.
-INJECTION_RE = re.compile(
-    r"\$\{\{[^}]*?(?<![.\w])"
-    r"(?:inputs\s*[.\[]|github\.(?:event\b|head_ref\b|ref_name\b))"
+INJECTION_ROOT_RE = re.compile(
+    r"(?<![.\w])(?:inputs\s*[.\[]|github\.(?:event\b|head_ref\b|ref_name\b))"
 )
 
 # R4: steps whose purpose is verifying provenance / attestations / signatures /
@@ -189,13 +192,14 @@ def check_run_rules(path, run_node, raw_lines, findings):
             )
         )
 
-    # R2 — expression injection inside a run body. node.value holds the
-    # literal shell text for block scalars; search it line by line so the
-    # report points at the offending line, not the run: indicator.
+    # R2 — expression injection inside a run body. node.value holds the literal
+    # shell text for block scalars; scan whole `${{ … }}` expressions (which may
+    # span lines) and report the line where each offending expression opens.
     body = scalar_text(run_node)
     base = run_node.start_mark.line + (1 if run_node.style in ("|", ">") else 0)
-    for offset, text in enumerate(body.splitlines()):
-        if INJECTION_RE.search(text):
+    for m in EXPR_RE.finditer(body):
+        if INJECTION_ROOT_RE.search(m.group(1)):
+            offset = body[: m.start()].count("\n")
             findings.append(
                 Finding(
                     path,

--- a/tools/wrangle-workflow-lint/test.bats
+++ b/tools/wrangle-workflow-lint/test.bats
@@ -147,6 +147,24 @@ teardown() {
     [[ "$output" == *"WWL002"* ]]
 }
 
+@test "WWL002: a root wrapped in format() is reported (the { } inside must not hide it)" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ format('\''{0}'\'', github.event.issue.title) }}"\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL002"* ]]
+}
+
+@test "WWL002: a root in an expression split across physical lines is reported" {
+    tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
+    printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: |\n          echo "${{\n            inputs.name\n          }}"\n' > "$tmp"
+    run "$LINTER" "$tmp"
+    rm -f "$tmp"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WWL002"* ]]
+}
+
 @test "WWL002: github.event.* interpolated into a run body is reported" {
     tmp="$(mktemp /tmp/wwl-XXXXXX.yml)"
     printf 'on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ github.event.issue.title }}"\n' > "$tmp"


### PR DESCRIPTION
claude: Closes the clean subset of #691 — the lint bypasses whose fixes do not over-flag.

## WWL002 — `format()` and split-line injection bypass
`\$\{\{[^}]*?…` stopped at the first `}`, so `${{ format('{0}', github.event.issue.title) }}` (and `inputs.*` in composite actions) slipped past the injection ban; line-by-line scanning also missed an expression split across physical lines. Now matches whole `${{ … }}` expressions (to `}}`, `DOTALL`) and searches the interior for the roots — the lookbehind/sibling semantics (`${{ matrix.inputs }}` not flagged) are preserved. New tests cover both bypasses; dogfood (whole-repo) still passes.

## WSL001/002 — node-kind enumeration gap
The top-level-kind `any:` list omitted `test_command` (`[[ … ]]`), `unset_command` (`unset X`), and `c_style_for_statement` (`for ((…))`), so a script starting with any of those bypassed the `set -euo pipefail` / `set -f` preamble rules. Added all three (they can never be the valid preamble, so only bypasses are closed). Regression tests added for each shape.

## WL003 — single-`*` glob false-positives WL004
The glob flag was set only for `**`, so `directories: ["/actions/*"]` fell through to WL004's literal coverage check and spuriously flagged every composite the glob covers — telling adopters to "fix" a working config. Any `*` now suppresses the literal coverage check; `**` stays flagged by WL003. Go tests added for the single-`*` case (no WL004, no WL003).

## Deliberately NOT included
**WSL006** (`curl | python3/perl/node`): not a clean add. `| bash` almost always executes stdin, but `| python3 -m json.tool` / `| node` / `perl` commonly *process data*, so adding those interpreters would false-positive on legitimate pipelines. Detecting "executes stdin as a script" is a larger change — left for a follow-up.

## Validation
WWL002 (pure Python) and WL003 (`go test` + gofmt + vet) validated locally. The **WSL rule changes are validated in CI** — ast-grep is not installable in my local sandbox (no pip/network), but the new regression tests + the dogfood test exercise them in the container. `test_command` is already used by WSL004, confirming the kind name; `unset_command`/`c_style_for_statement` are standard tree-sitter-bash kinds. None of these tools are self-ref-pinned, so no pin converge — clean squash.

Refs #691.