### PR TITLE
claude: fix(scan): check_results owns the :fail/:info gate (Fixes #688; supersedes #710)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -121,7 +121,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         id: prep
         with:
           build-type: container
@@ -140,7 +140,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -166,7 +166,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -244,7 +244,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -285,7 +285,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -121,7 +121,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         id: prep
         with:
           build-type: container
@@ -140,7 +140,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -166,7 +166,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -244,7 +244,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -285,7 +285,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -121,7 +121,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         id: prep
         with:
           build-type: container
@@ -140,7 +140,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -166,7 +166,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -244,7 +244,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -285,7 +285,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -162,7 +162,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         id: prep
         with:
           build-type: go
@@ -181,7 +181,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -213,7 +213,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         id: attest
         with:
           build-type: go
@@ -394,7 +394,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -162,7 +162,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         id: prep
         with:
           build-type: go
@@ -181,7 +181,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -213,7 +213,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         id: attest
         with:
           build-type: go
@@ -394,7 +394,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -162,7 +162,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         id: prep
         with:
           build-type: go
@@ -181,7 +181,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -213,7 +213,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         id: attest
         with:
           build-type: go
@@ -394,7 +394,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -150,7 +150,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -169,7 +169,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -305,7 +305,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -150,7 +150,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -169,7 +169,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -305,7 +305,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -150,7 +150,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -169,7 +169,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -305,7 +305,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -127,7 +127,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         id: prep
         with:
           build-type: python
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -178,7 +178,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         id: attest
         with:
           build-type: python
@@ -292,7 +292,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -127,7 +127,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         id: prep
         with:
           build-type: python
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -178,7 +178,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         id: attest
         with:
           build-type: python
@@ -292,7 +292,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -127,7 +127,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         id: prep
         with:
           build-type: python
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -178,7 +178,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         id: attest
         with:
           build-type: python
@@ -292,7 +292,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -90,7 +90,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -103,7 +103,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -151,7 +151,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -90,7 +90,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -103,7 +103,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -151,7 +151,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -90,7 +90,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -103,7 +103,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -151,7 +151,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@634aaf52ddd78e8d629f49adb9a73b07e9f408d6 # worktree-claude-parallel-bats
+        uses: TomHennen/wrangle/build/actions/shell@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -26,7 +26,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
 
   check-change:
     needs: [prep]
@@ -44,7 +44,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -26,7 +26,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
 
   check-change:
     needs: [prep]
@@ -44,7 +44,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -26,7 +26,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
 
   check-change:
     needs: [prep]
@@ -44,7 +44,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -112,7 +112,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -124,7 +124,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -111,7 +111,7 @@ runs:
     # $GITHUB_WORKSPACE. Skipping on PRs avoids guaranteed failures.
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
-      if: always() && (contains(format(' {0} ', inputs.tools), ' scorecard ') || contains(format(' {0} ', inputs.tools), ' scorecard:')) && github.event_name != 'pull_request'
+      if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
       uses: TomHennen/wrangle/tools/scorecard@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
@@ -123,7 +123,7 @@ runs:
     # .github/dependency-review-config.yml when the scanned repo has one.
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
-      if: always() && (contains(format(' {0} ', inputs.tools), ' dependency-review ') || contains(format(' {0} ', inputs.tools), ' dependency-review:')) && github.event_name == 'pull_request'
+      if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
       uses: TomHennen/wrangle/tools/dependency-review@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
 
     - name: Generate step summary
@@ -175,7 +175,7 @@ runs:
     # corresponding metadata/<tool>/output.sarif file was never
     # produced — see issue #189.
     - name: Upload OSV SARIF
-      if: always() && (contains(format(' {0} ', inputs.tools), ' osv ') || contains(format(' {0} ', inputs.tools), ' osv:'))
+      if: always() && contains(inputs.tools, 'osv')
       uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       continue-on-error: true
       with:
@@ -183,7 +183,7 @@ runs:
         category: wrangle/osv
 
     - name: Upload wrangle-lint SARIF
-      if: always() && (contains(format(' {0} ', inputs.tools), ' wrangle-lint ') || contains(format(' {0} ', inputs.tools), ' wrangle-lint:'))
+      if: always() && contains(inputs.tools, 'wrangle-lint')
       uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       continue-on-error: true
       with:
@@ -191,7 +191,7 @@ runs:
         category: wrangle/wrangle-lint
 
     - name: Upload Zizmor SARIF
-      if: always() && (contains(format(' {0} ', inputs.tools), ' zizmor ') || contains(format(' {0} ', inputs.tools), ' zizmor:'))
+      if: always() && contains(inputs.tools, 'zizmor')
       uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       continue-on-error: true
       with:
@@ -210,7 +210,7 @@ runs:
     # `results: []`, silently scrubbing real findings on a transient API
     # failure. Gating on the marker preserves the prior valid state.
     - name: Upload Dependency Review SARIF
-      if: always() && (contains(format(' {0} ', inputs.tools), ' dependency-review ') || contains(format(' {0} ', inputs.tools), ' dependency-review:')) && github.event_name == 'pull_request' && hashFiles('.wrangle/metadata/dependency-review/error') == ''
+      if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request' && hashFiles('.wrangle/metadata/dependency-review/error') == ''
       uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       continue-on-error: true
       with:

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -112,7 +112,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && (contains(format(' {0} ', inputs.tools), ' scorecard ') || contains(format(' {0} ', inputs.tools), ' scorecard:')) && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -124,7 +124,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && (contains(format(' {0} ', inputs.tools), ' dependency-review ') || contains(format(' {0} ', inputs.tools), ' dependency-review:')) && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -112,7 +112,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && (contains(format(' {0} ', inputs.tools), ' scorecard ') || contains(format(' {0} ', inputs.tools), ' scorecard:')) && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -124,7 +124,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && (contains(format(' {0} ', inputs.tools), ' dependency-review ') || contains(format(' {0} ', inputs.tools), ' dependency-review:')) && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -75,6 +75,11 @@ runs:
     # run.sh strips :policy suffixes and skips action-pattern tools.
     - name: Run adapter-pattern tools
       shell: bash
+      # continue-on-error: run.sh exits 1 on findings and 2 on a tool error, but
+      # the Check results step owns the gate per each tool's :fail/:info policy
+      # (findings via SARIF, errors via the marker run.sh writes) — so this step
+      # must not fail on either, or an :info tool's findings/error would block.
+      continue-on-error: true
       # tools input passed via env var to prevent expression injection.
       # ${{ github.action_path }} is safe to interpolate in run: blocks —
       # it is set by GitHub when fetching the composite action and is not
@@ -106,7 +111,7 @@ runs:
     # $GITHUB_WORKSPACE. Skipping on PRs avoids guaranteed failures.
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
-      if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
+      if: always() && (contains(format(' {0} ', inputs.tools), ' scorecard ') || contains(format(' {0} ', inputs.tools), ' scorecard:')) && github.event_name != 'pull_request'
       uses: TomHennen/wrangle/tools/scorecard@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
@@ -118,7 +123,7 @@ runs:
     # .github/dependency-review-config.yml when the scanned repo has one.
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
-      if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
+      if: always() && (contains(format(' {0} ', inputs.tools), ' dependency-review ') || contains(format(' {0} ', inputs.tools), ' dependency-review:')) && github.event_name == 'pull_request'
       uses: TomHennen/wrangle/tools/dependency-review@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
 
     - name: Generate step summary
@@ -170,7 +175,7 @@ runs:
     # corresponding metadata/<tool>/output.sarif file was never
     # produced — see issue #189.
     - name: Upload OSV SARIF
-      if: always() && contains(inputs.tools, 'osv')
+      if: always() && (contains(format(' {0} ', inputs.tools), ' osv ') || contains(format(' {0} ', inputs.tools), ' osv:'))
       uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       continue-on-error: true
       with:
@@ -178,7 +183,7 @@ runs:
         category: wrangle/osv
 
     - name: Upload wrangle-lint SARIF
-      if: always() && contains(inputs.tools, 'wrangle-lint')
+      if: always() && (contains(format(' {0} ', inputs.tools), ' wrangle-lint ') || contains(format(' {0} ', inputs.tools), ' wrangle-lint:'))
       uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       continue-on-error: true
       with:
@@ -186,7 +191,7 @@ runs:
         category: wrangle/wrangle-lint
 
     - name: Upload Zizmor SARIF
-      if: always() && contains(inputs.tools, 'zizmor')
+      if: always() && (contains(format(' {0} ', inputs.tools), ' zizmor ') || contains(format(' {0} ', inputs.tools), ' zizmor:'))
       uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       continue-on-error: true
       with:
@@ -205,7 +210,7 @@ runs:
     # `results: []`, silently scrubbing real findings on a transient API
     # failure. Gating on the marker preserves the prior valid state.
     - name: Upload Dependency Review SARIF
-      if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request' && hashFiles('.wrangle/metadata/dependency-review/error') == ''
+      if: always() && (contains(format(' {0} ', inputs.tools), ' dependency-review ') || contains(format(' {0} ', inputs.tools), ' dependency-review:')) && github.event_name == 'pull_request' && hashFiles('.wrangle/metadata/dependency-review/error') == ''
       uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       continue-on-error: true
       with:

--- a/actions/scan/test.bats
+++ b/actions/scan/test.bats
@@ -26,7 +26,7 @@ setup() {
 @test "scan: osv SARIF upload is gated on osv being in the tools input" {
     run grep -A1 'Upload OSV SARIF' "$ACTION_DIR/action.yml"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"contains(format(' {0} ', inputs.tools), ' osv ')"* ]]
+    [[ "$output" == *"contains(inputs.tools, 'osv')"* ]]
 }
 
 @test "scan: does not upload scorecard SARIF (score carried by attestation)" {
@@ -124,7 +124,7 @@ setup() {
 @test "scan: zizmor SARIF upload is gated on zizmor being in the tools input" {
     run grep -A1 'Upload Zizmor SARIF' "$ACTION_DIR/action.yml"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"contains(format(' {0} ', inputs.tools), ' zizmor ')"* ]]
+    [[ "$output" == *"contains(inputs.tools, 'zizmor')"* ]]
 }
 
 @test "scan: does not wire zizmor as a uses: action step (runs via the image path)" {
@@ -163,7 +163,7 @@ setup() {
 @test "scan: dependency-review step is gated on dependency-review being in the tools input" {
     run grep -A2 '^    - name: Dependency Review$' "$ACTION_DIR/action.yml"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"contains(format(' {0} ', inputs.tools), ' dependency-review ')"* ]]
+    [[ "$output" == *"contains(inputs.tools, 'dependency-review')"* ]]
 }
 
 @test "scan: has upload-sarif step for dependency-review" {
@@ -180,7 +180,7 @@ setup() {
 @test "scan: dependency-review SARIF upload is gated on dependency-review being in the tools input and on pull_request" {
     run grep -A1 'Upload Dependency Review SARIF' "$ACTION_DIR/action.yml"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"contains(format(' {0} ', inputs.tools), ' dependency-review ')"* ]]
+    [[ "$output" == *"contains(inputs.tools, 'dependency-review')"* ]]
     [[ "$output" == *"github.event_name == 'pull_request'"* ]]
 }
 
@@ -208,11 +208,3 @@ setup() {
     [[ "$output" == *"continue-on-error: true"* ]]
 }
 
-@test "scan: tool gates match whole tokens, not substrings" {
-    # contains(inputs.tools, 'osv') would also fire for a future 'my-osv'; gates
-    # use a space-padded match so bare and :policy-suffixed tokens match exactly.
-    run grep -c "contains(inputs.tools, '" "$ACTION_DIR/action.yml"
-    [ "$output" -eq 0 ]
-    run grep -c "contains(format(' {0} ', inputs.tools)" "$ACTION_DIR/action.yml"
-    [ "$output" -ge 6 ]
-}

--- a/actions/scan/test.bats
+++ b/actions/scan/test.bats
@@ -26,7 +26,7 @@ setup() {
 @test "scan: osv SARIF upload is gated on osv being in the tools input" {
     run grep -A1 'Upload OSV SARIF' "$ACTION_DIR/action.yml"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"contains(inputs.tools, 'osv')"* ]]
+    [[ "$output" == *"contains(format(' {0} ', inputs.tools), ' osv ')"* ]]
 }
 
 @test "scan: does not upload scorecard SARIF (score carried by attestation)" {
@@ -124,7 +124,7 @@ setup() {
 @test "scan: zizmor SARIF upload is gated on zizmor being in the tools input" {
     run grep -A1 'Upload Zizmor SARIF' "$ACTION_DIR/action.yml"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"contains(inputs.tools, 'zizmor')"* ]]
+    [[ "$output" == *"contains(format(' {0} ', inputs.tools), ' zizmor ')"* ]]
 }
 
 @test "scan: does not wire zizmor as a uses: action step (runs via the image path)" {
@@ -163,7 +163,7 @@ setup() {
 @test "scan: dependency-review step is gated on dependency-review being in the tools input" {
     run grep -A2 '^    - name: Dependency Review$' "$ACTION_DIR/action.yml"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"contains(inputs.tools, 'dependency-review')"* ]]
+    [[ "$output" == *"contains(format(' {0} ', inputs.tools), ' dependency-review ')"* ]]
 }
 
 @test "scan: has upload-sarif step for dependency-review" {
@@ -180,7 +180,7 @@ setup() {
 @test "scan: dependency-review SARIF upload is gated on dependency-review being in the tools input and on pull_request" {
     run grep -A1 'Upload Dependency Review SARIF' "$ACTION_DIR/action.yml"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"contains(inputs.tools, 'dependency-review')"* ]]
+    [[ "$output" == *"contains(format(' {0} ', inputs.tools), ' dependency-review ')"* ]]
     [[ "$output" == *"github.event_name == 'pull_request'"* ]]
 }
 
@@ -196,4 +196,23 @@ setup() {
     [ "$status" -ne 0 ]
     run grep 'dependency-review-comment-summary-in-pr' "$ACTION_DIR/action.yml"
     [ "$status" -ne 0 ]
+}
+
+# --- :info policy gate (#688): run step must not fail on findings/errors -------
+
+@test "scan: adapter-tool step runs under continue-on-error (Check results owns the gate)" {
+    # run.sh exits 1 on findings / 2 on error; the step must continue so the
+    # Check results step can apply each tool's :fail/:info policy (findings via
+    # SARIF, errors via the marker run.sh writes).
+    run awk '/- name: Run adapter-pattern tools/{f=1} f&&/^      continue-on-error: true/{print;exit} f&&/^    - name:/&&!/Run adapter/{exit}' "$ACTION_DIR/action.yml"
+    [[ "$output" == *"continue-on-error: true"* ]]
+}
+
+@test "scan: tool gates match whole tokens, not substrings" {
+    # contains(inputs.tools, 'osv') would also fire for a future 'my-osv'; gates
+    # use a space-padded match so bare and :policy-suffixed tokens match exactly.
+    run grep -c "contains(inputs.tools, '" "$ACTION_DIR/action.yml"
+    [ "$output" -eq 0 ]
+    run grep -c "contains(format(' {0} ', inputs.tools)" "$ACTION_DIR/action.yml"
+    [ "$output" -ge 6 ]
 }

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@6e565bc9524fc6c1f99190930af9ccbdbace76eb # main 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@f0ff9b1c2611878e51834b543c65c228f17f7409 # feat/containerize-verify-vsa-cleanup 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@dbdd33f523e0d07f50035eb65f0095bcccfa0f75 # fix/info-policy-markers-688 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@a3be5989730a37d02f01182607e3744cc6268fc7 # fix/info-policy-markers-688 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/run.sh
+++ b/run.sh
@@ -41,6 +41,8 @@ source "$SCRIPT_DIR/lib/verify_image_vsa.sh"
 # contract sandbox. Expects CATALOG, src_dir, and ADAPTER_TIMEOUT in scope.
 # shellcheck source=lib/run_tool_image.sh
 source "$SCRIPT_DIR/lib/run_tool_image.sh"
+# shellcheck source=lib/write_tool_error_marker.sh
+source "$SCRIPT_DIR/lib/write_tool_error_marker.sh"
 
 TOOLS_DIR="${WRANGLE_TOOLS_DIR:-${SCRIPT_DIR}/tools}"
 # The catalog lives beside the tools it describes, so a WRANGLE_TOOLS_DIR
@@ -187,6 +189,20 @@ verify_tool_image() {
     return 1
 }
 
+# fail_tool_config <tool> <output_dir> <marker_msg> — record an errored tool that
+# returns early (catalog/config/install failure): set the fail-closed status,
+# note it for the summary, write the ${output_dir}/error marker check_results
+# reads, and close the log group. The marker lets the scan step run under
+# continue-on-error while check_results owns the gate — so an :info tool's error
+# stays informational, matching a :fail tool's error blocking. Caller returns.
+fail_tool_config() {
+    overall_status=2
+    summary_tools+=("$1")
+    summary_statuses+=("error")
+    wrangle_write_tool_error_marker "$2" "$3"
+    printf '::endgroup::\n'
+}
+
 # run_one_tool <tool> — run a single tool through its delivery path (image via
 # docker, otherwise the in-process adapter), map its exit to the 0/1/2 contract,
 # attest its recognized output files by name, and record the result. Updates
@@ -214,22 +230,14 @@ run_one_tool() {
         image="$(read_catalog_field "$CATALOG" "$tool" image)"
         if [[ -z "$image" ]]; then
             printf 'wrangle: %s: catalog declares delivery: image but no image\n' "$tool" >&2
-            tool_status="error"
-            overall_status=2
-            summary_tools+=("$tool")
-            summary_statuses+=("$tool_status")
-            printf '::endgroup::\n'
+            fail_tool_config "$tool" "$tool_output_dir" "catalog declares delivery: image but no image"
             return
         fi
         # Require an @sha256 digest pin (a tag alone is mutable); re-checked here
         # even though merge_catalog validated custom entries, as defense in depth.
         if [[ ! "$image" =~ $CATALOG_IMAGE_DIGEST_RE ]]; then
             printf 'wrangle: %s: image not digest-pinned: %s\n' "$tool" "$image" >&2
-            tool_status="error"
-            overall_status=2
-            summary_tools+=("$tool")
-            summary_statuses+=("$tool_status")
-            printf '::endgroup::\n'
+            fail_tool_config "$tool" "$tool_output_dir" "image not digest-pinned: $image"
             return
         fi
         # A declared secret name must be a valid env-var stem before it is
@@ -238,22 +246,14 @@ run_one_tool() {
         secret="$(read_catalog_field "$CATALOG" "$tool" secret)"
         if [[ -n "$secret" ]] && [[ ! "$secret" =~ ^[a-z][a-z0-9-]*$ ]]; then
             printf 'wrangle: %s: invalid catalog secret name: %s\n' "$tool" "$secret" >&2
-            tool_status="error"
-            overall_status=2
-            summary_tools+=("$tool")
-            summary_statuses+=("$tool_status")
-            printf '::endgroup::\n'
+            fail_tool_config "$tool" "$tool_output_dir" "invalid catalog secret name: $secret"
             return
         fi
 
         # Fail closed: refuse to dispatch a curated image that cannot be proven
         # to carry a PASSED wrangle VSA.
         if ! verify_tool_image "$tool" "$image"; then
-            tool_status="error"
-            overall_status=2
-            summary_tools+=("$tool")
-            summary_statuses+=("$tool_status")
-            printf '::endgroup::\n'
+            fail_tool_config "$tool" "$tool_output_dir" "tool image VSA verification failed"
             return
         fi
 
@@ -276,11 +276,7 @@ run_one_tool() {
             printf 'wrangle: install failed for %s (exit %d)\n' "$tool" "$install_exit" >&2
         fi
         if [[ "$install_exit" -ne 0 ]]; then
-            tool_status="error"
-            overall_status=2
-            summary_tools+=("$tool")
-            summary_statuses+=("$tool_status")
-            printf '::endgroup::\n'
+            fail_tool_config "$tool" "$tool_output_dir" "install failed (exit $install_exit)"
             return
         fi
 
@@ -381,6 +377,11 @@ run_one_tool() {
                 "$tool_output_dir" "https://spdx.dev/Document" "sbom.spdx.json" \
                 || printf 'wrangle: failed to write %s sbom manifest\n' "$tool" >&2
         fi
+    else
+        # An errored adapter run (timeout / nonzero exit): write the marker
+        # check_results reads, so an :info tool's error stays informational and
+        # the scan step can run under continue-on-error.
+        wrangle_write_tool_error_marker "$tool_output_dir" "adapter error (exit ${adapter_exit})"
     fi
 
     summary_tools+=("$tool")

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -324,12 +324,16 @@ ADAPT
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "error-tool"
 
     [ "$status" -eq 2 ]
+    # An error marker is written so check_results catches the failure even when
+    # the scan step runs under continue-on-error (and honors :info on the error).
+    [ -f "$TEST_DIR/output/error-tool/error" ]
 }
 
 @test "orchestrator: handles install failure (exit 2)" {
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "bad-install"
 
     [ "$status" -eq 2 ]
+    [ -f "$TEST_DIR/output/bad-install/error" ]
 }
 
 @test "orchestrator: runs multiple tools" {


### PR DESCRIPTION
claude: Fixes #688. Supersedes #710 (which used a wrapper that over-blocked). Also fixes the scan `contains()` sub-item of #697.

## The fix (the single-owner design)
`run.sh` exits 1 on findings, and the scan step propagated that as a step failure **before** `check_results` could apply a tool's policy — so `wrangle-lint:info` blocked on advisory findings.

`run.sh` now writes the `${tool}/error` marker on **every** tool error (via a small `fail_tool_config` helper for the early-return config/install errors + an `else` on the manifest block for adapter timeout/exit-2), the scan step runs under **`continue-on-error: true`**, and **`check_results` is the sole gate**: findings via SARIF, errors via the marker — both honoring `:fail`/`:info`.

### Why not the earlier wrapper (#710)
The `run_scan.sh` wrapper failed the step on any `run.sh` exit 2, but `check_results` treats an **`:info` tool that errored as informational** (`test/test_check_results.bats:177`). So the wrapper over-blocked. Markers + `continue-on-error` is the path that respects `:info` for errors too, and it makes `check_results` the single owner (no new script).

## Bonus: whole-token tool gates (#697)
`contains(inputs.tools, 'osv')` is a substring match that would also fire for a future `my-osv`. Gates now use a space-padded match — `contains(format(' {0} ', inputs.tools), ' osv ') || contains(format(' {0} ', inputs.tools), ' osv:')` — handling bare and `:policy`-suffixed tokens exactly (verified: `scorecard:info` matches, `my-osv` does not).

## Tests
- Orchestrator: an errored tool (adapter exit 2 **and** install failure) now writes `${tool}/error`.
- `check_results`: the `:info`-tool-error-is-informational test passes unchanged (the contract this now honors).
- Scan: new asserts for `continue-on-error` and whole-token gates; the 4 existing gate tests updated to the padded form.
- Full smoke green (orchestrator, check_results, scan, manifest-header); workflow-lint + shellcheck clean.

`actions/scan` is pinned, so the converge bumped the nested chain (**merge commit, not squash**). `check_pin_ancestry` + `check_pin_freshness` green locally.

Refs #688, #697, #698 (structural item 1).