### PR TITLE
claude: build the bats clean-bin symlink farm once per file

### DIFF
--- a/test/test_verify_image_vsa.bats
+++ b/test/test_verify_image_vsa.bats
@@ -12,6 +12,26 @@
 _osv_uri="ghcr.io/tomhennen/wrangle/osv@sha256:c8abda59e3a64520128c427d2fe9bd223c27e0a2056181ead1b9d3c6a5fb3b75"
 _image="ghcr.io/tomhennen/wrangle/imgtool@sha256:c8abda59e3a64520128c427d2fe9bd223c27e0a2056181ead1b9d3c6a5fb3b75"
 
+# A shared clean bin of symlinks to every real tool on PATH except gh and jq —
+# the two the per-test setup shims or drops — built once per file so the gate
+# runs against a controlled PATH without a per-test symlink farm.
+setup_file() {
+    SHARED_BIN="$BATS_FILE_TMPDIR/bin"
+    mkdir -p "$SHARED_BIN"
+    local dir f name
+    IFS=':' read -ra _dirs <<< "$PATH"
+    for dir in "${_dirs[@]}"; do
+        [[ -d "$dir" ]] || continue
+        for f in "$dir"/*; do
+            [[ -x "$f" && ! -d "$f" ]] || continue
+            name="${f##*/}"
+            [[ "$name" == gh || "$name" == jq ]] && continue
+            [[ -e "$SHARED_BIN/$name" ]] || ln -s "$f" "$SHARED_BIN/$name"
+        done
+    done
+    export SHARED_BIN
+}
+
 setup() {
     LIB="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/lib/verify_image_vsa.sh"
     FIXTURES="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/test/fixtures/tool-image-vsa"
@@ -21,28 +41,17 @@ setup() {
     mkdir -p "$BIN"
     : > "$COUNT"
 
-    # A clean bin of symlinks to the real tools the lib needs (mktemp, grep,
-    # sleep, printf, cat, jq, timeout), with gh excluded so only the shim below
-    # is ever on PATH. Per-test PATH overrides drop jq or the gh shim to probe
-    # the env-error paths.
-    local dir f name
-    IFS=':' read -ra _dirs <<< "$PATH"
-    for dir in "${_dirs[@]}"; do
-        [[ -d "$dir" ]] || continue
-        for f in "$dir"/*; do
-            [[ -x "$f" && ! -d "$f" ]] || continue
-            name="${f##*/}"
-            [[ "$name" == gh ]] && continue
-            [[ -e "$BIN/$name" ]] || ln -s "$f" "$BIN/$name"
-        done
-    done
+    # Writable overlay ahead of the shared farm: the gh shim and this jq symlink
+    # are what tests add or drop to probe the env-error paths.
+    ln -s "$(command -v jq)" "$BIN/jq"
+    CLEAN_PATH="$BIN:$SHARED_BIN"
 
     # shellcheck source=/dev/null
     source "$LIB"
     # The shim emits this as the VSA's resourceUri; matches $_image so the gate's
     # resourceUri binding is satisfied unless a test overrides it.
     GH_RESOURCE_URI="$_image"
-    export TMP_DIR BIN COUNT FIXTURES GH_RESOURCE_URI
+    export TMP_DIR BIN COUNT FIXTURES GH_RESOURCE_URI CLEAN_PATH
 }
 
 teardown() {
@@ -113,7 +122,7 @@ GH
 
 @test "verify: gh absent -> rc 2, clear message" {
     # BIN excludes gh and no shim is installed.
-    run env PATH="$BIN" bash -c "source '$LIB'; verify_image_vsa '$_image'"
+    run env PATH="$CLEAN_PATH" bash -c "source '$LIB'; verify_image_vsa '$_image'"
     [ "$status" -eq 2 ]
     [[ "$output" == *"gh not found"* ]]
 }
@@ -121,7 +130,7 @@ GH
 @test "verify: jq absent -> rc 2, clear message" {
     _install_gh_shim
     rm -f "$BIN/jq"
-    run env PATH="$BIN" GH_COUNT="$COUNT" GH_SEQ="passed" bash -c "source '$LIB'; verify_image_vsa '$_image'"
+    run env PATH="$CLEAN_PATH" GH_COUNT="$COUNT" GH_SEQ="passed" bash -c "source '$LIB'; verify_image_vsa '$_image'"
     [ "$status" -eq 2 ]
     [[ "$output" == *"jq not found"* ]]
 }
@@ -130,7 +139,7 @@ GH
 
 @test "verify: attested PASSED L3, resourceUri matches -> rc 0, one gh call" {
     _install_gh_shim
-    run env PATH="$BIN" GH_COUNT="$COUNT" GH_SEQ="passed" WRANGLE_RETRY_DELAY=0 \
+    run env PATH="$CLEAN_PATH" GH_COUNT="$COUNT" GH_SEQ="passed" WRANGLE_RETRY_DELAY=0 \
         bash -c "source '$LIB'; verify_image_vsa '$_image'"
     [ "$status" -eq 0 ]
     [ "$(wc -l < "$COUNT")" -eq 1 ]
@@ -138,7 +147,7 @@ GH
 
 @test "verify: PASSED L3 but resourceUri is a DIFFERENT image -> rc 1, not retried" {
     _install_gh_shim
-    run env PATH="$BIN" GH_COUNT="$COUNT" GH_SEQ="passed" WRANGLE_RETRY_DELAY=0 \
+    run env PATH="$CLEAN_PATH" GH_COUNT="$COUNT" GH_SEQ="passed" WRANGLE_RETRY_DELAY=0 \
         GH_RESOURCE_URI="ghcr.io/tomhennen/wrangle/other@sha256:dead" \
         bash -c "source '$LIB'; verify_image_vsa '$_image'"
     [ "$status" -eq 1 ]
@@ -148,7 +157,7 @@ GH
 
 @test "verify: gh rc 0 but FAILED verdict -> rc 1, not retried" {
     _install_gh_shim
-    run env PATH="$BIN" GH_COUNT="$COUNT" GH_SEQ="failed" WRANGLE_RETRY_DELAY=0 \
+    run env PATH="$CLEAN_PATH" GH_COUNT="$COUNT" GH_SEQ="failed" WRANGLE_RETRY_DELAY=0 \
         bash -c "source '$LIB'; verify_image_vsa '$_image'"
     [ "$status" -eq 1 ]
     [ "$(wc -l < "$COUNT")" -eq 1 ]
@@ -156,7 +165,7 @@ GH
 
 @test "verify: malformed gh JSON -> rc 1, fail closed, not retried" {
     _install_gh_shim
-    run env PATH="$BIN" GH_COUNT="$COUNT" GH_SEQ="malformed" WRANGLE_RETRY_DELAY=0 \
+    run env PATH="$CLEAN_PATH" GH_COUNT="$COUNT" GH_SEQ="malformed" WRANGLE_RETRY_DELAY=0 \
         bash -c "source '$LIB'; verify_image_vsa '$_image'"
     [ "$status" -eq 1 ]
     [ "$(wc -l < "$COUNT")" -eq 1 ]
@@ -166,7 +175,7 @@ GH
 
 @test "verify: no-attestation failure -> rc 1, retried once" {
     _install_gh_shim
-    run env PATH="$BIN" GH_COUNT="$COUNT" GH_SEQ="noattest" WRANGLE_RETRY_DELAY=0 \
+    run env PATH="$CLEAN_PATH" GH_COUNT="$COUNT" GH_SEQ="noattest" WRANGLE_RETRY_DELAY=0 \
         bash -c "source '$LIB'; verify_image_vsa '$_image'"
     [ "$status" -eq 1 ]
     [ "$(wc -l < "$COUNT")" -eq 2 ]
@@ -174,7 +183,7 @@ GH
 
 @test "verify: transient gh failure then success -> rc 0, two gh calls" {
     _install_gh_shim
-    run env PATH="$BIN" GH_COUNT="$COUNT" GH_SEQ="transient passed" WRANGLE_RETRY_DELAY=0 \
+    run env PATH="$CLEAN_PATH" GH_COUNT="$COUNT" GH_SEQ="transient passed" WRANGLE_RETRY_DELAY=0 \
         bash -c "source '$LIB'; verify_image_vsa '$_image'"
     [ "$status" -eq 0 ]
     [ "$(wc -l < "$COUNT")" -eq 2 ]
@@ -182,7 +191,7 @@ GH
 
 @test "verify: persistent gh failure -> rc 1, retried once then fails closed" {
     _install_gh_shim
-    run env PATH="$BIN" GH_COUNT="$COUNT" GH_SEQ="transient" WRANGLE_RETRY_DELAY=0 \
+    run env PATH="$CLEAN_PATH" GH_COUNT="$COUNT" GH_SEQ="transient" WRANGLE_RETRY_DELAY=0 \
         bash -c "source '$LIB'; verify_image_vsa '$_image'"
     [ "$status" -eq 1 ]
     [ "$(wc -l < "$COUNT")" -eq 2 ]
@@ -190,7 +199,7 @@ GH
 
 @test "verify: gh timeout then success -> rc 0 (timeout exit is retried)" {
     _install_gh_shim
-    run env PATH="$BIN" GH_COUNT="$COUNT" GH_SEQ="timeout passed" WRANGLE_RETRY_DELAY=0 \
+    run env PATH="$CLEAN_PATH" GH_COUNT="$COUNT" GH_SEQ="timeout passed" WRANGLE_RETRY_DELAY=0 \
         bash -c "source '$LIB'; verify_image_vsa '$_image'"
     [ "$status" -eq 0 ]
     [ "$(wc -l < "$COUNT")" -eq 2 ]

--- a/test/test_verify_image_vsa.bats
+++ b/test/test_verify_image_vsa.bats
@@ -13,8 +13,7 @@ _osv_uri="ghcr.io/tomhennen/wrangle/osv@sha256:c8abda59e3a64520128c427d2fe9bd223
 _image="ghcr.io/tomhennen/wrangle/imgtool@sha256:c8abda59e3a64520128c427d2fe9bd223c27e0a2056181ead1b9d3c6a5fb3b75"
 
 # A shared clean bin of symlinks to every real tool on PATH except gh and jq —
-# the two the per-test setup shims or drops — built once per file so the gate
-# runs against a controlled PATH without a per-test symlink farm.
+# the two the per-test setup shims or drops.
 setup_file() {
     SHARED_BIN="$BATS_FILE_TMPDIR/bin"
     mkdir -p "$SHARED_BIN"

--- a/test/test_verify_tool_image.bats
+++ b/test/test_verify_tool_image.bats
@@ -13,6 +13,26 @@
 # live run against the curated osv image; the FAILED case mutates only the
 # verdict, proving the jq — the sole verdict check — catches a non-PASSED VSA.
 
+# A shared clean bin of symlinks to every real tool on PATH except gh and docker
+# — the two the tests shim — built once per file so run.sh runs against a
+# controlled PATH without a per-test symlink farm.
+setup_file() {
+    SHARED_BIN="$BATS_FILE_TMPDIR/bin"
+    mkdir -p "$SHARED_BIN"
+    local dir f name
+    IFS=':' read -ra _path_dirs <<< "$PATH"
+    for dir in "${_path_dirs[@]}"; do
+        [[ -d "$dir" ]] || continue
+        for f in "$dir"/*; do
+            [[ -x "$f" && ! -d "$f" ]] || continue
+            name="${f##*/}"
+            [[ "$name" == gh || "$name" == docker ]] && continue
+            [[ -e "$SHARED_BIN/$name" ]] || ln -s "$f" "$SHARED_BIN/$name"
+        done
+    done
+    export SHARED_BIN
+}
+
 setup() {
     ORIG_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
     RUN_SH="$ORIG_DIR/run.sh"
@@ -28,21 +48,10 @@ setup() {
     : > "$GH_LOG"
     : > "$DOCKER_LOG"
 
-    # A clean PATH of symlinks to the real tools run.sh needs, with gh and docker
-    # excluded so neither a real binary nor the host's leaks in; the shims below
-    # are the only gh/docker on PATH. EMPTYBIN is WRANGLE_BIN_DIR (env.sh prepends
-    # it) so it cannot reintroduce a real gh.
-    local dir name
-    IFS=':' read -ra _path_dirs <<< "$PATH"
-    for dir in "${_path_dirs[@]}"; do
-        [[ -d "$dir" ]] || continue
-        for f in "$dir"/*; do
-            [[ -x "$f" && ! -d "$f" ]] || continue
-            name="${f##*/}"
-            [[ "$name" == gh || "$name" == docker ]] && continue
-            [[ -e "$CLEANBIN/$name" ]] || ln -s "$f" "$CLEANBIN/$name"
-        done
-    done
+    # Writable overlay ahead of the shared farm holds the gh and docker shims, so
+    # they are the only gh/docker on PATH. EMPTYBIN is WRANGLE_BIN_DIR (env.sh
+    # prepends it) so it cannot reintroduce a real gh.
+    CLEAN_PATH="$CLEANBIN:$SHARED_BIN"
 
     # docker shim: records its invocation and exits per DOCKER_SHIM_EXIT. A real
     # container never runs in the unit suite; dispatch is asserted by the log.
@@ -54,7 +63,7 @@ exit "${DOCKER_SHIM_EXIT:-0}"
 DOCKER
     chmod +x "$CLEANBIN/docker"
 
-    export ORIG_DIR RUN_SH TMP_DIR SRC OUT TOOLS CLEANBIN EMPTYBIN GH_LOG DOCKER_LOG
+    export ORIG_DIR RUN_SH TMP_DIR SRC OUT TOOLS CLEANBIN EMPTYBIN GH_LOG DOCKER_LOG CLEAN_PATH
 }
 
 teardown() {
@@ -96,7 +105,7 @@ JSON
 }
 
 _run_orch() {
-    PATH="$CLEANBIN" WRANGLE_BIN_DIR="$EMPTYBIN" \
+    PATH="$CLEAN_PATH" WRANGLE_BIN_DIR="$EMPTYBIN" \
         GH_SHIM_LOG="$GH_LOG" DOCKER_SHIM_LOG="$DOCKER_LOG" \
         WRANGLE_TOOLS_DIR="$TOOLS" \
         run "$RUN_SH" -s "$SRC" -o "$OUT" "$@"

--- a/test/test_verify_tool_image.bats
+++ b/test/test_verify_tool_image.bats
@@ -14,8 +14,7 @@
 # verdict, proving the jq — the sole verdict check — catches a non-PASSED VSA.
 
 # A shared clean bin of symlinks to every real tool on PATH except gh and docker
-# — the two the tests shim — built once per file so run.sh runs against a
-# controlled PATH without a per-test symlink farm.
+# — the two the tests shim.
 setup_file() {
     SHARED_BIN="$BATS_FILE_TMPDIR/bin"
     mkdir -p "$SHARED_BIN"


### PR DESCRIPTION
## Problem

The `Build Shell` CI job runs all bats tests serially and takes ~712s. Profiling (run 28742124864) showed a cluster of ~25 tests each taking a uniform ~7.9s (~200s, ~28% of the suite): the VSA-gate unit tests in `test/test_verify_image_vsa.bats` and `test/test_verify_tool_image.bats`.

## Root cause

Each test's `setup()` built a "clean bin" by iterating **every executable in every directory on `$PATH`** and creating a symlink for each, so the `gh`/`docker` shims are the only ones on PATH and per-test overrides can drop `jq` to probe env-error paths. On a GitHub runner that PATH holds thousands of executables, and the farm was rebuilt for **every** test.

## Fix

Build the farm **once per file** in `setup_file()` (anchored at bats' auto-created, auto-cleaned `BATS_FILE_TMPDIR`), and put a small per-test **writable overlay ahead of it** on PATH for the shims and the `jq` symlink the env-error tests drop.

The guarantees the tests prove are unchanged:
- The shared farm excludes exactly the tools the tests control (`gh`+`jq` for the VSA file, `gh`+`docker` for the tool-image file), so the shim is the only `gh`/`docker`.
- The `gh`-absent and `jq`-absent tests still hit a genuinely missing binary (overlay drops it; farm never had it).

Chose the shared-farm approach over enumerating the specific binaries because `test/test_verify_tool_image.bats` drives the whole `run.sh` orchestrator (which sources `read_catalog.sh`, `merge_catalog.sh`, `run_tool_image.sh`, …) — its binary set can't be cleanly enumerated, and enumeration would silently rot as the lib grows. The farm needs no maintenance; if the lib ever needs a new binary the failure is an obvious command-not-found, not a false pass.

## Measured (local; CI's larger PATH makes the win bigger)

| File | Before | After |
|------|--------|-------|
| `test_verify_image_vsa.bats` (16 tests) | 41.3s | 2.7s |
| `test_verify_tool_image.bats` (7 tests) | 22.5s | 7.6s |

Expected CI saving: ~200s of the ~712s serial bats run. A parallel `--jobs` effort is landing separately; this fix shortens the slowest lane, so the per-file wall times above are the relevant numbers there.

## Scope

Repo-wide grep (post-#703) confirms these two files are the only ones with the iterate-all-of-PATH farm pattern; `actions/attest_provenance/test_sign_metadata.bats` prepends a single fake-tool dir (`$STUB_BIN:$PATH`) and is fine.

## Checks

- `bats test/test_verify_image_vsa.bats test/test_verify_tool_image.bats` — 23/23 pass
- `make shellcheck` — clean
- Diff is bats-only, so out of `wrangle-shell-lint` scope (`*.sh` / extensionless bash-shebang only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)