### PR TITLE
refactor(orchestrator): image-only tool delivery — drop the in-process adapter path (Stage A)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -116,7 +116,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         id: prep
         with:
           build-type: container
@@ -135,7 +135,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -161,7 +161,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -239,7 +239,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -278,7 +278,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -116,7 +116,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         id: prep
         with:
           build-type: container
@@ -135,7 +135,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -161,7 +161,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -239,7 +239,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -278,7 +278,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         id: prep
         with:
           build-type: go
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -360,7 +360,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         id: attest
         with:
           build-type: go
@@ -386,7 +386,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         id: prep
         with:
           build-type: go
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -360,7 +360,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         id: attest
         with:
           build-type: go
@@ -386,7 +386,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -142,7 +142,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -161,7 +161,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -195,7 +195,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -274,7 +274,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -297,7 +297,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -142,7 +142,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -161,7 +161,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -195,7 +195,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -274,7 +274,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -297,7 +297,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -119,7 +119,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         id: prep
         with:
           build-type: python
@@ -138,7 +138,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -170,7 +170,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -261,7 +261,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         id: attest
         with:
           build-type: python
@@ -284,7 +284,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -119,7 +119,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         id: prep
         with:
           build-type: python
@@ -138,7 +138,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -170,7 +170,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -261,7 +261,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         id: attest
         with:
           build-type: python
@@ -284,7 +284,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -190,7 +190,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -190,7 +190,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ All shell conventions — preamble form, quoting, `printf` over `echo`, `[[ ]]` 
 
 Tools live in `tools/<name>/`, in one of three patterns:
 
-- **adapter** — `adapter.sh` + `test.bats`; binary from a tools/go.mod `tool` directive or a bespoke `install.sh` for tools no package manager ships; wired into `actions/scan/action.yml`.
+- **adapter** — `adapter.sh` (the tool image's entrypoint) + `test.bats`; binary built into the tool's image from a tools/go.mod `tool` directive, or a bespoke `install.sh` run at image-build time for tools no package manager ships; run.sh dispatches the image, wired into `actions/scan/action.yml`.
 - **action** — `action.yml` + `test.bats`, for tools with official GitHub Actions.
 - **developer tooling** — whatever it needs + `test.bats`, for things used only during development, not by adopters (e.g. `bump_action_pins`, `wrangle-shell-lint`).
 

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -111,7 +111,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -123,7 +123,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -111,7 +111,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -123,7 +123,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -89,7 +89,6 @@ runs:
         WRANGLE_ROOT: ${{ github.action_path }}/../..
         WRANGLE_EXTRA_GITHUB_TOKEN: ${{ inputs.github-token }}
         GH_TOKEN: ${{ inputs.github-token }}
-        WRANGLE_INSTALL_TIMEOUT: "900"
       run: |
         # shellcheck source=../../lib/env.sh
         source "$WRANGLE_ROOT/lib/env.sh"

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@f7a7719abc895f2b552dca91ed144d7f301cbd3e # cleanup/image-only-delivery-a 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -285,14 +285,14 @@ Two conditions narrow every Build L3 claim:
 ┌──────────────────▼───────────────────────────────┐
 │  Wrangle Composite Action                        │
 │  actions/scan/action.yml                         │
-│  (installs tools, runs adapters, uploads results)│
+│  (runs tools via run.sh, uploads results)        │
 └──────────────────┬───────────────────────────────┘
                    │ calls
 ┌──────────────────▼───────────────────────────────┐
 │  Orchestrator + Tools                            │
-│  run.sh → go install tool (tools/go.mod)         │
-│         → tools/<name>/adapter.sh                │
-│  (download binaries, run tools, normalize output)│
+│  run.sh → docker run <tool image>                │
+│           (adapter.sh = image entrypoint)        │
+│  (run tool images, normalize output)             │
 └──────────────────────────────────────────────────┘
 ```
 
@@ -325,7 +325,7 @@ wrangle/
 │   └── actions/
 │       └── container/
 │           └── action.yml  # Container build/publish action
-├── run.sh                  # Orchestrator (installs + runs tools)
+├── run.sh                  # Orchestrator (dispatches tool images)
 ├── gh_workflow_examples/   # Copy-paste templates for adopters
 ├── test/                   # Integration tests, fixtures, schemas
 └── docs/
@@ -388,7 +388,7 @@ EXIT CODES (uniform across kinds):
   An sbom tool has no findings state, so it simply never returns 1.
 
 PRECONDITIONS:
-  Tool binary is on $PATH (handled by install script)
+  Tool binary is on $PATH inside the tool image
   jq is available
 
 ENVIRONMENT:
@@ -432,9 +432,9 @@ is already present.
 
 ### Install Script Interface
 
-Adapter tools are Go tools by default: a `tool` directive in `tools/go.mod`, which the orchestrator installs in one upfront `go install tool` (go.sum integrity, Dependabot freshness — DEP_MGMT branch 1). A tool that no package manager ships may instead carry a bespoke `tools/<name>/install.sh` (the escape hatch), downloading and verifying a binary per the integrity tiers below.
+Adapter tools' binaries are built into each tool's image at image-build time. A Go tool comes from a `tool` directive in `tools/go.mod` (go.sum integrity, Dependabot freshness — DEP_MGMT branch 1); a tool that no package manager ships instead carries a bespoke `tools/<name>/install.sh` that downloads and verifies a binary per the integrity tiers below.
 
-Install scripts are called by the orchestrator (`run.sh`), not by users directly.
+Install scripts run at image-build time (a Dockerfile `RUN` step), not by the orchestrator or by users directly.
 
 **Contract:**
 
@@ -562,7 +562,7 @@ IDEMPOTENCY:
 
 ### Orchestrator Interface
 
-`run.sh` (at the repo root) installs and runs multiple adapters.
+`run.sh` (at the repo root) runs multiple tools, each as its pinned image.
 
 **Contract:**
 
@@ -576,46 +576,41 @@ OPTIONS:
 ARGUMENTS:
   tool1, tool2   Tool specs to run (e.g., osv, zizmor, scorecard:info).
                  Optional :fail/:info suffix is stripped before processing.
-                 Action-pattern tools (an action.yml, or no adapter.sh and
-                 no catalog image entry) are silently skipped.
+                 Action-pattern tools (an action.yml) are silently skipped —
+                 they run via their own uses: step; a selected tool with no
+                 action.yml and no catalog image entry is rejected (exit 2).
 
 BEHAVIOR:
   For each tool:
     1. Strip :policy suffix if present (run.sh does not use the policy —
        that is handled by lib/check_results.sh in the scan action)
     2. Validate tool name matches ^[a-z][a-z0-9_-]*$ (reject otherwise)
-    3. Verify tools/<tool>/ directory exists, OR the catalog gives the tool a
-       `delivery: image` entry (a catalog-only image tool needs no local
-       directory); reject otherwise as an unknown tool
-    4. Skip if tools/<tool>/action.yml exists (action-pattern — handled by
+    3. Skip if tools/<tool>/action.yml exists (action-pattern — handled by
        uses: steps in the scan action; any adapter.sh present is only the
-       tool image's entrypoint). Otherwise resolve the tool's
-       tools/catalog.json entry: a `delivery: image` entry runs the tool's
-       pinned image via `docker run` (read-only /src, writable /output owned
-       by the runner UID, --network none unless the entry declares
-       `network: egress`, a `secret:` passed via -e); else skip if
-       tools/<tool>/adapter.sh is missing.
-    5. (adapter path) Run tools/<tool>/install.sh if present — go.mod tools
-       were all installed upfront (timeout: 5 minutes)
-    6. Create <output_dir>/<tool>/
-    7. Run the adapter or image with <src_dir> and <output_dir>/<tool>/ under
-       the uniform 0/1/2 exit contract (an image gets WRANGLE_KIND for its
-       input/stage). A scan tool writes output.sarif; an sbom tool writes
-       sbom.spdx.json (timeout: 10 minutes)
-    8. Record pass/fail status; attest the primary output file by name —
+       tool image's entrypoint)
+    4. Resolve the tool's tools/catalog.json entry: a `delivery: image` entry
+       runs the tool's pinned image via `docker run` (read-only /src, writable
+       /output owned by the runner UID, --network none unless the entry
+       declares `network: egress`, a `secret:` passed via -e). A tool with no
+       catalog image entry is rejected as an unknown tool
+    5. Create <output_dir>/<tool>/
+    6. Run the image with <src_dir> and <output_dir>/<tool>/ under the uniform
+       0/1/2 exit contract (WRANGLE_KIND carries its input/stage). A scan tool
+       writes output.sarif; an sbom tool writes sbom.spdx.json (timeout: 10
+       minutes)
+    7. Record pass/fail status; attest the primary output file by name —
        output.sarif via the scan/v1 manifest, sbom.spdx.json via its in-toto
        predicate https://spdx.dev/Document
 
   After all tools:
-    9. Print summary table to stdout
+    8. Print summary table to stdout
 
 TIMEOUTS:
-  Each adapter invocation is wrapped in `timeout(1)` to prevent a hung tool
+  Each tool image run is wrapped in `timeout(1)` to prevent a hung tool
   from consuming the entire GitHub Actions job timeout (default 6 hours).
 
-  Default timeouts:
-    - Install scripts: 5 minutes (sufficient for binary download + verify)
-    - Adapter scripts: 10 minutes (sufficient for scanning large repos)
+  Default: 10 minutes per tool (WRANGLE_ADAPTER_TIMEOUT, sufficient for
+  scanning large repos).
 
   A timeout expiration is treated as exit code 2 (tool failure). The
   orchestrator logs the timeout and continues to the next tool.
@@ -639,7 +634,7 @@ ENVIRONMENT ISOLATION:
   adapters. See the adapter API ENVIRONMENT section for the allowlist.
 
 NOTES:
-  The orchestrator resolves adapter and install script paths relative to its
+  The orchestrator resolves its helper scripts and the catalog relative to its
   own location (using $0 / BASH_SOURCE), not the caller's working directory.
   This is critical for portability when called via github.action_path.
 ```
@@ -800,12 +795,12 @@ This is the entire file an adopter needs. No secrets, no configuration, no depen
 
 Every tool lives in `tools/<name>/` regardless of which pattern it uses. There are two patterns:
 
-**Adapter pattern** — for tools distributed as standalone binaries (e.g., OSV-Scanner). The orchestrator (`run.sh`) handles installation and execution:
+**Adapter pattern** — for tools that run as a wrangle-published image (e.g., OSV-Scanner). The tool's `adapter.sh` is the image entrypoint; the orchestrator (`run.sh`) dispatches the image via `docker run`:
 
 ```
 tools/<name>/
-├── install.sh    # Downloads + verifies the tool binary
-├── adapter.sh    # Runs the tool, produces SARIF
+├── install.sh    # Downloads + verifies the tool binary at image-build time (tools no package manager ships)
+├── adapter.sh    # Image entrypoint: runs the tool, produces SARIF
 └── test.bats     # Tests for both scripts
 ```
 
@@ -846,13 +841,14 @@ The install scripts include OS/arch detection (`linux/darwin`, `amd64/arm64`) as
 
 ### Adding a New Tool
 
-**Adapter pattern** (standalone binary):
+**Adapter pattern** (runs as a wrangle-published image):
 
 1. Create `tools/foo/` directory with:
-   - `install.sh` — uses `lib/download_verify.sh` for download and verification
-   - `adapter.sh` — follows the adapter contract above
+   - `adapter.sh` — the image entrypoint; follows the adapter contract above
+   - `install.sh` — uses `lib/download_verify.sh` for download and verification when no package manager ships the tool (run at image-build time)
    - `test.bats` — tests using mock binaries (fast, deterministic)
-2. Add `foo` to the orchestrator's default tool list in `actions/scan/action.yml`
+2. Build and publish the tool's image and add its digest-pinned `delivery: image` entry to `tools/catalog.json` (see [Tool containerization](tool_container_design.md))
+3. Add `foo` to the orchestrator's default tool list in `actions/scan/action.yml`
 
 **Action pattern** (wraps upstream GitHub Action):
 
@@ -902,16 +898,9 @@ The `.wrangle/` directory is in `.gitignore` to prevent accidental commits. The 
 
 ## Design Decisions
 
-### Binary downloads as the default, container images per-tool
+### Tool delivery: container images per tool
 
-**Default:** Tools are downloaded as standalone binaries (or wrapped as actions) and run directly, because for most tools that wins on:
-- **Speed:** No image pull latency (cached binary downloads are near-instant)
-- **Simplicity:** No container registry to manage, no image build pipeline
-- **Portability:** Works on any runner (macOS, self-hosted, ARM — not just Linux with Docker)
-- **Testability:** No Docker-in-Docker complexity; scripts testable with bats-core locally
-- **Adoption friction:** No authentication needed to pull tool images
-
-**Per-tool exception:** A tool whose upstream ships only as a container, or that needs an isolated runtime, opts into container delivery through the catalog (`delivery: image` with a digest-pinned `image:`); the orchestrator runs it via `docker run` under the adapter contract sandbox. Binary/adapter delivery remains the default. See [docs/tool_container_design.md](tool_container_design.md).
+Each adapter-pattern tool runs as a **digest-pinned OCI image** resolved through the catalog (`delivery: image` with a digest-pinned `image:`); the orchestrator dispatches it via `docker run` under the adapter contract sandbox — the container is the unit of both distribution and isolation. Tools with a well-maintained official GitHub Action stay action-pattern (wrapped via `uses:`) instead. Rationale and the packaging model are in [docs/tool_container_design.md](tool_container_design.md).
 
 The container *build/publish* workflow (for building adopters' Docker images) is a separate concern and remains unchanged.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -392,32 +392,25 @@ PRECONDITIONS:
   jq is available
 
 ENVIRONMENT:
-  The orchestrator sets these WRANGLE_* variables for every tool image:
+  A tool image inherits nothing from the runner; the orchestrator passes only
+  these variables explicitly, via `docker run -e`:
     WRANGLE_KIND         the tool's kind (input/stage; see TOOL KIND above)
     WRANGLE_SOURCE_NAME  basename of the scanned source dir (the /src mount
                          hides its real path)
-    WRANGLE_EXTRA_<VAR>  the runner's WRANGLE_EXTRA_<VAR> reaches the tool as
-                         <VAR>, prefix stripped (see the WRANGLE_EXTRA_ rule below)
-
-  Adapters run with a restricted environment. Only the following variables
-  are passed through from the runner:
-    PATH, HOME, TMPDIR, RUNNER_TEMP, GITHUB_WORKSPACE, GITHUB_STEP_SUMMARY
-  Sensitive variables (GITHUB_TOKEN, ACTIONS_RUNTIME_TOKEN, etc.) are NOT
-  available to adapters by default. If a tool requires an additional
-  environment variable (e.g., a private vulnerability DB token), it can
-  be passed through by setting it in the composite action's `env:` block
-  with a `WRANGLE_EXTRA_` prefix. The orchestrator forwards any variable
-  matching `WRANGLE_EXTRA_*` to adapters with the prefix stripped.
-  Example: `WRANGLE_EXTRA_OSV_DB_TOKEN=xxx` becomes `OSV_DB_TOKEN=xxx`
-  in the adapter environment. This keeps the allowlist explicit without
-  requiring adapter forks for authenticated tools.
+    <VAR>                one catalog-declared secret: a tool whose entry names
+                         `secret: foo-bar` receives the runner's
+                         WRANGLE_EXTRA_FOO_BAR as FOO_BAR (uppercased, prefix
+                         stripped, forwarded by name). An undeclared
+                         WRANGLE_EXTRA_* is not forwarded.
+  Sensitive host variables (GITHUB_TOKEN, ACTIONS_RUNTIME_TOKEN, etc.) reach a
+  tool only when routed through that declared secret (e.g. zizmor's online audit
+  takes `secret: github-token`).
 
 SECURITY:
-  - Adapter scripts MUST NOT write files outside of output_dir.
-    The orchestrator performs a post-execution filesystem check to detect
-    unexpected modifications outside output_dir and flags violations.
-  - Adapter scripts MUST NOT make network requests beyond what the tool
-    requires for its scan (e.g., fetching vulnerability databases)
+  - The image cannot write outside its output: /src is mounted read-only and
+    only /output is writable — a fail-closed sandbox.
+  - A tool makes no network requests unless its catalog entry declares
+    `network: egress`; the default is `--network none`.
   - All output written to GITHUB_STEP_SUMMARY MUST be sanitized to
     prevent markdown/HTML injection
   - jq exit codes MUST be checked; malformed SARIF must not silently pass
@@ -630,8 +623,8 @@ INPUT VALIDATION:
   throughout the orchestrator and adapter scripts.
 
 ENVIRONMENT ISOLATION:
-  The orchestrator clears sensitive environment variables before invoking
-  adapters. See the adapter API ENVIRONMENT section for the allowlist.
+  A tool image inherits no runner environment; the orchestrator passes only the
+  variables in the adapter API ENVIRONMENT section explicitly, via `docker run -e`.
 
 NOTES:
   The orchestrator resolves its helper scripts and the catalog relative to its
@@ -890,7 +883,7 @@ Structure after a scan:
 
 The optional `error` file is the tool-error marker for action-pattern tools — see "Tool-error marker contract" under [Two Tool Patterns](#two-tool-patterns).
 
-The `.wrangle/` directory is in `.gitignore` to prevent accidental commits. The orchestrator's filesystem check (`run.sh`) excludes the metadata directory from its pre/post snapshots.
+The `.wrangle/` directory is in `.gitignore` to prevent accidental commits.
 
 **Future use:** The metadata directory is designed to become the source for signed attestations: "this commit was scanned by tools X, Y, Z with these results."
 
@@ -1096,8 +1089,7 @@ Action-pattern tools call these helpers from their own `action.yml`. The `format
 - Integrity verification (checksums + SLSA provenance) is the primary defense against malicious binaries
 - GitHub-hosted runners are ephemeral, limiting the blast radius of any compromise
 - For self-hosted runners, adopters should use [StepSecurity Harden-Runner](https://github.com/step-security/harden-runner) alongside wrangle for network monitoring
-- Post-execution filesystem check: the orchestrator snapshots the workspace file list before and after each adapter run, flagging any unexpected file modifications outside `output_dir`
-- Future versions may use lightweight sandboxing (bubblewrap, firejail) on Linux runners
+- Write confinement: each tool runs against a read-only `/src` mount with only `/output` writable, so it cannot modify the workspace it scans
 
 ### Protecting Wrangle Itself
 

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -18,8 +18,7 @@ Wrangle's tool layer solves four problems at once, each only partially:
    (zizmor), and action wrappers. Coverage is uneven and drift is a recurring review finding
    (#264/#277/#286).
 2. **Speed.** Adapter tools are installed and compiled on every run: `run.sh` `go install`s
-   osv-scanner's dependency tree cold, which is slow enough that the scan action raises
-   `WRANGLE_INSTALL_TIMEOUT` from its 300 s default to 900 s. The Go build cache that would help is off
+   osv-scanner's dependency tree cold, a slow per-run cost. The Go build cache that would help is off
    by default on attested paths for SLSA-L3 reasons.
 3. **Supply-chain isolation.** A tool today is contained by a stripped environment, the adapter
    contract, and a post-run filesystem snapshot — not a real sandbox. Stronger isolation was deferred
@@ -73,14 +72,13 @@ docker run --rm --network <policy> -u <runner_uid>:<gid> \
 
 ### 3.2 Isolation
 
-`docker run` replaces `run.sh`'s in-process isolation, so each current mechanism is carried over
-deliberately:
+The container is the sandbox; each isolation property is enforced explicitly:
 
-| Today (`run.sh`) | Container equivalent |
+| Isolation property | Container mechanism |
 |---|---|
-| `env -i <allowlist>` — adapter sees only allowed env | bare `docker run` inherits nothing; allowed vars passed explicitly with `-e` |
+| adapter sees only allowed env | bare `docker run` inherits nothing; allowed vars passed explicitly with `-e` |
 | `WRANGLE_EXTRA_*` forwarding | explicit `-e WRANGLE_EXTRA_*` per declaring tool |
-| post-run filesystem snapshot (warn-only) | `/src:ro` + `/output`-only mount — fail-closed write confinement, an upgrade |
+| write confinement | `/src:ro` + `/output`-only mount — fail-closed |
 
 Signing (`attest`) containers additionally never receive the OIDC mint-request vars
 (`ACTIONS_ID_TOKEN_REQUEST_*`); the host mints the short-lived `SIGSTORE_ID_TOKEN` and passes only that
@@ -184,10 +182,10 @@ thing for the pin tooling to track and for adopters to read.
 
 The shipped catalog (`tools/catalog.json`) is parsed with `jq` (`lib/read_catalog.sh`) and has **two
 consumers**: the scan orchestrator dispatches entries the `tools:` selection names that carry
-`delivery: image` (the docker-run path; a tool not listed — or one with `delivery: adapter`/no `delivery`
-— takes the in-process adapter path), and the verify action resolves one **fixed key**
-(`attest-toolbox`) for its in-container `ampel verify`. An entry may therefore omit `delivery` to opt out
-of scan dispatch while still being a reviewable grant the verify path resolves; `check_catalog` pin- and
+`delivery: image` via `docker run` (a selected tool with no catalog image entry and no `action.yml` is
+rejected as unknown), and the verify action resolves one **fixed key** (`attest-toolbox`) for its
+in-container `ampel verify`. An entry the `tools:` selection never names is not scan-dispatched, yet
+remains a reviewable grant the verify path resolves by fixed key; `check_catalog` pin- and
 namespace-lints any entry naming an `image`, regardless of `delivery`. Capabilities default closed: an
 absent `network`/`secret` means none. The `kind` field is recorded but unused today; the
 `command:`/`args:`/`WRANGLE_KIND` passthrough and kind-based (scan vs sbom) dispatch land when a
@@ -263,8 +261,7 @@ Schema below is the proposed shape; exact field names and file locations are bik
 }
 ```
 
-(During migration a catalog entry may carry `delivery: adapter` to keep running the old in-process
-adapter for a tool not yet containerized; the default is `delivery: image`. See §10.)
+(Every catalog entry carries `delivery: image` — the only path the orchestrator dispatches.)
 
 As the `wrangle-lint`/`wrangle-attest` entries above show, an entry can carry an optional
 `command:`/`args:` so several tools share **one** image (a unified `wrangle` binary or a toolbox image),

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 set -f  # disable globbing — tool names come from external input
 
-# Wrangle orchestrator — installs and runs security tool adapters.
+# Wrangle orchestrator — runs security tool images under the contract sandbox.
 #
 # Usage: run.sh [-s <src_dir>] [-o <output_dir>] <tool1> [tool2] ...
 #
@@ -19,7 +19,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/env.sh"
 
 # Catalog reader: resolves a tool's curated entry (delivery, image, network,
-# secret) from tools/catalog.json. A tool with no entry runs the adapter path.
+# secret) from tools/catalog.json.
 # shellcheck source=lib/read_catalog.sh
 source "$SCRIPT_DIR/lib/read_catalog.sh"
 
@@ -46,8 +46,7 @@ source "$SCRIPT_DIR/lib/write_tool_error_marker.sh"
 
 TOOLS_DIR="${WRANGLE_TOOLS_DIR:-${SCRIPT_DIR}/tools}"
 # The catalog lives beside the tools it describes, so a WRANGLE_TOOLS_DIR
-# override (hermetic orchestrator tests) gets its own catalog — or none, in
-# which case every tool runs the adapter path.
+# override (hermetic orchestrator tests) gets its own catalog.
 CATALOG="${WRANGLE_CATALOG:-${TOOLS_DIR}/catalog.json}"
 
 # Only wrangle-namespace images carry wrangle's VSA identity, so only these get
@@ -78,11 +77,6 @@ if [[ -n "$custom_tools" ]] && [[ -e "$custom_tools" ]]; then
     CATALOG="$effective_catalog"
 fi
 
-# is_image[$tool]=1 marks a catalog tool with delivery: image (the docker-run
-# path); absence means the adapter path. Resolved once per tool in the parse
-# loop so the dispatch loop branches on that single answer.
-declare -A is_image=()
-
 # Defaults
 src_dir="."
 output_dir="./metadata"
@@ -103,11 +97,11 @@ if [[ $# -eq 0 ]]; then
     exit 2
 fi
 
-# Parse tool specs: strip :policy suffixes, collect the tools run by run.sh —
-# adapter-pattern tools (have an adapter.sh) plus catalog image-delivery tools
-# (run via docker run). Action-pattern tools (have an action.yml) are invoked
-# via their uses: step, so run.sh skips them even when an adapter.sh is present
-# only as their image entrypoint. Unknown tools (no directory) are rejected.
+# Parse tool specs: strip :policy suffixes, collect the tools run by run.sh.
+# run.sh dispatches only catalog image-delivery tools (via docker run). An
+# action-pattern tool (has an action.yml) is invoked via its uses: step, so it
+# is skipped here even when an adapter.sh is present only as its image
+# entrypoint. Any other selected tool has no way to run and is rejected.
 declare -a run_tools=()
 for spec in "$@"; do
     tool="${spec%%:*}"
@@ -115,35 +109,21 @@ for spec in "$@"; do
         printf 'wrangle: invalid tool name: %s (must match %s)\n' "$tool" "$CATALOG_TOOL_NAME_RE" >&2
         exit 2
     fi
-    # Resolve delivery once. Empty -> adapter path; "image" -> docker path; any
-    # other non-empty value is a catalog typo, not a silent adapter fallthrough.
-    delivery="$(read_catalog_field "$CATALOG" "$tool" delivery)"
-    case "$delivery" in
-        image) is_image[$tool]=1 ;;
-        ''|adapter) ;;
-        *)
-            printf 'wrangle: %s: unrecognized catalog delivery: %s\n' "$tool" "$delivery" >&2
-            exit 2 ;;
-    esac
-    if [[ -d "${TOOLS_DIR}/${tool}" ]]; then
-        # An action.yml means the tool runs via its uses: step; skip it here even
-        # if an adapter.sh exists (it is only the tool image's contract entrypoint).
-        if [[ -f "${TOOLS_DIR}/${tool}/action.yml" ]]; then
-            continue
-        fi
-    elif [[ -z "${is_image[$tool]:-}" ]]; then
-        # A catalog delivery: image tool is dispatched from its image, so it needs
-        # no local directory; anything else with no directory is unknown.
-        printf 'wrangle: unknown tool: %s (no directory at %s/%s/ and no catalog image entry)\n' "$tool" "$TOOLS_DIR" "$tool" >&2
+    # An action.yml means the tool runs via its uses: step, not run.sh.
+    if [[ -d "${TOOLS_DIR}/${tool}" ]] && [[ -f "${TOOLS_DIR}/${tool}/action.yml" ]]; then
+        continue
+    fi
+    # Image delivery is the only path run.sh dispatches; a tool must carry a
+    # catalog delivery: image entry, else it is unknown/unrunnable.
+    if [[ "$(read_catalog_field "$CATALOG" "$tool" delivery)" != image ]]; then
+        printf 'wrangle: unknown tool: %s (no catalog image entry in %s)\n' "$tool" "$CATALOG" >&2
         exit 2
     fi
-    if [[ -n "${is_image[$tool]:-}" ]] || [[ -f "${TOOLS_DIR}/${tool}/adapter.sh" ]]; then
-        run_tools+=("$tool")
-    fi
+    run_tools+=("$tool")
 done
 
 if [[ ${#run_tools[@]} -eq 0 ]]; then
-    printf 'wrangle: no adapter-pattern tools to run\n'
+    printf 'wrangle: no tools to run\n'
     exit 0
 fi
 
@@ -152,8 +132,7 @@ mkdir -p "$output_dir"
 # Track overall status: 0=clean, 1=findings, 2=error
 overall_status=0
 
-# Timeout defaults (seconds)
-INSTALL_TIMEOUT="${WRANGLE_INSTALL_TIMEOUT:-300}"
+# Adapter timeout (seconds) — bounds each tool image's run.
 ADAPTER_TIMEOUT="${WRANGLE_ADAPTER_TIMEOUT:-600}"
 
 # Summary tracking
@@ -203,10 +182,10 @@ fail_tool_config() {
     printf '::endgroup::\n'
 }
 
-# run_one_tool <tool> — run a single tool through its delivery path (image via
-# docker, otherwise the in-process adapter), map its exit to the 0/1/2 contract,
-# attest its recognized output files by name, and record the result. Updates
-# overall_status and the summary arrays.
+# run_one_tool <tool> — run a single tool's pinned image under the contract
+# sandbox, map its exit to the 0/1/2 contract, attest its recognized output
+# files by name, and record the result. Updates overall_status and the summary
+# arrays.
 run_one_tool() {
     local tool="$1"
     printf '::group::wrangle/%s\n' "$tool"
@@ -214,112 +193,50 @@ run_one_tool() {
 
     local tool_status="pass"
     local adapter_exit=0
-    # tool_output_dir is the SAME ${output_dir}/${tool}/ both paths write to —
-    # the downstream collectors consume ${metadata}/${tool}/output.sarif.
+    # tool_output_dir is ${output_dir}/${tool}/; the downstream collectors
+    # consume ${metadata}/${tool}/output.sarif.
     local tool_output_dir="${output_dir}/${tool}"
     mkdir -p "$tool_output_dir"
 
-    if [[ -n "${is_image[$tool]:-}" ]]; then
-        # Image-delivery: run the tool's pinned image under the contract
-        # sandbox (read-only /src, writable /output owned by the runner UID).
-        # The image's entrypoint IS the adapter, so it maps the same 0/1/2
-        # exit contract and writes its recognized output files into /output.
-        printf 'wrangle: running %s (image)...\n' "$tool"
+    # Run the tool's pinned image under the contract sandbox (read-only /src,
+    # writable /output owned by the runner UID). The image's entrypoint IS the
+    # adapter, mapping the same 0/1/2 exit contract and writing its recognized
+    # output files into /output.
+    printf 'wrangle: running %s (image)...\n' "$tool"
 
-        local image
-        image="$(read_catalog_field "$CATALOG" "$tool" image)"
-        if [[ -z "$image" ]]; then
-            printf 'wrangle: %s: catalog declares delivery: image but no image\n' "$tool" >&2
-            fail_tool_config "$tool" "$tool_output_dir" "catalog declares delivery: image but no image"
-            return
-        fi
-        # Require an @sha256 digest pin (a tag alone is mutable); re-checked here
-        # even though merge_catalog validated custom entries, as defense in depth.
-        if [[ ! "$image" =~ $CATALOG_IMAGE_DIGEST_RE ]]; then
-            printf 'wrangle: %s: image not digest-pinned: %s\n' "$tool" "$image" >&2
-            fail_tool_config "$tool" "$tool_output_dir" "image not digest-pinned: $image"
-            return
-        fi
-        # A declared secret name must be a valid env-var stem before it is
-        # mapped into the container (config error, not a tool result).
-        local secret
-        secret="$(read_catalog_field "$CATALOG" "$tool" secret)"
-        if [[ -n "$secret" ]] && [[ ! "$secret" =~ ^[a-z][a-z0-9-]*$ ]]; then
-            printf 'wrangle: %s: invalid catalog secret name: %s\n' "$tool" "$secret" >&2
-            fail_tool_config "$tool" "$tool_output_dir" "invalid catalog secret name: $secret"
-            return
-        fi
-
-        # Fail closed: refuse to dispatch a curated image that cannot be proven
-        # to carry a PASSED wrangle VSA.
-        if ! verify_tool_image "$tool" "$image"; then
-            fail_tool_config "$tool" "$tool_output_dir" "tool image VSA verification failed"
-            return
-        fi
-
-        run_tool_image "$tool" "$image" "$tool_output_dir" \
-            "$src_dir" "$CATALOG" "$ADAPTER_TIMEOUT" || adapter_exit=$?
-    else
-        # Adapter-pattern (in-process) path.
-
-        # Step 1: Install — only tools with a bespoke install.sh (the escape
-        # hatch for tools no package manager ships).
-        local install_exit=0
-        if [[ -f "${TOOLS_DIR}/${tool}/install.sh" ]]; then
-            printf 'wrangle: installing %s...\n' "$tool"
-            timeout "$INSTALL_TIMEOUT" "${TOOLS_DIR}/${tool}/install.sh" || install_exit=$?
-        fi
-
-        if [[ "$install_exit" -eq 124 ]]; then
-            printf 'wrangle: %s install timed out after %ds\n' "$tool" "$INSTALL_TIMEOUT" >&2
-        elif [[ "$install_exit" -ne 0 ]]; then
-            printf 'wrangle: install failed for %s (exit %d)\n' "$tool" "$install_exit" >&2
-        fi
-        if [[ "$install_exit" -ne 0 ]]; then
-            fail_tool_config "$tool" "$tool_output_dir" "install failed (exit $install_exit)"
-            return
-        fi
-
-        # Step 2: Snapshot workspace for post-execution filesystem check
-        # Records file paths, sizes, and mtimes to detect additions, removals, and modifications
-        local pre_snapshot post_snapshot
-        pre_snapshot="$(mktemp "${TMPDIR:-/tmp}/wrangle-pre-XXXXX")"
-        # Exclude output_dir from snapshot — when metadata dir is inside src_dir
-        # (workspace-relative), adapter writes there are expected, not rogue.
-        find "$src_dir" -not -path "${output_dir}/*" -type f -printf '%p %s %T@\n' 2>/dev/null | sort > "$pre_snapshot" || true
-
-        # Step 3: Run adapter with isolated environment
-        printf 'wrangle: running %s...\n' "$tool"
-
-        # Build restricted environment: only allowlisted variables + WRANGLE_EXTRA_*
-        local -a adapter_env=(
-            "PATH=${PATH}"
-            "HOME=${HOME:-}"
-            "TMPDIR=${TMPDIR:-/tmp}"
-            "RUNNER_TEMP=${RUNNER_TEMP:-}"
-            "GITHUB_WORKSPACE=${GITHUB_WORKSPACE:-}"
-            "GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-}"
-        )
-        # Forward WRANGLE_EXTRA_* variables with prefix stripped
-        local key value stripped_key
-        while IFS='=' read -r key value; do
-            if [[ "$key" == WRANGLE_EXTRA_* ]]; then
-                stripped_key="${key#WRANGLE_EXTRA_}"
-                adapter_env+=("${stripped_key}=${value}")
-            fi
-        done < <(env)
-
-        timeout "$ADAPTER_TIMEOUT" env -i "${adapter_env[@]}" \
-            "${TOOLS_DIR}/${tool}/adapter.sh" "$src_dir" "$tool_output_dir" || adapter_exit=$?
-
-        # Step 4: Post-execution filesystem check
-        post_snapshot="$(mktemp "${TMPDIR:-/tmp}/wrangle-post-XXXXX")"
-        find "$src_dir" -not -path "${output_dir}/*" -type f -printf '%p %s %T@\n' 2>/dev/null | sort > "$post_snapshot" || true
-        if ! diff -q "$pre_snapshot" "$post_snapshot" >/dev/null 2>&1; then
-            printf 'wrangle: WARNING: %s modified files outside its output directory\n' "$tool" >&2
-        fi
-        rm -f "$pre_snapshot" "$post_snapshot"
+    local image
+    image="$(read_catalog_field "$CATALOG" "$tool" image)"
+    if [[ -z "$image" ]]; then
+        printf 'wrangle: %s: catalog declares delivery: image but no image\n' "$tool" >&2
+        fail_tool_config "$tool" "$tool_output_dir" "catalog declares delivery: image but no image"
+        return
     fi
+    # Require an @sha256 digest pin (a tag alone is mutable); re-checked here
+    # even though merge_catalog validated custom entries, as defense in depth.
+    if [[ ! "$image" =~ $CATALOG_IMAGE_DIGEST_RE ]]; then
+        printf 'wrangle: %s: image not digest-pinned: %s\n' "$tool" "$image" >&2
+        fail_tool_config "$tool" "$tool_output_dir" "image not digest-pinned: $image"
+        return
+    fi
+    # A declared secret name must be a valid env-var stem before it is mapped
+    # into the container (config error, not a tool result).
+    local secret
+    secret="$(read_catalog_field "$CATALOG" "$tool" secret)"
+    if [[ -n "$secret" ]] && [[ ! "$secret" =~ ^[a-z][a-z0-9-]*$ ]]; then
+        printf 'wrangle: %s: invalid catalog secret name: %s\n' "$tool" "$secret" >&2
+        fail_tool_config "$tool" "$tool_output_dir" "invalid catalog secret name: $secret"
+        return
+    fi
+
+    # Fail closed: refuse to dispatch a curated image that cannot be proven to
+    # carry a PASSED wrangle VSA.
+    if ! verify_tool_image "$tool" "$image"; then
+        fail_tool_config "$tool" "$tool_output_dir" "tool image VSA verification failed"
+        return
+    fi
+
+    run_tool_image "$tool" "$image" "$tool_output_dir" \
+        "$src_dir" "$CATALOG" "$ADAPTER_TIMEOUT" || adapter_exit=$?
 
     # Uniform 0/1/2 exit contract across kinds; a tool's kind selects its
     # input/stage, not this mapping.

--- a/test/fixtures/image-contract/entrypoint.sh
+++ b/test/fixtures/image-contract/entrypoint.sh
@@ -18,6 +18,11 @@ case "$mode" in
     error)
         printf 'mock: simulated tool error\n' >&2
         exit 2 ;;
+    slow)
+        # Outlast a short WRANGLE_ADAPTER_TIMEOUT so the timeout->exit-2 mapping
+        # can be driven.
+        sleep 30
+        exit 0 ;;
     malformed)
         printf 'not valid json{' > "$out/output.sarif"
         exit 0 ;;

--- a/test/image/test_run_image_dispatch.bats
+++ b/test/image/test_run_image_dispatch.bats
@@ -114,10 +114,76 @@ _run_orch() {
     [ "$(jq '[.runs[].results[]] | length' "$OUT/mocktool/output.sarif")" -gt 0 ]
 }
 
-@test "run.sh image dispatch: tool error -> exit 2" {
+@test "run.sh image dispatch: tool error -> exit 2 and an error marker" {
     printf 'error' > "$SRC/MODE"
     _run_orch mocktool
     [ "$status" -eq 2 ]
+    # The marker lets check_results catch the failure even under continue-on-error
+    # (and honor an :info policy on the error).
+    [ -f "$OUT/mocktool/error" ]
+}
+
+@test "run.sh image dispatch: an errored tool among several -> exit 2" {
+    # Two tools, both erroring, in one run; overall status must reach 2 (an error
+    # is never downgraded).
+    printf 'error' > "$SRC/MODE"
+    cat > "$TOOLS/catalog.json" <<JSON
+{"tools":{"toola":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE"},"toolb":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE"}}}
+JSON
+    _run_orch toola toolb
+    [ "$status" -eq 2 ]
+}
+
+@test "run.sh image dispatch: run timeout -> exit 2" {
+    printf 'slow' > "$SRC/MODE"
+    WRANGLE_TOOLS_DIR="$TOOLS" WRANGLE_ADAPTER_TIMEOUT=1 \
+        run "$RUN_SH" -s "$SRC" -o "$OUT" mocktool
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"timed out"* ]]
+}
+
+@test "run.sh image dispatch: two image tools land in distinct dirs without clobbering" {
+    printf 'clean' > "$SRC/MODE"
+    cat > "$TOOLS/catalog.json" <<JSON
+{"tools":{"toola":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE"},"toolb":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE"}}}
+JSON
+    _run_orch toola toolb
+    [ "$status" -eq 0 ]
+    [ -f "$OUT/toola/output.sarif" ]
+    [ -f "$OUT/toolb/output.sarif" ]
+}
+
+@test "run.sh image dispatch: writes the scan/v1 manifest for a wired tool token" {
+    # run.sh's shared post-run path writes the scan/v1 manifest for osv/wrangle-lint/
+    # zizmor tokens. Drive it deterministically with the mock image under the osv key.
+    printf 'clean' > "$SRC/MODE"
+    cat > "$TOOLS/catalog.json" <<JSON
+{"tools":{"osv":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE"}}}
+JSON
+    _run_orch osv
+    [ "$status" -eq 0 ]
+    local manifest="$OUT/osv/wrangle_attestation_metadata.json"
+    [ -f "$manifest" ]
+    [ "$(jq -r '."predicate-type"' "$manifest")" = "https://github.com/TomHennen/wrangle/attestation/scan/v1" ]
+    [ "$(jq -r '.tool.name' "$manifest")" = "osv-scanner" ]
+    [ "$(jq -r '.result' "$manifest")" = "clean" ]
+}
+
+@test "run.sh image dispatch: no scan manifest for an unwired tool token" {
+    printf 'clean' > "$SRC/MODE"
+    _run_orch mocktool
+    [ "$status" -eq 0 ]
+    [ ! -f "$OUT/mocktool/wrangle_attestation_metadata.json" ]
+}
+
+@test "run.sh image dispatch: an undeclared host GITHUB_TOKEN never reaches the container" {
+    # With no catalog secret:, docker gets only the -e flags run_tool_image builds;
+    # a host GITHUB_TOKEN must not be among them. The mock records what it saw.
+    printf 'secret' > "$SRC/MODE"
+    WRANGLE_TOOLS_DIR="$TOOLS" GITHUB_TOKEN="ghs_should_not_leak" \
+        run "$RUN_SH" -s "$SRC" -o "$OUT" mocktool
+    [ "$status" -eq 0 ]
+    [ -z "$(cat "$OUT/mocktool/github_token_seen")" ]
 }
 
 @test "run.sh image dispatch: writes output.sarif into output_dir/<tool>/" {
@@ -293,4 +359,15 @@ JSON
     [ "$(jq -r '."predicate-type"' "$meta/wrangle_attestation_metadata.json")" = "https://spdx.dev/Document" ]
     [ "$(jq -r '."result-file"' "$meta/wrangle_attestation_metadata.json")" = "sbom.spdx.json" ]
     [ ! -d "$meta/mocktool" ]
+}
+
+@test "generate_sbom: fails closed when the dispatched tool errors" {
+    # The image errors and writes no SBOM (a failed VSA gate / tool error looks
+    # the same). run.sh returns 2; generate_sbom must propagate, not relocate.
+    _sbom_catalog
+    printf 'sbom-error' > "$SRC/MODE"
+    local meta="$TMP_DIR/meta"
+    WRANGLE_TOOLS_DIR="$TOOLS" run "$ORIG_DIR/lib/generate_sbom.sh" "$SRC" "$meta" mocktool
+    [ "$status" -ne 0 ]
+    [ ! -f "$meta/sbom.spdx.json" ]
 }

--- a/test/image/test_run_image_dispatch.bats
+++ b/test/image/test_run_image_dispatch.bats
@@ -4,7 +4,7 @@
 # docs/tool_container_design.md §3.5): a tool whose catalog entry declares
 # delivery: image is run via `docker run` under the contract sandbox, writing
 # the SAME ${output_dir}/${tool}/output.sarif the downstream collectors consume,
-# with the 0/1/2 exit contract mapped. Adapter-path tools are unaffected.
+# with the 0/1/2 exit contract mapped.
 #
 # Needs docker, so it lives under test/image/ (outside the Makefile's unit
 # `bats` glob, which expands test/ non-recursively) and runs in the dogfooded
@@ -77,7 +77,7 @@ setup() {
     SRC="$TMP_DIR/src"
     OUT="$TMP_DIR/out"
     TOOLS="$TMP_DIR/tools"
-    mkdir -p "$SRC" "$OUT" "$TOOLS/mocktool" "$TOOLS/adaptertool"
+    mkdir -p "$SRC" "$OUT" "$TOOLS/mocktool"
 
     # MOCK_IMAGE is the local-registry digest pin from setup_file (a real,
     # engine-portable repo digest, which run.sh's digest-pin check requires).
@@ -88,16 +88,6 @@ setup() {
     cat > "$TOOLS/catalog.json" <<JSON
 {"tools":{"mocktool":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE"}}}
 JSON
-
-    # An adapter-path tool sharing the same run, to prove the adapter seam is
-    # untouched when a catalog image tool is present.
-    cat > "$TOOLS/adaptertool/adapter.sh" <<'ADAPT'
-#!/bin/bash
-set -euo pipefail
-printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"adaptertool"}},"results":[]}]}\n' > "$2/output.sarif"
-exit 0
-ADAPT
-    chmod +x "$TOOLS/adaptertool/adapter.sh"
 }
 
 teardown() {
@@ -153,27 +143,6 @@ _run_orch() {
     [ "$status" -eq 0 ]
     # /src is mounted read-only; confirm the source tree is untouched.
     [ "$(find "$SRC" -type f | wc -l | tr -d ' ')" -eq "$before" ]
-}
-
-@test "run.sh: adapter-path tool is unaffected alongside an image tool" {
-    printf 'clean' > "$SRC/MODE"
-    _run_orch mocktool adaptertool
-    [ "$status" -eq 0 ]
-    [ -f "$OUT/mocktool/output.sarif" ]
-    [ -f "$OUT/adaptertool/output.sarif" ]
-    grep -q '"name":"adaptertool"' "$OUT/adaptertool/output.sarif"
-}
-
-@test "run.sh: a delivery: adapter catalog entry still runs the adapter" {
-    # An entry that names the tool but declares delivery: adapter must NOT be
-    # dispatched via docker — it falls through to the in-process adapter.
-    cat > "$TOOLS/catalog.json" <<'JSON'
-{"tools":{"adaptertool":{"kind":"scan","delivery":"adapter"}}}
-JSON
-    _run_orch adaptertool
-    [ "$status" -eq 0 ]
-    [ -f "$OUT/adaptertool/output.sarif" ]
-    grep -q '"name":"adaptertool"' "$OUT/adaptertool/output.sarif"
 }
 
 @test "run.sh image dispatch: a declared secret reaches the container env" {

--- a/test/test_generate_sbom.bats
+++ b/test/test_generate_sbom.bats
@@ -4,8 +4,10 @@
 # curated container SBOM tool through run.sh and lifts its <tool>/ outputs up to
 # the metadata-dir root the attest engine discovers.
 #
-# Drives run.sh's adapter path via a stub tool (WRANGLE_TOOLS_DIR), so the
-# relocation and fail-closed glue are exercised without docker.
+# Drives run.sh's image dispatch via a mock `docker` on PATH, so the relocation
+# and fail-closed glue are exercised without a real container.
+
+DIGEST="sha256:$(printf '0%.0s' {1..64})"
 
 setup() {
     ORIG_DIR="$(pwd)"
@@ -14,23 +16,48 @@ setup() {
     SRC="$TEST_DIR/src"
     META="$TEST_DIR/meta"
     TOOLS="$TEST_DIR/tools"
-    mkdir -p "$SRC" "$TOOLS/stubsbom"
+    BIN_DIR="$TEST_DIR/bin"
+    MOCK_SPEC="$TEST_DIR/spec"
+    mkdir -p "$SRC" "$TOOLS" "$BIN_DIR" "$MOCK_SPEC"
+    export MOCK_SPEC
     printf 'source\n' > "$SRC/file.txt"
+    command -v jq >/dev/null 2>&1 || { printf 'jq not on PATH\n' >&2; return 1; }
 
-    # A stub sbom-kind adapter: writes sbom.spdx.json, exit 0. No catalog, so
-    # run.sh takes the adapter path (no docker); its shared post-run step writes
-    # the spdx attest manifest just as the image path would.
-    cat > "$TOOLS/stubsbom/adapter.sh" <<'ADAPT'
-#!/bin/bash
-set -euo pipefail
-printf '{"spdxVersion":"SPDX-2.3"}\n' > "$2/sbom.spdx.json"
+    export WRANGLE_VERIFY_TOOL_IMAGES=0
+
+    # Mock `docker`: derive the tool from the /output mount and replay
+    # $MOCK_SPEC/<tool>.{sbom,exit} into it — the sbom-kind image's behavior.
+    cat > "$BIN_DIR/docker" <<'DOCKER'
+#!/usr/bin/env bash
+set -u
+out="" ; prev=""
+for a in "$@"; do
+    [[ "$prev" == "-v" && "$a" == *:/output ]] && out="${a%:/output}"
+    prev="$a"
+done
+[[ -n "$out" ]] || { printf 'mock docker: no /output mount\n' >&2; exit 96; }
+tool="$(basename "$out")"
+spec="$MOCK_SPEC/$tool"
+[[ -f "$spec.sbom" ]] && cp "$spec.sbom" "$out/sbom.spdx.json"
+[[ -f "$spec.exit" ]] && exit "$(cat "$spec.exit")"
 exit 0
-ADAPT
-    chmod +x "$TOOLS/stubsbom/adapter.sh"
+DOCKER
+    chmod +x "$BIN_DIR/docker"
+    export PATH="$BIN_DIR:$PATH"
 }
 
 teardown() {
     rm -rf "$TEST_DIR"
+}
+
+# _sbom_tool <tool> — declare <tool> as a kind: sbom delivery: image tool.
+_sbom_tool() {
+    local cat="$TOOLS/catalog.json" tmp
+    [[ -f "$cat" ]] || printf '{"tools":{}}' > "$cat"
+    tmp="$(mktemp)"
+    jq --arg t "$1" --arg img "ghcr.io/tomhennen/wrangle/$1@$DIGEST" \
+        '.tools[$t] = {kind:"sbom", delivery:"image", image:$img}' "$cat" > "$tmp"
+    mv "$tmp" "$cat"
 }
 
 _run_gen() {
@@ -44,6 +71,9 @@ _run_gen() {
 }
 
 @test "generate_sbom: lifts SBOM + manifest to the metadata-dir root" {
+    _sbom_tool stubsbom
+    printf '{"spdxVersion":"SPDX-2.3"}\n' > "$MOCK_SPEC/stubsbom.sbom"
+    printf '0' > "$MOCK_SPEC/stubsbom.exit"
     _run_gen "$SRC" "$META" stubsbom
     [ "$status" -eq 0 ]
     [ -f "$META/sbom.spdx.json" ]
@@ -53,6 +83,9 @@ _run_gen() {
 }
 
 @test "generate_sbom: manifest names the SPDX predicate and result file" {
+    _sbom_tool stubsbom
+    printf '{"spdxVersion":"SPDX-2.3"}\n' > "$MOCK_SPEC/stubsbom.sbom"
+    printf '0' > "$MOCK_SPEC/stubsbom.exit"
     _run_gen "$SRC" "$META" stubsbom
     [ "$status" -eq 0 ]
     [ "$(jq -r '."predicate-type"' "$META/wrangle_attestation_metadata.json")" = "https://spdx.dev/Document" ]
@@ -60,9 +93,11 @@ _run_gen() {
 }
 
 @test "generate_sbom: defaults the tool to the sbom slot when none is given" {
-    # No catalog in the mock tools dir, so a stub sbom/ dir dispatches via the
-    # adapter path — exercising the ${3:-sbom} default without docker.
-    cp -r "$TOOLS/stubsbom" "$TOOLS/sbom"
+    # No tool arg -> the ${3:-sbom} default; the catalog's sbom entry dispatches
+    # via the image path (image tools need no local directory).
+    _sbom_tool sbom
+    printf '{"spdxVersion":"SPDX-2.3"}\n' > "$MOCK_SPEC/sbom.sbom"
+    printf '0' > "$MOCK_SPEC/sbom.exit"
     _run_gen "$SRC" "$META"
     [ "$status" -eq 0 ]
     [ -f "$META/sbom.spdx.json" ]
@@ -70,13 +105,10 @@ _run_gen() {
 }
 
 @test "generate_sbom: fails closed when the dispatched tool errors" {
-    # A stub that produces no SBOM and exits 2 (the shape of a failed VSA gate /
+    # A tool that produces no SBOM and exits 2 (the shape of a failed VSA gate /
     # tool error). run.sh returns 2; generate_sbom must propagate, not relocate.
-    cat > "$TOOLS/stubsbom/adapter.sh" <<'ADAPT'
-#!/bin/bash
-exit 2
-ADAPT
-    chmod +x "$TOOLS/stubsbom/adapter.sh"
+    _sbom_tool stubsbom
+    printf '2' > "$MOCK_SPEC/stubsbom.exit"
     _run_gen "$SRC" "$META" stubsbom
     [ "$status" -ne 0 ]
     [ ! -f "$META/sbom.spdx.json" ]

--- a/test/test_generate_sbom.bats
+++ b/test/test_generate_sbom.bats
@@ -1,115 +1,12 @@
 #!/usr/bin/env bats
 
-# Tests for lib/generate_sbom.sh — the build-composite SBOM dispatch that runs a
-# curated container SBOM tool through run.sh and lifts its <tool>/ outputs up to
-# the metadata-dir root the attest engine discovers.
-#
-# Drives run.sh's image dispatch via a mock `docker` on PATH, so the relocation
-# and fail-closed glue are exercised without a real container.
-
-DIGEST="sha256:$(printf '0%.0s' {1..64})"
-
-setup() {
-    ORIG_DIR="$(pwd)"
-    TEST_DIR="$(mktemp -d)"
-    export ORIG_DIR TEST_DIR
-    SRC="$TEST_DIR/src"
-    META="$TEST_DIR/meta"
-    TOOLS="$TEST_DIR/tools"
-    BIN_DIR="$TEST_DIR/bin"
-    MOCK_SPEC="$TEST_DIR/spec"
-    mkdir -p "$SRC" "$TOOLS" "$BIN_DIR" "$MOCK_SPEC"
-    export MOCK_SPEC
-    printf 'source\n' > "$SRC/file.txt"
-    command -v jq >/dev/null 2>&1 || { printf 'jq not on PATH\n' >&2; return 1; }
-
-    export WRANGLE_VERIFY_TOOL_IMAGES=0
-
-    # Mock `docker`: derive the tool from the /output mount and replay
-    # $MOCK_SPEC/<tool>.{sbom,exit} into it — the sbom-kind image's behavior.
-    cat > "$BIN_DIR/docker" <<'DOCKER'
-#!/usr/bin/env bash
-set -u
-out="" ; prev=""
-for a in "$@"; do
-    [[ "$prev" == "-v" && "$a" == *:/output ]] && out="${a%:/output}"
-    prev="$a"
-done
-[[ -n "$out" ]] || { printf 'mock docker: no /output mount\n' >&2; exit 96; }
-tool="$(basename "$out")"
-spec="$MOCK_SPEC/$tool"
-[[ -f "$spec.sbom" ]] && cp "$spec.sbom" "$out/sbom.spdx.json"
-[[ -f "$spec.exit" ]] && exit "$(cat "$spec.exit")"
-exit 0
-DOCKER
-    chmod +x "$BIN_DIR/docker"
-    export PATH="$BIN_DIR:$PATH"
-}
-
-teardown() {
-    rm -rf "$TEST_DIR"
-}
-
-# _sbom_tool <tool> — declare <tool> as a kind: sbom delivery: image tool.
-_sbom_tool() {
-    local cat="$TOOLS/catalog.json" tmp
-    [[ -f "$cat" ]] || printf '{"tools":{}}' > "$cat"
-    tmp="$(mktemp)"
-    jq --arg t "$1" --arg img "ghcr.io/tomhennen/wrangle/$1@$DIGEST" \
-        '.tools[$t] = {kind:"sbom", delivery:"image", image:$img}' "$cat" > "$tmp"
-    mv "$tmp" "$cat"
-}
-
-_run_gen() {
-    WRANGLE_TOOLS_DIR="$TOOLS" run "$ORIG_DIR/lib/generate_sbom.sh" "$@"
-}
+# Unit test for lib/generate_sbom.sh's docker-independent guard. The dispatch +
+# relocation behavior (running a curated SBOM image through run.sh and lifting
+# its <tool>/ outputs to the metadata-dir root) needs a real container, so it is
+# covered in test/image/test_run_image_dispatch.bats.
 
 @test "generate_sbom: rejects wrong argument count" {
-    _run_gen "$SRC"
+    run "$(pwd)/lib/generate_sbom.sh" "$(pwd)"
     [ "$status" -eq 2 ]
     [[ "$output" == *"Usage:"* ]]
-}
-
-@test "generate_sbom: lifts SBOM + manifest to the metadata-dir root" {
-    _sbom_tool stubsbom
-    printf '{"spdxVersion":"SPDX-2.3"}\n' > "$MOCK_SPEC/stubsbom.sbom"
-    printf '0' > "$MOCK_SPEC/stubsbom.exit"
-    _run_gen "$SRC" "$META" stubsbom
-    [ "$status" -eq 0 ]
-    [ -f "$META/sbom.spdx.json" ]
-    [ -f "$META/wrangle_attestation_metadata.json" ]
-    # The per-tool subdir run.sh wrote into is emptied and removed.
-    [ ! -d "$META/stubsbom" ]
-}
-
-@test "generate_sbom: manifest names the SPDX predicate and result file" {
-    _sbom_tool stubsbom
-    printf '{"spdxVersion":"SPDX-2.3"}\n' > "$MOCK_SPEC/stubsbom.sbom"
-    printf '0' > "$MOCK_SPEC/stubsbom.exit"
-    _run_gen "$SRC" "$META" stubsbom
-    [ "$status" -eq 0 ]
-    [ "$(jq -r '."predicate-type"' "$META/wrangle_attestation_metadata.json")" = "https://spdx.dev/Document" ]
-    [ "$(jq -r '."result-file"' "$META/wrangle_attestation_metadata.json")" = "sbom.spdx.json" ]
-}
-
-@test "generate_sbom: defaults the tool to the sbom slot when none is given" {
-    # No tool arg -> the ${3:-sbom} default; the catalog's sbom entry dispatches
-    # via the image path (image tools need no local directory).
-    _sbom_tool sbom
-    printf '{"spdxVersion":"SPDX-2.3"}\n' > "$MOCK_SPEC/sbom.sbom"
-    printf '0' > "$MOCK_SPEC/sbom.exit"
-    _run_gen "$SRC" "$META"
-    [ "$status" -eq 0 ]
-    [ -f "$META/sbom.spdx.json" ]
-    [ ! -d "$META/sbom" ]
-}
-
-@test "generate_sbom: fails closed when the dispatched tool errors" {
-    # A tool that produces no SBOM and exits 2 (the shape of a failed VSA gate /
-    # tool error). run.sh returns 2; generate_sbom must propagate, not relocate.
-    _sbom_tool stubsbom
-    printf '2' > "$MOCK_SPEC/stubsbom.exit"
-    _run_gen "$SRC" "$META" stubsbom
-    [ "$status" -ne 0 ]
-    [ ! -f "$META/sbom.spdx.json" ]
 }

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -1,209 +1,54 @@
 #!/usr/bin/env bats
 
-# Tests for run.sh (orchestrator)
-# Uses mock tool directories with mock install/adapter scripts.
+# Tests for run.sh (orchestrator): the hermetic parse/selection seam and the
+# path-independent post-run logic (0/1/2 exit mapping, scan/v1 manifest, error
+# marker). run.sh dispatches every tool via its catalog image, so a mock `docker`
+# on PATH stands in for the container — it derives the tool from the /output
+# mount and replays a per-tool exit code + SARIF. Real image dispatch (sandbox,
+# secret, network, uid ownership) is covered against a built image in
+# test/image/test_run_image_dispatch.bats.
+
+DIGEST="sha256:$(printf '0%.0s' {1..64})"
 
 setup() {
     TEST_DIR="$(mktemp -d)"
-    export TEST_DIR
     ORIG_DIR="$(pwd)"
-    export ORIG_DIR
+    export TEST_DIR ORIG_DIR
 
-    # Forward the golden-SARIF fixtures dir to the mock osv adapter.
-    export WRANGLE_EXTRA_FIXTURES="$ORIG_DIR/test/fixtures"
+    MOCK_TOOLS="$TEST_DIR/tools"
+    BIN_DIR="$TEST_DIR/bin"
+    MOCK_SPEC="$TEST_DIR/spec"
+    mkdir -p "$MOCK_TOOLS" "$BIN_DIR" "$MOCK_SPEC" "$TEST_DIR/src" "$TEST_DIR/output"
+    export MOCK_TOOLS MOCK_SPEC
+    command -v jq >/dev/null 2>&1 || { printf 'jq not on PATH\n' >&2; return 1; }
 
-    # Create a mock tools directory structure that run.sh can find
-    export MOCK_TOOLS="$TEST_DIR/tools"
+    # Curated-image VSA verification needs Sigstore; disabled for the mock images,
+    # whose refs carry no real attestation.
+    export WRANGLE_VERIFY_TOOL_IMAGES=0
 
-    # Create a clean tool (exit 0)
-    mkdir -p "$MOCK_TOOLS/clean-tool"
-    cat > "$MOCK_TOOLS/clean-tool/install.sh" << 'INST'
-#!/bin/bash
-set -euo pipefail
-printf 'wrangle: installed clean-tool\n'
+    # Mock `docker`: on `docker run ... -v OUT:/output ... -- image /src /output`,
+    # derive the tool from the /output mount, replay $MOCK_SPEC/<tool>.{sarif,exit}
+    # (and .sleep, for the timeout test), and refuse if a host secret leaked onto
+    # an -e flag — the container must never see GITHUB_TOKEN.
+    cat > "$BIN_DIR/docker" <<'DOCKER'
+#!/usr/bin/env bash
+set -u
+out="" ; prev=""
+for a in "$@"; do
+    [[ "$prev" == "-v" && "$a" == *:/output ]] && out="${a%:/output}"
+    [[ "$a" == GITHUB_TOKEN* ]] && { printf 'mock docker: GITHUB_TOKEN reached the container\n' >&2; exit 97; }
+    prev="$a"
+done
+[[ -n "$out" ]] || { printf 'mock docker: no /output mount\n' >&2; exit 96; }
+tool="$(basename "$out")"
+spec="$MOCK_SPEC/$tool"
+[[ -f "$spec.sarif" ]] && cp "$spec.sarif" "$out/output.sarif"
+[[ -f "$spec.sleep" ]] && sleep "$(cat "$spec.sleep")"
+[[ -f "$spec.exit" ]] && exit "$(cat "$spec.exit")"
 exit 0
-INST
-    chmod +x "$MOCK_TOOLS/clean-tool/install.sh"
-
-    cat > "$MOCK_TOOLS/clean-tool/adapter.sh" << 'ADAPT'
-#!/bin/bash
-set -euo pipefail
-cat > "$2/output.sarif" << 'SARIF'
-{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"clean-tool"}},"results":[]}]}
-SARIF
-exit 0
-ADAPT
-    chmod +x "$MOCK_TOOLS/clean-tool/adapter.sh"
-
-    # Create a findings tool (exit 1)
-    mkdir -p "$MOCK_TOOLS/findings-tool"
-    cat > "$MOCK_TOOLS/findings-tool/install.sh" << 'INST'
-#!/bin/bash
-set -euo pipefail
-printf 'wrangle: installed findings-tool\n'
-exit 0
-INST
-    chmod +x "$MOCK_TOOLS/findings-tool/install.sh"
-
-    cat > "$MOCK_TOOLS/findings-tool/adapter.sh" << 'ADAPT'
-#!/bin/bash
-set -euo pipefail
-cat > "$2/output.sarif" << 'SARIF'
-{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"findings-tool"}},"results":[{"ruleId":"TEST-1","message":{"text":"found"}}]}]}
-SARIF
-exit 1
-ADAPT
-    chmod +x "$MOCK_TOOLS/findings-tool/adapter.sh"
-
-    # Create an error tool (exit 2)
-    mkdir -p "$MOCK_TOOLS/error-tool"
-    cat > "$MOCK_TOOLS/error-tool/install.sh" << 'INST'
-#!/bin/bash
-set -euo pipefail
-printf 'wrangle: installed error-tool\n'
-exit 0
-INST
-    chmod +x "$MOCK_TOOLS/error-tool/install.sh"
-
-    cat > "$MOCK_TOOLS/error-tool/adapter.sh" << 'ADAPT'
-#!/bin/bash
-set -euo pipefail
-exit 2
-ADAPT
-    chmod +x "$MOCK_TOOLS/error-tool/adapter.sh"
-
-    # Create a tool with failing install
-    mkdir -p "$MOCK_TOOLS/bad-install"
-    cat > "$MOCK_TOOLS/bad-install/install.sh" << 'INST'
-#!/bin/bash
-set -euo pipefail
-printf 'wrangle: install failed\n' >&2
-exit 1
-INST
-    chmod +x "$MOCK_TOOLS/bad-install/install.sh"
-
-    cat > "$MOCK_TOOLS/bad-install/adapter.sh" << 'ADAPT'
-#!/bin/bash
-exit 0
-ADAPT
-    chmod +x "$MOCK_TOOLS/bad-install/adapter.sh"
-
-    # Create a slow tool for timeout testing
-    mkdir -p "$MOCK_TOOLS/slow-tool"
-    cat > "$MOCK_TOOLS/slow-tool/install.sh" << 'INST'
-#!/bin/bash
-set -euo pipefail
-printf 'wrangle: installed slow-tool\n'
-exit 0
-INST
-    chmod +x "$MOCK_TOOLS/slow-tool/install.sh"
-
-    cat > "$MOCK_TOOLS/slow-tool/adapter.sh" << 'ADAPT'
-#!/bin/bash
-set -euo pipefail
-sleep 30
-exit 0
-ADAPT
-    chmod +x "$MOCK_TOOLS/slow-tool/adapter.sh"
-
-    # Create a tool with slow install for timeout testing
-    mkdir -p "$MOCK_TOOLS/slow-install"
-    cat > "$MOCK_TOOLS/slow-install/install.sh" << 'INST'
-#!/bin/bash
-set -euo pipefail
-sleep 30
-exit 0
-INST
-    chmod +x "$MOCK_TOOLS/slow-install/install.sh"
-
-    cat > "$MOCK_TOOLS/slow-install/adapter.sh" << 'ADAPT'
-#!/bin/bash
-exit 0
-ADAPT
-    chmod +x "$MOCK_TOOLS/slow-install/adapter.sh"
-
-    # Create a tool that checks its environment (for isolation tests)
-    mkdir -p "$MOCK_TOOLS/env-check"
-    cat > "$MOCK_TOOLS/env-check/install.sh" << 'INST'
-#!/bin/bash
-set -euo pipefail
-exit 0
-INST
-    chmod +x "$MOCK_TOOLS/env-check/install.sh"
-
-    cat > "$MOCK_TOOLS/env-check/adapter.sh" << 'ADAPT'
-#!/bin/bash
-set -euo pipefail
-# Dump environment to output for test inspection
-env | sort > "$2/env_dump.txt"
-cat > "$2/output.sarif" << 'SARIF'
-{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"env-check"}},"results":[]}]}
-SARIF
-exit 0
-ADAPT
-    chmod +x "$MOCK_TOOLS/env-check/adapter.sh"
-
-    # Create a tool that writes outside its output directory (for filesystem check test)
-    mkdir -p "$MOCK_TOOLS/rogue-tool"
-    cat > "$MOCK_TOOLS/rogue-tool/install.sh" << 'INST'
-#!/bin/bash
-set -euo pipefail
-exit 0
-INST
-    chmod +x "$MOCK_TOOLS/rogue-tool/install.sh"
-
-    cat > "$MOCK_TOOLS/rogue-tool/adapter.sh" << 'ADAPT'
-#!/bin/bash
-set -euo pipefail
-# Write output normally
-cat > "$2/output.sarif" << 'SARIF'
-{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"rogue-tool"}},"results":[]}]}
-SARIF
-# Also write outside output_dir (into src_dir) — should trigger warning
-echo "rogue file" > "$1/rogue_file.txt"
-exit 0
-ADAPT
-    chmod +x "$MOCK_TOOLS/rogue-tool/adapter.sh"
-
-    # Mock osv tool: run.sh writes a scan/v1 manifest for the osv token.
-    # Copies a golden SARIF (findings/empty) per WRANGLE_EXTRA_RESULTS, with the
-    # fixtures dir forwarded as WRANGLE_EXTRA_FIXTURES (run.sh strips env but
-    # forwards WRANGLE_EXTRA_*); tool name/version come from the golden driver.
-    mkdir -p "$MOCK_TOOLS/osv"
-    cat > "$MOCK_TOOLS/osv/install.sh" << 'INST'
-#!/bin/bash
-set -euo pipefail
-exit 0
-INST
-    chmod +x "$MOCK_TOOLS/osv/install.sh"
-
-    cat > "$MOCK_TOOLS/osv/adapter.sh" << 'ADAPT'
-#!/bin/bash
-set -euo pipefail
-if [[ "${RESULTS:-}" == "findings" ]]; then
-    cp "${FIXTURES}/findings.sarif" "$2/output.sarif"
-    exit 1
-fi
-cp "${FIXTURES}/empty.sarif" "$2/output.sarif"
-exit 0
-ADAPT
-    chmod +x "$MOCK_TOOLS/osv/adapter.sh"
-
-    # Mock wrangle-lint adapter: like osv, run.sh writes a scan/v1 manifest for
-    # the wrangle-lint token. Its SARIF driver name is wrangle-lint.
-    mkdir -p "$MOCK_TOOLS/wrangle-lint"
-    cat > "$MOCK_TOOLS/wrangle-lint/adapter.sh" << 'ADAPT'
-#!/bin/bash
-set -euo pipefail
-cat > "$2/output.sarif" << 'SARIF'
-{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"wrangle-lint","version":"1.2.3"}},"results":[]}]}
-SARIF
-exit 0
-ADAPT
-    chmod +x "$MOCK_TOOLS/wrangle-lint/adapter.sh"
-
-    # Create test source and output directories
-    mkdir -p "$TEST_DIR/src" "$TEST_DIR/output"
+DOCKER
+    chmod +x "$BIN_DIR/docker"
+    export PATH="$BIN_DIR:$PATH"
 }
 
 teardown() {
@@ -211,268 +56,216 @@ teardown() {
     rm -rf "$TEST_DIR"
 }
 
-# Helper: run the orchestrator with WRANGLE_TOOLS_DIR pointing to our mocks
+# _image_tool <tool> [kind] — declare <tool> as a delivery: image tool in the
+# mock catalog (kind: scan by default), digest-pinned on the curated namespace.
+_image_tool() {
+    local tool="$1" kind="${2:-scan}" cat="$MOCK_TOOLS/catalog.json" tmp
+    [[ -f "$cat" ]] || printf '{"tools":{}}' > "$cat"
+    tmp="$(mktemp)"
+    jq --arg t "$tool" --arg k "$kind" --arg img "ghcr.io/tomhennen/wrangle/$tool@$DIGEST" \
+        '.tools[$t] = {kind:$k, delivery:"image", image:$img}' "$cat" > "$tmp"
+    mv "$tmp" "$cat"
+}
+
+# _spec <tool> <exit> [sarif-file] — set the mock image's replayed exit code and,
+# optionally, the SARIF it writes into /output.
+_spec() {
+    printf '%s' "$2" > "$MOCK_SPEC/$1.exit"
+    if [[ -n "${3:-}" ]]; then cp "$3" "$MOCK_SPEC/$1.sarif"; fi
+}
+
 run_orchestrator() {
     WRANGLE_TOOLS_DIR="$MOCK_TOOLS" run "$ORIG_DIR/run.sh" "$@"
 }
 
-# --- Input validation tests ---
+# --- Input validation / selection tests ---
 
 @test "orchestrator: rejects tool name with path traversal" {
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "../etc/passwd"
-
     [ "$status" -eq 2 ]
     [[ "$output" == *"invalid tool name"* ]]
 }
 
 @test "orchestrator: rejects tool name with semicolon" {
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "foo;curl"
-
     [ "$status" -eq 2 ]
     [[ "$output" == *"invalid tool name"* ]]
 }
 
 @test "orchestrator: rejects tool name with uppercase" {
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "FooBar"
-
     [ "$status" -eq 2 ]
     [[ "$output" == *"invalid tool name"* ]]
 }
 
 @test "orchestrator: rejects tool name starting with number" {
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "1tool"
-
     [ "$status" -eq 2 ]
     [[ "$output" == *"invalid tool name"* ]]
 }
 
 @test "orchestrator: accepts valid tool names" {
-    # Valid: lowercase, starts with letter, may contain digits/hyphens/underscores
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
-
+    _image_tool cleantool
+    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
     [ "$status" -eq 0 ]
 }
 
-@test "orchestrator: rejects unknown tool (no directory)" {
+@test "orchestrator: rejects unknown tool (no directory, no catalog entry)" {
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "nonexistent"
-
     [ "$status" -eq 2 ]
     [[ "$output" == *"unknown tool"* ]]
 }
 
 @test "orchestrator: skips action-pattern tool (directory exists, no adapter.sh)" {
-    # Create a tool directory with action.yml but no adapter.sh
     mkdir -p "$MOCK_TOOLS/action-tool"
     echo "name: test" > "$MOCK_TOOLS/action-tool/action.yml"
-
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "action-tool"
-
     [ "$status" -eq 0 ]
 }
 
 @test "orchestrator: skips action-pattern tool even when an adapter.sh is present" {
     # A tool with an action.yml runs via its uses: step; an adapter.sh present
-    # only as its image entrypoint must not pull it onto the in-process path.
+    # only as its image entrypoint must not pull it onto the run.sh dispatch path.
     mkdir -p "$MOCK_TOOLS/action-img-tool"
     echo "name: test" > "$MOCK_TOOLS/action-img-tool/action.yml"
-    cat > "$MOCK_TOOLS/action-img-tool/adapter.sh" << 'ADAPT'
-#!/bin/bash
-exit 2
-ADAPT
+    printf '#!/bin/bash\nexit 2\n' > "$MOCK_TOOLS/action-img-tool/adapter.sh"
     chmod +x "$MOCK_TOOLS/action-img-tool/adapter.sh"
-
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "action-img-tool"
-
     [ "$status" -eq 0 ]
     [ ! -f "$TEST_DIR/output/action-img-tool/output.sarif" ]
 }
 
 @test "orchestrator: strips policy suffix from tool names" {
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool:fail"
-
+    _image_tool cleantool
+    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool:fail"
     [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/clean-tool/output.sarif" ]
+    [ -f "$TEST_DIR/output/cleantool/output.sarif" ]
 }
 
-@test "orchestrator: skips action-pattern tools in mixed list" {
+@test "orchestrator: skips action-pattern tools in a mixed list" {
+    _image_tool cleantool
+    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
     mkdir -p "$MOCK_TOOLS/action-tool"
     echo "name: test" > "$MOCK_TOOLS/action-tool/action.yml"
-
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool" "action-tool:info"
-
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool" "action-tool:info"
     [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/clean-tool/output.sarif" ]
+    [ -f "$TEST_DIR/output/cleantool/output.sarif" ]
 }
 
-# --- Execution tests ---
+@test "orchestrator: no tools provided prints usage" {
+    run_orchestrator
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Usage"* ]] || [[ "$output" == *"usage"* ]]
+}
+
+# --- Execution: 0/1/2 exit mapping (mock docker) ---
 
 @test "orchestrator: runs clean tool (exit 0)" {
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
-
+    _image_tool cleantool
+    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
     [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/clean-tool/output.sarif" ]
+    [ -f "$TEST_DIR/output/cleantool/output.sarif" ]
 }
 
 @test "orchestrator: runs findings tool (exit 1)" {
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "findings-tool"
-
+    _image_tool findingstool
+    _spec findingstool 1 "$ORIG_DIR/test/fixtures/findings.sarif"
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "findingstool"
     [ "$status" -eq 1 ]
-    [ -f "$TEST_DIR/output/findings-tool/output.sarif" ]
+    [ -f "$TEST_DIR/output/findingstool/output.sarif" ]
 }
 
-@test "orchestrator: runs error tool (exit 2)" {
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "error-tool"
-
+@test "orchestrator: runs error tool (exit 2) and writes an error marker" {
+    _image_tool errortool
+    _spec errortool 2
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "errortool"
     [ "$status" -eq 2 ]
-    # An error marker is written so check_results catches the failure even when
-    # the scan step runs under continue-on-error (and honors :info on the error).
-    [ -f "$TEST_DIR/output/error-tool/error" ]
-}
-
-@test "orchestrator: handles install failure (exit 2)" {
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "bad-install"
-
-    [ "$status" -eq 2 ]
-    [ -f "$TEST_DIR/output/bad-install/error" ]
+    # The marker lets check_results catch the failure even under continue-on-error
+    # (and honor :info on the error).
+    [ -f "$TEST_DIR/output/errortool/error" ]
 }
 
 @test "orchestrator: runs multiple tools" {
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool" "findings-tool"
-
-    # Findings from one tool means exit 1
+    _image_tool cleantool
+    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
+    _image_tool findingstool
+    _spec findingstool 1 "$ORIG_DIR/test/fixtures/findings.sarif"
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool" "findingstool"
     [ "$status" -eq 1 ]
-    [ -f "$TEST_DIR/output/clean-tool/output.sarif" ]
-    [ -f "$TEST_DIR/output/findings-tool/output.sarif" ]
+    [ -f "$TEST_DIR/output/cleantool/output.sarif" ]
+    [ -f "$TEST_DIR/output/findingstool/output.sarif" ]
 }
 
 @test "orchestrator: multiple tools land in distinct scan/<tool> dirs without clobbering" {
-    # The build workflows fold this output into the unified metadata's scan/.
-    # If a future change collapsed the per-tool subdir, the second tool would
-    # overwrite the first's output.sarif and the merge would silently become a
-    # clobber. Run two tools and assert both survive AND keep their own content.
+    # The build workflows fold this output into the unified metadata's scan/. If a
+    # future change collapsed the per-tool subdir, the second tool would overwrite
+    # the first's output.sarif. Run two and assert both survive with their content.
     for t in osv zizmor; do
-        mkdir -p "$MOCK_TOOLS/$t"
-        printf '#!/bin/bash\nexit 0\n' > "$MOCK_TOOLS/$t/install.sh"
-        chmod +x "$MOCK_TOOLS/$t/install.sh"
-        cat > "$MOCK_TOOLS/$t/adapter.sh" << ADAPT
-#!/bin/bash
-set -euo pipefail
-printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"$t"}},"results":[]}]}\n' > "\$2/output.sarif"
-exit 0
-ADAPT
-        chmod +x "$MOCK_TOOLS/$t/adapter.sh"
+        _image_tool "$t"
+        printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"%s"}},"results":[]}]}\n' "$t" \
+            > "$MOCK_SPEC/$t.sarif"
+        printf '0' > "$MOCK_SPEC/$t.exit"
     done
-
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv" "zizmor"
     [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/osv/output.sarif" ]
-    [ -f "$TEST_DIR/output/zizmor/output.sarif" ]
-    # Each subdir kept its own tool's SARIF — no cross-tool overwrite.
     grep -q '"name":"osv"' "$TEST_DIR/output/osv/output.sarif"
     grep -q '"name":"zizmor"' "$TEST_DIR/output/zizmor/output.sarif"
 }
 
 @test "orchestrator: error takes precedence over findings" {
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool" "error-tool"
-
+    _image_tool cleantool
+    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
+    _image_tool errortool
+    _spec errortool 2
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool" "errortool"
     [ "$status" -eq 2 ]
 }
 
 @test "orchestrator: prints summary table" {
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
-
-    [[ "$output" == *"clean-tool"* ]]
+    _image_tool cleantool
+    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
+    [[ "$output" == *"cleantool"* ]]
 }
-
-# --- Default options tests ---
 
 @test "orchestrator: uses default src_dir and output_dir" {
+    _image_tool cleantool
+    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
     cd "$TEST_DIR/src"
     mkdir -p metadata
-    WRANGLE_TOOLS_DIR="$MOCK_TOOLS" run "$ORIG_DIR/run.sh" "clean-tool"
-
+    WRANGLE_TOOLS_DIR="$MOCK_TOOLS" run "$ORIG_DIR/run.sh" "cleantool"
     [ "$status" -eq 0 ]
 }
 
-@test "orchestrator: no tools provided prints usage" {
-    run_orchestrator
-
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"Usage"* ]] || [[ "$output" == *"usage"* ]]
-}
-
-# --- Path resolution tests ---
-
-# --- Timeout tests ---
-
-@test "orchestrator: adapter timeout produces exit 2" {
+@test "orchestrator: image run timeout produces exit 2" {
+    _image_tool slowtool
+    _spec slowtool 0
+    printf '30' > "$MOCK_SPEC/slowtool.sleep"
     WRANGLE_TOOLS_DIR="$MOCK_TOOLS" WRANGLE_ADAPTER_TIMEOUT=1 \
-        run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" "slow-tool"
-
+        run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" "slowtool"
     [ "$status" -eq 2 ]
     [[ "$output" == *"timed out"* ]]
 }
 
-@test "orchestrator: install timeout produces exit 2" {
-    WRANGLE_TOOLS_DIR="$MOCK_TOOLS" WRANGLE_INSTALL_TIMEOUT=1 \
-        run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" "slow-install"
-
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"timed out"* ]]
-}
-
-# --- Path resolution tests ---
-
-# --- Environment isolation tests ---
-
-@test "orchestrator: strips GITHUB_TOKEN from adapter environment" {
+@test "orchestrator: GITHUB_TOKEN never reaches the container" {
+    # docker gets only the -e flags run_tool_image builds; a host GITHUB_TOKEN
+    # must not be among them. The mock docker exits 97 if it sees one.
+    _image_tool cleantool
+    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
     export GITHUB_TOKEN="secret-token-value"
-    WRANGLE_TOOLS_DIR="$MOCK_TOOLS" run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" "env-check"
-
-    [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/env-check/env_dump.txt" ]
-    # GITHUB_TOKEN must not be in the adapter's environment
-    ! grep -q "GITHUB_TOKEN" "$TEST_DIR/output/env-check/env_dump.txt"
-}
-
-@test "orchestrator: forwards WRANGLE_EXTRA_ vars with prefix stripped" {
-    export WRANGLE_EXTRA_MY_VAR="test-value"
-    WRANGLE_TOOLS_DIR="$MOCK_TOOLS" run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" "env-check"
-
-    [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/env-check/env_dump.txt" ]
-    # MY_VAR (without prefix) should be present
-    grep -q "MY_VAR=test-value" "$TEST_DIR/output/env-check/env_dump.txt"
-}
-
-@test "orchestrator: detects filesystem modifications outside output_dir" {
-    WRANGLE_TOOLS_DIR="$MOCK_TOOLS" run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" "rogue-tool"
-
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"WARNING"* ]]
-    [[ "$output" == *"modified files"* ]]
-}
-
-@test "orchestrator: PATH is available to adapter" {
-    WRANGLE_TOOLS_DIR="$MOCK_TOOLS" run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" "env-check"
-
-    [ "$status" -eq 0 ]
-    grep -q "^PATH=" "$TEST_DIR/output/env-check/env_dump.txt"
-}
-
-# --- Path resolution tests ---
-
-@test "orchestrator: resolves tool paths relative to script, not cwd" {
-    # Run from a different directory than the script
-    cd "$TEST_DIR"
-    WRANGLE_TOOLS_DIR="$MOCK_TOOLS" run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
-
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
     [ "$status" -eq 0 ]
 }
 
-# --- scan/v1 attestation manifest (issue #420) ---
+# --- scan/v1 attestation manifest (issue #420), written in run.sh's shared
+# post-run path regardless of how the tool ran ---
 
 @test "orchestrator: writes an osv scan/v1 manifest next to output.sarif (clean)" {
+    _image_tool osv
+    _spec osv 0 "$ORIG_DIR/test/fixtures/empty.sarif"
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv"
     [ "$status" -eq 0 ]
     manifest="$TEST_DIR/output/osv/wrangle_attestation_metadata.json"
@@ -490,14 +283,19 @@ ADAPT
 }
 
 @test "orchestrator: osv manifest records result=findings when osv reports findings" {
-    WRANGLE_EXTRA_RESULTS=findings run_orchestrator \
-        -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv"
+    _image_tool osv
+    _spec osv 1 "$ORIG_DIR/test/fixtures/findings.sarif"
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv"
     [ "$status" -eq 1 ]
     run jq -r '.result' "$TEST_DIR/output/osv/wrangle_attestation_metadata.json"
     [[ "$output" == "findings" ]]
 }
 
 @test "orchestrator: writes a wrangle-lint scan/v1 manifest next to output.sarif" {
+    _image_tool wrangle-lint
+    printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"wrangle-lint","version":"1.2.3"}},"results":[]}]}\n' \
+        > "$MOCK_SPEC/wrangle-lint.sarif"
+    printf '0' > "$MOCK_SPEC/wrangle-lint.exit"
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "wrangle-lint"
     [ "$status" -eq 0 ]
     manifest="$TEST_DIR/output/wrangle-lint/wrangle_attestation_metadata.json"
@@ -510,69 +308,48 @@ ADAPT
     [[ "$output" == "clean" ]]
 }
 
-@test "orchestrator: writes no scan manifest for an unwired adapter" {
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
+@test "orchestrator: writes no scan manifest for an unwired tool" {
+    _image_tool cleantool
+    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
     [ "$status" -eq 0 ]
-    [ ! -f "$TEST_DIR/output/clean-tool/wrangle_attestation_metadata.json" ]
+    [ ! -f "$TEST_DIR/output/cleantool/wrangle_attestation_metadata.json" ]
 }
 
-# --- image delivery: digest-pin enforcement (no docker; regex runs first) ---
+# --- Path resolution ---
 
-# Drive run.sh's image-ref validation directly: the @sha256 check rejects a
-# tag-only image before any docker call, and accepts a registry host:port pin.
-_image_catalog() {
-    # An image tool is "known" by its directory (no adapter.sh — the image is
-    # the adapter); the catalog marks delivery: image.
-    mkdir -p "$TEST_DIR/src" "$MOCK_TOOLS/imgtool"
-    cat > "$MOCK_TOOLS/catalog.json" <<JSON
-{"tools":{"imgtool":{"kind":"scan","delivery":"image","image":"$1"}}}
-JSON
+@test "orchestrator: resolves tool paths relative to script, not cwd" {
+    _image_tool cleantool
+    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
+    cd "$TEST_DIR"
+    WRANGLE_TOOLS_DIR="$MOCK_TOOLS" run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
+    [ "$status" -eq 0 ]
 }
+
+# --- image delivery: digest-pin enforcement (regex runs before any docker) ---
 
 @test "orchestrator: image delivery rejects a tag-only (non-digest-pinned) image" {
-    _image_catalog "registry.internal:5000/osv:latest"
+    cat > "$MOCK_TOOLS/catalog.json" <<JSON
+{"tools":{"imgtool":{"kind":"scan","delivery":"image","image":"registry.internal:5000/osv:latest"}}}
+JSON
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "imgtool"
     [ "$status" -eq 2 ]
     [[ "$output" == *"not digest-pinned"* ]]
 }
 
-@test "orchestrator: image delivery accepts a registry host:port digest pin" {
-    digest="sha256:0000000000000000000000000000000000000000000000000000000000000000"
-    _image_catalog "registry.internal:5000/wrangle-osv@$digest"
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "imgtool"
-    # The pin passes validation, so the digest-pin error never fires; the run
-    # then fails at docker (image absent / docker may be unavailable here).
-    [[ "$output" != *"not digest-pinned"* ]]
-}
-
-# --- catalog-only image tool: admitted with no local tools/<name>/ dir ---
-
 @test "orchestrator: a delivery: image tool with no directory is admitted (not unknown)" {
-    digest="sha256:0000000000000000000000000000000000000000000000000000000000000000"
-    mkdir -p "$TEST_DIR/src"
-    # No $MOCK_TOOLS/byotool directory; the catalog alone defines it.
-    cat > "$MOCK_TOOLS/catalog.json" <<JSON
-{"tools":{"byotool":{"kind":"sbom","delivery":"image","image":"registry.internal:5000/byo@$digest"}}}
-JSON
+    _image_tool byotool sbom
+    _spec byotool 0
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
-    # Reaches the image path rather than the "unknown tool" gate; docker then
-    # fails (image absent / docker may be unavailable), which is not our concern.
     [[ "$output" != *"unknown tool"* ]]
     [[ "$output" == *"running byotool (image)"* ]]
 }
 
-@test "orchestrator: a tool with no directory and no catalog image entry is unknown" {
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "nodir"
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"unknown tool"* ]]
-}
-
 @test "orchestrator: the curated sbom key dispatches as a catalog-only image tool" {
     # The default SBOM path (sbom-tool: sbom) has no tools/sbom/ dir, so it relies
-    # on the dir-gate resolving the real catalog's sbom entry to the image path.
+    # on the parse loop resolving the real catalog's sbom entry to the image path.
     [ ! -d "$ORIG_DIR/tools/sbom" ]
-    mkdir -p "$TEST_DIR/src"
-    WRANGLE_TOOLS_DIR="$ORIG_DIR/tools" WRANGLE_VERIFY_TOOL_IMAGES=0 \
+    WRANGLE_TOOLS_DIR="$ORIG_DIR/tools" \
         run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" sbom
     [[ "$output" != *"unknown tool"* ]]
     [[ "$output" == *"running sbom (image)"* ]]
@@ -589,6 +366,7 @@ _write_custom_tools() {
 
 @test "orchestrator: auto-discovers .wrangle/tools.json and admits a selected new tool" {
     _write_custom_tools "{\"tools\":{\"byotool\":{\"kind\":\"sbom\",\"delivery\":\"image\",\"image\":\"registry.internal:5000/byo@$_byo_digest\"}}}"
+    _spec byotool 0
     GITHUB_WORKSPACE="$TEST_DIR/ws" \
         run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
     [[ "$output" != *"unknown tool"* ]]
@@ -596,11 +374,13 @@ _write_custom_tools() {
 }
 
 @test "orchestrator: no .wrangle/tools.json leaves the default catalog untouched" {
+    _image_tool cleantool
+    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
     mkdir -p "$TEST_DIR/ws" "$TEST_DIR/src"
     GITHUB_WORKSPACE="$TEST_DIR/ws" \
-        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
     [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/clean-tool/output.sarif" ]
+    [ -f "$TEST_DIR/output/cleantool/output.sarif" ]
 }
 
 @test "orchestrator: a .wrangle/tools.json symlink resolving outside the workspace is rejected" {
@@ -608,7 +388,7 @@ _write_custom_tools() {
     printf '{"tools":{}}' > "$TEST_DIR/outside.json"
     ln -s "$TEST_DIR/outside.json" "$TEST_DIR/ws/.wrangle/tools.json"
     GITHUB_WORKSPACE="$TEST_DIR/ws" \
-        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
     [ "$status" -eq 2 ]
     [[ "$output" == *"resolves outside the workspace"* ]]
 }
@@ -622,12 +402,14 @@ _write_custom_tools() {
 }
 
 @test "orchestrator: a custom tool defined but NOT selected is never dispatched" {
-    # Selection gates execution: an injected .wrangle/tools.json entry that the
-    # selection does not name must stay defined-but-never-run (the property that
-    # makes auto-discovery safe under pull_request_target).
+    # Selection gates execution: an injected .wrangle/tools.json entry the
+    # selection does not name stays defined-but-never-run (the property that makes
+    # auto-discovery safe under pull_request_target).
+    _image_tool cleantool
+    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
     _write_custom_tools "{\"tools\":{\"injected\":{\"kind\":\"sbom\",\"delivery\":\"image\",\"image\":\"registry.internal:5000/evil@$_byo_digest\"}}}"
     GITHUB_WORKSPACE="$TEST_DIR/ws" \
-        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "clean-tool"
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
     [ "$status" -eq 0 ]
     [[ "$output" != *"injected"* ]]
     [ ! -d "$TEST_DIR/output/injected" ]

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -28,8 +28,8 @@ teardown() {
 # _image_tool <tool> [kind] — declare <tool> as a delivery: image tool in the
 # mock catalog, digest-pinned on the curated namespace.
 _image_tool() {
-    local tool="$1" kind="${2:-scan}" cat="$MOCK_TOOLS/catalog.json" tmp
-    local digest="sha256:$(printf '0%.0s' {1..64})"
+    local tool="$1" kind="${2:-scan}" cat="$MOCK_TOOLS/catalog.json" tmp digest
+    digest="sha256:$(printf '0%.0s' {1..64})"
     [[ -f "$cat" ]] || printf '{"tools":{}}' > "$cat"
     tmp="$(mktemp)"
     jq --arg t "$tool" --arg k "$kind" --arg img "ghcr.io/tomhennen/wrangle/$tool@$digest" \

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -335,6 +335,9 @@ JSON
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "imgtool"
     [ "$status" -eq 2 ]
     [[ "$output" == *"not digest-pinned"* ]]
+    # A config failure writes the error marker too, so an :info tool with a bad
+    # pin still blocks the check (check_results reads the marker).
+    [ -f "$TEST_DIR/output/imgtool/error" ]
 }
 
 @test "orchestrator: a delivery: image tool with no directory is admitted (not unknown)" {

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -1,54 +1,23 @@
 #!/usr/bin/env bats
 
-# Tests for run.sh (orchestrator): the hermetic parse/selection seam and the
-# path-independent post-run logic (0/1/2 exit mapping, scan/v1 manifest, error
-# marker). run.sh dispatches every tool via its catalog image, so a mock `docker`
-# on PATH stands in for the container — it derives the tool from the /output
-# mount and replays a per-tool exit code + SARIF. Real image dispatch (sandbox,
-# secret, network, uid ownership) is covered against a built image in
+# Unit tests for run.sh (orchestrator): the docker-independent parse/selection
+# seam — tool-name validation, action-pattern skip, unknown-tool rejection,
+# digest-pin enforcement, and custom-tool (.wrangle/tools.json) discovery. These
+# assert what run.sh decides BEFORE it dispatches an image, so they need no
+# container. Actual image execution (0/1/2 mapping, manifest, error marker,
+# secret/network/uid) is covered against a real image in
 # test/image/test_run_image_dispatch.bats.
-
-DIGEST="sha256:$(printf '0%.0s' {1..64})"
 
 setup() {
     TEST_DIR="$(mktemp -d)"
     ORIG_DIR="$(pwd)"
     export TEST_DIR ORIG_DIR
-
     MOCK_TOOLS="$TEST_DIR/tools"
-    BIN_DIR="$TEST_DIR/bin"
-    MOCK_SPEC="$TEST_DIR/spec"
-    mkdir -p "$MOCK_TOOLS" "$BIN_DIR" "$MOCK_SPEC" "$TEST_DIR/src" "$TEST_DIR/output"
-    export MOCK_TOOLS MOCK_SPEC
+    mkdir -p "$MOCK_TOOLS" "$TEST_DIR/src" "$TEST_DIR/output"
     command -v jq >/dev/null 2>&1 || { printf 'jq not on PATH\n' >&2; return 1; }
-
-    # Curated-image VSA verification needs Sigstore; disabled for the mock images,
-    # whose refs carry no real attestation.
+    # No real image is dispatched here, so the VSA gate (which needs Sigstore) is
+    # off; each test asserts the decision run.sh prints before `docker run`.
     export WRANGLE_VERIFY_TOOL_IMAGES=0
-
-    # Mock `docker`: on `docker run ... -v OUT:/output ... -- image /src /output`,
-    # derive the tool from the /output mount, replay $MOCK_SPEC/<tool>.{sarif,exit}
-    # (and .sleep, for the timeout test), and refuse if a host secret leaked onto
-    # an -e flag — the container must never see GITHUB_TOKEN.
-    cat > "$BIN_DIR/docker" <<'DOCKER'
-#!/usr/bin/env bash
-set -u
-out="" ; prev=""
-for a in "$@"; do
-    [[ "$prev" == "-v" && "$a" == *:/output ]] && out="${a%:/output}"
-    [[ "$a" == GITHUB_TOKEN* ]] && { printf 'mock docker: GITHUB_TOKEN reached the container\n' >&2; exit 97; }
-    prev="$a"
-done
-[[ -n "$out" ]] || { printf 'mock docker: no /output mount\n' >&2; exit 96; }
-tool="$(basename "$out")"
-spec="$MOCK_SPEC/$tool"
-[[ -f "$spec.sarif" ]] && cp "$spec.sarif" "$out/output.sarif"
-[[ -f "$spec.sleep" ]] && sleep "$(cat "$spec.sleep")"
-[[ -f "$spec.exit" ]] && exit "$(cat "$spec.exit")"
-exit 0
-DOCKER
-    chmod +x "$BIN_DIR/docker"
-    export PATH="$BIN_DIR:$PATH"
 }
 
 teardown() {
@@ -57,28 +26,22 @@ teardown() {
 }
 
 # _image_tool <tool> [kind] — declare <tool> as a delivery: image tool in the
-# mock catalog (kind: scan by default), digest-pinned on the curated namespace.
+# mock catalog, digest-pinned on the curated namespace.
 _image_tool() {
     local tool="$1" kind="${2:-scan}" cat="$MOCK_TOOLS/catalog.json" tmp
+    local digest="sha256:$(printf '0%.0s' {1..64})"
     [[ -f "$cat" ]] || printf '{"tools":{}}' > "$cat"
     tmp="$(mktemp)"
-    jq --arg t "$tool" --arg k "$kind" --arg img "ghcr.io/tomhennen/wrangle/$tool@$DIGEST" \
+    jq --arg t "$tool" --arg k "$kind" --arg img "ghcr.io/tomhennen/wrangle/$tool@$digest" \
         '.tools[$t] = {kind:$k, delivery:"image", image:$img}' "$cat" > "$tmp"
     mv "$tmp" "$cat"
-}
-
-# _spec <tool> <exit> [sarif-file] — set the mock image's replayed exit code and,
-# optionally, the SARIF it writes into /output.
-_spec() {
-    printf '%s' "$2" > "$MOCK_SPEC/$1.exit"
-    if [[ -n "${3:-}" ]]; then cp "$3" "$MOCK_SPEC/$1.sarif"; fi
 }
 
 run_orchestrator() {
     WRANGLE_TOOLS_DIR="$MOCK_TOOLS" run "$ORIG_DIR/run.sh" "$@"
 }
 
-# --- Input validation / selection tests ---
+# --- Tool-name validation ---
 
 @test "orchestrator: rejects tool name with path traversal" {
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "../etc/passwd"
@@ -104,12 +67,13 @@ run_orchestrator() {
     [[ "$output" == *"invalid tool name"* ]]
 }
 
-@test "orchestrator: accepts valid tool names" {
-    _image_tool cleantool
-    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
-    [ "$status" -eq 0 ]
+@test "orchestrator: no tools provided prints usage" {
+    run_orchestrator
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Usage"* ]] || [[ "$output" == *"usage"* ]]
 }
+
+# --- Selection: unknown-tool rejection & action-pattern skip ---
 
 @test "orchestrator: rejects unknown tool (no directory, no catalog entry)" {
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "nonexistent"
@@ -122,211 +86,40 @@ run_orchestrator() {
     echo "name: test" > "$MOCK_TOOLS/action-tool/action.yml"
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "action-tool"
     [ "$status" -eq 0 ]
+    [[ "$output" == *"no tools to run"* ]]
 }
 
 @test "orchestrator: skips action-pattern tool even when an adapter.sh is present" {
     # A tool with an action.yml runs via its uses: step; an adapter.sh present
-    # only as its image entrypoint must not pull it onto the run.sh dispatch path.
+    # only as its image entrypoint must not pull it onto the dispatch path.
     mkdir -p "$MOCK_TOOLS/action-img-tool"
     echo "name: test" > "$MOCK_TOOLS/action-img-tool/action.yml"
     printf '#!/bin/bash\nexit 2\n' > "$MOCK_TOOLS/action-img-tool/adapter.sh"
     chmod +x "$MOCK_TOOLS/action-img-tool/adapter.sh"
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "action-img-tool"
     [ "$status" -eq 0 ]
-    [ ! -f "$TEST_DIR/output/action-img-tool/output.sarif" ]
+    [ ! -d "$TEST_DIR/output/action-img-tool" ]
 }
 
-@test "orchestrator: strips policy suffix from tool names" {
-    _image_tool cleantool
-    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool:fail"
-    [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/cleantool/output.sarif" ]
-}
-
-@test "orchestrator: skips action-pattern tools in a mixed list" {
-    _image_tool cleantool
-    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
+@test "orchestrator: skips the action-pattern tool in a mixed list, dispatches the image tool" {
+    _image_tool osv
     mkdir -p "$MOCK_TOOLS/action-tool"
     echo "name: test" > "$MOCK_TOOLS/action-tool/action.yml"
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool" "action-tool:info"
-    [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/cleantool/output.sarif" ]
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv" "action-tool:info"
+    # osv reaches image dispatch; action-tool is skipped (no dir, never dispatched).
+    [[ "$output" == *"running osv (image)"* ]]
+    [ ! -d "$TEST_DIR/output/action-tool" ]
 }
 
-@test "orchestrator: no tools provided prints usage" {
-    run_orchestrator
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"Usage"* ]] || [[ "$output" == *"usage"* ]]
-}
-
-# --- Execution: 0/1/2 exit mapping (mock docker) ---
-
-@test "orchestrator: runs clean tool (exit 0)" {
-    _image_tool cleantool
-    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
-    [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/cleantool/output.sarif" ]
-}
-
-@test "orchestrator: runs findings tool (exit 1)" {
-    _image_tool findingstool
-    _spec findingstool 1 "$ORIG_DIR/test/fixtures/findings.sarif"
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "findingstool"
-    [ "$status" -eq 1 ]
-    [ -f "$TEST_DIR/output/findingstool/output.sarif" ]
-}
-
-@test "orchestrator: runs error tool (exit 2) and writes an error marker" {
-    _image_tool errortool
-    _spec errortool 2
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "errortool"
-    [ "$status" -eq 2 ]
-    # The marker lets check_results catch the failure even under continue-on-error
-    # (and honor :info on the error).
-    [ -f "$TEST_DIR/output/errortool/error" ]
-}
-
-@test "orchestrator: runs multiple tools" {
-    _image_tool cleantool
-    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
-    _image_tool findingstool
-    _spec findingstool 1 "$ORIG_DIR/test/fixtures/findings.sarif"
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool" "findingstool"
-    [ "$status" -eq 1 ]
-    [ -f "$TEST_DIR/output/cleantool/output.sarif" ]
-    [ -f "$TEST_DIR/output/findingstool/output.sarif" ]
-}
-
-@test "orchestrator: multiple tools land in distinct scan/<tool> dirs without clobbering" {
-    # The build workflows fold this output into the unified metadata's scan/. If a
-    # future change collapsed the per-tool subdir, the second tool would overwrite
-    # the first's output.sarif. Run two and assert both survive with their content.
-    for t in osv zizmor; do
-        _image_tool "$t"
-        printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"%s"}},"results":[]}]}\n' "$t" \
-            > "$MOCK_SPEC/$t.sarif"
-        printf '0' > "$MOCK_SPEC/$t.exit"
-    done
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv" "zizmor"
-    [ "$status" -eq 0 ]
-    grep -q '"name":"osv"' "$TEST_DIR/output/osv/output.sarif"
-    grep -q '"name":"zizmor"' "$TEST_DIR/output/zizmor/output.sarif"
-}
-
-@test "orchestrator: error takes precedence over findings" {
-    _image_tool cleantool
-    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
-    _image_tool errortool
-    _spec errortool 2
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool" "errortool"
-    [ "$status" -eq 2 ]
-}
-
-@test "orchestrator: prints summary table" {
-    _image_tool cleantool
-    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
-    [[ "$output" == *"cleantool"* ]]
-}
-
-@test "orchestrator: uses default src_dir and output_dir" {
-    _image_tool cleantool
-    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
-    cd "$TEST_DIR/src"
-    mkdir -p metadata
-    WRANGLE_TOOLS_DIR="$MOCK_TOOLS" run "$ORIG_DIR/run.sh" "cleantool"
-    [ "$status" -eq 0 ]
-}
-
-@test "orchestrator: image run timeout produces exit 2" {
-    _image_tool slowtool
-    _spec slowtool 0
-    printf '30' > "$MOCK_SPEC/slowtool.sleep"
-    WRANGLE_TOOLS_DIR="$MOCK_TOOLS" WRANGLE_ADAPTER_TIMEOUT=1 \
-        run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" "slowtool"
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"timed out"* ]]
-}
-
-@test "orchestrator: GITHUB_TOKEN never reaches the container" {
-    # docker gets only the -e flags run_tool_image builds; a host GITHUB_TOKEN
-    # must not be among them. The mock docker exits 97 if it sees one.
-    _image_tool cleantool
-    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
-    export GITHUB_TOKEN="secret-token-value"
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
-    [ "$status" -eq 0 ]
-}
-
-# --- scan/v1 attestation manifest (issue #420), written in run.sh's shared
-# post-run path regardless of how the tool ran ---
-
-@test "orchestrator: writes an osv scan/v1 manifest next to output.sarif (clean)" {
+@test "orchestrator: strips the :policy suffix before resolving the tool" {
     _image_tool osv
-    _spec osv 0 "$ORIG_DIR/test/fixtures/empty.sarif"
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv"
-    [ "$status" -eq 0 ]
-    manifest="$TEST_DIR/output/osv/wrangle_attestation_metadata.json"
-    [ -f "$manifest" ]
-    run jq -r '."predicate-type"' "$manifest"
-    [[ "$output" == "https://github.com/TomHennen/wrangle/attestation/scan/v1" ]]
-    run jq -r '.tool.name' "$manifest"
-    [[ "$output" == "osv-scanner" ]]
-    run jq -r '.tool.version' "$manifest"
-    [[ "$output" == "1.0.0" ]]
-    run jq -r '.result' "$manifest"
-    [[ "$output" == "clean" ]]
-    run jq -r '."result-file"' "$manifest"
-    [[ "$output" == "output.sarif" ]]
+    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv:info"
+    # The suffix is stripped, so osv (not "osv:info") resolves to the image path.
+    [[ "$output" == *"running osv (image)"* ]]
+    [[ "$output" != *"invalid tool name"* ]]
 }
 
-@test "orchestrator: osv manifest records result=findings when osv reports findings" {
-    _image_tool osv
-    _spec osv 1 "$ORIG_DIR/test/fixtures/findings.sarif"
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv"
-    [ "$status" -eq 1 ]
-    run jq -r '.result' "$TEST_DIR/output/osv/wrangle_attestation_metadata.json"
-    [[ "$output" == "findings" ]]
-}
-
-@test "orchestrator: writes a wrangle-lint scan/v1 manifest next to output.sarif" {
-    _image_tool wrangle-lint
-    printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"wrangle-lint","version":"1.2.3"}},"results":[]}]}\n' \
-        > "$MOCK_SPEC/wrangle-lint.sarif"
-    printf '0' > "$MOCK_SPEC/wrangle-lint.exit"
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "wrangle-lint"
-    [ "$status" -eq 0 ]
-    manifest="$TEST_DIR/output/wrangle-lint/wrangle_attestation_metadata.json"
-    [ -f "$manifest" ]
-    run jq -r '.tool.name' "$manifest"
-    [[ "$output" == "wrangle-lint" ]]
-    run jq -r '.tool.version' "$manifest"
-    [[ "$output" == "1.2.3" ]]
-    run jq -r '.result' "$manifest"
-    [[ "$output" == "clean" ]]
-}
-
-@test "orchestrator: writes no scan manifest for an unwired tool" {
-    _image_tool cleantool
-    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
-    run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
-    [ "$status" -eq 0 ]
-    [ ! -f "$TEST_DIR/output/cleantool/wrangle_attestation_metadata.json" ]
-}
-
-# --- Path resolution ---
-
-@test "orchestrator: resolves tool paths relative to script, not cwd" {
-    _image_tool cleantool
-    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
-    cd "$TEST_DIR"
-    WRANGLE_TOOLS_DIR="$MOCK_TOOLS" run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
-    [ "$status" -eq 0 ]
-}
-
-# --- image delivery: digest-pin enforcement (regex runs before any docker) ---
+# --- Digest-pin enforcement (regex runs before any docker) ---
 
 @test "orchestrator: image delivery rejects a tag-only (non-digest-pinned) image" {
     cat > "$MOCK_TOOLS/catalog.json" <<JSON
@@ -342,10 +135,18 @@ JSON
 
 @test "orchestrator: a delivery: image tool with no directory is admitted (not unknown)" {
     _image_tool byotool sbom
-    _spec byotool 0
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
     [[ "$output" != *"unknown tool"* ]]
     [[ "$output" == *"running byotool (image)"* ]]
+}
+
+@test "orchestrator: resolves its libs and tools relative to the script, not cwd" {
+    # run.sh sources lib/*.sh and finds the catalog via SCRIPT_DIR; invoked from an
+    # unrelated cwd it must still resolve osv to the image path (not fail to load).
+    _image_tool osv
+    cd "$TEST_DIR"
+    WRANGLE_TOOLS_DIR="$MOCK_TOOLS" run "$ORIG_DIR/run.sh" -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv"
+    [[ "$output" == *"running osv (image)"* ]]
 }
 
 @test "orchestrator: the curated sbom key dispatches as a catalog-only image tool" {
@@ -358,7 +159,7 @@ JSON
     [[ "$output" == *"running sbom (image)"* ]]
 }
 
-# --- custom tools: auto-discovered .wrangle/tools.json at the workspace root ---
+# --- Custom tools: auto-discovered .wrangle/tools.json at the workspace root ---
 
 _byo_digest="sha256:0000000000000000000000000000000000000000000000000000000000000000"
 
@@ -369,7 +170,6 @@ _write_custom_tools() {
 
 @test "orchestrator: auto-discovers .wrangle/tools.json and admits a selected new tool" {
     _write_custom_tools "{\"tools\":{\"byotool\":{\"kind\":\"sbom\",\"delivery\":\"image\",\"image\":\"registry.internal:5000/byo@$_byo_digest\"}}}"
-    _spec byotool 0
     GITHUB_WORKSPACE="$TEST_DIR/ws" \
         run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
     [[ "$output" != *"unknown tool"* ]]
@@ -377,13 +177,12 @@ _write_custom_tools() {
 }
 
 @test "orchestrator: no .wrangle/tools.json leaves the default catalog untouched" {
-    _image_tool cleantool
-    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
+    _image_tool osv
     mkdir -p "$TEST_DIR/ws" "$TEST_DIR/src"
     GITHUB_WORKSPACE="$TEST_DIR/ws" \
-        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
-    [ "$status" -eq 0 ]
-    [ -f "$TEST_DIR/output/cleantool/output.sarif" ]
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv"
+    # osv resolves from the curated catalog, unaffected by the absent custom file.
+    [[ "$output" == *"running osv (image)"* ]]
 }
 
 @test "orchestrator: a .wrangle/tools.json symlink resolving outside the workspace is rejected" {
@@ -391,7 +190,7 @@ _write_custom_tools() {
     printf '{"tools":{}}' > "$TEST_DIR/outside.json"
     ln -s "$TEST_DIR/outside.json" "$TEST_DIR/ws/.wrangle/tools.json"
     GITHUB_WORKSPACE="$TEST_DIR/ws" \
-        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv"
     [ "$status" -eq 2 ]
     [[ "$output" == *"resolves outside the workspace"* ]]
 }
@@ -408,12 +207,10 @@ _write_custom_tools() {
     # Selection gates execution: an injected .wrangle/tools.json entry the
     # selection does not name stays defined-but-never-run (the property that makes
     # auto-discovery safe under pull_request_target).
-    _image_tool cleantool
-    _spec cleantool 0 "$ORIG_DIR/test/fixtures/empty.sarif"
+    _image_tool osv
     _write_custom_tools "{\"tools\":{\"injected\":{\"kind\":\"sbom\",\"delivery\":\"image\",\"image\":\"registry.internal:5000/evil@$_byo_digest\"}}}"
     GITHUB_WORKSPACE="$TEST_DIR/ws" \
-        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "cleantool"
-    [ "$status" -eq 0 ]
+        run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv"
     [[ "$output" != *"injected"* ]]
     [ ! -d "$TEST_DIR/output/injected" ]
 }

--- a/tools/wrangle-lint/SPEC.md
+++ b/tools/wrangle-lint/SPEC.md
@@ -9,7 +9,7 @@ wrangle-specific policy (see [Scope](#scope)).
 | Property | Value |
 |----------|-------|
 | Pattern | Adapter (`tools/wrangle-lint/adapter.sh` + the first-party `wrangle-lint` Go binary) |
-| Integrity verification | First-party Go (`tool` directive in `tools/go.mod`), built by the orchestrator's upfront `go install tool`; dependency integrity via go.sum / sum.golang.org (DEP_MGMT branch 1) |
+| Integrity verification | First-party Go (`tool` directive in `tools/go.mod`), built into the tool's image at image-build time; dependency integrity via go.sum / sum.golang.org (DEP_MGMT branch 1) |
 | SARIF output | `$WRANGLE_METADATA_DIR/wrangle-lint/output.sarif` (written by the binary) |
 | SARIF upload | Wrangle uploads with category `wrangle/wrangle-lint` |
 | Default policy | `:fail` — config footguns block the check |

--- a/tools/wrangle-lint/adapter.sh
+++ b/tools/wrangle-lint/adapter.sh
@@ -8,7 +8,7 @@ set -f  # disable globbing — adapter walks adopter-controlled paths
 # scanners, which check code/workflows rather than whether config is wired up.
 #
 # The wrangle-lint binary is a first-party Go tool (a tool directive in
-# tools/go.mod); run.sh installs it onto PATH via the upfront `go install tool`.
+# tools/go.mod), on PATH inside this tool's image.
 #
 # Usage: adapter.sh <src_dir> <output_dir>
 # Exit: 0 = no findings, 1 = findings found, 2 = tool error


### PR DESCRIPTION
claude: Stage A of image-only tool delivery (#740). The #596 containerization migration made every shipped tool image-delivered; this removes run.sh's now-dead **in-process adapter path** so image dispatch is the only path.

## What changes
- **`run.sh`** dispatches only catalog `delivery: image` tools via `docker run`. A selected tool with no catalog image entry (and no `action.yml`) is rejected as unknown (exit 2). Dropped: the in-process branch, the `install.sh` + install-timeout + pre/post filesystem-snapshot machinery, the `is_image` map, and `WRANGLE_INSTALL_TIMEOUT`. `adapter.sh` stays the tool image's ENTRYPOINT; `install.sh` (e.g. syft) stays a build-time image concern.
- **Tests:** the hermetic `test_orchestrator.bats` + `test_generate_sbom.bats` now drive run.sh through a mock `docker` on PATH — preserving the fast, always-on coverage of run.sh's *path-independent* post-run logic (0/1/2 exit mapping, scan/v1 manifest, error marker). The install / filesystem-check / `env -i` isolation tests are deleted (obsoleted by the container sandbox — docker gives that isolation for free). Real image dispatch (sandbox, secret, `--network none`, uid ownership) stays covered against a built image in `test/image/test_run_image_dispatch.bats`, whose two `delivery: adapter` tests are removed.
- **Docs:** SPEC, tool_container_design, CLAUDE, and wrangle-lint SPEC/adapter comment stop describing orchestrator-driven install, the upfront `go install tool` (drift — run.sh never did this post-migration), and `delivery: adapter` as live mechanisms.

## Capability check
`WRANGLE_EXTRA_*` authenticated-API access is **not** lost: `run_tool_image` forwards the catalog-declared `secret:` as `WRANGLE_EXTRA_<NAME>` into the container. The in-process branch's blanket forwarding was the looser variant. GITHUB_TOKEN isolation is by-construction (docker only receives the `-e` flags run_tool_image builds); a mock-docker assertion guards it.

## Not in this PR
- **Stage B** removes the now single-valued `delivery` field entirely (key on "names an `image`"): `catalog.json`, currency scripts, `check_catalog`, `merge_catalog`, and tests. Left here per reviewability.
- `docs/tool_container_design.md`'s §1 problem-statement framing graduates from "proposal" to "implemented" when the #619 signing path lands — a doc follow-up, not this PR.

## Testing
`bats` unit suite green (915 tests, excluding docker-gated `test/image/` and the venv-gated shell-lint). run.sh shellchecks clean.

Refs #740.