### PR TITLE
claude: bump curated tool-image digests to :latest

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -116,7 +116,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         id: prep
         with:
           build-type: container
@@ -135,7 +135,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -161,7 +161,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -239,7 +239,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -278,7 +278,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -116,7 +116,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         id: prep
         with:
           build-type: container
@@ -135,7 +135,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -161,7 +161,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -239,7 +239,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -278,7 +278,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -116,7 +116,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         id: prep
         with:
           build-type: container
@@ -135,7 +135,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -161,7 +161,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -239,7 +239,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -278,7 +278,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -116,7 +116,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         id: prep
         with:
           build-type: container
@@ -135,7 +135,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -161,7 +161,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -239,7 +239,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -278,7 +278,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         id: prep
         with:
           build-type: go
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -360,7 +360,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         id: attest
         with:
           build-type: go
@@ -386,7 +386,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         id: prep
         with:
           build-type: go
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -360,7 +360,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         id: attest
         with:
           build-type: go
@@ -386,7 +386,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         id: prep
         with:
           build-type: go
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -360,7 +360,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         id: attest
         with:
           build-type: go
@@ -386,7 +386,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         id: prep
         with:
           build-type: go
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -360,7 +360,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         id: attest
         with:
           build-type: go
@@ -386,7 +386,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -142,7 +142,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -161,7 +161,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -195,7 +195,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -274,7 +274,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -297,7 +297,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -142,7 +142,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -161,7 +161,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -195,7 +195,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -274,7 +274,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -297,7 +297,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -142,7 +142,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -161,7 +161,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -195,7 +195,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -274,7 +274,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -297,7 +297,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -142,7 +142,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -161,7 +161,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -195,7 +195,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -274,7 +274,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -297,7 +297,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -119,7 +119,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         id: prep
         with:
           build-type: python
@@ -138,7 +138,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -170,7 +170,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -261,7 +261,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         id: attest
         with:
           build-type: python
@@ -284,7 +284,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -119,7 +119,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         id: prep
         with:
           build-type: python
@@ -138,7 +138,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -170,7 +170,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -261,7 +261,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         id: attest
         with:
           build-type: python
@@ -284,7 +284,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -119,7 +119,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         id: prep
         with:
           build-type: python
@@ -138,7 +138,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -170,7 +170,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -261,7 +261,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         id: attest
         with:
           build-type: python
@@ -284,7 +284,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -119,7 +119,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         id: prep
         with:
           build-type: python
@@ -138,7 +138,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -170,7 +170,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -261,7 +261,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         id: attest
         with:
           build-type: python
@@ -284,7 +284,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -190,7 +190,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -190,7 +190,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -190,7 +190,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -190,7 +190,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -112,7 +112,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -124,7 +124,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -112,7 +112,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -124,7 +124,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -112,7 +112,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -124,7 +124,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -112,7 +112,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -124,7 +124,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@3024dd8132278c582bad8871749690ed232ed3bc # main 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@f3e96800057e69786a49950deb309f6c234a4bc2 # reconv736 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@e90123e37b0c0807ca24a1a30a3e51d3956773d3 # followup-toolbox-ampel-bump 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@aedc41134c82b815157769b4a1f846d27a7c7675 # main 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@adb7c40dfa8d7a9025e43596ae2e63c131f51ad8 # reconv738 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -4,32 +4,32 @@
     "osv": {
       "kind": "scan",
       "delivery": "image",
-      "image": "ghcr.io/tomhennen/wrangle/osv@sha256:14fde2ba4d8de3b7d76b283adf99483be016f595b5819aa6426dc568ae09ee92",
+      "image": "ghcr.io/tomhennen/wrangle/osv@sha256:c6316e86f7dcdcf7ba08e84b40807e837f920c71bf1b0622bf4bae4e2167eeb4",
       "network": "egress"
     },
     "zizmor": {
       "kind": "scan",
       "delivery": "image",
-      "image": "ghcr.io/tomhennen/wrangle/zizmor@sha256:88901daad9c79fe85edc5ce7cb40d1fbb659cb82b790ca5291ff0b76c256001f",
+      "image": "ghcr.io/tomhennen/wrangle/zizmor@sha256:5c4c93346ed8880d4923af84260926ccb9501f00146d62ee00e8d07b98d940d9",
       "network": "egress",
       "secret": "github-token"
     },
     "wrangle-lint": {
       "kind": "scan",
       "delivery": "image",
-      "image": "ghcr.io/tomhennen/wrangle/wrangle-lint@sha256:e4f3ecbd9f22f58fbe6651c35deb6ed6a44ba67beb1c1218333843798625b0a5",
+      "image": "ghcr.io/tomhennen/wrangle/wrangle-lint@sha256:f168f1d3cfebc145c555e3556c55fdb82c90b5ebeb51586d0f634231bcdeadbd",
       "network": "none"
     },
     "sbom": {
       "kind": "sbom",
       "delivery": "image",
-      "image": "ghcr.io/tomhennen/wrangle/syft@sha256:bffbcfb675ac8b75c196841985830068cf7883a625ef183e03de294ca9205d1b",
+      "image": "ghcr.io/tomhennen/wrangle/syft@sha256:2b94574c8895299a99ad9159af23315257b1841db9a6483764621e0bcae876f4",
       "network": "none"
     },
     "attest-toolbox": {
       "kind": "attest",
       "delivery": "image",
-      "image": "ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:3995f05ad0584c77ca5d46af64a4b6bd3728c1bd1be18963fd3d3f88844f0b8c",
+      "image": "ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:7aed5ac0d202f235dc61656db24e17a34b728f5d1ef3618a1ea61479e6765151",
       "network": "egress",
       "token": "sigstore"
     }


### PR DESCRIPTION
claude: Bumps all five curated image digests to current :latest via `make bump-catalog-to-latest`, replacing the bot's withdrawn #684 (its digests went stale when today's tools/ merges — #487 ast-grep, #664, #734 zizmor 1.26.1 — triggered image republishes). `tools/check_catalog.sh` passes; the pull-time VSA gate in CI verifies each new digest's attestation for real. First-party images, cooldown-exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)