### PR TITLE
claude: fix(container,docs): deprecate the dead gh_token secret; fix release/e2e doc drift (#695)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -124,7 +124,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         id: prep
         with:
           build-type: container
@@ -143,7 +143,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -169,7 +169,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -247,7 +247,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -286,7 +286,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -86,10 +86,6 @@ on:
         required: false
         type: string
         default: policies/wrangle-default-container-v1.hjson
-    secrets:
-      gh_token:
-        description: "GitHub token with write access"
-        required: true
     outputs:
       digest:
         description: "Image digest pushed to the registry."
@@ -273,9 +269,7 @@ jobs:
           # Must match the cosign built from tools/go.mod — the version the suite tests.
           cosign-release: v3.0.6
 
-      # Use the job's own GITHUB_TOKEN (packages: write above), like the build
-      # job — not the passed gh_token, which zizmor's secrets-outside-env flags
-      # for use without a dedicated environment.
+      # Use the job's own GITHUB_TOKEN (packages: write above), like the build job.
       - name: Log in to ghcr for the VSA referrer push
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -86,6 +86,13 @@ on:
         required: false
         type: string
         default: policies/wrangle-default-container-v1.hjson
+    secrets:
+      gh_token:
+        description: >
+          Deprecated no-op — no job consumes it; every job authenticates with
+          its own GITHUB_TOKEN. Kept optional so callers still passing it don't
+          break; stop passing it, it is slated for removal.
+        required: false
     outputs:
       digest:
         description: "Image digest pushed to the registry."

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -117,7 +117,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         id: prep
         with:
           build-type: container
@@ -136,7 +136,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -162,7 +162,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -240,7 +240,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -279,7 +279,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -162,7 +162,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         id: prep
         with:
           build-type: go
@@ -181,7 +181,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -213,7 +213,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         id: attest
         with:
           build-type: go
@@ -394,7 +394,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -162,7 +162,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         id: prep
         with:
           build-type: go
@@ -181,7 +181,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -213,7 +213,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         id: attest
         with:
           build-type: go
@@ -394,7 +394,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -150,7 +150,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -169,7 +169,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -305,7 +305,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -150,7 +150,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -169,7 +169,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -305,7 +305,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -127,7 +127,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         id: prep
         with:
           build-type: python
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -178,7 +178,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         id: attest
         with:
           build-type: python
@@ -292,7 +292,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -127,7 +127,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         id: prep
         with:
           build-type: python
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -178,7 +178,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         id: attest
         with:
           build-type: python
@@ -292,7 +292,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -90,7 +90,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -103,7 +103,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -151,7 +151,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -90,7 +90,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -103,7 +103,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -151,7 +151,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -26,7 +26,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
 
   check-change:
     needs: [prep]
@@ -44,7 +44,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -26,7 +26,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
 
   check-change:
     needs: [prep]
@@ -44,7 +44,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/local_publish_images.yml
+++ b/.github/workflows/local_publish_images.yml
@@ -61,8 +61,6 @@ jobs:
       imagename: ${{ matrix.imagename }}
       registry: ghcr.io
       release-events: main-and-tags
-    secrets:
-      gh_token: ${{ secrets.GITHUB_TOKEN }}
 
   # Open (never auto-merge) a catalog bump PR for the just-published digests.
   # main-only, on the trusted push trigger (no pull_request_target).

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -112,7 +112,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -124,7 +124,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -112,7 +112,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -124,7 +124,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@67da09e58ee3f3a151beba4f0246c94fbc8b1da2 # fix/info-policy-markers-688 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@6a2f7b967117938f798b55a8040a452239aa7e8d # fix/remove-dead-gh-token-695 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -4,7 +4,7 @@ Wrangle builds a container image from your Dockerfile and publishes it to ghcr.i
 
 ## Quick start
 
-Copy [`build_and_publish_containers.yml`](../../../gh_workflow_examples/build_and_publish_containers.yml) into `.github/workflows/` and fill in three inputs (the example wires the permissions and `gh_token` secret):
+Copy [`build_and_publish_containers.yml`](../../../gh_workflow_examples/build_and_publish_containers.yml) into `.github/workflows/` and fill in three inputs (the example wires the permissions):
 
 | Input | Value |
 |-------|-------|

--- a/build/actions/container/SPEC.md
+++ b/build/actions/container/SPEC.md
@@ -50,8 +50,10 @@ Multi-registry support is a planned extension. See "Known limitations" for the s
 
 ### Reusable workflow secrets
 
-None. Every job authenticates with its own `GITHUB_TOKEN` (each requests the
-`packages: write` / `id-token: write` it needs), so the caller passes no secrets.
+None required. Every job authenticates with its own `GITHUB_TOKEN` (each requests
+the `packages: write` / `id-token: write` it needs). A deprecated optional
+`gh_token` secret remains declared for callers still passing it (it is a no-op,
+slated for removal) — new callers pass no secrets.
 
 ### Reusable workflow outputs
 

--- a/build/actions/container/SPEC.md
+++ b/build/actions/container/SPEC.md
@@ -50,9 +50,8 @@ Multi-registry support is a planned extension. See "Known limitations" for the s
 
 ### Reusable workflow secrets
 
-| Secret | Required | Description |
-|--------|----------|-------------|
-| `gh_token` | yes | GitHub token, used by the composite action and by the attest/verify jobs for GHCR operations (registry login, pushing the attestation and VSA referrers) |
+None. Every job authenticates with its own `GITHUB_TOKEN` (each requests the
+`packages: write` / `id-token: write` it needs), so the caller passes no secrets.
 
 ### Reusable workflow outputs
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -83,8 +83,10 @@ published as a GitHub Release** — a bare `git tag`/`git push` creates
 only a loose tag with no release attestation. Two tag-immutability
 controls (below) are already configured on the repo.
 
-1. Update the pinned `uses:` version references in
-   `gh_workflow_examples/`.
+1. Update the pinned `uses: …@vX.Y.Z` version references — these live in
+   `gh_workflow_examples/` **and** across the adopter-facing docs and per-action
+   READMEs (the `cut-release` skill enumerates the full set), not just the
+   examples.
 2. Publish a Release on the target commit: GitHub's **Draft a new
    release** UI (pick the commit, type `vX.Y.Z`, publish), or
    `gh release create vX.Y.Z`. Never ship a bare `git tag && git push`

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -18,7 +18,7 @@ wrangle's reusable workflows call wrangle's own composite actions by SHA-pinned 
 This needs no special handling and is what nearly every PR does. A change to a self-referenced action that is backward-compatible just leaves the nested pins alone: the integration test exercises the main-pinned (old) action, which still passes; the change itself is covered by the action's own bats and by the post-merge showcase. After merge, routine `tools/bump_action_pins.sh <main-sha>` rolls every pin forward to the new code. The only thing you give up is pre-merge integration coverage *of that one action change* — an accepted gap.
 
 ### Bootstrap pin: only when the main-pinned action would fail
-You need a bootstrap pin only when leaving the pin at main would make the integration test fail on code the PR didn't ship — i.e. the workflow now depends on something not yet on main: a **new** policy file the action reads, a new required behavior, or a change that makes the old action incompatible with the new wiring. (Example: the PR that introduced `policies/wrangle-provenance-v1.hjson` plus `actions/verify`'s policy-path resolution — main had neither, so the integration test couldn't pass without pointing at the branch.)
+You need a bootstrap pin only when leaving the pin at main would make the integration test fail on code the PR didn't ship — i.e. the workflow now depends on something not yet on main: a **new** policy file the action reads, a new required behavior, or a change that makes the old action incompatible with the new wiring. (Example: the PR that introduced `policies/wrangle-provenance-go-v1.hjson` plus `actions/verify`'s policy-path resolution — main had neither, so the integration test couldn't pass without pointing at the branch.)
 
 In that case, for the duration of the PR:
 
@@ -27,7 +27,7 @@ In that case, for the duration of the PR:
 3. Note the bootstrap pin in the PR description.
 
 ### Merge however you like — the check tells you when to bump
-A branch SHA can't become a main SHA until the code is on main, so a bootstrap pin is always bumped post-merge. You don't have to manage the merge method to make this safe — `tools/check_pin_ancestry.sh` (in the `integration` CI job, `fetch-depth: 0`) is the control. It resolves every wrangle self-ref pin at its pinned SHA — following the pins nested inside each composite at that SHA, not just the working-tree copy — and asserts each is reachable from `HEAD`: green on the PR (the branch SHA is an ancestor of the branch), and after merge:
+A branch SHA can't become a main SHA until the code is on main, so a bootstrap pin is always bumped post-merge. You don't have to manage the merge method to make this safe — `tools/check_pin_ancestry.sh` (in the `pin-ancestry` CI job, `fetch-depth: 0`) is the control. It resolves every wrangle self-ref pin at its pinned SHA — following the pins nested inside each composite at that SHA, not just the working-tree copy — and asserts each is reachable from `HEAD`: green on the PR (the branch SHA is an ancestor of the branch), and after merge:
 
 - **Red on main** → a pin is unreachable (you squashed a bootstrap pin, or forgot a bump). Run `tools/bump_action_pins.sh <main-sha>` and push. Until you do, main is red and the unattended showcase can't resolve that action.
 - **Green** → every pin resolves; bump at leisure (it just refreshes the SHA and the `# main` label).

--- a/gh_workflow_examples/build_and_publish_containers.yml
+++ b/gh_workflow_examples/build_and_publish_containers.yml
@@ -29,5 +29,3 @@ jobs:
       path: PATH/TO/FOLDER/WITH/Dockerfile
       imagename: ghcr.io/${{ github.repository }}/YOUR_IMAGE_NAME
       registry: 'ghcr.io'
-    secrets:
-      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/integration/SPEC.md
+++ b/test/integration/SPEC.md
@@ -207,8 +207,6 @@ jobs:
       path: container
       imagename: ghcr.io/tomhennen/wrangle-test-staging
       registry: ghcr.io
-    secrets:
-      gh_token: ${{ secrets.GITHUB_TOKEN }}
 
   test-scan:
     uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@__WRANGLE_SHA__


### PR DESCRIPTION
claude: Refs #695. Step 1 of the dead-`gh_token` removal, plus the remaining #695 doc drift.

## gh_token — made optional (deprecated), not yet removed
`build_and_publish_container.yml` declared `gh_token` **required** but no job consumes it (every job uses its own `GITHUB_TOKEN`). Removing a *required* reusable-workflow secret atomically breaks callers that still pass it — including the wrangle-test companion, which dispatches against this ref and **can't stop passing `gh_token` until `main` stops requiring it** (else the release-showcase heartbeat against `main` breaks). So this is the standard 2-step deprecation:
- **This PR:** `gh_token` → `required: false` (deprecated no-op), and the **in-repo caller (`local_publish_images.yml`), the example, and the docs stop passing/documenting it as required.** Non-breaking — the companion keeps passing it (now accepted as optional), so the integration test stays green.
- **Follow-up (tracked):** update the companion caller off `gh_token`, then remove the declaration entirely.

**Release note:** the container reusable workflow no longer requires `gh_token`; callers should stop passing it (it will be removed).

## #695 doc drift (the mechanical items)
- `RELEASING.md`'s pin-bump step listed only `gh_workflow_examples/`, though `@vX.Y.Z` refs span the docs/READMEs — now points at the cut-release skill's full set.
- `e2e_testing.md` cited a nonexistent `policies/wrangle-provenance-v1.hjson` (per-eco files exist) and named the wrong CI job for `check_pin_ancestry` (`integration` → `pin-ancestry`).

(The other #695 items — SPEC `verify-attestation`, policy-header, osv-digest, README — shipped in #712.)

## Tests
Container + trigger-guard bats pass; workflow-lint clean. `actions/scan`/composites pinned, so the converge bumped the chain (**merge commit**); pin checks green locally.

Refs #695.