### PR TITLE
claude: fix(scan): :info policy no longer blocks on adapter-tool findings (Fixes #688)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -125,7 +125,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         id: prep
         with:
           build-type: container
@@ -144,7 +144,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -173,7 +173,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      uses: TomHennen/wrangle/build/actions/container@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -251,7 +251,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -292,7 +292,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -166,7 +166,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         id: prep
         with:
           build-type: go
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -220,7 +220,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/checks@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -283,7 +283,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/go/build@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         id: release
         with:
           path: ${{ inputs.path }}
@@ -375,7 +375,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         id: attest
         with:
           build-type: go
@@ -401,7 +401,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         id: prep
         with:
           build-type: npm
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -210,7 +210,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/npm@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -289,7 +289,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         id: attest
         with:
           build-type: npm
@@ -312,7 +312,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -131,7 +131,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         id: prep
         with:
           build-type: python
@@ -150,7 +150,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/build/actions/python@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         id: build
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/attest_provenance@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         id: attest
         with:
           build-type: python
@@ -299,7 +299,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/verify_release@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -85,7 +85,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -98,7 +98,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/scan@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -147,7 +147,7 @@ jobs:
         # setup-script input and multi-path bats — the main-pinned version
         # would ignore setup-script and fail the dogfooded integration bats.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+        uses: TomHennen/wrangle/build/actions/shell@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -28,7 +28,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      - uses: TomHennen/wrangle/actions/prep@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
 
   check-change:
     needs: [prep]
@@ -46,7 +46,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+        uses: TomHennen/wrangle/actions/scan@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -140,7 +140,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      uses: TomHennen/wrangle/tools/scorecard@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -152,7 +152,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+      uses: TomHennen/wrangle/tools/dependency-review@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -123,13 +123,11 @@ runs:
       run: |
         # shellcheck source=../../lib/env.sh
         source "$WRANGLE_ROOT/lib/env.sh"
-        # $WRANGLE_TOOLS is intentionally unquoted so it word-splits into
-        # multiple arguments. This is safe because the orchestrator validates
-        # each token against ^[a-z][a-z0-9_-]*$ and runs set -f.
-        "$WRANGLE_ROOT/run.sh" \
-          -s "$GITHUB_WORKSPACE" \
-          -o "$WRANGLE_METADATA_DIR" \
-          $WRANGLE_TOOLS
+        # run_scan.sh maps run.sh's exit: findings are policy-gated by the Check
+        # results step, so only a tool error fails here. $WRANGLE_TOOLS is
+        # unquoted to word-split into validated tokens (orchestrator re-checks).
+        "$WRANGLE_ROOT/actions/scan/run_scan.sh" \
+          "$GITHUB_WORKSPACE" "$WRANGLE_METADATA_DIR" $WRANGLE_TOOLS
 
     # Action-pattern tools: invoked via local path. Inside a reusable
     # workflow, ./ resolves to this repo at the called ref (the adopter's

--- a/actions/scan/run_scan.sh
+++ b/actions/scan/run_scan.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # tools word-split into validated tokens; the orchestrator re-validates
+
+# Run the adapter-pattern orchestrator (run.sh) and map its exit for the scan
+# step: findings (run.sh exit 1) are gated by the later Check results step per
+# each tool's :fail/:info policy, so they MUST NOT fail this step; only a tool
+# error (exit 2+) does. run.sh keeps its own 0/1/2 contract for standalone use.
+#
+# Usage: run_scan.sh <src_dir> <output_dir> <tool[:policy]>...
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRANGLE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if [[ $# -lt 3 ]]; then
+    printf 'Usage: run_scan.sh <src_dir> <output_dir> <tool[:policy]>...\n' >&2
+    exit 2
+fi
+
+src="$1"
+out="$2"
+shift 2
+
+rc=0
+"$WRANGLE_ROOT/run.sh" -s "$src" -o "$out" "$@" || rc=$?
+if [[ "$rc" -ge 2 ]]; then
+    exit "$rc"
+fi

--- a/actions/scan/test.bats
+++ b/actions/scan/test.bats
@@ -224,3 +224,50 @@ setup() {
     [[ "$output" != *"go.sum"* ]]
     [[ "$output" != *"go.mod"* ]]
 }
+
+# --- run_scan.sh: run.sh exit mapping (findings don't fail the step) ----------
+
+# Build a throwaway <root>/actions/scan/run_scan.sh + a stub <root>/run.sh that
+# exits with $STUB_RC, so the exit mapping is tested without the real orchestrator.
+_run_scan_with_stub() {
+    local stub_rc="$1"
+    local root="$BATS_TEST_TMPDIR/tree"
+    mkdir -p "$root/actions/scan"
+    cp "$ACTION_DIR/run_scan.sh" "$root/actions/scan/run_scan.sh"
+    cat > "$root/run.sh" <<STUB
+#!/bin/bash
+exit $stub_rc
+STUB
+    chmod +x "$root/run.sh" "$root/actions/scan/run_scan.sh"
+    run "$root/actions/scan/run_scan.sh" /src /out osv wrangle-lint:info
+}
+
+@test "run_scan: a clean orchestrator run (0) passes the step" {
+    _run_scan_with_stub 0
+    [ "$status" -eq 0 ]
+}
+
+@test "run_scan: findings (run.sh exit 1) do NOT fail the step (policy gated later)" {
+    _run_scan_with_stub 1
+    [ "$status" -eq 0 ]
+}
+
+@test "run_scan: a tool error (run.sh exit 2) fails the step (fail-closed)" {
+    _run_scan_with_stub 2
+    [ "$status" -eq 2 ]
+}
+
+@test "run_scan: a timeout (run.sh exit 124) fails the step" {
+    _run_scan_with_stub 124
+    [ "$status" -eq 124 ]
+}
+
+@test "run_scan: usage error on too few args" {
+    run "$ACTION_DIR/run_scan.sh" /src /out
+    [ "$status" -eq 2 ]
+}
+
+@test "scan: action.yml runs adapters via run_scan.sh (findings don't fail the step)" {
+    run grep 'run_scan.sh' "$ACTION_DIR/action.yml"
+    [ "$status" -eq 0 ]
+}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@164092de47bcea7375105b01ca361a260d30696d # fix/scorecard-table-safety-697 2026-07-04
+    - uses: TomHennen/wrangle/actions/verify@5bde5a3132a16e6c1dbea86389f9329a76b4c2cd # fix/info-policy-adapter-688 2026-07-04
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}


### PR DESCRIPTION
claude: Fixes #688.

## Problem
`run.sh` exits 1 on findings, and the scan step propagated that as a step failure **before** the Check results step could apply a tool's policy. So `tools: "… wrangle-lint:info"` blocked the job on advisory findings — contradicting `action.yml`'s own "Tools with :info policy are noted but don't block" and the SPEC policy contract. Latent for the shipped default only because its sole `:info` tool (scorecard) is action-pattern, not adapter-pattern.

## Why not `continue-on-error`
`continue-on-error` alone would **fail-open on tool errors**: `run.sh` writes no error marker for adapter tools, and `check_results` treats "no marker + no SARIF" as *skipped* — so an errored adapter tool would silently pass. The exit contract needs to distinguish findings (1) from error (2), which `continue-on-error` cannot.

## Fix
New `actions/scan/run_scan.sh` wraps `run.sh` and maps its exit for the step:
- **0 (clean) / 1 (findings) → step passes** — findings are gated by the later `Check results` step per each tool's `:fail`/`:info` policy.
- **2+ (tool error / timeout) → step fails** — fail-closed on errors, unchanged.

`run.sh` keeps its own 0/1/2 contract for standalone use. Extracted to a script (not inline) because the exit-map would exceed WWL001's run-block budget and reintroduce the `[[ ]] && exit` set-e trap; extraction also makes it unit-testable.

## Tests
`run_scan.sh` unit tests via a stub `run.sh` exiting 0/1/2/124: clean passes, **findings (1) pass**, error (2) fails, timeout (124) fails, usage error. Plus a structural assert that the action calls `run_scan.sh`. `bats actions/scan/test.bats` all pass; orchestrator + manifest-header suites unaffected; workflow-lint (WWL001) clean; shellcheck clean.

`actions/scan` is a pinned tree, so the converge bumped the nested chain (**merge commit, not squash**). `check_pin_ancestry` + `check_pin_freshness` green locally.

Refs #688, #698 (structural item 1: single-owner contract — check_results owns the findings gate).