### PR TITLE
claude: purge a PR's Actions caches when it closes

### DIFF
--- a/.github/workflows/cache_janitor.yml
+++ b/.github/workflows/cache_janitor.yml
@@ -1,0 +1,25 @@
+name: Cache Janitor
+
+# A closed PR's caches otherwise linger up to GitHub's 7-day TTL, and at the
+# 10GB quota the LRU evictor can't tell them apart from main's hot caches.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete the closed PR's caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          gh cache list -R "$REPO" --ref "$REF" --limit 100 --json id --jq '.[].id' \
+            | while read -r id; do gh cache delete -R "$REPO" "$id"; done


### PR DESCRIPTION
claude: Closed-PR cache refs only age out via GitHub's 7-day unused TTL, and at the 10GB quota the LRU evictor can't distinguish them from main's hot buildx/go caches — so dead experiments squeeze out useful entries (observed today: the repo sat at 9.74GB/10GB, 2.6GB of it a single on-hold PR's caches, ~1.5GB more from long-closed PRs).

This adds a wrangle-internal janitor: on `pull_request: closed`, delete that PR's `refs/pull/N/merge` caches. No checkout, no third-party actions, `actions: write` only (the minimum for cache deletion; `permissions: {}` at workflow level).

Upstream alternatives considered per CLAUDE.md rule 4: GitHub has no repo setting for close-time cache eviction (only the TTL/LRU defaults); `actions/cache`'s docs recommend exactly this event-driven `gh cache delete` pattern, so this uses stock `gh` rather than a marketplace action.

The one-time backlog was purged manually today (9.74GB → ~6.5GB); this keeps it from re-accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)