### PR TITLE
claude: fix(verify): fail closed on empty VSA signing output (#693)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -124,7 +124,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         id: prep
         with:
           build-type: container
@@ -143,7 +143,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -169,7 +169,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -247,7 +247,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -286,7 +286,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -124,7 +124,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         id: prep
         with:
           build-type: container
@@ -143,7 +143,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -169,7 +169,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -247,7 +247,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -286,7 +286,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -162,7 +162,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         id: prep
         with:
           build-type: go
@@ -181,7 +181,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -213,7 +213,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         id: attest
         with:
           build-type: go
@@ -394,7 +394,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -162,7 +162,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         id: prep
         with:
           build-type: go
@@ -181,7 +181,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -213,7 +213,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -276,7 +276,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         id: attest
         with:
           build-type: go
@@ -394,7 +394,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -150,7 +150,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -169,7 +169,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -305,7 +305,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -150,7 +150,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -169,7 +169,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -305,7 +305,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -127,7 +127,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         id: prep
         with:
           build-type: python
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -178,7 +178,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         id: attest
         with:
           build-type: python
@@ -292,7 +292,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -127,7 +127,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         id: prep
         with:
           build-type: python
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -178,7 +178,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -269,7 +269,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         id: attest
         with:
           build-type: python
@@ -292,7 +292,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -122,7 +122,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -198,7 +198,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -109,7 +109,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -122,7 +122,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -198,7 +198,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -26,7 +26,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
 
   check-change:
     needs: [prep]
@@ -44,7 +44,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -26,7 +26,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
 
   check-change:
     needs: [prep]
@@ -44,7 +44,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -112,7 +112,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -124,7 +124,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -112,7 +112,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -124,7 +124,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/verify/run_verify.sh
+++ b/actions/verify/run_verify.sh
@@ -162,6 +162,13 @@ wrangle_sign_vsa() {
     wrangle_retry_once "$vsa" wrangle_toolbox_exec \
         --sigstore -- bnd "${args[@]}" || rc=$?
     rm -f "$vsa.unsigned"
+    # bnd can exit 0 yet emit nothing; an empty output would silently append no
+    # VSA line to the bundle (jq -c on empty input yields nothing). Fail closed,
+    # matching the attest side (lib/sign_metadata.sh).
+    if [[ "$rc" -eq 0 && ! -s "$vsa" ]]; then
+        printf 'wrangle: VSA signing produced no output for %s\n' "$vsa" >&2
+        return 1
+    fi
     return "$rc"
 }
 

--- a/actions/verify/test_run_verify.bats
+++ b/actions/verify/test_run_verify.bats
@@ -962,6 +962,9 @@ _install_toolbox_shims() {
     cat > "$TEST_DIR/docker" <<EOF
 #!/bin/bash
 printf '%s\n' "\$*" > "$TEST_DIR/docker.args"
+# bnd statement (VSA signing) writes the signed statement to stdout; emit a
+# placeholder so the caller's non-empty-output guard (empty = fail closed) is met.
+case "\$*" in *"bnd statement"*) printf '{"signed":"vsa"}\n' ;; esac
 EOF
     chmod +x "$TEST_DIR/docker"
     cat > "$TEST_DIR/gh" <<EOF
@@ -1117,4 +1120,16 @@ EOF
     grep -q "lacks id-token: write" <<< "$output"
     [ ! -f "$TEST_DIR/docker.args" ]
     [ ! -f "$TEST_DIR/bnd.called" ]
+}
+
+@test "run_verify: sign_vsa fails closed when bnd emits no output" {
+    # bnd can exit 0 yet write nothing; an empty signed VSA would silently append
+    # no VSA line to the bundle (jq -c on empty input yields nothing).
+    local stub="$TEST_DIR/stubbin"; mkdir -p "$stub"
+    printf '#!/bin/bash\nexit 0\n' > "$stub/bnd"   # exit 0, empty stdout
+    chmod +x "$stub/bnd"
+    printf '{"unsigned":"vsa"}' > "$VSA"
+    PATH="$stub:$PATH" run wrangle_sign_vsa "$VSA"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"produced no output"* ]]
 }

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@7908aadf0476e392d5b7bb046845363ff8da2140 # fix/verify-empty-vsa-693 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@5596e0bab0ac67d0daa12f585b5492444e1c6579 # fix/remove-dead-gh-token-695 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@63e0e70e8cd0f522758c4571541318cb264d96a2 # fix/verify-empty-vsa-693 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}


### PR DESCRIPTION
claude: The last #693 item (deferred earlier because run_verify.sh was the #717 agent's active surface; #717 has landed).

## Problem
`wrangle_sign_vsa` runs `bnd` via `wrangle_retry_once`, capturing its stdout to the VSA file. A `bnd` that exits 0 but emits nothing leaves the file empty, and the downstream `jq -c . "$tmp_vsa"` on empty input yields nothing — so the bundle gets **no VSA line**, silently. The attest side already fail-closes on empty signed statements (`lib/sign_metadata.sh:167`); verify now matches.

## Fix
After signing, if the retry succeeded but the output file is empty, fail closed with a message.

## Tests
New: `wrangle_sign_vsa` with a `bnd` stub that exits 0 with empty stdout returns non-zero ("produced no output"). The existing in-container sign test's recording-docker shim now emits the signed line for `bnd statement`, so it exercises the non-empty path. `bats actions/verify/test_run_verify.bats` all pass; shellcheck clean.

`actions/verify` is pinned, so the converge bumped the chain (**merge commit**). Pin checks green locally.

Refs #693.