### PR TITLE
claude: fix(pins): freshness catches a retargeted nested self-ref pin (Fixes #690)

### DIFF
--- a/test/test_check_pin_freshness.bats
+++ b/test/test_check_pin_freshness.bats
@@ -94,6 +94,38 @@ run_fresh() { run bash -c "cd '$REPO' && '$SCRIPT'"; }
     [[ "$output" != *"STALE: actions/release"* ]]
 }
 
+@test "check_pin_freshness: FAILS when a composite retargets a nested pin to a different path" {
+    # release@old wires actions/verify; HEAD's release wires actions/other. The
+    # pin is reachable and each nested target is itself unchanged, but the parent
+    # resolves DIFFERENT wiring — a path retarget, not a sha bump, so it is STALE.
+    local v; v="$(write_verify 'echo hi')"
+    mkdir -p "$REPO/actions/other"
+    printf 'name: other\n' > "$REPO/actions/other/action.yml"
+    git -C "$REPO" add actions/other && git -C "$REPO" commit -q -m other
+    local o; o="$(git -C "$REPO" rev-parse HEAD)"
+
+    mkdir -p "$REPO/actions/release"
+    printf 'name: release\n' > "$REPO/actions/release/action.yml"
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # pin\n' "$v" \
+        >> "$REPO/actions/release/action.yml"
+    git -C "$REPO" add actions/release && git -C "$REPO" commit -q -m 'release wires verify'
+    local rel_old; rel_old="$(git -C "$REPO" rev-parse HEAD)"
+
+    printf 'name: release\n' > "$REPO/actions/release/action.yml"
+    printf '      - uses: TomHennen/wrangle/actions/other@%s # pin\n' "$o" \
+        >> "$REPO/actions/release/action.yml"
+    git -C "$REPO" add actions/release && git -C "$REPO" commit -q -m 'release retargets to other'
+
+    printf '      - uses: TomHennen/wrangle/actions/release@%s # pin\n' "$rel_old" \
+        > "$REPO/.github/workflows/x.yml"
+    # Ancestry holds; freshness must catch the retarget.
+    run bash -c "cd '$REPO' && '$(dirname "$SCRIPT")/check_pin_ancestry.sh'"
+    [ "$status" -eq 0 ]
+    run_fresh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"STALE: actions/release"* ]]
+}
+
 @test "check_pin_freshness: PASSES (no-op) on an older pin whose path never changed" {
     # A pin at an older sha is FRESH if its path is byte-identical to HEAD's —
     # don't false-positive just because the sha is old.

--- a/tools/check_pin_freshness.sh
+++ b/tools/check_pin_freshness.sh
@@ -48,12 +48,17 @@ escaped_prefix="$(printf '%s' "$REPO_PREFIX" | sed 's/\./\\./g')"
 pin_re="${escaped_prefix}/[^@[:space:]]+@[0-9a-f]{40}"
 
 # path_content_stale <sha> <subpath> — true (0) iff <subpath>'s tree at <sha>
-# differs from HEAD's in a line that is NOT a self-ref pin reference. Pin-SHA-only
-# differences are ignored here; each nested pin's own freshness is checked as the
-# BFS descends. -G/-S can't express "only these lines changed", so we diff with
-# no context and scan the +/- body lines.
+# differs from HEAD's in a line that is NOT a pure self-ref pin SHA bump. A
+# non-pin change is drift. A pin line is a bump ONLY when just its sha (and the
+# trailing branch/date comment) moved; a retargeted pin (the ref PATH changed,
+# e.g. actions/inner -> actions/other) or an added/removed nested pin IS drift,
+# because the pinned parent then resolves different wiring than HEAD. Each
+# surviving nested pin's own freshness is checked as the BFS descends. -G/-S
+# can't express "only these lines changed", so we diff with no context and scan
+# the +/- body lines.
 path_content_stale() {
-    local sha="$1" subpath="$2" line
+    local sha="$1" subpath="$2" line body norm
+    local -a minus=() plus=()
     while IFS= read -r line; do
         # Skip diff headers (+++/---) and hunk markers; inspect only body changes.
         case "$line" in
@@ -61,11 +66,26 @@ path_content_stale() {
             '+'* | '-'*) ;;
             *) continue ;;
         esac
+        body="${line:1}"
         # A changed line that isn't a self-ref pin reference = real content drift.
-        if ! printf '%s' "${line:1}" | grep -qE "$pin_re"; then
+        if ! printf '%s' "$body" | grep -qE "$pin_re"; then
             return 0
         fi
+        # Pin line: normalize away the sha and the trailing bump comment (both
+        # move on every re-bump) so what remains is the ref path. Retarget/add/
+        # remove then shows as a normalized-set mismatch below.
+        norm="$(printf '%s' "$body" | sed -E 's/@[0-9a-f]{40}/@SHA/g; s/[[:space:]]*#.*$//')"
+        case "${line:0:1}" in
+            '-') minus+=("$norm") ;;
+            '+') plus+=("$norm") ;;
+        esac
     done < <(git -C "$repo_root" diff --unified=0 "$sha" HEAD -- "$subpath" 2>/dev/null)
+    # The pin changes are a pure sha bump iff the sha/comment-stripped multisets
+    # match; any difference is a retargeted or added/removed pin = drift.
+    local m p
+    m="$(printf '%s\n' ${minus[@]+"${minus[@]}"} | sort)"
+    p="$(printf '%s\n' ${plus[@]+"${plus[@]}"} | sort)"
+    [[ "$m" != "$p" ]] && return 0
     return 1
 }
 


### PR DESCRIPTION
claude: Fixes #690.

## Problem
`check_pin_freshness.sh`'s `path_content_stale` treated **any** changed diff line matching the self-ref pin regex as an ignorable sha bump. A composite that retargets a nested `uses: TomHennen/wrangle/actions/inner@X` to `…/actions/other@Y` produces two lines that both match the regex, so the retarget was classified as a bump and the path read as fresh — while the pinned parent keeps resolving the **old** wiring. Same "resolves stale code" class as #552/#558, but for a path change rather than a script change.

## Fix
Pin lines are normalized (the 40-hex sha and the trailing `# branch date` bump comment stripped, both of which move on every re-bump) and the `-`/`+` multisets compared. If the normalized sets match, it was a pure sha bump (fresh); if a ref **path** changed, or a nested pin was added/removed, that is drift (stale). Non-pin changes remain drift as before.

## Tests
New: a composite retargeting a nested pin to a different path FAILS with `STALE: actions/release` (ancestry still green, each nested target itself unchanged — so only the retarget can be the signal). Existing behavior preserved: plain sha bumps and converged nested chains stay fresh; script changes stay stale. `bats test/test_check_pin_freshness.bats` all pass; shellcheck clean.

The script is run directly in CI (not a self-ref-pinned action), so no pin converge — clean squash.

Refs #690, #698 (the shared-pin-matcher unification is the larger structural item; this closes the correctness hole).