### PR TITLE
claude: remove the inert go-cache input from reusable workflows (0.4.0 breaking)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -68,14 +68,6 @@ on:
         required: false
         type: string
         default: "osv zizmor scorecard:info dependency-review wrangle-lint"
-      go-cache:
-        description: >
-          Deprecated no-op. The source-scan tools now ship as curated,
-          digest-pinned images and no longer build from source, so this
-          caches nothing. Retained so callers that still set it don't fail.
-        required: false
-        type: string
-        default: ""
       policy:
         description: |
           wrangle PolicySet the release is verified against (path under

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -102,14 +102,6 @@ on:
         required: false
         type: string
         default: "osv zizmor scorecard:info dependency-review wrangle-lint"
-      go-cache:
-        description: >
-          Deprecated no-op. The source-scan tools now ship as curated,
-          digest-pinned images and no longer build from source, so this
-          caches nothing. Retained so callers that still set it don't fail.
-        required: false
-        type: string
-        default: ""
       policy:
         description: |
           wrangle PolicySet the release is verified against (path under

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -83,14 +83,6 @@ on:
         required: false
         type: string
         default: "osv zizmor scorecard:info dependency-review wrangle-lint"
-      go-cache:
-        description: >
-          Deprecated no-op. The source-scan tools now ship as curated,
-          digest-pinned images and no longer build from source, so this
-          caches nothing. Retained so callers that still set it don't fail.
-        required: false
-        type: string
-        default: ""
       policy:
         description: |
           wrangle PolicySet the release is verified against (path under

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -63,14 +63,6 @@ on:
         required: false
         type: string
         default: "osv zizmor scorecard:info dependency-review wrangle-lint"
-      go-cache:
-        description: >
-          Deprecated no-op. The source-scan tools now ship as curated,
-          digest-pinned images and no longer build from source, so this
-          caches nothing. Retained so callers that still set it don't fail.
-        required: false
-        type: string
-        default: ""
       policy:
         description: |
           wrangle PolicySet the release is verified against (path under

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -41,14 +41,6 @@ on:
         required: false
         type: string
         default: "osv zizmor scorecard:info dependency-review wrangle-lint"
-      go-cache:
-        description: >
-          Deprecated no-op. The source-scan tools now ship as curated,
-          digest-pinned images and no longer build from source, so this
-          caches nothing. Retained so callers that still set it don't fail.
-        required: false
-        type: string
-        default: ""
       go-tools-dir:
         description: >
           Workspace-relative directory holding a go.mod + go.sum whose

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -8,14 +8,6 @@ on:
         required: false
         type: string
         default: "osv zizmor scorecard:info dependency-review wrangle-lint"
-      go-cache:
-        description: >
-          Deprecated no-op. The source-scan tools now ship as curated,
-          digest-pinned images and no longer build from source, so this
-          caches nothing. Retained so callers that still set it don't fail.
-        required: false
-        type: string
-        default: ""
 
 jobs:
   # MUST stay first under `jobs:`: prep's guard refuses unsafe triggers


### PR DESCRIPTION
Fixes #718.

Removes the `go-cache` input from the six reusable workflows (`build_shell`, `check_source_change`, `build_and_publish_{go,npm,python,container}`).

**Why now:** the source-scan tools (osv/zizmor/wrangle-lint) ship as digest-pinned images and no longer build from source, so `go-cache` caches nothing. It's been a **declared-but-inert no-op since #717** removed the caller-side threading — no `with: go-cache:` remains anywhere, and no example passes it.

**Breaking:** this is the removal itself. A reusable-workflow caller that still sets `go-cache:` will now get an `unknown input` startup error — which is why it was deferred to the next breaking release (v0.4.0). Adopters on pinned release tags are unaffected until they bump to `@v0.4.0`; the 0.4.0 notes should call out "drop any `go-cache:` from your `with:` block (it's been a no-op since the containerized scan tools landed)."

The lone remaining reference is a dated historical note in `docs/SLSA_L3_AUDIT.md` (that doc is explicitly the point-in-time record, not current behavior) — left intact.

Validation: `./test.sh quick` green (actionlint + wrangle-workflow-lint validate the workflows). Pin-neutral — workflow input declarations only, no action/`lib/`/catalog change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
