### PR TITLE
refactor(catalog): remove the redundant delivery field (image-only, Stage B)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -116,7 +116,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         id: prep
         with:
           build-type: container
@@ -135,7 +135,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -161,7 +161,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      uses: TomHennen/wrangle/build/actions/container@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -239,7 +239,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -278,7 +278,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -116,7 +116,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/prep@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         id: prep
         with:
           build-type: container
@@ -135,7 +135,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/scan@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -161,7 +161,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      uses: TomHennen/wrangle/build/actions/container@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -239,7 +239,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -278,7 +278,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/verify_release@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/prep@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         id: prep
         with:
           build-type: go
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/scan@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/build/actions/go/checks@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/build/actions/go/build@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         id: release
         with:
           path: ${{ inputs.path }}
@@ -360,7 +360,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/attest_provenance@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         id: attest
         with:
           build-type: go
@@ -386,7 +386,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/verify_release@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -154,7 +154,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         id: prep
         with:
           build-type: go
@@ -173,7 +173,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/checks@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/go/build@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         id: release
         with:
           path: ${{ inputs.path }}
@@ -360,7 +360,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         id: attest
         with:
           build-type: go
@@ -386,7 +386,7 @@ jobs:
       contents: write       # create the release if absent and upload the attested archives + checksums + bundles
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -142,7 +142,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/prep@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         id: prep
         with:
           build-type: npm
@@ -161,7 +161,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/scan@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -195,7 +195,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/build/actions/npm@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         id: build
         with:
           path: ${{ inputs.path }}
@@ -274,7 +274,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/attest_provenance@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         id: attest
         with:
           build-type: npm
@@ -297,7 +297,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/verify_release@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -142,7 +142,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         id: prep
         with:
           build-type: npm
@@ -161,7 +161,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -195,7 +195,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/npm@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         id: build
         with:
           path: ${{ inputs.path }}
@@ -274,7 +274,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         id: attest
         with:
           build-type: npm
@@ -297,7 +297,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -119,7 +119,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/prep@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         id: prep
         with:
           build-type: python
@@ -138,7 +138,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/scan@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -170,7 +170,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/build/actions/python@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         id: build
         with:
           path: ${{ inputs.path }}
@@ -261,7 +261,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/attest_provenance@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         id: attest
         with:
           build-type: python
@@ -284,7 +284,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/verify_release@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -119,7 +119,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         id: prep
         with:
           build-type: python
@@ -138,7 +138,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -170,7 +170,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/build/actions/python@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         id: build
         with:
           path: ${{ inputs.path }}
@@ -261,7 +261,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/attest_provenance@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         id: attest
         with:
           build-type: python
@@ -284,7 +284,7 @@ jobs:
       contents: write       # create the release if absent and attach the bundle on tag pushes
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/verify_release@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/scan@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -190,7 +190,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+        uses: TomHennen/wrangle/build/actions/shell@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/prep@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/scan@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -190,7 +190,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+        uses: TomHennen/wrangle/build/actions/shell@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      - uses: TomHennen/wrangle/actions/prep@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+        uses: TomHennen/wrangle/actions/scan@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      - uses: TomHennen/wrangle/actions/prep@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+        uses: TomHennen/wrangle/actions/scan@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Prefer your own SBOM generator over wrangle's default (syft)? On the go, python,
      "tools": {
        "my-sbom": {
          "kind": "sbom",
-         "delivery": "image",
          "image": "ghcr.io/myorg/my-sbom-generator@sha256:<digest>"
        }
      }

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -111,7 +111,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      uses: TomHennen/wrangle/tools/scorecard@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -123,7 +123,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+      uses: TomHennen/wrangle/tools/dependency-review@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -111,7 +111,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      uses: TomHennen/wrangle/tools/scorecard@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -123,7 +123,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+      uses: TomHennen/wrangle/tools/dependency-review@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
+    - uses: TomHennen/wrangle/actions/verify@58114e5180fffef5af1af9fa5d458b7efc52cbc1 # main 2026-07-06
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -87,7 +87,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@3e14800a41178da5ee591817cffced2078a1be29 # cleanup/image-only-delivery-a 2026-07-05
+    - uses: TomHennen/wrangle/actions/verify@146838db3e7fefb5c4fccdf9b8dfaff275370b3d # main 2026-07-06
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -581,7 +581,7 @@ BEHAVIOR:
     3. Skip if tools/<tool>/action.yml exists (action-pattern — handled by
        uses: steps in the scan action; any adapter.sh present is only the
        tool image's entrypoint)
-    4. Resolve the tool's tools/catalog.json entry: a `delivery: image` entry
+    4. Resolve the tool's tools/catalog.json entry: an entry naming an `image`
        runs the tool's pinned image via `docker run` (read-only /src, writable
        /output owned by the runner UID, --network none unless the entry
        declares `network: egress`, a `secret:` passed via -e). A tool with no
@@ -649,7 +649,6 @@ select an injected tool.
   "tools": {
     "my-sbom": {                                  // a tool wrangle doesn't ship — full definition
       "kind": "sbom",
-      "delivery": "image",
       "image": "ghcr.io/myorg/my-sbom@sha256:<64hex>"
     }
   }
@@ -662,7 +661,7 @@ under a new name and deselect the curated one via `tools:` / `sbom-tool:`. Each 
 capabilities standalone; nothing inherits from any curated entry.
 
 **Per-entry validation** (any failure fails closed, aborting the run): tool name matches
-`^[a-z][a-z0-9_-]*$`; `kind` ∈ {`scan`, `sbom`, `attest`}; `delivery` is `image`; `image` is digest-pinned
+`^[a-z][a-z0-9_-]*$`; `kind` ∈ {`scan`, `sbom`, `attest`}; `image` is digest-pinned
 (`name@sha256:<64hex>`) **and outside the wrangle namespace** (`ghcr.io/tomhennen/wrangle/*` is rejected —
 a custom tool cannot borrow a wrangle VSA identity); a declared `network` ∈ {`none`, `egress`} and `secret`
 matches `^[a-z][a-z0-9-]*$`. The value rules are shared with the curated-catalog linter via
@@ -840,7 +839,7 @@ The install scripts include OS/arch detection (`linux/darwin`, `amd64/arm64`) as
    - `adapter.sh` — the image entrypoint; follows the adapter contract above
    - `install.sh` — uses `lib/download_verify.sh` for download and verification when no package manager ships the tool (run at image-build time)
    - `test.bats` — tests using mock binaries (fast, deterministic)
-2. Build and publish the tool's image and add its digest-pinned `delivery: image` entry to `tools/catalog.json` (see [Tool containerization](tool_container_design.md))
+2. Build and publish the tool's image and add its digest-pinned image entry to `tools/catalog.json` (see [Tool containerization](tool_container_design.md))
 3. Add `foo` to the orchestrator's default tool list in `actions/scan/action.yml`
 
 **Action pattern** (wraps upstream GitHub Action):
@@ -850,7 +849,7 @@ The install scripts include OS/arch detection (`linux/darwin`, `amd64/arm64`) as
    - `test.bats` — structural tests (action.yml exists, SHA pinned, etc.)
 2. Add a `uses: ./tools/foo` step in `actions/scan/action.yml`
 
-Everything for one tool lives in one directory, with no workflow changes for adopters. Most tools deliver as a downloaded binary or a wrapped action; a tool that needs a container delivers as one via the catalog (`delivery: image`, see Design Decisions below).
+Everything for one tool lives in one directory, with no workflow changes for adopters. Most tools deliver as a downloaded binary or a wrapped action; a tool that needs a container delivers as one via the catalog (a digest-pinned `image` entry, see Design Decisions below).
 
 ### Tool Sub-specifications
 
@@ -893,7 +892,7 @@ The `.wrangle/` directory is in `.gitignore` to prevent accidental commits.
 
 ### Tool delivery: container images per tool
 
-Each adapter-pattern tool runs as a **digest-pinned OCI image** resolved through the catalog (`delivery: image` with a digest-pinned `image:`); the orchestrator dispatches it via `docker run` under the adapter contract sandbox — the container is the unit of both distribution and isolation. Tools with a well-maintained official GitHub Action stay action-pattern (wrapped via `uses:`) instead. Rationale and the packaging model are in [docs/tool_container_design.md](tool_container_design.md).
+Each adapter-pattern tool runs as a **digest-pinned OCI image** resolved through the catalog (a digest-pinned `image:` entry); the orchestrator dispatches it via `docker run` under the adapter contract sandbox — the container is the unit of both distribution and isolation. Tools with a well-maintained official GitHub Action stay action-pattern (wrapped via `uses:`) instead. Rationale and the packaging model are in [docs/tool_container_design.md](tool_container_design.md).
 
 The container *build/publish* workflow (for building adopters' Docker images) is a separate concern and remains unchanged.
 

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -181,12 +181,12 @@ thing for the pin tooling to track and for adopters to read.
   a lint warning on a stale pin) but cannot vouch for an image it does not control.
 
 The shipped catalog (`tools/catalog.json`) is parsed with `jq` (`lib/read_catalog.sh`) and has **two
-consumers**: the scan orchestrator dispatches entries the `tools:` selection names that carry
-`delivery: image` via `docker run` (a selected tool with no catalog image entry and no `action.yml` is
+consumers**: the scan orchestrator dispatches entries the `tools:` selection names that name an
+`image` via `docker run` (a selected tool with no catalog image entry and no `action.yml` is
 rejected as unknown), and the verify action resolves one **fixed key** (`attest-toolbox`) for its
 in-container `ampel verify`. An entry the `tools:` selection never names is not scan-dispatched, yet
-remains a reviewable grant the verify path resolves by fixed key; `check_catalog` pin- and
-namespace-lints any entry naming an `image`, regardless of `delivery`. Capabilities default closed: an
+remains a reviewable grant the verify path resolves by fixed key; every entry must name an `image`,
+which `check_catalog` pin- and namespace-lints. Capabilities default closed: an
 absent `network`/`secret` means none. The `kind` field is recorded but unused today; the
 `command:`/`args:`/`WRANGLE_KIND` passthrough and kind-based (scan vs sbom) dispatch land when a
 command-shared or sbom tool does. `osv` carries `network: egress` because it refreshes its advisory DB
@@ -261,7 +261,7 @@ Schema below is the proposed shape; exact field names and file locations are bik
 }
 ```
 
-(Every catalog entry carries `delivery: image` — the only path the orchestrator dispatches.)
+(Every catalog entry names an `image` — the only path the orchestrator dispatches.)
 
 As the `wrangle-lint`/`wrangle-attest` entries above show, an entry can carry an optional
 `command:`/`args:` so several tools share **one** image (a unified `wrangle` binary or a toolbox image),
@@ -271,9 +271,9 @@ apply per entry; the cost is a larger per-entry surface to validate (§8).
 
 > **Deferral note.** The unified `wrangle` image above (one image shared by `wrangle-lint` and
 > `wrangle-attest`, selected by `command:`) is a proposed shape, deferred to #642; neither image exists
-> today. The shipped `tools/catalog.json` diverges: `wrangle-lint` is on its own image, signing runs in a
-> separate `attest-toolbox` entry (`kind: attest`, `token: sigstore`), and every entry carries an explicit
-> `delivery: image`. Read `tools/catalog.json` for the current shape.
+> today. The shipped `tools/catalog.json` diverges: `wrangle-lint` is on its own image, and signing runs
+> in a separate `attest-toolbox` entry (`kind: attest`, `token: sigstore`). Read `tools/catalog.json` for
+> the current shape.
 
 **Adopter — selecting tools** (pin wrangle, choose which to run):
 
@@ -402,7 +402,7 @@ not a meaningful per-delivery signal.)
   mechanism regression is recovered by pinning an earlier wrangle version.
   **Status (#596 Track 2):** the toolbox image (`tools/attest-toolbox/`, all four binaries from
   `tools/go.mod`) is built and published like the scan images. Under the curated catalog's
-  `attest-toolbox` grant (`delivery: image`, digest-pinned, `network: egress`, `token: sigstore`) all
+  `attest-toolbox` grant (digest-pinned image, `network: egress`, `token: sigstore`) all
   three sign sites run in it: the verify job's VSA sign (`bnd statement`) and referrer pushes,
   `attest_provenance`'s `wrangle-attest --sign` + store push, and `attest_metadata_oci`'s sign + `cosign`
   OCI push/download — plus the `oci:` collector verify path (registry auth threaded in-container). The
@@ -454,8 +454,7 @@ model. Still open:
 4. **Make the catalog digest-aware** (§6) — the parallel `check_catalog*` / `bump_catalog_digest` checks;
    required before any image is consumed in a production wrangle workflow.
 5. **Go all-in for the `scan` kind.** Rather than a long mixed-mode tail, migrate the scan adapter tools
-   together once the prototype proves out; the catalog's `delivery:` field covers the brief cutover (and
-   any tool that stays adapter/action-pattern). osv, then zizmor, behind the curated catalog.
+   together once the prototype proves out. osv, then zizmor, behind the curated catalog.
 6. **Extend to `sbom`** — syft as the reference implementation and the first adopter-substitutable
    contract test.
 7. **Track 2 — signing in a container** (consume-the-pin, §7/#619): the attest/verify toolbox (with its

--- a/lib/merge_catalog.sh
+++ b/lib/merge_catalog.sh
@@ -45,7 +45,7 @@ merge_catalog() {
         return 1
     fi
 
-    local rc=0 tool kind delivery image network secret token
+    local rc=0 tool kind image network secret token
     while IFS= read -r tool; do
         [[ -z "$tool" ]] && continue
         if [[ ! "$tool" =~ $CATALOG_TOOL_NAME_RE ]]; then
@@ -79,18 +79,12 @@ merge_catalog() {
             rc=1
         fi
 
-        # A custom tool is always net-new and image-delivered.
-        delivery="$(read_catalog_field "$custom" "$tool" delivery)"
-        if [[ "$delivery" != "image" ]]; then
-            printf 'wrangle: custom-tools: %s: must declare delivery: image\n' "$tool" >&2
-            rc=1
-        fi
-
-        # The image must be digest-pinned and OUTSIDE the wrangle namespace: a
-        # custom tool is adopter-trusted and cannot borrow a wrangle VSA identity.
+        # A custom tool is always net-new: it must name a digest-pinned image
+        # OUTSIDE the wrangle namespace — adopter-trusted, it cannot borrow a
+        # wrangle VSA identity.
         image="$(read_catalog_field "$custom" "$tool" image)"
         if [[ -z "$image" ]]; then
-            printf 'wrangle: custom-tools: %s: must declare a digest-pinned image\n' "$tool" >&2
+            printf 'wrangle: custom-tools: %s: must name a digest-pinned image\n' "$tool" >&2
             rc=1
         elif [[ ! "$image" =~ $CATALOG_IMAGE_DIGEST_RE ]]; then
             printf 'wrangle: custom-tools: %s: image must be digest-pinned (name@sha256:<64hex>): %s\n' "$tool" "$image" >&2

--- a/run.sh
+++ b/run.sh
@@ -18,8 +18,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/env.sh
 source "$SCRIPT_DIR/lib/env.sh"
 
-# Catalog reader: resolves a tool's curated entry (delivery, image, network,
-# secret) from tools/catalog.json.
+# Catalog reader: resolves a tool's curated entry (image, network, secret) from
+# tools/catalog.json.
 # shellcheck source=lib/read_catalog.sh
 source "$SCRIPT_DIR/lib/read_catalog.sh"
 
@@ -98,10 +98,10 @@ if [[ $# -eq 0 ]]; then
 fi
 
 # Parse tool specs: strip :policy suffixes, collect the tools run by run.sh.
-# run.sh dispatches only catalog image-delivery tools (via docker run). An
-# action-pattern tool (has an action.yml) is invoked via its uses: step, so it
-# is skipped here even when an adapter.sh is present only as its image
-# entrypoint. Any other selected tool has no way to run and is rejected.
+# run.sh dispatches only catalog image tools (via docker run). An action-pattern
+# tool (has an action.yml) is invoked via its uses: step, so it is skipped here
+# even when an adapter.sh is present only as its image entrypoint. Any other
+# selected tool has no way to run and is rejected.
 declare -a run_tools=()
 for spec in "$@"; do
     tool="${spec%%:*}"
@@ -113,9 +113,9 @@ for spec in "$@"; do
     if [[ -d "${TOOLS_DIR}/${tool}" ]] && [[ -f "${TOOLS_DIR}/${tool}/action.yml" ]]; then
         continue
     fi
-    # Image delivery is the only path run.sh dispatches; a tool must carry a
-    # catalog delivery: image entry, else it is unknown/unrunnable.
-    if [[ "$(read_catalog_field "$CATALOG" "$tool" delivery)" != image ]]; then
+    # A curated image is the only path run.sh dispatches; a tool must name a
+    # catalog image entry, else it is unknown/unrunnable.
+    if [[ -z "$(read_catalog_field "$CATALOG" "$tool" image)" ]]; then
         printf 'wrangle: unknown tool: %s (no catalog image entry in %s)\n' "$tool" "$CATALOG" >&2
         exit 2
     fi
@@ -207,8 +207,8 @@ run_one_tool() {
     local image
     image="$(read_catalog_field "$CATALOG" "$tool" image)"
     if [[ -z "$image" ]]; then
-        printf 'wrangle: %s: catalog declares delivery: image but no image\n' "$tool" >&2
-        fail_tool_config "$tool" "$tool_output_dir" "catalog declares delivery: image but no image"
+        printf 'wrangle: %s: catalog entry names no image\n' "$tool" >&2
+        fail_tool_config "$tool" "$tool_output_dir" "catalog entry names no image"
         return
     fi
     # Require an @sha256 digest pin (a tag alone is mutable); re-checked here

--- a/test/image/test_byo_sbom.bats
+++ b/test/image/test_byo_sbom.bats
@@ -68,7 +68,7 @@ setup() {
     printf 'sbom-real' > "$SRC/MODE"
 
     cat > "$WS/.wrangle/tools.json" <<JSON
-{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"$BYO_IMAGE"}}}
+{"tools":{"my-sbom":{"kind":"sbom","image":"$BYO_IMAGE"}}}
 JSON
     export ORIG_DIR RUN_SH TMP_DIR WS SRC OUT TOOLS
 }

--- a/test/image/test_run_image_dispatch.bats
+++ b/test/image/test_run_image_dispatch.bats
@@ -1,10 +1,10 @@
 #!/usr/bin/env bats
 
-# Validates run.sh's catalog-driven image-delivery dispatch (#596,
-# docs/tool_container_design.md §3.5): a tool whose catalog entry declares
-# delivery: image is run via `docker run` under the contract sandbox, writing
-# the SAME ${output_dir}/${tool}/output.sarif the downstream collectors consume,
-# with the 0/1/2 exit contract mapped.
+# Validates run.sh's catalog-driven image dispatch (#596,
+# docs/tool_container_design.md §3.5): a tool whose catalog entry names an image
+# is run via `docker run` under the contract sandbox, writing the SAME
+# ${output_dir}/${tool}/output.sarif the downstream collectors consume, with the
+# 0/1/2 exit contract mapped.
 #
 # Needs docker, so it lives under test/image/ (outside the Makefile's unit
 # `bats` glob, which expands test/ non-recursively) and runs in the dogfooded
@@ -83,10 +83,10 @@ setup() {
     # engine-portable repo digest, which run.sh's digest-pin check requires).
     export ORIG_DIR RUN_SH TMP_DIR SRC OUT TOOLS
 
-    # A mock catalog declaring mocktool as a delivery: image tool pointing at
+    # A mock catalog declaring mocktool as a curated image tool pointing at
     # the local mock image. network omitted -> none (the default).
     cat > "$TOOLS/catalog.json" <<JSON
-{"tools":{"mocktool":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE"}}}
+{"tools":{"mocktool":{"kind":"scan","image":"$MOCK_IMAGE"}}}
 JSON
 }
 
@@ -128,7 +128,7 @@ _run_orch() {
     # is never downgraded).
     printf 'error' > "$SRC/MODE"
     cat > "$TOOLS/catalog.json" <<JSON
-{"tools":{"toola":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE"},"toolb":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE"}}}
+{"tools":{"toola":{"kind":"scan","image":"$MOCK_IMAGE"},"toolb":{"kind":"scan","image":"$MOCK_IMAGE"}}}
 JSON
     _run_orch toola toolb
     [ "$status" -eq 2 ]
@@ -145,7 +145,7 @@ JSON
 @test "run.sh image dispatch: two image tools land in distinct dirs without clobbering" {
     printf 'clean' > "$SRC/MODE"
     cat > "$TOOLS/catalog.json" <<JSON
-{"tools":{"toola":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE"},"toolb":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE"}}}
+{"tools":{"toola":{"kind":"scan","image":"$MOCK_IMAGE"},"toolb":{"kind":"scan","image":"$MOCK_IMAGE"}}}
 JSON
     _run_orch toola toolb
     [ "$status" -eq 0 ]
@@ -158,7 +158,7 @@ JSON
     # zizmor tokens. Drive it deterministically with the mock image under the osv key.
     printf 'clean' > "$SRC/MODE"
     cat > "$TOOLS/catalog.json" <<JSON
-{"tools":{"osv":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE"}}}
+{"tools":{"osv":{"kind":"scan","image":"$MOCK_IMAGE"}}}
 JSON
     _run_orch osv
     [ "$status" -eq 0 ]
@@ -215,7 +215,7 @@ JSON
     # A catalog secret: maps WRANGLE_EXTRA_<NAME> into the image as <NAME>,
     # forwarded by name (not on docker's argv). Assert it actually arrives.
     cat > "$TOOLS/catalog.json" <<JSON
-{"tools":{"mocktool":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE","secret":"mock-secret"}}}
+{"tools":{"mocktool":{"kind":"scan","image":"$MOCK_IMAGE","secret":"mock-secret"}}}
 JSON
     printf 'secret' > "$SRC/MODE"
     WRANGLE_TOOLS_DIR="$TOOLS" WRANGLE_EXTRA_MOCK_SECRET="s3cr3t-value" \
@@ -230,7 +230,7 @@ JSON
     # the GITHUB_TOKEN env var inside the container, sourced from run.sh's
     # WRANGLE_EXTRA_GITHUB_TOKEN. This guards the env-bridge the adapter relies on.
     cat > "$TOOLS/catalog.json" <<JSON
-{"tools":{"mocktool":{"kind":"scan","delivery":"image","image":"$MOCK_IMAGE","secret":"github-token"}}}
+{"tools":{"mocktool":{"kind":"scan","image":"$MOCK_IMAGE","secret":"github-token"}}}
 JSON
     printf 'secret' > "$SRC/MODE"
     WRANGLE_TOOLS_DIR="$TOOLS" WRANGLE_EXTRA_GITHUB_TOKEN="ghs_mocktoken" \
@@ -258,7 +258,7 @@ JSON
         || skip_or_fail "local osv image (wrangle-osv:test) not built"
 
     cat > "$TOOLS/catalog.json" <<JSON
-{"tools":{"osv":{"kind":"scan","delivery":"image","image":"$OSV_IMAGE","network":"egress"}}}
+{"tools":{"osv":{"kind":"scan","image":"$OSV_IMAGE","network":"egress"}}}
 JSON
     mkdir -p "$TOOLS/osv"
     printf 'just text, no manifests\n' > "$SRC/README.txt"
@@ -280,7 +280,7 @@ JSON
         || skip_or_fail "local osv image (wrangle-osv:test) not built"
 
     cat > "$TOOLS/catalog.json" <<JSON
-{"tools":{"osv":{"kind":"scan","delivery":"image","image":"$OSV_IMAGE","network":"egress"}}}
+{"tools":{"osv":{"kind":"scan","image":"$OSV_IMAGE","network":"egress"}}}
 JSON
     mkdir -p "$TOOLS/osv"
     cp "$ORIG_DIR/tools/osv/testdata/vulnerable_go.mod" "$SRC/go.mod"
@@ -299,7 +299,7 @@ JSON
 # sbom.spdx.json and records the WRANGLE_KIND it saw.
 _sbom_catalog() {
     cat > "$TOOLS/catalog.json" <<JSON
-{"tools":{"mocktool":{"kind":"sbom","delivery":"image","image":"$MOCK_IMAGE"}}}
+{"tools":{"mocktool":{"kind":"sbom","image":"$MOCK_IMAGE"}}}
 JSON
 }
 

--- a/test/test_bump_catalog_digest.bats
+++ b/test/test_bump_catalog_digest.bats
@@ -12,7 +12,7 @@ setup() {
     export WRANGLE_CATALOG="$CATALOG"
     command -v jq >/dev/null 2>&1 || { printf 'jq not on PATH\n' >&2; return 1; }
     printf '%s\n' \
-        '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@'"$DIGEST_A"'","network":"egress"}}}' \
+        '{"tools":{"osv":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/osv@'"$DIGEST_A"'","network":"egress"}}}' \
         > "$CATALOG"
 }
 
@@ -39,18 +39,18 @@ image_of() { jq -r '.tools.osv.image' "$CATALOG"; }
 }
 
 @test "bump_catalog_digest: non-image tool is rejected (exit 2)" {
-    printf '%s\n' '{"tools":{"foo":{"kind":"scan","delivery":"adapter"}}}' > "$CATALOG"
+    printf '%s\n' '{"tools":{"foo":{"kind":"scan"}}}' > "$CATALOG"
     run "$SCRIPT" foo "$DIGEST_B"
     [ "$status" -eq 2 ]
-    [[ "$output" == *"not an image-delivery tool"* ]]
+    [[ "$output" == *"not an image tool"* ]]
 }
 
 @test "bump_catalog_digest: a kind:attest image entry (the toolbox) is bumpable, not rejected" {
     # Regression for #689: the signing toolbox is a curated image entry; the
-    # manual digest-bump remediation must accept it — the check keys on
-    # delivery: image, not kind.
+    # manual digest-bump remediation must accept it — the check keys on the
+    # named image, not kind.
     printf '%s\n' \
-        '{"tools":{"attest-toolbox":{"kind":"attest","delivery":"image","image":"ghcr.io/tomhennen/wrangle/attest-toolbox@'"$DIGEST_A"'","network":"egress","token":"sigstore"}}}' \
+        '{"tools":{"attest-toolbox":{"kind":"attest","image":"ghcr.io/tomhennen/wrangle/attest-toolbox@'"$DIGEST_A"'","network":"egress","token":"sigstore"}}}' \
         > "$CATALOG"
     run "$SCRIPT" attest-toolbox "$DIGEST_B"
     [ "$status" -eq 0 ]

--- a/test/test_bump_catalog_to_latest.bats
+++ b/test/test_bump_catalog_to_latest.bats
@@ -17,7 +17,7 @@ setup() {
     command -v jq >/dev/null 2>&1 || { printf 'jq not on PATH\n' >&2; return 1; }
 
     printf '%s\n' \
-        '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@'"$DIGEST_A"'","network":"egress"}}}' \
+        '{"tools":{"osv":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/osv@'"$DIGEST_A"'","network":"egress"}}}' \
         > "$CATALOG"
 }
 
@@ -77,7 +77,7 @@ SHIM
     # Token-fail shim: a resolved non-curated entry would surface as exit 2.
     install_curl
     printf '%s\n' \
-        '{"tools":{"adopter":{"kind":"scan","delivery":"image","image":"registry.example.com/x/y@'"$DIGEST_A"'"}}}' \
+        '{"tools":{"adopter":{"kind":"scan","image":"registry.example.com/x/y@'"$DIGEST_A"'"}}}' \
         > "$CATALOG"
     SHIM_TOKEN_FAIL=1 run "$SCRIPT"
     [ "$status" -eq 0 ]
@@ -89,7 +89,7 @@ SHIM
 @test "bump_catalog_to_latest: resolvable entry bumped despite a sibling backend error (exit 2)" {
     install_curl_per_image
     printf '%s\n' \
-        '{"tools":{"toola":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toola@'"$DIGEST_A"'"},"toolb":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toolb@'"$DIGEST_A"'"}}}' \
+        '{"tools":{"toola":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/toola@'"$DIGEST_A"'"},"toolb":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/toolb@'"$DIGEST_A"'"}}}' \
         > "$CATALOG"
     run "$SCRIPT"
     [ "$status" -eq 2 ]

--- a/test/test_check_catalog.bats
+++ b/test/test_check_catalog.bats
@@ -14,48 +14,48 @@ setup() {
 write_catalog() { printf '%s\n' "$1" > "$CATALOG"; }
 
 @test "check_catalog: valid curated catalog passes" {
-    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'","network":"egress"}}}'
+    write_catalog '{"tools":{"osv":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'","network":"egress"}}}'
     run "$SCRIPT"
     [ "$status" -eq 0 ]
 }
 
 @test "check_catalog: mutable tag on the curated namespace reports not-digest-pinned" {
-    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv:latest"}}}'
+    write_catalog '{"tools":{"osv":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/osv:latest"}}}'
     run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"not digest-pinned"* ]]
 }
 
 @test "check_catalog: off-namespace ghcr image fails" {
-    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/someoneelse/osv@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
+    write_catalog '{"tools":{"osv":{"kind":"scan","image":"ghcr.io/someoneelse/osv@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
     run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"curated namespace"* ]]
 }
 
 @test "check_catalog: missing kind fails" {
-    write_catalog '{"tools":{"osv":{"delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
+    write_catalog '{"tools":{"osv":{"image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
     run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"missing kind"* ]]
 }
 
 @test "check_catalog: bad network value fails" {
-    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'","network":"full"}}}'
+    write_catalog '{"tools":{"osv":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'","network":"full"}}}'
     run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"invalid network"* ]]
 }
 
 @test "check_catalog: bad secret name fails" {
-    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'","secret":"Bad_Name"}}}'
+    write_catalog '{"tools":{"osv":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'","secret":"Bad_Name"}}}'
     run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"invalid secret"* ]]
 }
 
 @test "check_catalog: valid sbom entry passes" {
-    write_catalog '{"tools":{"syft":{"kind":"sbom","delivery":"image","image":"ghcr.io/tomhennen/wrangle/syft@sha256:'"$(printf 'a%.0s' {1..64})"'","network":"none"}}}'
+    write_catalog '{"tools":{"syft":{"kind":"sbom","image":"ghcr.io/tomhennen/wrangle/syft@sha256:'"$(printf 'a%.0s' {1..64})"'","network":"none"}}}'
     run "$SCRIPT"
     [ "$status" -eq 0 ]
 }
@@ -68,39 +68,39 @@ write_catalog() { printf '%s\n' "$1" > "$CATALOG"; }
 }
 
 @test "check_catalog: non-ghcr digest-pinned image is off-namespace (fails)" {
-    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"registry.example.com/team/osv@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
+    write_catalog '{"tools":{"osv":{"kind":"scan","image":"registry.example.com/team/osv@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
     run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"off the curated namespace"* ]]
 }
 
-@test "check_catalog: typo'd delivery value fails (no silent image-check skip)" {
-    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"imagge","image":"ghcr.io/tomhennen/wrangle/osv:latest"}}}'
+@test "check_catalog: an entry naming no image is rejected" {
+    write_catalog '{"tools":{"osv":{"kind":"scan","network":"egress"}}}'
     run "$SCRIPT"
     [ "$status" -eq 1 ]
-    [[ "$output" == *"unrecognized delivery"* ]]
+    [[ "$output" == *"no image"* ]]
 }
 
 @test "check_catalog: dot-dot tool segment is rejected" {
-    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/..@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
+    write_catalog '{"tools":{"osv":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/..@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
     run "$SCRIPT"
     [ "$status" -eq 1 ]
 }
 
-@test "check_catalog: a no-delivery entry with a curated digest-pinned image passes (the toolbox grant)" {
+@test "check_catalog: a kind: attest entry with a curated digest-pinned image passes (the toolbox grant)" {
     write_catalog '{"tools":{"attest-toolbox":{"kind":"attest","image":"ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:'"$(printf 'a%.0s' {1..64})"'","network":"egress"}}}'
     run "$SCRIPT"
     [ "$status" -eq 0 ]
 }
 
-@test "check_catalog: a no-delivery entry with a mutable image is rejected (pin enforced without delivery)" {
+@test "check_catalog: a kind: attest entry with a mutable image is rejected (pin enforced)" {
     write_catalog '{"tools":{"attest-toolbox":{"kind":"attest","image":"ghcr.io/tomhennen/wrangle/attest-toolbox:latest"}}}'
     run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"not digest-pinned"* ]]
 }
 
-@test "check_catalog: a no-delivery entry with an off-namespace image is rejected" {
+@test "check_catalog: a kind: attest entry with an off-namespace image is rejected" {
     write_catalog '{"tools":{"attest-toolbox":{"kind":"attest","image":"ghcr.io/someoneelse/attest-toolbox@sha256:'"$(printf 'a%.0s' {1..64})"'"}}}'
     run "$SCRIPT"
     [ "$status" -eq 1 ]
@@ -121,14 +121,14 @@ write_catalog() { printf '%s\n' "$1" > "$CATALOG"; }
 }
 
 @test "check_catalog: token grant on a scan entry is forbidden" {
-    write_catalog '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'","token":"sigstore"}}}'
+    write_catalog '{"tools":{"osv":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/osv@sha256:'"$(printf 'a%.0s' {1..64})"'","token":"sigstore"}}}'
     run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"token grant forbidden"* ]]
 }
 
 @test "check_catalog: token grant on an sbom entry is forbidden" {
-    write_catalog '{"tools":{"sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/tomhennen/wrangle/syft@sha256:'"$(printf 'a%.0s' {1..64})"'","token":"sigstore"}}}'
+    write_catalog '{"tools":{"sbom":{"kind":"sbom","image":"ghcr.io/tomhennen/wrangle/syft@sha256:'"$(printf 'a%.0s' {1..64})"'","token":"sigstore"}}}'
     run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"token grant forbidden"* ]]

--- a/test/test_check_catalog_freshness.bats
+++ b/test/test_check_catalog_freshness.bats
@@ -17,7 +17,7 @@ setup() {
     command -v jq >/dev/null 2>&1 || { printf 'jq not on PATH\n' >&2; return 1; }
 
     printf '%s\n' \
-        '{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@'"$DIGEST_A"'","network":"egress"}}}' \
+        '{"tools":{"osv":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/osv@'"$DIGEST_A"'","network":"egress"}}}' \
         > "$CATALOG"
 }
 
@@ -74,13 +74,13 @@ SHIM
 
 @test "check_catalog_freshness: a kind:attest image entry (the signing toolbox) is covered, not skipped" {
     # Regression for #689: the toolbox image the signing path depends on must be
-    # freshness-checked like any curated image. The filter keys on
-    # delivery: image, not kind — so a kind: attest entry drifts loudly, not
+    # freshness-checked like any curated image. The filter keys on the named
+    # image, not kind — so a kind: attest entry drifts loudly, not
     # silently. (A stale, validly-attested toolbox digest is the one risk the
     # pull-time VSA gate cannot catch.)
     install_curl
     printf '%s\n' \
-        '{"tools":{"attest-toolbox":{"kind":"attest","delivery":"image","image":"ghcr.io/tomhennen/wrangle/attest-toolbox@'"$DIGEST_A"'","network":"egress","token":"sigstore"}}}' \
+        '{"tools":{"attest-toolbox":{"kind":"attest","image":"ghcr.io/tomhennen/wrangle/attest-toolbox@'"$DIGEST_A"'","network":"egress","token":"sigstore"}}}' \
         > "$CATALOG"
     SHIM_DIGEST="$DIGEST_B" run "$SCRIPT"
     [ "$status" -eq 1 ]
@@ -107,7 +107,7 @@ SHIM
 @test "check_catalog_freshness: drift wins over a second tool's backend error (exit 1)" {
     install_curl_per_image
     printf '%s\n' \
-        '{"tools":{"toola":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toola@'"$DIGEST_A"'"},"toolb":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toolb@'"$DIGEST_A"'"}}}' \
+        '{"tools":{"toola":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/toola@'"$DIGEST_A"'"},"toolb":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/toolb@'"$DIGEST_A"'"}}}' \
         > "$CATALOG"
     run "$SCRIPT"
     [ "$status" -eq 1 ]
@@ -119,7 +119,7 @@ SHIM
     # Token-fail shim: if a non-curated entry were resolved, this would exit 2.
     install_curl
     printf '%s\n' \
-        '{"tools":{"adopter":{"kind":"scan","delivery":"image","image":"registry.example.com/x/y@'"$DIGEST_A"'"}}}' \
+        '{"tools":{"adopter":{"kind":"scan","image":"registry.example.com/x/y@'"$DIGEST_A"'"}}}' \
         > "$CATALOG"
     SHIM_TOKEN_FAIL=1 run "$SCRIPT"
     [ "$status" -eq 0 ]

--- a/test/test_check_catalog_provenance_freshness.bats
+++ b/test/test_check_catalog_provenance_freshness.bats
@@ -49,7 +49,7 @@ _commit() {  # _commit <relpath> <content> -> exports the new HEAD sha in $LAST
 
 _catalog() {
     cat > "$CATALOG" <<JSON
-{"tools":{"osv":{"kind":"scan","delivery":"image","image":"$1","network":"egress"}}}
+{"tools":{"osv":{"kind":"scan","image":"$1","network":"egress"}}}
 JSON
 }
 
@@ -210,8 +210,8 @@ RUN true'
 RUN true'  # toola now stale vs base
     cat > "$CATALOG" <<JSON
 {"tools":{
-  "toola":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toola@$DIGEST"},
-  "toolb":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/toolb@$DIGEST"}}}
+  "toola":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/toola@$DIGEST"},
+  "toolb":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/toolb@$DIGEST"}}}
 JSON
     cat >"$BIN_DIR/gh" <<SHIM
 #!/usr/bin/env bash

--- a/test/test_merge_catalog.bats
+++ b/test/test_merge_catalog.bats
@@ -16,8 +16,8 @@ setup() {
     CUSTOM="$TEST_DIR/custom.json"
     cat > "$CURATED" <<JSON
 {"tools":{
-  "osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@$DIGEST","network":"egress","secret":"github-token"},
-  "sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/tomhennen/wrangle/syft@$DIGEST","network":"none"}
+  "osv":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/osv@$DIGEST","network":"egress","secret":"github-token"},
+  "sbom":{"kind":"sbom","image":"ghcr.io/tomhennen/wrangle/syft@$DIGEST","network":"none"}
 }}
 JSON
 }
@@ -30,7 +30,7 @@ _merge() { run "$MERGE" "$CURATED" "$CUSTOM"; }
 
 @test "merge: a net-new custom tool is unioned in; curated tools survive" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
+{"tools":{"my-sbom":{"kind":"sbom","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
 JSON
     _merge
     [ "$status" -eq 0 ]
@@ -41,7 +41,7 @@ JSON
 
 @test "merge: a name colliding with a curated tool is REJECTED (add-only, no override)" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/myorg/osv@$DIGEST2"}}}
+{"tools":{"osv":{"kind":"scan","image":"ghcr.io/myorg/osv@$DIGEST2"}}}
 JSON
     _merge
     [ "$status" -ne 0 ]
@@ -51,7 +51,7 @@ JSON
 
 @test "merge: an added tool gets exactly the grants it declares (no curated inheritance)" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-scan":{"kind":"scan","delivery":"image","image":"ghcr.io/myorg/s@$DIGEST","network":"egress","secret":"my-token"}}}
+{"tools":{"my-scan":{"kind":"scan","image":"ghcr.io/myorg/s@$DIGEST","network":"egress","secret":"my-token"}}}
 JSON
     _merge
     [ "$status" -eq 0 ]
@@ -63,7 +63,7 @@ JSON
 
 @test "merge: an added tool with no network/secret declares neither" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
+{"tools":{"my-sbom":{"kind":"sbom","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
 JSON
     _merge
     [ "$status" -eq 0 ]
@@ -73,7 +73,7 @@ JSON
 
 @test "merge: rejects an invalid tool name" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"BadName":{"kind":"sbom","delivery":"image","image":"ghcr.io/x@$DIGEST"}}}
+{"tools":{"BadName":{"kind":"sbom","image":"ghcr.io/x@$DIGEST"}}}
 JSON
     _merge
     [ "$status" -ne 0 ]
@@ -82,7 +82,7 @@ JSON
 
 @test "merge: rejects an out-of-allowlist kind" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-sbom":{"kind":"exfiltrate","delivery":"image","image":"ghcr.io/x@$DIGEST"}}}
+{"tools":{"my-sbom":{"kind":"exfiltrate","image":"ghcr.io/x@$DIGEST"}}}
 JSON
     _merge
     [ "$status" -ne 0 ]
@@ -91,7 +91,7 @@ JSON
 
 @test "merge: rejects an out-of-allowlist network" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/x@$DIGEST","network":"host"}}}
+{"tools":{"my-sbom":{"kind":"sbom","image":"ghcr.io/x@$DIGEST","network":"host"}}}
 JSON
     _merge
     [ "$status" -ne 0 ]
@@ -100,7 +100,7 @@ JSON
 
 @test "merge: rejects an invalid secret name" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/x@$DIGEST","secret":"BAD_NAME"}}}
+{"tools":{"my-sbom":{"kind":"sbom","image":"ghcr.io/x@$DIGEST","secret":"BAD_NAME"}}}
 JSON
     _merge
     [ "$status" -ne 0 ]
@@ -109,7 +109,7 @@ JSON
 
 @test "merge: rejects a non-digest-pinned image" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/x:latest"}}}
+{"tools":{"my-sbom":{"kind":"sbom","image":"ghcr.io/x:latest"}}}
 JSON
     _merge
     [ "$status" -ne 0 ]
@@ -118,25 +118,16 @@ JSON
 
 @test "merge: rejects a tool with no image" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-sbom":{"kind":"sbom","delivery":"image"}}}
+{"tools":{"my-sbom":{"kind":"sbom"}}}
 JSON
     _merge
     [ "$status" -ne 0 ]
-    [[ "$output" == *"must declare a digest-pinned image"* ]]
-}
-
-@test "merge: rejects a tool that is not delivery: image" {
-    cat > "$CUSTOM" <<JSON
-{"tools":{"my-sbom":{"kind":"sbom","image":"ghcr.io/x@$DIGEST"}}}
-JSON
-    _merge
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"must declare delivery: image"* ]]
+    [[ "$output" == *"must name a digest-pinned image"* ]]
 }
 
 @test "merge: rejects a custom tool carrying a token grant (curated toolbox only)" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-attest":{"kind":"attest","delivery":"image","image":"ghcr.io/myorg/my-attest@$DIGEST","token":"sigstore"}}}
+{"tools":{"my-attest":{"kind":"attest","image":"ghcr.io/myorg/my-attest@$DIGEST","token":"sigstore"}}}
 JSON
     _merge
     [ "$status" -ne 0 ]
@@ -145,7 +136,7 @@ JSON
 
 @test "merge: an off-namespace custom image is allowed (adopter-trusted)" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
+{"tools":{"my-sbom":{"kind":"sbom","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
 JSON
     _merge
     [ "$status" -eq 0 ]
@@ -154,7 +145,7 @@ JSON
 
 @test "merge: rejects a custom image in the wrangle namespace (no borrowing a VSA identity)" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@$DIGEST"}}}
+{"tools":{"my-osv":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/osv@$DIGEST"}}}
 JSON
     _merge
     [ "$status" -ne 0 ]
@@ -163,7 +154,7 @@ JSON
 
 @test "merge: rejects a wrangle-namespace image via the registry-port form" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-osv":{"kind":"scan","delivery":"image","image":"ghcr.io:443/tomhennen/wrangle/osv@$DIGEST"}}}
+{"tools":{"my-osv":{"kind":"scan","image":"ghcr.io:443/tomhennen/wrangle/osv@$DIGEST"}}}
 JSON
     _merge
     [ "$status" -ne 0 ]
@@ -178,9 +169,9 @@ JSON
 }
 
 @test "merge: preserves curated top-level siblings such as _comment" {
-    printf '{"_comment":"keep me","tools":{"osv":{"kind":"scan","delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@%s"}}}' "$DIGEST" > "$CURATED"
+    printf '{"_comment":"keep me","tools":{"osv":{"kind":"scan","image":"ghcr.io/tomhennen/wrangle/osv@%s"}}}' "$DIGEST" > "$CURATED"
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
+{"tools":{"my-sbom":{"kind":"sbom","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
 JSON
     _merge
     [ "$status" -eq 0 ]
@@ -203,7 +194,7 @@ JSON
 
 @test "merge: tolerates a missing curated catalog (adopter-only tools)" {
     cat > "$CUSTOM" <<JSON
-{"tools":{"my-sbom":{"kind":"sbom","delivery":"image","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
+{"tools":{"my-sbom":{"kind":"sbom","image":"ghcr.io/myorg/my-sbom@$DIGEST"}}}
 JSON
     run "$MERGE" "$TEST_DIR/does-not-exist.json" "$CUSTOM"
     [ "$status" -eq 0 ]

--- a/test/test_orchestrator.bats
+++ b/test/test_orchestrator.bats
@@ -25,7 +25,7 @@ teardown() {
     rm -rf "$TEST_DIR"
 }
 
-# _image_tool <tool> [kind] — declare <tool> as a delivery: image tool in the
+# _image_tool <tool> [kind] — declare <tool> as a curated image tool in the
 # mock catalog, digest-pinned on the curated namespace.
 _image_tool() {
     local tool="$1" kind="${2:-scan}" cat="$MOCK_TOOLS/catalog.json" tmp digest
@@ -33,7 +33,7 @@ _image_tool() {
     [[ -f "$cat" ]] || printf '{"tools":{}}' > "$cat"
     tmp="$(mktemp)"
     jq --arg t "$tool" --arg k "$kind" --arg img "ghcr.io/tomhennen/wrangle/$tool@$digest" \
-        '.tools[$t] = {kind:$k, delivery:"image", image:$img}' "$cat" > "$tmp"
+        '.tools[$t] = {kind:$k, image:$img}' "$cat" > "$tmp"
     mv "$tmp" "$cat"
 }
 
@@ -121,9 +121,9 @@ run_orchestrator() {
 
 # --- Digest-pin enforcement (regex runs before any docker) ---
 
-@test "orchestrator: image delivery rejects a tag-only (non-digest-pinned) image" {
+@test "orchestrator: image dispatch rejects a tag-only (non-digest-pinned) image" {
     cat > "$MOCK_TOOLS/catalog.json" <<JSON
-{"tools":{"imgtool":{"kind":"scan","delivery":"image","image":"registry.internal:5000/osv:latest"}}}
+{"tools":{"imgtool":{"kind":"scan","image":"registry.internal:5000/osv:latest"}}}
 JSON
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "imgtool"
     [ "$status" -eq 2 ]
@@ -133,7 +133,7 @@ JSON
     [ -f "$TEST_DIR/output/imgtool/error" ]
 }
 
-@test "orchestrator: a delivery: image tool with no directory is admitted (not unknown)" {
+@test "orchestrator: a curated image tool with no directory is admitted (not unknown)" {
     _image_tool byotool sbom
     run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
     [[ "$output" != *"unknown tool"* ]]
@@ -169,7 +169,7 @@ _write_custom_tools() {
 }
 
 @test "orchestrator: auto-discovers .wrangle/tools.json and admits a selected new tool" {
-    _write_custom_tools "{\"tools\":{\"byotool\":{\"kind\":\"sbom\",\"delivery\":\"image\",\"image\":\"registry.internal:5000/byo@$_byo_digest\"}}}"
+    _write_custom_tools "{\"tools\":{\"byotool\":{\"kind\":\"sbom\",\"image\":\"registry.internal:5000/byo@$_byo_digest\"}}}"
     GITHUB_WORKSPACE="$TEST_DIR/ws" \
         run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
     [[ "$output" != *"unknown tool"* ]]
@@ -196,7 +196,7 @@ _write_custom_tools() {
 }
 
 @test "orchestrator: an invalid .wrangle/tools.json entry aborts the run" {
-    _write_custom_tools '{"tools":{"byotool":{"kind":"sbom","delivery":"image","image":"ghcr.io/x:latest"}}}'
+    _write_custom_tools '{"tools":{"byotool":{"kind":"sbom","image":"ghcr.io/x:latest"}}}'
     GITHUB_WORKSPACE="$TEST_DIR/ws" \
         run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "byotool"
     [ "$status" -eq 2 ]
@@ -208,7 +208,7 @@ _write_custom_tools() {
     # selection does not name stays defined-but-never-run (the property that makes
     # auto-discovery safe under pull_request_target).
     _image_tool osv
-    _write_custom_tools "{\"tools\":{\"injected\":{\"kind\":\"sbom\",\"delivery\":\"image\",\"image\":\"registry.internal:5000/evil@$_byo_digest\"}}}"
+    _write_custom_tools "{\"tools\":{\"injected\":{\"kind\":\"sbom\",\"image\":\"registry.internal:5000/evil@$_byo_digest\"}}}"
     GITHUB_WORKSPACE="$TEST_DIR/ws" \
         run_orchestrator -s "$TEST_DIR/src" -o "$TEST_DIR/output" "osv"
     [[ "$output" != *"injected"* ]]

--- a/test/test_read_catalog.bats
+++ b/test/test_read_catalog.bats
@@ -18,19 +18,16 @@ setup() {
   "tools": {
     "osv": {
       "kind": "scan",
-      "delivery": "image",
       "image": "ghcr.io/tomhennen/wrangle/osv@sha256:abc123",
       "network": "egress"
     },
     "syft": {
       "kind": "sbom",
-      "delivery": "image",
       "image": "ghcr.io/tomhennen/wrangle/syft@sha256:def456",
       "format": "spdx-json"
     },
     "legacy": {
-      "kind": "scan",
-      "delivery": "adapter"
+      "kind": "scan"
     }
   }
 }
@@ -79,11 +76,6 @@ teardown() {
     [ -z "$output" ]
 }
 
-@test "read_catalog: delivery: adapter is read as adapter" {
-    run "$READER" "$CATALOG" legacy delivery
-    [ "$output" = "adapter" ]
-}
-
 @test "read_catalog: a missing catalog file yields nothing, exit 0" {
     run "$READER" "$TMP_DIR/none.json" osv kind
     [ "$status" -eq 0 ]
@@ -102,9 +94,7 @@ teardown() {
     [[ "$output" == *"Usage"* ]]
 }
 
-@test "read_catalog: the shipped catalog resolves osv as a delivery: image scan tool" {
-    run "$READER" "$ORIG_DIR/tools/catalog.json" osv delivery
-    [ "$output" = "image" ]
+@test "read_catalog: the shipped catalog resolves osv as an image scan tool" {
     run "$READER" "$ORIG_DIR/tools/catalog.json" osv kind
     [ "$output" = "scan" ]
     run "$READER" "$ORIG_DIR/tools/catalog.json" osv image
@@ -114,8 +104,6 @@ teardown() {
 }
 
 @test "read_catalog: the shipped catalog resolves zizmor as a digest-pinned image with egress + github-token" {
-    run "$READER" "$ORIG_DIR/tools/catalog.json" zizmor delivery
-    [ "$output" = "image" ]
     run "$READER" "$ORIG_DIR/tools/catalog.json" zizmor kind
     [ "$output" = "scan" ]
     run "$READER" "$ORIG_DIR/tools/catalog.json" zizmor image
@@ -127,8 +115,6 @@ teardown() {
 }
 
 @test "read_catalog: the shipped catalog resolves wrangle-lint as a digest-pinned image, no network or secret" {
-    run "$READER" "$ORIG_DIR/tools/catalog.json" wrangle-lint delivery
-    [ "$output" = "image" ]
     run "$READER" "$ORIG_DIR/tools/catalog.json" wrangle-lint kind
     [ "$output" = "scan" ]
     run "$READER" "$ORIG_DIR/tools/catalog.json" wrangle-lint image

--- a/test/test_tool_image_tags.bats
+++ b/test/test_tool_image_tags.bats
@@ -21,15 +21,15 @@ teardown() {
     [[ -n "${TMP_DIR:-}" ]] && rm -rf "$TMP_DIR"
 }
 
-@test "catalog_image_dirs: selects every entry naming an image, delivery or not" {
-    # An image-bearing entry is selected regardless of its delivery field —
-    # the check_catalog.sh posture.
+@test "catalog_image_dirs: selects every entry naming an image, skips an imageless one" {
+    # An image-bearing entry is selected; an entry with no image is not — the
+    # check_catalog.sh posture.
     cat > "$TMP_DIR/catalog.json" <<'JSON'
 {"tools":{
-  "osv":{"delivery":"image","image":"ghcr.io/tomhennen/wrangle/osv@sha256:abc"},
-  "sbom":{"delivery":"image","image":"ghcr.io/tomhennen/wrangle/syft@sha256:def"},
+  "osv":{"image":"ghcr.io/tomhennen/wrangle/osv@sha256:abc"},
+  "sbom":{"image":"ghcr.io/tomhennen/wrangle/syft@sha256:def"},
   "attest-toolbox":{"kind":"attest","image":"ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:123"},
-  "legacy":{"delivery":"adapter"}
+  "legacy":{"kind":"scan"}
 }}
 JSON
     run catalog_image_dirs "$TMP_DIR/catalog.json"

--- a/test/test_verify_tool_image.bats
+++ b/test/test_verify_tool_image.bats
@@ -99,7 +99,7 @@ _adopter_image="ghcr.io/adopter/imgtool@sha256:c8abda59e3a64520128c427d2fe9bd223
 
 _catalog() {
     cat > "$TOOLS/catalog.json" <<JSON
-{"tools":{"imgtool":{"kind":"scan","delivery":"image","image":"$1"}}}
+{"tools":{"imgtool":{"kind":"scan","image":"$1"}}}
 JSON
 }
 

--- a/test/tool_image_tags.sh
+++ b/test/tool_image_tags.sh
@@ -11,9 +11,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CATALOG="$REPO_ROOT/tools/catalog.json"
 
 # catalog_image_dirs <catalog_file> — print the tools/ subdirectory name of
-# every entry naming an image (with or without delivery: image, matching
-# check_catalog.sh): the image ref's path tail (minus @digest) is the tool's
-# directory and Dockerfile home.
+# every entry naming an image (matching check_catalog.sh): the image ref's path
+# tail (minus @digest) is the tool's directory and Dockerfile home.
 catalog_image_dirs() {
     local file="$1" image ref
     [[ -f "$file" ]] || return 0

--- a/tools/bump_catalog_digest.sh
+++ b/tools/bump_catalog_digest.sh
@@ -12,7 +12,7 @@ set -f
 # Usage: bump_catalog_digest.sh <tool> <digest>      # digest: sha256:<64 hex>
 #
 # Exit: 0 written (or already current — idempotent), 2 bad usage / unknown tool /
-#       non-image tool / bad digest / unreadable catalog.
+#       non-image entry / bad digest / unreadable catalog.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/read_catalog.sh
@@ -34,15 +34,15 @@ bump_catalog_digest() {
         return 2
     fi
 
-    local delivery image
-    delivery="$(read_catalog_field "$file" "$tool" delivery)"
+    local kind image
+    kind="$(read_catalog_field "$file" "$tool" kind)"
     image="$(read_catalog_field "$file" "$tool" image)"
-    if [[ -z "$delivery" && -z "$image" ]]; then
+    if [[ -z "$kind" && -z "$image" ]]; then
         printf 'bump_catalog_digest: unknown tool: %s\n' "$tool" >&2
         return 2
     fi
-    if [[ "$delivery" != "image" || -z "$image" ]]; then
-        printf 'bump_catalog_digest: %s is not an image-delivery tool\n' "$tool" >&2
+    if [[ -z "$image" ]]; then
+        printf 'bump_catalog_digest: %s is not an image tool\n' "$tool" >&2
         return 2
     fi
 

--- a/tools/bump_catalog_to_latest.sh
+++ b/tools/bump_catalog_to_latest.sh
@@ -5,7 +5,7 @@ set -f  # disable globbing — handles external tool names
 # tools/bump_catalog_to_latest.sh — repoint every curated first-party catalog
 # entry to its current registry `:latest` digest. The batch driver behind the
 # post-publish auto-bump (docs/tool_container_design.md §11): it resolves
-# `:latest` for each ghcr.io/tomhennen/wrangle/* `delivery: image` entry and
+# `:latest` for each ghcr.io/tomhennen/wrangle/* image entry and
 # applies bump_catalog_digest.sh to any that drifted. Adopter-override entries
 # (a foreign namespace) are skipped — wrangle owns only its own images.
 #
@@ -55,7 +55,7 @@ bump_catalog_to_latest() {
         fi
         bumped=$((bumped + 1))
     done < <(jq -r '.tools // {} | to_entries[]
-        | select(.value.delivery == "image")
+        | select(.value.image != null)
         | [.key, .value.image] | @tsv' "$file")
 
     printf 'bump_catalog_to_latest: bumped %d of %d curated image digest(s)\n' "$bumped" "$checked"

--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -3,32 +3,27 @@
   "tools": {
     "osv": {
       "kind": "scan",
-      "delivery": "image",
       "image": "ghcr.io/tomhennen/wrangle/osv@sha256:c6316e86f7dcdcf7ba08e84b40807e837f920c71bf1b0622bf4bae4e2167eeb4",
       "network": "egress"
     },
     "zizmor": {
       "kind": "scan",
-      "delivery": "image",
       "image": "ghcr.io/tomhennen/wrangle/zizmor@sha256:5c4c93346ed8880d4923af84260926ccb9501f00146d62ee00e8d07b98d940d9",
       "network": "egress",
       "secret": "github-token"
     },
     "wrangle-lint": {
       "kind": "scan",
-      "delivery": "image",
       "image": "ghcr.io/tomhennen/wrangle/wrangle-lint@sha256:f168f1d3cfebc145c555e3556c55fdb82c90b5ebeb51586d0f634231bcdeadbd",
       "network": "none"
     },
     "sbom": {
       "kind": "sbom",
-      "delivery": "image",
       "image": "ghcr.io/tomhennen/wrangle/syft@sha256:2b94574c8895299a99ad9159af23315257b1841db9a6483764621e0bcae876f4",
       "network": "none"
     },
     "attest-toolbox": {
       "kind": "attest",
-      "delivery": "image",
       "image": "ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:7aed5ac0d202f235dc61656db24e17a34b728f5d1ef3618a1ea61479e6765151",
       "network": "egress",
       "token": "sigstore"

--- a/tools/check_catalog.sh
+++ b/tools/check_catalog.sh
@@ -8,11 +8,10 @@ set -f  # disable globbing — handles external tool/field names
 # off-namespace image reference can't pass CI green.
 #
 # For every tool it asserts: the file is valid JSON, a `kind` is declared, the
-# `delivery` (if set) is one run.sh recognizes, a declared `network`/`secret`
-# is from the allowed, default-closed set, and a `token` grant is `sigstore` and
-# only on a `kind: attest` entry. A `delivery: image` entry must also name
-# an image. Any entry naming an `image` (image-delivery or not) must be digest-pinned
-# (@sha256: + 64 hex, never a bare tag / :latest / @latest) on the curated namespace
+# entry names an `image`, a declared `network`/`secret` is from the allowed,
+# default-closed set, and a `token` grant is `sigstore` and only on a
+# `kind: attest` entry. The `image` must be digest-pinned (@sha256: + 64 hex,
+# never a bare tag / :latest / @latest) on the curated namespace
 # ghcr.io/tomhennen/wrangle/<tool> — adopter overrides never live in this in-repo
 # catalog (§3.6), so a different host or namespace is a violation.
 #
@@ -46,7 +45,7 @@ validate_catalog() {
         return 1
     fi
 
-    local tool kind delivery image network secret token
+    local tool kind image network secret token
     while IFS= read -r tool; do
         [[ -z "$tool" ]] && continue
 
@@ -85,36 +84,20 @@ validate_catalog() {
             fi
         fi
 
-        # Same allowlist run.sh enforces: empty/adapter/image. A typo'd value must
-        # not skip image enforcement and pass green.
-        delivery="$(read_catalog_field "$file" "$tool" delivery)"
-        case "$delivery" in
-            ''|adapter|image) ;;
-            *)
-                printf 'check_catalog: %s: unrecognized delivery: %s\n' "$tool" "$delivery" >&2
-                rc=1 ;;
-        esac
-
-        if [[ "$delivery" == "image" ]]; then
-            image="$(read_catalog_field "$file" "$tool" image)"
-            if [[ -z "$image" ]]; then
-                printf 'check_catalog: %s: delivery: image but no image\n' "$tool" >&2
-                rc=1
-            fi
-        fi
-
-        # Any entry naming an image, with or without delivery: image.
+        # Every curated entry names an image; that image must be digest-pinned on
+        # the curated namespace.
         image="$(read_catalog_field "$file" "$tool" image)"
-        if [[ -n "$image" ]]; then
-            if [[ "$image" =~ $IMAGE_STRICT_RE ]]; then
-                : # curated, digest-pinned — ok
-            elif [[ "$image" == "$CURATED_PREFIX"* ]]; then
-                printf 'check_catalog: %s: image not digest-pinned (needs ghcr.io/tomhennen/wrangle/<tool>@sha256:<64hex>): %s\n' "$tool" "$image" >&2
-                rc=1
-            else
-                printf 'check_catalog: %s: image off the curated namespace ghcr.io/tomhennen/wrangle/: %s\n' "$tool" "$image" >&2
-                rc=1
-            fi
+        if [[ -z "$image" ]]; then
+            printf 'check_catalog: %s: no image\n' "$tool" >&2
+            rc=1
+        elif [[ "$image" =~ $IMAGE_STRICT_RE ]]; then
+            : # curated, digest-pinned — ok
+        elif [[ "$image" == "$CURATED_PREFIX"* ]]; then
+            printf 'check_catalog: %s: image not digest-pinned (needs ghcr.io/tomhennen/wrangle/<tool>@sha256:<64hex>): %s\n' "$tool" "$image" >&2
+            rc=1
+        else
+            printf 'check_catalog: %s: image off the curated namespace ghcr.io/tomhennen/wrangle/: %s\n' "$tool" "$image" >&2
+            rc=1
         fi
     done < <(jq -r '.tools // {} | keys[]' "$file")
 

--- a/tools/check_catalog_freshness.sh
+++ b/tools/check_catalog_freshness.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 set -f  # disable globbing — handles external tool names
 
 # tools/check_catalog_freshness.sh — adoption-lag freshness check for the curated
-# image entries in tools/catalog.json. For each curated `delivery: image` entry on
+# image entries in tools/catalog.json. For each curated image entry on
 # the registry namespace ghcr.io/tomhennen/wrangle/*, it resolves the registry
 # digest of the tool's moving `:latest` tag and compares it to the catalog's
 # pinned @sha256: digest. A mismatch means wrangle published a newer tool image
@@ -43,7 +43,7 @@ source "$SCRIPT_DIR/../lib/registry.sh"
 # check_freshness <catalog_file> — returns 0 in sync, 1 drift, 2 backend error.
 check_freshness() {
     local file="$1" rc=0 drift=0 backend_err=0
-    local tool delivery image imagename pinned resolved checked=0
+    local tool image imagename pinned resolved checked=0
 
     if [[ ! -f "$file" ]]; then
         printf 'check_catalog_freshness: catalog not found: %s\n' "$file" >&2
@@ -56,9 +56,8 @@ check_freshness() {
 
     while IFS= read -r tool; do
         [[ -z "$tool" ]] && continue
-        delivery="$(read_catalog_field "$file" "$tool" delivery)"
-        [[ "$delivery" == "image" ]] || continue
         image="$(read_catalog_field "$file" "$tool" image)"
+        [[ -n "$image" ]] || continue
         imagename="${image%@sha256:*}"
         pinned="${image##*@}"
 

--- a/tools/check_catalog_provenance_freshness.sh
+++ b/tools/check_catalog_provenance_freshness.sh
@@ -67,7 +67,7 @@ provenance_build_commit() {
 # image, 2 backend/env error.
 check_provenance_freshness() {
     local file="$1" rc=0 stale=0 backend_err=0
-    local tool delivery image imagename commit checked=0 repo_root
+    local tool image imagename commit checked=0 repo_root
 
     if ! command -v gh >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
         printf 'check_catalog_provenance_freshness: gh and jq are required\n' >&2
@@ -88,9 +88,8 @@ check_provenance_freshness() {
 
     while IFS= read -r tool; do
         [[ -z "$tool" ]] && continue
-        delivery="$(read_catalog_field "$file" "$tool" delivery)"
-        [[ "$delivery" == "image" ]] || continue
         image="$(read_catalog_field "$file" "$tool" image)"
+        [[ -n "$image" ]] || continue
         imagename="${image%@sha256:*}"
 
         # Skip adopter-override entries — not wrangle-signed.

--- a/tools/zizmor/SPEC.md
+++ b/tools/zizmor/SPEC.md
@@ -2,7 +2,7 @@
 
 | Property | Value |
 |----------|-------|
-| Pattern | Adapter, delivered as a contract image (catalog `delivery: image`); `adapter.sh` is the image ENTRYPOINT and `run.sh` invokes it via `docker run` |
+| Pattern | Adapter, delivered as a contract image (catalog `image` entry); `adapter.sh` is the image ENTRYPOINT and `run.sh` invokes it via `docker run` |
 | Integrity verification | zizmor installed into the image from the hash-pinned `tools/zizmor/requirements.txt` (`pip --require-hashes`, the canonical PyPI distribution — keeps the dependency manifest in-repo for Dependabot/osv) |
 | SARIF output | `adapter.sh` runs `zizmor --format sarif` and writes `$WRANGLE_METADATA_DIR/zizmor/output.sarif` |
 | Human-readable output | `output.md` generated from SARIF via `lib/sarif_to_md.sh` for step summary details |
@@ -16,7 +16,7 @@
 
 Zizmor has two install paths, both driven by the hash-pinned `tools/zizmor/requirements.txt` and kept fresh by Dependabot (pip ecosystem; see `.github/dependabot.yml`):
 
-1. **CI / adopters** — the `tools/zizmor/Dockerfile` installs zizmor via `pip --require-hashes` into the tool image; `run.sh` runs that image (catalog `delivery: image`).
+1. **CI / adopters** — the `tools/zizmor/Dockerfile` installs zizmor via `pip --require-hashes` into the tool image; `run.sh` runs that image (catalog `image` entry).
 2. **Local test container** — `test/Dockerfile` installs zizmor the same way into a managed venv. `make zizmor` (and the default `./test.sh`) runs this copy against the wrangle repo so workflow security findings surface in the same `make test` loop as shellcheck and actionlint.
 
 Pip refuses any artifact whose sha256 isn't in `requirements.txt`, so version and hashes always move together.

--- a/tools/zizmor/test.bats
+++ b/tools/zizmor/test.bats
@@ -2,7 +2,7 @@
 
 # Tests for tools/zizmor/ (image pattern).
 #
-# zizmor ships as a contract image (catalog delivery: image); adapter.sh is its
+# zizmor ships as a contract image (catalog image entry); adapter.sh is its
 # ENTRYPOINT, mapping `zizmor --format sarif` to the 0/1/2 exit contract. These
 # cover that mapping through a PATH shim (the invalid-SARIF / tool-error / no-
 # inputs branches a real scanner won't emit on demand), the requirements pin +


### PR DESCRIPTION
claude: Stage B of the image-only tool-delivery cleanup (tracking #740).

## What
Stage A left `run.sh` dispatching only catalog **image** tools, so every entry now names an `image` and the single-valued `delivery` field is redundant. This removes `delivery` entirely and re-keys every consumer on **"the entry names an `image`"**.

New per-tool catalog schema: `{kind, image, network?, secret?, token?}` — an entry naming an `image` IS a curated image tool.

## How each consumer was re-keyed
- **tools/catalog.json** — dropped `"delivery": "image"` from all 5 entries; nothing else.
- **run.sh** — parse loop now rejects a tool whose entry names no `image` (same "unknown tool … no catalog image entry" error/exit 2); the near-dead `run_one_tool` guard reworded to "catalog entry names no image"; comments updated.
- **tools/check_catalog.sh** — the `delivery` read + allowlist + `delivery == image` conditional are gone; **every entry MUST name an image** (unconditional error otherwise), then the existing digest-pin + curated-namespace enforcement runs verbatim. `kind`/`network`/`secret`/`token` validation unchanged.
- **lib/merge_catalog.sh** (adopter custom-tool security control) — the `delivery != image` guard is replaced by the pre-existing image-presence check, which is now the control: a custom entry must name a digest-pinned image **outside** the wrangle namespace. All other guards (add-only, no curated collision, no token grant, off-namespace-but-pinned) intact.
- **Currency scripts** — `bump_catalog_to_latest` / `check_catalog_freshness` / `check_catalog_provenance_freshness` gate on `image != null` / image-presence instead of `delivery == "image"`. `bump_catalog_digest` keys "unknown tool" off an absent `kind` and "not an image tool" off an absent `image`, preserving both messages.
- **Tests** — stripped `"delivery"` from every image fixture; the old non-image / `delivery: adapter` cases now represent "not a tool" as **an entry with no `image`**. Added a `check_catalog` regression: a no-image entry is rejected. Deleted the now-obsolete "typo'd delivery" and "not delivery: image" tests.
- **Docs** — SPEC.md catalog schema/BYO sections, tool_container_design.md §3.6 + schema example + attest-toolbox grant, README BYO example, and zizmor per-tool SPEC/test state the schema as `{kind, image, network?, secret?, token?}`.

## Testing
- `make shellcheck` — clean.
- Affected unit bats (check_catalog, merge_catalog, both freshness, both bump, read_catalog, tool_image_tags, verify_tool_image, orchestrator) — 117/117 green.
- `./tools/check_catalog.sh` on the delivery-stripped real catalog — exit 0.
- `bats test/image/test_run_image_dispatch.bats test/image/test_byo_sbom.bats` (docker available) — 29/29 green.
- Repo-wide grep: zero remaining references to a catalog `delivery` field; only generic "delivery" senses (VSA "delivery gap", the "Tool delivery" heading, "image-delivery" adjective, Stage-A branch-name pin comments) remain.

Closes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)