### PR TITLE
claude: bump actions/setup-go to v6.5.0 (takes over #668)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -116,7 +116,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         id: prep
         with:
           build-type: container
@@ -135,7 +135,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -161,7 +161,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -239,7 +239,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -278,7 +278,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         id: prep
         with:
           build-type: go
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         id: release
         with:
           path: ${{ inputs.path }}
@@ -360,7 +360,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         id: attest
         with:
           build-type: go
@@ -386,7 +386,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -142,7 +142,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         id: prep
         with:
           build-type: npm
@@ -161,7 +161,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -195,7 +195,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -274,7 +274,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         id: attest
         with:
           build-type: npm
@@ -297,7 +297,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -119,7 +119,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         id: prep
         with:
           build-type: python
@@ -138,7 +138,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -170,7 +170,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         id: build
         with:
           path: ${{ inputs.path }}
@@ -261,7 +261,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         id: attest
         with:
           build-type: python
@@ -284,7 +284,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -190,7 +190,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -141,7 +141,7 @@ jobs:
       # trust-on-hit (docs/SLSA_L3_AUDIT.md) is not an L3 concern here.
       - name: Set up Go with module + build cache
         if: ${{ inputs.go-tools-dir != '' }}
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: ${{ inputs.go-tools-dir }}/go.mod
           cache-dependency-path: ${{ inputs.go-tools-dir }}/go.sum

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: tools/go.mod
           cache-dependency-path: tools/go.sum

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -112,7 +112,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -124,7 +124,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@b631f580ca2ff137bd96ee62af40d97c333e3f4a # reconv738 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@08acbc66f65c6397aa2ce935fef4ea376e3de647 # fix742 2026-07-05
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/go/build/action.yml
+++ b/build/actions/go/build/action.yml
@@ -121,7 +121,7 @@ runs:
         "${{ github.action_path }}/../compute_metadata.sh" "$INPUT_PATH"
 
     - name: Setup Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ inputs.go-version || '' }}
         go-version-file: ${{ inputs.go-version == '' && format('{0}/go.mod', inputs.path) || '' }}

--- a/build/actions/go/checks/action.yml
+++ b/build/actions/go/checks/action.yml
@@ -87,7 +87,7 @@ runs:
         "${{ github.action_path }}/../compute_metadata.sh" "$INPUT_PATH"
 
     - name: Setup Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ inputs.go-version || '' }}
         go-version-file: ${{ inputs.go-version == '' && format('{0}/go.mod', inputs.path) || '' }}


### PR DESCRIPTION
claude: Takes over dependabot #668, which is structurally unmergeable (it can't add the pin-convergence commits check_pin_freshness demands). Bumps actions/setup-go 4a36011→924ae3a (v6.5.0, released 2026-06-24, cooldown passed) in all four places the pin-uniformity test enforces: .github/workflows/{build_shell,test}.yml and build/actions/go/{build,checks}/action.yml. The composite-dir changes stale the go build-type pins, so the branch carries a pin-convergence commit — **merge as a MERGE COMMIT, not a squash** (a squash orphans the pinned SHA). Merging lets #668 be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)