### PR TITLE
claude: fix(freshness): fold catalog.json + lib/ into pin-freshness scope (#713, #720)

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -118,6 +118,12 @@ All three must hold before you ask the owner to cut. Do not shortcut.
    (registry unreachable) means the precondition is UNVERIFIED — do not proceed.**
    Retry until the result is 0 or 1; a visible exit-2 is not a satisfied gate.
 
+   After any catalog digest bump lands on `main`, re-run **Phase 1's**
+   `tools/converge_action_pins.sh`: freshness folds `tools/catalog.json` into every
+   pin's scope, so the bump stales the consumers until the pins are re-bumped onto
+   it. Same Phase 1 caveats — merge-commit-not-squash, and run so the labels land
+   `# main`. A stale-catalog release ships pins that resolve the *old* digest.
+
    Then confirm each digest was built from the **current** tool source (the
    stronger §11 guarantee the adoption-lag check does not prove — and the gate
    for the containerized signing path, #633). Run on a full-history checkout

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -121,7 +121,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         id: prep
         with:
           build-type: container
@@ -140,7 +140,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -166,7 +166,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -244,7 +244,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -285,7 +285,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -121,7 +121,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         id: prep
         with:
           build-type: container
@@ -140,7 +140,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -166,7 +166,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -244,7 +244,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -285,7 +285,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -121,7 +121,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         id: prep
         with:
           build-type: container
@@ -140,7 +140,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -166,7 +166,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -244,7 +244,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -285,7 +285,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -162,7 +162,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         id: prep
         with:
           build-type: go
@@ -181,7 +181,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -213,7 +213,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         id: attest
         with:
           build-type: go
@@ -394,7 +394,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -162,7 +162,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         id: prep
         with:
           build-type: go
@@ -181,7 +181,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -213,7 +213,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         id: attest
         with:
           build-type: go
@@ -394,7 +394,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -162,7 +162,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         id: prep
         with:
           build-type: go
@@ -181,7 +181,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -213,7 +213,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         id: attest
         with:
           build-type: go
@@ -394,7 +394,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -150,7 +150,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -169,7 +169,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -305,7 +305,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -150,7 +150,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -169,7 +169,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -305,7 +305,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -150,7 +150,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -169,7 +169,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -305,7 +305,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -127,7 +127,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         id: prep
         with:
           build-type: python
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -178,7 +178,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         id: attest
         with:
           build-type: python
@@ -292,7 +292,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -127,7 +127,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         id: prep
         with:
           build-type: python
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -178,7 +178,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         id: attest
         with:
           build-type: python
@@ -292,7 +292,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -127,7 +127,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         id: prep
         with:
           build-type: python
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -178,7 +178,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         id: attest
         with:
           build-type: python
@@ -292,7 +292,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -90,7 +90,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -103,7 +103,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -151,7 +151,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -90,7 +90,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -103,7 +103,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -151,7 +151,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@634aaf52ddd78e8d629f49adb9a73b07e9f408d6 # worktree-claude-parallel-bats
+        uses: TomHennen/wrangle/build/actions/shell@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -90,7 +90,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -103,7 +103,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -151,7 +151,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -26,7 +26,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
 
   check-change:
     needs: [prep]
@@ -44,7 +44,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -26,7 +26,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
 
   check-change:
     needs: [prep]
@@ -44,7 +44,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -26,7 +26,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
 
   check-change:
     needs: [prep]
@@ -44,7 +44,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/local_publish_images.yml
+++ b/.github/workflows/local_publish_images.yml
@@ -81,6 +81,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # Full history: open_catalog_bump_pr.sh converges the self-ref pins,
+          # which resolves each pinned sha's tree — a shallow clone lacks them.
+          fetch-depth: 0
 
       # Resolve each curated `:latest` and rewrite drifted catalog entries. A
       # registry backend error (exit 2) is advisory — any resolvable entry is

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -107,7 +107,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -119,7 +119,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@f9cade74746aec18e54c2e6bcd6f7a5ee3fbd048 # main 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@5641905781cd0154617e4ab7e3f1eaf94f5ccabd # main 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/test/test_check_pin_freshness.bats
+++ b/test/test_check_pin_freshness.bats
@@ -126,6 +126,22 @@ run_fresh() { run bash -c "cd '$REPO' && '$SCRIPT'"; }
     [[ "$output" == *"STALE: actions/release"* ]]
 }
 
+@test "check_pin_freshness: lib/ and tools/catalog.json carry no self-ref pin refs (pin-free-scope invariant)" {
+    # Folding lib/ + tools/catalog.json into every pin's diff scope is only sound
+    # because they hold NO self-ref pin reference: any change to them then always
+    # hits the not-a-pin drift branch. Enforce that mechanically with the same pin
+    # regex the script builds — loose TomHennen/wrangle strings without an
+    # @<40-hex> ref (e.g. in lib/verify_image_vsa.sh) correctly do not match.
+    local root; root="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    local prefix escaped_prefix pin_re
+    prefix="${WRANGLE_PINS_REPO:-TomHennen/wrangle}"
+    escaped_prefix="$(printf '%s' "$prefix" | sed 's/\./\\./g')"
+    pin_re="${escaped_prefix}/[^@[:space:]]+@[0-9a-f]{40}"
+    run grep -rnE "$pin_re" "$root/lib" "$root/tools/catalog.json"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
 @test "check_pin_freshness: FAILS when tools/catalog.json changes after the pin (catalog consumer staleness)" {
     # Catalog consumers read the pinned action's own tools/catalog.json, so a
     # catalog-only digest bump must stale the pins that carry it. verify itself is

--- a/test/test_check_pin_freshness.bats
+++ b/test/test_check_pin_freshness.bats
@@ -126,6 +126,69 @@ run_fresh() { run bash -c "cd '$REPO' && '$SCRIPT'"; }
     [[ "$output" == *"STALE: actions/release"* ]]
 }
 
+@test "check_pin_freshness: FAILS when tools/catalog.json changes after the pin (catalog consumer staleness)" {
+    # Catalog consumers read the pinned action's own tools/catalog.json, so a
+    # catalog-only digest bump must stale the pins that carry it. verify itself is
+    # unchanged; only the catalog moved after the pin.
+    write_verify 'echo hi' >/dev/null
+    mkdir -p "$REPO/tools"
+    printf '{"tools":{"osv":{"image":"x@sha256:aaa"}}}\n' > "$REPO/tools/catalog.json"
+    git -C "$REPO" add tools/catalog.json && git -C "$REPO" commit -q -m 'catalog v1'
+    local pinsha; pinsha="$(git -C "$REPO" rev-parse HEAD)"
+    printf '{"tools":{"osv":{"image":"x@sha256:bbb"}}}\n' > "$REPO/tools/catalog.json"
+    git -C "$REPO" commit -qam 'catalog v2'
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # pin\n' "$pinsha" \
+        > "$REPO/.github/workflows/x.yml"
+    run_fresh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *STALE* ]]
+}
+
+@test "check_pin_freshness: FAILS when a lib/ helper changes after the pin (lib consumer staleness)" {
+    # Consumers source the pinned action's own lib/ helpers, so a lib-only change
+    # must stale the pins that carry it. verify itself is unchanged.
+    write_verify 'echo hi' >/dev/null
+    mkdir -p "$REPO/lib"
+    printf 'echo OLD\n' > "$REPO/lib/toolbox_run.sh"
+    git -C "$REPO" add lib && git -C "$REPO" commit -q -m 'lib v1'
+    local pinsha; pinsha="$(git -C "$REPO" rev-parse HEAD)"
+    printf 'echo NEW\n' > "$REPO/lib/toolbox_run.sh"
+    git -C "$REPO" commit -qam 'lib v2'
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # pin\n' "$pinsha" \
+        > "$REPO/.github/workflows/x.yml"
+    run_fresh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *STALE* ]]
+}
+
+@test "check_pin_freshness: PASSES on a pure nested-pin SHA bump with catalog/lib in scope (#709 invariant)" {
+    # A converged composite pins an OLDER sha whose only diff to HEAD is a nested
+    # pin's SHA (same ref path) — a pure bump, not drift. Folding catalog/lib into
+    # scope must not disturb that: both are present and unchanged, so it stays FRESH.
+    mkdir -p "$REPO/tools" "$REPO/lib"
+    printf '{"tools":{}}\n' > "$REPO/tools/catalog.json"
+    printf 'echo lib\n' > "$REPO/lib/x.sh"
+    git -C "$REPO" add -A && git -C "$REPO" commit -q -m 'catalog + lib base'
+    local v1; v1="$(write_verify 'echo hi')"          # verify content is fixed hereafter
+    mkdir -p "$REPO/actions/release"
+    printf 'name: release\n' > "$REPO/actions/release/action.yml"
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # pin\n' "$v1" \
+        >> "$REPO/actions/release/action.yml"
+    git -C "$REPO" add actions/release && git -C "$REPO" commit -q -m 'release pins verify@v1'
+    local rel_old; rel_old="$(git -C "$REPO" rev-parse HEAD)"
+    # Pure SHA bump: re-pin nested verify v1 -> rel_old (verify content identical);
+    # catalog + lib untouched.
+    printf 'name: release\n' > "$REPO/actions/release/action.yml"
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # pin\n' "$rel_old" \
+        >> "$REPO/actions/release/action.yml"
+    git -C "$REPO" commit -qam 'release re-pins verify (pure sha bump)'
+    printf '      - uses: TomHennen/wrangle/actions/release@%s # pin\n' "$rel_old" \
+        > "$REPO/.github/workflows/x.yml"
+    run_fresh
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"resolve to HEAD content"* ]]
+}
+
 @test "check_pin_freshness: PASSES (no-op) on an older pin whose path never changed" {
     # A pin at an older sha is FRESH if its path is byte-identical to HEAD's —
     # don't false-positive just because the sha is old.

--- a/test/test_open_catalog_bump_pr.bats
+++ b/test/test_open_catalog_bump_pr.bats
@@ -7,7 +7,9 @@
 # $SHIM_PR_EXISTS so both the create and the update branches are covered.
 
 setup() {
-    SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/tools/open_catalog_bump_pr.sh"
+    TOOLS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/tools"
+    SCRIPT="$TOOLS_DIR/open_catalog_bump_pr.sh"
+    FRESHNESS="$TOOLS_DIR/check_pin_freshness.sh"
     BIN_DIR="$BATS_TEST_TMPDIR/bin"
     WORK="$BATS_TEST_TMPDIR/work"
     REMOTE="$BATS_TEST_TMPDIR/remote.git"
@@ -27,10 +29,22 @@ setup() {
     git -C "$WORK" config user.name t
     git -C "$WORK" config user.email t@example.com
     git -C "$WORK" config commit.gpgsign false
-    mkdir -p "$WORK/tools"
+    # The repo must carry a converged self-ref pin: open_catalog_bump_pr.sh now
+    # converges the pins after the catalog commit, and converge errors on a repo
+    # with no pins at all. A workflow pins a verify action at the sha where its
+    # tree first appears, so the chain is fresh until the catalog moves.
+    mkdir -p "$WORK/tools" "$WORK/actions/verify" "$WORK/.github/workflows" "$WORK/lib"
     printf '{"tools":{}}\n' > "$WORK/tools/catalog.json"
+    printf 'name: verify\n' > "$WORK/actions/verify/action.yml"
+    printf 'echo hi\n' > "$WORK/actions/verify/run.sh"
+    printf 'echo lib\n' > "$WORK/lib/helper.sh"
     git -C "$WORK" add -A
-    git -C "$WORK" commit -qm init
+    git -C "$WORK" commit -qm 'init: catalog + verify action + lib'
+    local vsha; vsha="$(git -C "$WORK" rev-parse HEAD)"
+    printf '      - uses: TomHennen/wrangle/actions/verify@%s # main\n' "$vsha" \
+        > "$WORK/.github/workflows/x.yml"
+    git -C "$WORK" add -A
+    git -C "$WORK" commit -qm 'pin verify'
     git -C "$WORK" branch -M main
     git -C "$WORK" remote add origin "$REMOTE"
     git -C "$WORK" push -q origin main
@@ -70,6 +84,21 @@ SHIM
     grep -q 'pr create' "$GH_LOG"
     grep -q -- '--base main' "$GH_LOG"
     grep -q -- '--head bot/catalog-autobump' "$GH_LOG"
+}
+
+@test "open_catalog_bump_pr: converges the pins so the bump branch passes freshness" {
+    # The catalog commit stales the consuming pin (freshness folds catalog into
+    # scope); the script must converge so the PR is not born red.
+    printf '{"tools":{"osv":{"image":"x@sha256:new"}}}\n' > "$WORK/tools/catalog.json"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    # The pushed branch resolves current content: freshness passes on its HEAD.
+    git -C "$WORK" checkout -q bot/catalog-autobump
+    run bash -c "cd '$WORK' && '$FRESHNESS'"
+    [ "$status" -eq 0 ]
+    # Catalog commit + at least one convergence commit landed on the branch.
+    run git -C "$WORK" rev-list --count main..bot/catalog-autobump
+    [ "$output" -ge 2 ]
 }
 
 @test "open_catalog_bump_pr: an already-open PR is refreshed, not recreated" {

--- a/tools/check_pin_freshness.sh
+++ b/tools/check_pin_freshness.sh
@@ -56,6 +56,13 @@ pin_re="${escaped_prefix}/[^@[:space:]]+@[0-9a-f]{40}"
 # surviving nested pin's own freshness is checked as the BFS descends. -G/-S
 # can't express "only these lines changed", so we diff with no context and scan
 # the +/- body lines.
+#
+# tools/catalog.json and lib/ are folded into every pin's diff scope: consumers
+# resolve the pinned action's own catalog and lib helpers, so a catalog-only or
+# lib-only change must stale the pins that carry it to main. Both are pin-free
+# (JSON / shell with no self-ref refs), so any change hits the not-a-pin drift
+# branch. catalog is scoped to that one file — tools/ also holds go.mod/go.sum/
+# scripts that churn independently of the pins; lib/ is scoped whole.
 path_content_stale() {
     local sha="$1" subpath="$2" line body norm
     local -a minus=() plus=()
@@ -79,7 +86,7 @@ path_content_stale() {
             '-') minus+=("$norm") ;;
             '+') plus+=("$norm") ;;
         esac
-    done < <(git -C "$repo_root" diff --unified=0 "$sha" HEAD -- "$subpath" 2>/dev/null)
+    done < <(git -C "$repo_root" diff --unified=0 "$sha" HEAD -- "$subpath" tools/catalog.json lib/ 2>/dev/null)
     # The pin changes are a pure sha bump iff the sha/comment-stripped multisets
     # match; any difference is a retargeted or added/removed pin = drift.
     local m p

--- a/tools/open_catalog_bump_pr.sh
+++ b/tools/open_catalog_bump_pr.sh
@@ -6,11 +6,18 @@ set -f
 #
 # Runs after bump_catalog_to_latest.sh in the post-publish workflow: it takes the
 # already-modified tools/catalog.json in the working tree, commits it to a
-# dedicated bot branch, and opens a PR (or force-updates the existing one, so a
-# rolling publish keeps a single PR rather than piling up). No-op when the catalog
-# is unchanged. First-party rebuilds are cooldown-exempt (§11), so the PR is
-# meant to be reviewed and merged on CI/review latency, not held for the 7-day
-# community-vetting delay. Uses git + the gh CLI with the ambient GITHUB_TOKEN.
+# dedicated bot branch, converges the self-ref pins onto that commit, and opens a
+# PR (or force-updates the existing one, so a rolling publish keeps a single PR
+# rather than piling up). No-op when the catalog is unchanged. First-party
+# rebuilds are cooldown-exempt (§11), so the PR is meant to be reviewed and merged
+# on CI/review latency, not held for the 7-day community-vetting delay. Uses git +
+# the gh CLI with the ambient GITHUB_TOKEN.
+#
+# The convergence step is required: check_pin_freshness folds tools/catalog.json
+# into every pin's scope, so a catalog-only commit stales the consumers until the
+# pins are re-bumped onto it. Converging in-PR carries fresh pins so the bump PR
+# passes the blocking freshness gate. Pins get # <branch> labels here (the branch
+# isn't on main yet); cut-release Phase 1's main-converge relabels them # main.
 #
 # Setup requirement: the repository must have "Allow GitHub Actions to create and
 # approve pull requests" enabled, or `gh pr create` with GITHUB_TOKEN fails.
@@ -23,6 +30,8 @@ BASE="${WRANGLE_AUTOBUMP_BASE:-main}"
 CATALOG_REL="tools/catalog.json"
 BOT_NAME="github-actions[bot]"
 BOT_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 pr_title() {
     printf 'chore(catalog): bump curated tool-image digests to :latest'
@@ -43,6 +52,10 @@ CI/review latency to keep the catalog current.
 
 Adopter-override entries (a foreign namespace) are never touched here; those
 pins stay adopter-owned.
+
+**Merge as a merge commit, not a squash.** Beyond the catalog bump this PR carries
+self-ref pin-convergence commits (one per nesting level); squashing re-orphans the
+intermediate pins. The `# <branch>` pin labels are relabelled `# main` at release.
 
 Refs #619, #596.
 BODY
@@ -91,10 +104,18 @@ main() {
     fi
     : "${WRANGLE_AUTOBUMP_GH_REPO:?set WRANGLE_AUTOBUMP_GH_REPO (owner/repo)}"
 
+    # Set the bot identity at repo scope: the catalog commit and every
+    # converge_action_pins.sh pin commit (which commits with no inline identity)
+    # both need it, and the CI checkout configures none.
+    git config user.name "$BOT_NAME"
+    git config user.email "$BOT_EMAIL"
+
     git switch -C "$BRANCH" >/dev/null 2>&1 || { printf 'open_catalog_bump_pr: could not create branch %s\n' "$BRANCH" >&2; return 2; }
     git add "$CATALOG_REL"
-    git -c "user.name=$BOT_NAME" -c "user.email=$BOT_EMAIL" \
-        commit -m "$(pr_title)" >/dev/null || { printf 'open_catalog_bump_pr: commit failed\n' >&2; return 2; }
+    git commit -m "$(pr_title)" >/dev/null || { printf 'open_catalog_bump_pr: commit failed\n' >&2; return 2; }
+    # The catalog commit stales every pin (freshness folds tools/catalog.json into
+    # each pin's scope); converge re-bumps them onto it so the PR passes freshness.
+    "$SCRIPT_DIR/converge_action_pins.sh" || { printf 'open_catalog_bump_pr: pin convergence failed\n' >&2; return 2; }
     push_branch || { printf 'open_catalog_bump_pr: push failed\n' >&2; return 2; }
     open_or_update_pr || { printf 'open_catalog_bump_pr: gh pr open failed\n' >&2; return 2; }
 }

--- a/tools/open_catalog_bump_pr.sh
+++ b/tools/open_catalog_bump_pr.sh
@@ -15,9 +15,7 @@ set -f
 #
 # The convergence step is required: check_pin_freshness folds tools/catalog.json
 # into every pin's scope, so a catalog-only commit stales the consumers until the
-# pins are re-bumped onto it. Converging in-PR carries fresh pins so the bump PR
-# passes the blocking freshness gate. Pins get # <branch> labels here (the branch
-# isn't on main yet); cut-release Phase 1's main-converge relabels them # main.
+# pins are re-bumped onto it.
 #
 # Setup requirement: the repository must have "Allow GitHub Actions to create and
 # approve pull requests" enabled, or `gh pr create` with GITHUB_TOKEN fails.


### PR DESCRIPTION
claude: closes the pin-freshness blind spot for catalog- and lib-only changes.

## Problem

`check_pin_freshness`'s `path_content_stale` diffed only each pin's action
subpath. But catalog consumers (`actions/scan` via run.sh/run_tool_image;
`actions/verify` + verify_release + attest_* via `lib/toolbox_run.sh`) read
`tools/catalog.json`, and every action sources `lib/` helpers, **from the pinned
action's own tree**. Both live outside every action subpath, so a catalog-only or
lib-only change produced **zero** staleness → converge was a no-op → the change
never reached the pinned consumers on `main` or in a release. A release's
Phase-4 catalog bump would then ship pins resolving the *stale* catalog.

Fixes #713 (catalog) and #720 (its lib/ twin).

## Change (one coherent PR, three coupled pieces)

1. **Freshness sees the catalog + lib.** In `path_content_stale`, the `git diff`
   scope becomes `<subpath> tools/catalog.json lib/` (that one catalog file —
   `tools/` also holds go.mod/go.sum/scripts that churn independently; `lib/`
   whole). Both are pin-free, so any change hits the existing not-a-pin drift
   branch; the #709 retarget-multiset logic is untouched. Converge's commits
   touch neither, so post-bump the diff is empty and it settles.

2. **Auto-bump converges.** With freshness now seeing the catalog, a catalog-only
   bump PR fails the blocking gate until its pins converge. `open_catalog_bump_pr.sh`
   now runs `converge_action_pins.sh` after the catalog commit, before push, so the
   PR carries fresh pins. The `bump-catalog` job gains `fetch-depth: 0` (the pin
   walk resolves each pinned sha's tree) and the bot git identity is set at repo
   scope (converge commits carry no inline identity). **Label decision:** an in-PR
   converge writes `# <branch>` labels; accepted as-is (pins are functionally
   correct; freshness/ancestry ignore the comment) and cut-release Phase 1's
   main-converge relabels them `# main`. Documented in the script + PR body.

3. **cut-release Phase 4** re-runs Phase-1 `converge_action_pins.sh` after the
   catalog-freshness digest bump (now effective — it catches the catalog change).

## Main-consistency converge (in this PR)

The tightened check found a pre-existing **lib/-only** violation on `main`:
`build/actions/shell`'s pinned sha resolves the now-deleted
`lib/install_go_tools.sh`. This PR converges `main` to consistency (1 commit,
`WRANGLE_PINS_BRANCH=main` → `# main` labels), as the tightened lint fixing its
own pre-existing violation. Catalog is already consistent (#684, the live
catalog-only auto-bump, is still **open**, not merged).

## Merge as a MERGE COMMIT, not a squash

This PR carries a pin-convergence commit; squashing re-orphans the intermediate
pins.

## Validation

- `./test.sh quick` green (0 failures, exit 0).
- New freshness tests: catalog-only change → STALE; lib-only change → STALE;
  pure nested-pin SHA bump with catalog/lib in scope → FRESH (#709 invariant).
- Auto-bump tests updated: fixture now carries a converged pin; new test asserts
  the bump branch passes `check_pin_freshness` and carries the converge commit.
- `check_pin_ancestry` + `check_pin_freshness` (tightened) both pass on the
  merge ref (`git merge --no-commit --no-ff origin/main`).

Fixes #713
Fixes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)