### PR TITLE
claude: blocking catalog-freshness release gate + design-doc drift fix (#596)

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -105,8 +105,13 @@ All three must hold before you ask the owner to cut. Do not shortcut.
    `showcase` concurrency group; cancel a hung job (releases persist) to free the queue.
 2. **Explicit owner sign-off on release contents.** Present exactly what's in the release
    (the milestone, the diff highlights) and get an explicit yes — separate from "cut it".
-   Also confirm the curated tool-image catalog is fresh — no entry is behind its
-   published `:latest` (the §11 release precondition):
+   Also confirm the curated tool-image catalog is fresh (the §11 release precondition):
+   dispatch the **Catalog Release Gate** workflow (`.github/workflows/catalog_release_gate.yml`,
+   `workflow_dispatch`) on the release commit and require a green run — it runs both freshness
+   checks below fail-closed (any non-zero, including exit 2 registry-unreachable, blocks). The
+   commands below are the same checks, for reading the failure and driving remediation locally.
+
+   Adoption lag — no entry is behind its published `:latest`:
 
    ```bash
    ./tools/check_catalog_freshness.sh   # exit 0 in-sync; 1 drift (bump per its remediation); 2 registry unreachable

--- a/.github/workflows/catalog_freshness.yml
+++ b/.github/workflows/catalog_freshness.yml
@@ -6,8 +6,9 @@ name: Catalog Freshness
 # Kept off the per-PR path to avoid per-PR registry calls; the same check is a
 # release precondition (see the cut-release runbook). Advisory first because it
 # depends on a live registry (network/registry flake), unlike the deterministic
-# git-only pin checks which block directly — a failed run notifies; the intended
-# rollout is to a blocking release gate that fails closed on exit 2.
+# git-only pin checks which block directly — a failed run notifies. The blocking
+# release precondition is catalog_release_gate.yml, which runs the same check
+# fail-closed on exit 2.
 
 on:
   schedule:

--- a/.github/workflows/catalog_provenance_freshness.yml
+++ b/.github/workflows/catalog_provenance_freshness.yml
@@ -1,7 +1,7 @@
 name: Catalog Provenance Freshness
 
 # Weekly advisory that each published tool image was built from current source.
-# The cut-release runbook runs the same check as a blocking gate.
+# catalog_release_gate.yml runs the same check fail-closed as the release gate.
 
 on:
   schedule:

--- a/.github/workflows/catalog_release_gate.yml
+++ b/.github/workflows/catalog_release_gate.yml
@@ -1,0 +1,40 @@
+name: Catalog Release Gate
+
+# Blocking release precondition (#596): the operator runs this by hand before
+# `gh release create` (cut-release runbook Phase 4) and cuts only on a green run.
+# It runs both catalog-freshness checks fail-closed — any non-zero fails the job:
+# exit 1 (a digest is stale/behind :latest or its source changed) and exit 2
+# (registry/attestation unreachable = precondition UNVERIFIED) both block the
+# release. This is the opposite polarity to the weekly advisories
+# (catalog_freshness.yml, catalog_provenance_freshness.yml), which warn on exit 2
+# so a transient blip can't page — correct for a heads-up, wrong for a gate.
+#
+# Dispatch-only on purpose: there is no automated release/tag workflow to hook
+# (releases are a manual `gh release create` against an immutable tag), and a
+# push/tag trigger would run after the tag exists (too late to block) and paint a
+# transient exit-2 red X on an already-cut, legitimately-vetted release.
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  release-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0   # provenance freshness diffs each image's build commit against HEAD
+
+      - name: Check catalog image freshness (adoption lag)
+        run: ./tools/check_catalog_freshness.sh
+
+      - name: Check catalog image provenance freshness (source built)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./tools/check_catalog_provenance_freshness.sh

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -82,6 +82,10 @@ deliberately:
 | `WRANGLE_EXTRA_*` forwarding | explicit `-e WRANGLE_EXTRA_*` per declaring tool |
 | post-run filesystem snapshot (warn-only) | `/src:ro` + `/output`-only mount — fail-closed write confinement, an upgrade |
 
+Signing (`attest`) containers additionally never receive the OIDC mint-request vars
+(`ACTIONS_ID_TOKEN_REQUEST_*`); the host mints the short-lived `SIGSTORE_ID_TOKEN` and passes only that
+by name (§7).
+
 SPEC's Adapter Script Interface (environment/security sections) is updated in the same change.
 
 ### 3.3 Tool kinds

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -57,6 +57,7 @@ The orchestrator runs each tool as:
 
 ```
 docker run --rm --network <policy> -u <runner_uid>:<gid> \
+  --cap-drop ALL --security-opt no-new-privileges \
   -v <src>:/src:ro -v <out>:/output [-e WRANGLE_KIND=<kind>] [declared tool env] <image> /src /output
 ```
 
@@ -266,6 +267,12 @@ As the `wrangle-lint`/`wrangle-attest` entries above show, an entry can carry an
 selected by command rather than a separate image per tool — handy for the owned-Go tools (§3.4) and for a
 BYO image that exposes more than one tool. The capability rules (§3.7) and least-privilege defaults still
 apply per entry; the cost is a larger per-entry surface to validate (§8).
+
+> **Deferral note.** The unified `wrangle` image above (one image shared by `wrangle-lint` and
+> `wrangle-attest`, selected by `command:`) is a proposed shape, deferred to #642; neither image exists
+> today. The shipped `tools/catalog.json` diverges: `wrangle-lint` is on its own image, signing runs in a
+> separate `attest-toolbox` entry (`kind: attest`, `token: sigstore`), and every entry carries an explicit
+> `delivery: image`. Read `tools/catalog.json` for the current shape.
 
 **Adopter — selecting tools** (pin wrangle, choose which to run):
 


### PR DESCRIPTION
**Part of #596.** Two changes that clear the umbrella's tail: a fail-closed release gate for the curated tool-image catalog, and design-doc drift fixes. (#632 / #633 / #642 / #623 stay open as tracked follow-ups; this PR doesn't build the digest-ancestry or cooldown work.)

## The catalog release gate

Wrangle's curated tool images (osv, zizmor, wrangle-lint, syft, attest-toolbox) are digest-pinned in `tools/catalog.json`. Two scripts answer "is a pinned digest safe to ship in a release?":
- `check_catalog_freshness.sh` — is any pinned digest behind its published `:latest`?
- `check_catalog_provenance_freshness.sh` — was each pinned digest built from current source, not a stale build?

### Before this change — what happens at release time
- Those checks run only **weekly (advisory)**, and a "can't reach the registry" result (exit 2) **warns and passes**.
- At release, the cut-release runbook tells the operator to run the two commands **by hand** and read the exit codes themselves.
- **Outcome:** whether a release ships a stale or unverifiable catalog rides on the operator remembering to run the CLI locally and correctly judging an exit-2 "couldn't verify." Nothing stops a release from proceeding past a warning.

### With this change — what happens at release time
- A new **Catalog Release Gate** workflow runs both checks in a clean CI checkout, **fail-closed**: a stale digest (exit 1) *or* a "couldn't verify" (exit 2) turns the run **red**.
- The operator dispatches it on the release commit and cuts the release only on a green run.
- **Outcome:** the release's catalog check is now a single auditable green/red run, in a clean environment, that **fails on "couldn't verify"** instead of leaving that to the operator's eye. An unverifiable catalog can no longer slip through as a warning.

### What it deliberately does NOT do
It does not *automatically* block the tag. Wrangle has no release automation — a release is a manual `gh release create` against an immutable tag — so there is no automated step to hard-gate. The operator still runs the gate and honors a red result. Truly *enforced* blocking would require building release automation (a workflow that runs the gate and only tags on green); that's a separate follow-up, not folded in here.

The weekly advisories are unchanged: they keep **warning (not failing)** on exit 2, which is right for a heads-up that shouldn't page on a transient registry blip. Their header comments now point at the gate.

## Design-doc drift (`docs/tool_container_design.md`)
- **§3.1** — the illustrated `docker run` now shows the `--cap-drop ALL --security-opt no-new-privileges` the real runners apply.
- **§3.2** — noted that signing containers never receive the OIDC mint-request vars (`ACTIONS_ID_TOKEN_REQUEST_*`); the host threads only the short-lived `SIGSTORE_ID_TOKEN`.
- **§3.8** — deferral note: the unified `wrangle` image in the illustration doesn't exist (deferred to #642); the shipped catalog diverges.
- §6 left as-is (already reconciled in #662).

## Validation
`./test.sh quick` green — actionlint, `wrangle-workflow-lint`, and zizmor all pass on the new workflow. Pin-neutral (workflows + docs only; no `lib/` or `tools/catalog.json` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)