### PR TITLE
claude: test(catalog): lock currency coverage of the attest-toolbox image (Fixes #689)

### DIFF
--- a/test/test_bump_catalog_digest.bats
+++ b/test/test_bump_catalog_digest.bats
@@ -45,6 +45,18 @@ image_of() { jq -r '.tools.osv.image' "$CATALOG"; }
     [[ "$output" == *"not an image-delivery tool"* ]]
 }
 
+@test "bump_catalog_digest: a kind:attest image entry (the toolbox) is bumpable, not rejected" {
+    # Regression for #689: the signing toolbox is a curated image entry; the
+    # manual digest-bump remediation must accept it — the check keys on
+    # delivery: image, not kind.
+    printf '%s\n' \
+        '{"tools":{"attest-toolbox":{"kind":"attest","delivery":"image","image":"ghcr.io/tomhennen/wrangle/attest-toolbox@'"$DIGEST_A"'","network":"egress","token":"sigstore"}}}' \
+        > "$CATALOG"
+    run "$SCRIPT" attest-toolbox "$DIGEST_B"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.tools["attest-toolbox"].image' "$CATALOG")" = "ghcr.io/tomhennen/wrangle/attest-toolbox@$DIGEST_B" ]
+}
+
 @test "bump_catalog_digest: idempotent re-run leaves the file byte-identical" {
     run "$SCRIPT" osv "$DIGEST_B"
     [ "$status" -eq 0 ]

--- a/test/test_check_catalog_freshness.bats
+++ b/test/test_check_catalog_freshness.bats
@@ -72,6 +72,22 @@ SHIM
     [[ "$output" == *"bump_catalog_digest.sh osv $DIGEST_B"* ]]
 }
 
+@test "check_catalog_freshness: a kind:attest image entry (the signing toolbox) is covered, not skipped" {
+    # Regression for #689: the toolbox image the signing path depends on must be
+    # freshness-checked like any curated image. The filter keys on
+    # delivery: image, not kind — so a kind: attest entry drifts loudly, not
+    # silently. (A stale, validly-attested toolbox digest is the one risk the
+    # pull-time VSA gate cannot catch.)
+    install_curl
+    printf '%s\n' \
+        '{"tools":{"attest-toolbox":{"kind":"attest","delivery":"image","image":"ghcr.io/tomhennen/wrangle/attest-toolbox@'"$DIGEST_A"'","network":"egress","token":"sigstore"}}}' \
+        > "$CATALOG"
+    SHIM_DIGEST="$DIGEST_B" run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"behind :latest"* ]]
+    [[ "$output" == *"attest-toolbox"* ]]
+}
+
 @test "check_catalog_freshness: registry unreachable is an env error (exit 2)" {
     install_curl
     SHIM_TOKEN_FAIL=1 run "$SCRIPT"


### PR DESCRIPTION
claude: Fixes #689.

## Status: the gap is already closed — this locks it
When I filed #689, the `attest-toolbox` catalog entry had **no `delivery`**, so the four currency scripts (freshness, provenance-freshness, digest-bump, bump-to-latest — all keyed on `delivery == "image"`) skipped it: the signing-path toolbox digest could sit stale-but-green, the one risk the pull-time VSA gate can't catch.

The #619 sign-site containerization (dd3db0a) gave the toolbox entry `delivery: image`, so it is now covered by all four scripts (`jq select(.delivery=="image")` includes `attest-toolbox`). But there was **no test locking that** — a future change dropping `delivery` would silently re-open the hole.

## This PR
Regression coverage only (no code change — the fix already shipped):
- `check_catalog_freshness`: a `kind: attest` `delivery: image` entry with a drifted digest **fails loudly** (named in the bump remediation), not silently skipped.
- `bump_catalog_digest`: a `kind: attest` image entry is **accepted** (bumpable), not rejected as "not an image-delivery tool".

Both encode the invariant: currency keys on `delivery: image`, not `kind`. Test-only, converge-free — clean squash.

Fixes #689.