### PR TITLE
claude: documented-recipe verifier (step 1 of 2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
       - "/actions/prep"
       - "/actions/scan"
       - "/actions/verify"
+      - "/actions/verify-showcase-recipes"
       - "/actions/verify-vsa"
       - "/actions/verify_release"
       - "/build/actions/container"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SHELL := /bin/bash
 # The bats suites that need real binaries and network (skip_or_fail-gated).
 # Local-only convenience subset for `./test.sh integration`; CI runs every
 # .bats via the dogfooded shell build's auto-detect (local_build_shell.yml).
-INTEGRATION_BATS := tools/osv/test.bats policies/test.bats actions/verify/test_run_verify.bats actions/verify/test_validate_verify_inputs.bats test/consumer/verify_consumer_vsa.bats test/consumer/verify_consumer_provenance.bats
+INTEGRATION_BATS := tools/osv/test.bats policies/test.bats actions/verify/test_run_verify.bats actions/verify/test_validate_verify_inputs.bats test/consumer/verify_consumer_vsa.bats test/consumer/verify_consumer_provenance.bats test/consumer/verify_documented_recipes.bats
 
 # Default target
 all: test

--- a/actions/verify-showcase-recipes/action.yml
+++ b/actions/verify-showcase-recipes/action.yml
@@ -1,0 +1,76 @@
+name: Wrangle verify documented recipes
+description: >
+  Run the artifact-verification recipes documented in docs/verifying_artifacts.md
+  against live wrangle-built artifacts, proving the documented adopter commands
+  (raw ampel / cosign / gh attestation) still verify. Installs the pinned ampel
+  and cosign from wrangle's tools/go.mod and calls tools/verify_documented_recipes.sh.
+  Intended for a showcase run, not adopter workflows.
+
+inputs:
+  file:
+    description: File artifact (Go / Python / npm dist) to verify.
+    required: false
+    default: ""
+  bundle:
+    description: The <artifact>.intoto.jsonl bundle for --file.
+    required: false
+    default: ""
+  image:
+    description: Container image name without a digest (e.g. ghcr.io/org/name).
+    required: false
+    default: ""
+  digest:
+    description: sha256 hex (no "sha256:" prefix) of --image.
+    required: false
+    default: ""
+  resource-uri:
+    description: The resourceUri the VSA must name (purl or OCI ref).
+    required: false
+    default: ""
+  repo:
+    description: Origin repository the VSA/provenance signer must name (<owner>/<repo>).
+    required: false
+    default: ${{ github.repository }}
+  build-type:
+    description: Build type for the cosign/gh signer literal (go, python, npm, container).
+    required: false
+    default: ""
+  provenance:
+    description: Also run the `gh attestation verify` recipe (needs file + repo + build-type).
+    required: false
+    default: "false"
+  attestation-store:
+    description: Also run the `github:` collector recipe (needs repo + resource-uri).
+    required: false
+    default: "false"
+  non-strict:
+    description: Relax to the non-strict policy/identity (wrangle's own dogfood builds).
+    required: false
+    default: "false"
+  github-token:
+    description: Token for `gh attestation verify` and the `github:` collector reads.
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install ampel + cosign
+      shell: bash
+      run: "${{ github.action_path }}/install_tools.sh"
+
+    - name: Run documented recipes
+      shell: bash
+      env:
+        FILE: ${{ inputs.file }}
+        BUNDLE: ${{ inputs.bundle }}
+        IMAGE: ${{ inputs.image }}
+        DIGEST: ${{ inputs.digest }}
+        RESOURCE_URI: ${{ inputs.resource-uri }}
+        REPO: ${{ inputs.repo }}
+        BUILD_TYPE: ${{ inputs.build-type }}
+        PROVENANCE: ${{ inputs.provenance }}
+        ATTESTATION_STORE: ${{ inputs.attestation-store }}
+        NON_STRICT: ${{ inputs.non-strict }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: "${{ github.action_path }}/run_recipes.sh"

--- a/actions/verify-showcase-recipes/install_tools.sh
+++ b/actions/verify-showcase-recipes/install_tools.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Install ampel and cosign at the versions pinned in tools/go.mod, onto PATH for
+# later steps. tools/go.mod is the single source of truth for these pins
+# (branch-1 / Dependabot-covered per DEP_MGMT.md), so there is no second checksum
+# to drift; env.sh asserts GOPROXY/GOSUMDB so sum-database verification can't be
+# disabled by the runner's environment.
+set -euo pipefail
+set -f
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=../../lib/env.sh
+source "$REPO_ROOT/lib/env.sh"
+
+mkdir -p "$WRANGLE_BIN_DIR"
+GOBIN="$(cd "$WRANGLE_BIN_DIR" && pwd)" go -C "$REPO_ROOT/tools" install \
+    github.com/carabiner-dev/ampel/cmd/ampel \
+    github.com/sigstore/cosign/v3/cmd/cosign
+
+# Later composite steps run in fresh shells; env.sh's PATH export covers only
+# this process.
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+    printf '%s\n' "$WRANGLE_BIN_DIR" >> "$GITHUB_PATH"
+fi
+
+printf 'verify-showcase-recipes: installed:\n'
+ampel version | head -1
+cosign version 2>&1 | grep GitVersion

--- a/actions/verify-showcase-recipes/run_recipes.sh
+++ b/actions/verify-showcase-recipes/run_recipes.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Assemble tools/verify_documented_recipes.sh's flags from the action inputs
+# (threaded in as env, never interpolated into this body) and run it.
+#
+# Env: FILE BUNDLE IMAGE DIGEST RESOURCE_URI REPO BUILD_TYPE (values), and
+# PROVENANCE ATTESTATION_STORE NON_STRICT ("true" to enable).
+set -euo pipefail
+set -f
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${WRANGLE_RECIPE_RUNNER:-$SCRIPT_DIR/../../tools/verify_documented_recipes.sh}"
+
+args=()
+[[ -n "${FILE:-}" ]]         && args+=(--file "$FILE")
+[[ -n "${BUNDLE:-}" ]]       && args+=(--bundle "$BUNDLE")
+[[ -n "${IMAGE:-}" ]]        && args+=(--image "$IMAGE")
+[[ -n "${DIGEST:-}" ]]       && args+=(--digest "$DIGEST")
+[[ -n "${RESOURCE_URI:-}" ]] && args+=(--resource-uri "$RESOURCE_URI")
+[[ -n "${REPO:-}" ]]         && args+=(--repo "$REPO")
+[[ -n "${BUILD_TYPE:-}" ]]   && args+=(--type "$BUILD_TYPE")
+[[ "${PROVENANCE:-}" == "true" ]]        && args+=(--provenance)
+[[ "${ATTESTATION_STORE:-}" == "true" ]] && args+=(--attestation-store)
+[[ "${NON_STRICT:-}" == "true" ]]        && args+=(--non-strict)
+
+exec "$RUNNER" "${args[@]}"

--- a/actions/verify-showcase-recipes/test_action.bats
+++ b/actions/verify-showcase-recipes/test_action.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+
+# Structure guard for the verify-showcase-recipes composite and hermetic tests
+# for run_recipes.sh's env->flag assembly (stub runner, no tools, no network).
+
+setup() {
+    DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    ACTION="$DIR/action.yml"
+    RUN="$DIR/run_recipes.sh"
+    STUB="$BATS_TEST_TMPDIR/runner.sh"
+    # A stub runner that records the exact argv it was called with.
+    printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$@"\n' > "$STUB"
+    chmod +x "$STUB"
+    export DIR ACTION RUN STUB
+}
+
+@test "action is a composite that installs tools then runs the recipes" {
+    grep -Fq "using: composite" "$ACTION"
+    grep -Fq '${{ github.action_path }}/install_tools.sh' "$ACTION"
+    grep -Fq '${{ github.action_path }}/run_recipes.sh' "$ACTION"
+}
+
+@test "action threads every coordinate through env, not the run body" {
+    # Attacker-controllable inputs must reach the script via env: (WWL002), so the
+    # run: bodies are bare script paths with no ${{ inputs.* }} interpolation.
+    grep -Fq 'FILE: ${{ inputs.file }}' "$ACTION"
+    grep -Fq 'REPO: ${{ inputs.repo }}' "$ACTION"
+    grep -Fq 'GITHUB_TOKEN: ${{ inputs.github-token }}' "$ACTION"
+    run bash -c 'grep -E "run: .*\\$\\{\\{ inputs\\." "$ACTION"'
+    [[ "$status" -ne 0 ]]
+}
+
+@test "install_tools.sh installs ampel + cosign from tools/go.mod (single source)" {
+    grep -Fq 'go -C "$REPO_ROOT/tools" install' "$DIR/install_tools.sh"
+    grep -Fq 'github.com/carabiner-dev/ampel/cmd/ampel' "$DIR/install_tools.sh"
+    grep -Fq 'github.com/sigstore/cosign/v3/cmd/cosign' "$DIR/install_tools.sh"
+}
+
+@test "run_recipes.sh assembles file-class flags from env" {
+    WRANGLE_RECIPE_RUNNER="$STUB" \
+        FILE=dist/pkg.tgz BUNDLE=dist/pkg.tgz.intoto.jsonl \
+        RESOURCE_URI="pkg:npm/x@1" REPO=o/r BUILD_TYPE=npm \
+        run "$RUN"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"--file"$'\n'"dist/pkg.tgz"* ]]
+    [[ "$output" == *"--bundle"$'\n'"dist/pkg.tgz.intoto.jsonl"* ]]
+    [[ "$output" == *"--type"$'\n'"npm"* ]]
+}
+
+@test "run_recipes.sh emits boolean flags only when true" {
+    WRANGLE_RECIPE_RUNNER="$STUB" \
+        IMAGE=ghcr.io/o/i DIGEST=abc REPO=o/r \
+        PROVENANCE=false ATTESTATION_STORE=true NON_STRICT=false \
+        run "$RUN"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"--attestation-store"* ]]
+    [[ "$output" != *"--provenance"* ]]
+    [[ "$output" != *"--non-strict"* ]]
+}
+
+@test "run_recipes.sh omits flags for empty inputs" {
+    WRANGLE_RECIPE_RUNNER="$STUB" REPO=o/r run "$RUN"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"--file"* ]]
+    [[ "$output" != *"--image"* ]]
+    [[ "$output" == *"--repo"$'\n'"o/r"* ]]
+}

--- a/actions/verify-showcase-recipes/test_verify_recipes.bats
+++ b/actions/verify-showcase-recipes/test_verify_recipes.bats
@@ -96,8 +96,7 @@ _stub() {
 @test "a newly-added placeholder in the doc fails the substitution guard" {
     printf '```bash\nampel verify --subject <artifact> --context foo:<brand-new>\n```\n' \
         > "$BATS_TEST_TMPDIR/drift.md"
-    export WRANGLE_RECIPES_DOC="$BATS_TEST_TMPDIR/drift.md"
-    run bash -c '
+    WRANGLE_RECIPES_DOC="$BATS_TEST_TMPDIR/drift.md" run bash -c '
         source "$SCRIPT"
         REPO=o/r; RESOURCE_URI=x; ARTIFACT_NAME=a; IMAGE_NAME=; DIGEST=; BUILD_TYPE=go; NON_STRICT=0
         _substitute "$(_select_block "--subject <artifact>")"
@@ -109,16 +108,14 @@ _stub() {
 @test "a duplicated recipe block fails selection (drift, not silent pick)" {
     printf '```bash\nfoo --collector oci: one\n```\n```bash\nfoo --collector oci: two\n```\n' \
         > "$BATS_TEST_TMPDIR/dup.md"
-    export WRANGLE_RECIPES_DOC="$BATS_TEST_TMPDIR/dup.md"
-    run bash -c 'source "$SCRIPT"; _select_block "--collector oci:"'
+    WRANGLE_RECIPES_DOC="$BATS_TEST_TMPDIR/dup.md" run bash -c 'source "$SCRIPT"; _select_block "--collector oci:"'
     [[ "$status" -eq 2 ]]
     [[ "$output" == *"found 2"* ]]
 }
 
 @test "a missing recipe block fails selection" {
     printf '```bash\nunrelated command\n```\n' > "$BATS_TEST_TMPDIR/missing.md"
-    export WRANGLE_RECIPES_DOC="$BATS_TEST_TMPDIR/missing.md"
-    run bash -c 'source "$SCRIPT"; _select_block "--collector oci:"'
+    WRANGLE_RECIPES_DOC="$BATS_TEST_TMPDIR/missing.md" run bash -c 'source "$SCRIPT"; _select_block "--collector oci:"'
     [[ "$status" -eq 2 ]]
     [[ "$output" == *"found 0"* ]]
 }

--- a/actions/verify-showcase-recipes/test_verify_recipes.bats
+++ b/actions/verify-showcase-recipes/test_verify_recipes.bats
@@ -1,0 +1,195 @@
+#!/usr/bin/env bats
+
+# Hermetic tests for tools/verify_documented_recipes.sh — no network, no live
+# artifacts. Two layers:
+#   - anti-drift: every documented recipe extracts to exactly one template block
+#     and fully substitutes against the REAL docs/verifying_artifacts.md; a
+#     duplicated, missing, or newly-placeheldered block fails closed.
+#   - orchestration: with stub ampel/gh on PATH, a recipe's exit code drives the
+#     script's PASS/FAIL and exit status, retry is bounded, and bad inputs are
+#     rejected before anything runs.
+# The real-tool pass/tamper checks against the captured fixtures need Sigstore,
+# so they live in the integration suite (test/consumer), not here.
+
+setup() {
+    DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/tools/verify_documented_recipes.sh"
+    DOC="$REPO_ROOT/docs/verifying_artifacts.md"
+    STUB="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$STUB"
+    HEX="$(printf 'x' | sha256sum | cut -d' ' -f1)"
+    export DIR REPO_ROOT SCRIPT DOC STUB HEX
+}
+
+# A stub that echoes its argv and exits ${STUB_RC:-0}, so orchestration tests
+# assert exit-code plumbing and the substituted command line without a real tool.
+_stub() {
+    local name="$1"
+    printf '#!/usr/bin/env bash\nprintf "STUB %s %%s\\n" "$*"\nexit ${STUB_RC:-0}\n' "$name" > "$STUB/$name"
+    chmod +x "$STUB/$name"
+}
+
+# --- anti-drift: selection + substitution against the real doc ----------------
+
+@test "every documented recipe selects exactly one template block from the real doc" {
+    run bash -c '
+        source "$SCRIPT"
+        for sig in \
+            "--collector jsonl:<artifact>" \
+            "sha256sum <artifact>" \
+            ".predicate.verifiedLevels[]" \
+            "--collector oci:" \
+            "cosign download attestation" \
+            "--collector github:" \
+            "gh attestation verify"; do
+            _select_block "$sig" >/dev/null || exit 1
+        done
+        echo ALL_SELECTED
+    '
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *ALL_SELECTED* ]]
+}
+
+@test "every recipe substitutes with no placeholder left over against the real doc" {
+    run bash -c '
+        source "$SCRIPT"
+        REPO="o/r"; RESOURCE_URI="pkg:npm/x@1"; ARTIFACT_NAME="a.tgz"
+        IMAGE_NAME="ghcr.io/o/i"; DIGEST="'"$HEX"'"; BUILD_TYPE="npm"; NON_STRICT=0
+        for sig in \
+            "--collector jsonl:<artifact>" "sha256sum <artifact>" \
+            ".predicate.verifiedLevels[]" "--collector oci:" \
+            "cosign download attestation" "--collector github:" \
+            "gh attestation verify"; do
+            _substitute "$(_select_block "$sig")" >/dev/null || exit 1
+        done
+        echo ALL_SUBSTITUTED
+    '
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *ALL_SUBSTITUTED* ]]
+}
+
+@test "non-strict swaps the ampel policy to the non-strict variant" {
+    run bash -c '
+        source "$SCRIPT"
+        REPO="o/r"; RESOURCE_URI="pkg:npm/x@1"; ARTIFACT_NAME="a.tgz"
+        IMAGE_NAME=""; DIGEST=""; BUILD_TYPE="npm"; NON_STRICT=1
+        _substitute "$(_select_block "--collector jsonl:<artifact>")"
+    '
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"wrangle-vsa-consumer-nonstrict-v1.hjson"* ]]
+}
+
+@test "non-strict relaxes the cosign release-tag anchor to any ref" {
+    run bash -c '
+        source "$SCRIPT"
+        REPO="o/r"; RESOURCE_URI="pkg:npm/x@1"; ARTIFACT_NAME="a.tgz"
+        IMAGE_NAME=""; DIGEST=""; BUILD_TYPE="npm"; NON_STRICT=1
+        _substitute "$(_select_block "sha256sum <artifact>")"
+    '
+    [[ "$status" -eq 0 ]]
+    # The strict release-tag anchor must be gone; the workflow prefix stays.
+    [[ "$output" != *"refs/tags/v[0-9.]+"* ]]
+    [[ "$output" == *'build_and_publish_npm\.yml@'* ]]
+}
+
+@test "a newly-added placeholder in the doc fails the substitution guard" {
+    printf '```bash\nampel verify --subject <artifact> --context foo:<brand-new>\n```\n' \
+        > "$BATS_TEST_TMPDIR/drift.md"
+    export WRANGLE_RECIPES_DOC="$BATS_TEST_TMPDIR/drift.md"
+    run bash -c '
+        source "$SCRIPT"
+        REPO=o/r; RESOURCE_URI=x; ARTIFACT_NAME=a; IMAGE_NAME=; DIGEST=; BUILD_TYPE=go; NON_STRICT=0
+        _substitute "$(_select_block "--subject <artifact>")"
+    '
+    [[ "$status" -eq 2 ]]
+    [[ "$output" == *"unsubstituted placeholder"* ]]
+}
+
+@test "a duplicated recipe block fails selection (drift, not silent pick)" {
+    printf '```bash\nfoo --collector oci: one\n```\n```bash\nfoo --collector oci: two\n```\n' \
+        > "$BATS_TEST_TMPDIR/dup.md"
+    export WRANGLE_RECIPES_DOC="$BATS_TEST_TMPDIR/dup.md"
+    run bash -c 'source "$SCRIPT"; _select_block "--collector oci:"'
+    [[ "$status" -eq 2 ]]
+    [[ "$output" == *"found 2"* ]]
+}
+
+@test "a missing recipe block fails selection" {
+    printf '```bash\nunrelated command\n```\n' > "$BATS_TEST_TMPDIR/missing.md"
+    export WRANGLE_RECIPES_DOC="$BATS_TEST_TMPDIR/missing.md"
+    run bash -c 'source "$SCRIPT"; _select_block "--collector oci:"'
+    [[ "$status" -eq 2 ]]
+    [[ "$output" == *"found 0"* ]]
+}
+
+# --- orchestration: stub-driven exit-code plumbing + retry --------------------
+
+@test "attestation-store recipe PASSES when ampel exits 0" {
+    _stub ampel
+    PATH="$STUB:$PATH" WRANGLE_RECIPE_RETRY_DELAY=0 run "$SCRIPT" \
+        --attestation-store --repo o/r --resource-uri "pkg:npm/x@1" --digest "$HEX"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"PASS:"* ]]
+    [[ "$output" == *"1 passed, 0 failed"* ]]
+}
+
+@test "attestation-store recipe FAILS (exit 1) and retries when ampel keeps failing" {
+    _stub ampel
+    PATH="$STUB:$PATH" STUB_RC=1 WRANGLE_RECIPE_RETRIES=3 WRANGLE_RECIPE_RETRY_DELAY=0 run "$SCRIPT" \
+        --attestation-store --repo o/r --resource-uri "pkg:npm/x@1" --digest "$HEX"
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"attempt 1/3"* ]]
+    [[ "$output" == *"attempt 2/3"* ]]
+    [[ "$output" == *"FAIL:"* ]]
+}
+
+@test "non-strict flag reaches the executed ampel command line" {
+    _stub ampel
+    PATH="$STUB:$PATH" WRANGLE_RECIPE_RETRY_DELAY=0 run "$SCRIPT" \
+        --attestation-store --repo o/r --resource-uri "pkg:npm/x@1" --digest "$HEX" --non-strict
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"nonstrict"* ]]
+}
+
+@test "provenance recipe PASSES when gh exits 0" {
+    _stub gh
+    printf 'x' > "$BATS_TEST_TMPDIR/art.tgz"
+    PATH="$STUB:$PATH" WRANGLE_RECIPE_RETRY_DELAY=0 run "$SCRIPT" \
+        --provenance --file "$BATS_TEST_TMPDIR/art.tgz" --repo o/r --type npm
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"build_and_publish_npm.yml"* ]]
+    [[ "$output" == *"1 passed, 0 failed"* ]]
+}
+
+# --- input validation (fail before any recipe runs, exit 2) ------------------
+
+@test "rejects a malformed --repo" {
+    run "$SCRIPT" --attestation-store --repo not-a-repo --resource-uri x --digest "$HEX"
+    [[ "$status" -eq 2 ]]
+    [[ "$output" == *"bad --repo"* ]]
+}
+
+@test "rejects a non-hex --digest" {
+    run "$SCRIPT" --attestation-store --repo o/r --resource-uri x --digest NOTHEX
+    [[ "$status" -eq 2 ]]
+}
+
+@test "rejects an unknown build --type" {
+    printf 'x' > "$BATS_TEST_TMPDIR/art.tgz"
+    run "$SCRIPT" --provenance --file "$BATS_TEST_TMPDIR/art.tgz" --repo o/r --type rust
+    [[ "$status" -eq 2 ]]
+    [[ "$output" == *"bad --type"* ]]
+}
+
+@test "rejects an unknown flag" {
+    run "$SCRIPT" --bogus
+    [[ "$status" -eq 2 ]]
+    [[ "$output" == *"unknown argument"* ]]
+}
+
+@test "no coordinates prints usage and exits 2" {
+    run "$SCRIPT"
+    [[ "$status" -eq 2 ]]
+    [[ "$output" == *"Usage:"* ]]
+}

--- a/test/consumer/verify_documented_recipes.bats
+++ b/test/consumer/verify_documented_recipes.bats
@@ -56,7 +56,10 @@ require_tools() {
     require_sigstore
     cp "$BLOB" "$TMP/tampered.tgz"
     printf 'tamper' >> "$TMP/tampered.tgz"   # one extra byte -> different sha256
+    # Tamper failure is deterministic, so retrying (and re-hitting Sigstore) is
+    # pointless — fail fast.
     PATH="$(dirname "$AMPEL_BIN"):$(dirname "$COSIGN_BIN"):$PATH" \
+        WRANGLE_RECIPE_RETRIES=1 \
         run "$SCRIPT" --file "$TMP/tampered.tgz" --bundle "$BUNDLE" \
         --resource-uri "$RESOURCE_URI" --repo "$SIGNER_REPO" --type npm
     [[ "$status" -eq 1 ]]

--- a/test/consumer/verify_documented_recipes.bats
+++ b/test/consumer/verify_documented_recipes.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+# End-to-end check that tools/verify_documented_recipes.sh — the extract-and-run
+# recipe runner a showcase calls — actually verifies a real keyless VSA by
+# executing the fenced blocks from docs/verifying_artifacts.md. Drives the
+# checked-in npm fixture (a real release-tag-signed VSA + its package blob),
+# through the file-artifact recipes (ampel jsonl collector, cosign + jq, the
+# verifiedLevels read).
+#
+# Needs real cosign + ampel + Sigstore reachability and fetches the shipped
+# consumer policy by locator, so it runs in the integration job, not the
+# hermetic unit suite. skip_or_fail keeps sandboxed local dev from hard-failing
+# while CI rejects a silent skip.
+
+load "../lib/bats_helpers"
+
+RESOURCE_URI="pkg:npm/@tomhennen/wrangle-integration-fixture@0.0.1-dev.27500274491"
+SIGNER_REPO="TomHennen/wrangle-test"
+
+setup() {
+    DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    FIX="$DIR/fixtures"
+    REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/tools/verify_documented_recipes.sh"
+    BLOB="$FIX/npm-package.tgz"
+    BUNDLE="$FIX/npm-vsa.intoto.jsonl"
+    AMPEL_BIN="$(command -v ampel || echo "${WRANGLE_BIN_DIR:-/nonexistent}/ampel")"
+    COSIGN_BIN="$(command -v cosign || echo "${WRANGLE_BIN_DIR:-/nonexistent}/cosign")"
+    TMP="$(mktemp -d)"
+}
+
+teardown() { rm -rf "$TMP"; }
+
+require_sigstore() {
+    if in_ci; then return 0; fi
+    curl -fsS -m 10 -o /dev/null https://rekor.sigstore.dev/api/v1/log 2>/dev/null \
+        || skip_or_fail "rekor.sigstore.dev unreachable"
+}
+
+require_tools() {
+    [[ -x "$AMPEL_BIN" && -x "$COSIGN_BIN" ]] || skip_or_fail "real ampel + cosign not available"
+}
+
+@test "runner verifies a real release-tag VSA through the documented file recipes" {
+    require_tools
+    require_sigstore
+    PATH="$(dirname "$AMPEL_BIN"):$(dirname "$COSIGN_BIN"):$PATH" \
+        run "$SCRIPT" --file "$BLOB" --bundle "$BUNDLE" \
+        --resource-uri "$RESOURCE_URI" --repo "$SIGNER_REPO" --type npm
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"3 passed, 0 failed"* ]]
+}
+
+@test "runner FAILS closed on tampered artifact bytes (valid VSA, wrong content)" {
+    require_tools
+    require_sigstore
+    cp "$BLOB" "$TMP/tampered.tgz"
+    printf 'tamper' >> "$TMP/tampered.tgz"   # one extra byte -> different sha256
+    PATH="$(dirname "$AMPEL_BIN"):$(dirname "$COSIGN_BIN"):$PATH" \
+        run "$SCRIPT" --file "$TMP/tampered.tgz" --bundle "$BUNDLE" \
+        --resource-uri "$RESOURCE_URI" --repo "$SIGNER_REPO" --type npm
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"FAIL:"* ]]
+}

--- a/tools/verify_documented_recipes.sh
+++ b/tools/verify_documented_recipes.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# Run the artifact-verification recipes documented in docs/verifying_artifacts.md
+# against real artifact coordinates, to prove those adopter commands still work.
+#
+# Anti-drift by construction: the recipes are not reimplemented here. Each fenced
+# ```bash block is EXTRACTED from docs/verifying_artifacts.md at run time, its
+# <placeholders> substituted from the flags, and the result executed verbatim.
+# The checker therefore cannot diverge from the documented commands — a doc that
+# stops working fails the run, and a doc whose placeholder set changes fails the
+# substitution guard rather than running half-filled.
+#
+# A block is selected by a literal content signature that matches exactly one
+# fenced block (zero or many => the doc drifted, hard error), and only the
+# <placeholder> TEMPLATE blocks are targeted — the concrete worked examples
+# (which carry no `<...>`) are never selected.
+#
+# Exit: 0 = every selected recipe verified; 1 = a recipe failed verification;
+# 2 = usage / configuration / doc-drift error.
+#
+# Tooling: ampel and cosign are expected on PATH (the verify-showcase-recipes
+# action installs them from tools/go.mod); jq and gh are assumed present. Only
+# `gh attestation verify`, the `github:` collector, and the Sigstore/OCI reads
+# are network-bound; because a documented recipe is one fenced block, retry is
+# applied at block granularity (the idempotent fetch is retried alongside the
+# verify — harmless). On exhausted retries the recipe FAILS; it never skips.
+#
+# Public ghcr images are assumed (no registry pull auth); the private-image doc
+# path is out of scope. `gh attestation verify` needs GITHUB_TOKEN in the env.
+set -euo pipefail
+set -f
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Overridable so the hermetic tests can point at drift fixtures.
+DOC="${WRANGLE_RECIPES_DOC:-$REPO_ROOT/docs/verifying_artifacts.md}"
+
+RETRY_MAX="${WRANGLE_RECIPE_RETRIES:-3}"
+RETRY_DELAY="${WRANGLE_RECIPE_RETRY_DELAY:-5}"
+
+# Coordinates (all default empty so `set -u` is safe before parsing).
+FILE_PATH=""
+BUNDLE_PATH=""
+IMAGE_NAME=""
+DIGEST=""
+RESOURCE_URI=""
+REPO=""
+BUILD_TYPE=""
+DO_PROVENANCE=0
+DO_ATTESTATION_STORE=0
+NON_STRICT="${WRANGLE_VSA_NON_STRICT:-0}"
+
+# Substitution values (filled during dispatch).
+ARTIFACT_NAME=""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+log()  { printf 'verify-recipes: %s\n' "$*"; }
+die()  { printf 'verify-recipes: ERROR: %s\n' "$*" >&2; exit 2; }
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: verify_documented_recipes.sh <coordinates>
+
+  File artifact (Go / Python / npm):
+    --file PATH --bundle PATH --resource-uri URI --repo ORG/REPO --type TYPE
+
+  Container image:
+    --image NAME --digest SHA256HEX --repo ORG/REPO
+
+  Add-ons:
+    --provenance            also run `gh attestation verify` (needs --file --repo --type)
+    --attestation-store     also run the github: collector (needs --resource-uri --repo)
+    --non-strict            relax to the non-strict policy/identity (or WRANGLE_VSA_NON_STRICT=1)
+
+TYPE is one of: go python npm container.
+EOF
+    exit 2
+}
+
+# --- input validation (allowlists: these values are substituted into an executed
+# --- shell block, so anything outside the charset is rejected up front) --------
+_need()        { [[ -n "$2" ]] || die "$1 is required for this recipe"; }
+_valid_repo()  { [[ "$1" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; }
+_valid_uri()   { [[ "$1" =~ ^[A-Za-z0-9._:/@+-]+$ ]]; }
+_valid_digest(){ [[ "$1" =~ ^[0-9a-f]{64}$ ]]; }
+_valid_type()  { [[ "$1" =~ ^(go|python|npm|container)$ ]]; }
+_valid_image() { [[ "$1" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]]; }
+_valid_name()  { [[ "$1" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; }
+
+# --- doc extraction ------------------------------------------------------------
+# Emit every fenced ```bash block whose text contains the literal substring $1,
+# each terminated by NUL.
+_blocks_matching() {
+    local sig="$1"
+    awk -v sig="$sig" '
+        $0 == "```bash" { inb = 1; blk = ""; next }
+        $0 == "```"     { if (inb && index(blk, sig)) printf "%s\0", blk; inb = 0; next }
+        inb             { blk = blk $0 "\n" }
+    ' "$DOC"
+}
+
+# Print THE single template block matching signature $1; a count other than one
+# means docs/verifying_artifacts.md drifted from what this checker expects.
+_select_block() {
+    local sig="$1"
+    local -a matches=()
+    mapfile -d '' matches < <(_blocks_matching "$sig")
+    (( ${#matches[@]} == 1 )) \
+        || die "expected exactly one doc block matching '$sig', found ${#matches[@]} — docs/verifying_artifacts.md drifted"
+    printf '%s' "${matches[0]}"
+}
+
+# Substitute the documented placeholders in the block on $1, then fail if any
+# `<...>` survives — a surviving placeholder is an un-mapped doc token, i.e.
+# drift, and must break the run rather than execute a half-filled command.
+_substitute() {
+    local blk="$1"
+    blk="${blk//"<your-org>/<your-repo>"/"$REPO"}"
+    blk="${blk//"<owner>/<repo>"/"$REPO"}"
+    blk="${blk//"<resourceUri from the table above>"/"$RESOURCE_URI"}"
+    blk="${blk//"<artifact>"/"$ARTIFACT_NAME"}"
+    blk="${blk//"<imagename>"/"$IMAGE_NAME"}"
+    blk="${blk//"<digest>"/"$DIGEST"}"
+    blk="${blk//"<type>"/"$BUILD_TYPE"}"
+    if [[ "$NON_STRICT" == "1" ]]; then
+        # The doc documents only the strict recipes; these two relaxations mirror
+        # the actions/verify-vsa gate's WRANGLE_VSA_NON_STRICT fallback (any
+        # wrangle build ref, not just release tags) for wrangle's own dogfood
+        # builds, whose VSAs carry a bare @<sha> signer identity.
+        local strict_policy='wrangle-vsa-consumer-v1.hjson'
+        local strict_anchor='@refs/tags/v[0-9.]+$'
+        blk="${blk//"$strict_policy"/wrangle-vsa-consumer-nonstrict-v1.hjson}"
+        blk="${blk//"$strict_anchor"/@}"
+    fi
+    if [[ "$blk" =~ \<[^\>]+\> ]]; then
+        die "unsubstituted placeholder ${BASH_REMATCH[0]} in recipe — the recipe map is out of date with docs/verifying_artifacts.md"
+    fi
+    printf '%s' "$blk"
+}
+
+# --- recipe execution ----------------------------------------------------------
+# Run a selected+substituted block. Args: name signature retry(0|1).
+# The block runs in a private temp CWD (blocks 7/8 both write vsa.intoto.jsonl),
+# with `set -euo pipefail` prepended so a mid-block `jq -e`/pipeline failure
+# fails the recipe closed. File-class inputs are staged under the doc's bare
+# filenames (`<artifact>`, `<artifact>.intoto.jsonl`).
+_run_recipe() {
+    local name="$1" sig="$2" retry="$3"
+    local blk work script attempt rc
+    blk="$(_select_block "$sig")"
+    blk="$(_substitute "$blk")"
+
+    work="$(mktemp -d)"
+    script="$work/recipe.sh"
+    { printf 'set -euo pipefail\n'; printf '%s\n' "$blk"; } > "$script"
+    if [[ -n "$FILE_PATH" ]]; then
+        cp "$FILE_PATH" "$work/$ARTIFACT_NAME"
+        [[ -z "$BUNDLE_PATH" ]] || cp "$BUNDLE_PATH" "$work/$ARTIFACT_NAME.intoto.jsonl"
+    fi
+
+    log "--- recipe: $name"
+    attempt=0
+    rc=0
+    while : ; do
+        attempt=$((attempt + 1))
+        rc=0
+        ( cd "$work" && bash "$script" ) || rc=$?
+        [[ $rc -eq 0 ]] && break
+        if [[ "$retry" != "1" || $attempt -ge $RETRY_MAX ]]; then break; fi
+        log "recipe '$name' attempt $attempt/$RETRY_MAX failed (rc=$rc); retrying in ${RETRY_DELAY}s"
+        sleep "$RETRY_DELAY"
+    done
+    rm -rf "$work"
+
+    if [[ $rc -eq 0 ]]; then
+        log "PASS: $name"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        log "FAIL: $name (rc=$rc)"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --file)              FILE_PATH="$2"; shift 2 ;;
+            --bundle)            BUNDLE_PATH="$2"; shift 2 ;;
+            --image)             IMAGE_NAME="$2"; shift 2 ;;
+            --digest)            DIGEST="$2"; shift 2 ;;
+            --resource-uri)      RESOURCE_URI="$2"; shift 2 ;;
+            --repo)              REPO="$2"; shift 2 ;;
+            --type)              BUILD_TYPE="$2"; shift 2 ;;
+            --provenance)        DO_PROVENANCE=1; shift ;;
+            --attestation-store) DO_ATTESTATION_STORE=1; shift ;;
+            --non-strict)        NON_STRICT=1; shift ;;
+            -h|--help)           usage ;;
+            *) die "unknown argument: $1" ;;
+        esac
+    done
+}
+
+main() {
+    parse_args "$@"
+
+    local ran=0
+
+    # File-artifact class: the ampel jsonl recipe, the cosign+jq fallback, and
+    # the verifiedLevels read. Gated on --bundle (the class's unique input), so
+    # a bare --file with --provenance drives only the provenance recipe.
+    if [[ -n "$BUNDLE_PATH" ]]; then
+        _need --file "$FILE_PATH"
+        [[ -f "$FILE_PATH" ]]   || die "no such file: $FILE_PATH"
+        [[ -f "$BUNDLE_PATH" ]] || die "no such bundle: $BUNDLE_PATH"
+        ARTIFACT_NAME="$(basename "$FILE_PATH")"
+        _valid_name "$ARTIFACT_NAME" || die "artifact filename has disallowed characters: $ARTIFACT_NAME"
+        _need --resource-uri "$RESOURCE_URI"; _valid_uri "$RESOURCE_URI"  || die "bad --resource-uri: $RESOURCE_URI"
+        _need --repo "$REPO";                 _valid_repo "$REPO"         || die "bad --repo: $REPO"
+        _need --type "$BUILD_TYPE";           _valid_type "$BUILD_TYPE"   || die "bad --type: $BUILD_TYPE"
+
+        _run_recipe "file VSA via ampel (jsonl collector)" '--collector jsonl:<artifact>' 1
+        _run_recipe "file VSA via cosign + jq"             'sha256sum <artifact>'         1
+        _run_recipe "verifiedLevels read (jq)"             '.predicate.verifiedLevels[]'  0
+        ran=1
+    fi
+
+    # Container-image class: ampel oci collector + cosign download attestation.
+    if [[ -n "$IMAGE_NAME" ]]; then
+        _need --image "$IMAGE_NAME";  _valid_image "$IMAGE_NAME"  || die "bad --image: $IMAGE_NAME"
+        _need --digest "$DIGEST";     _valid_digest "$DIGEST"     || die "bad --digest (want 64 hex, no sha256: prefix): $DIGEST"
+        _need --repo "$REPO";         _valid_repo "$REPO"         || die "bad --repo: $REPO"
+
+        _run_recipe "image VSA via ampel (oci collector)"      '--collector oci:'            1
+        _run_recipe "image VSA via cosign download attestation" 'cosign download attestation' 1
+        ran=1
+    fi
+
+    # By-digest read from the GitHub attestation store (any build type).
+    if [[ "$DO_ATTESTATION_STORE" -eq 1 ]]; then
+        _need --repo "$REPO";                 _valid_repo "$REPO"        || die "bad --repo: $REPO"
+        _need --resource-uri "$RESOURCE_URI"; _valid_uri "$RESOURCE_URI" || die "bad --resource-uri: $RESOURCE_URI"
+        if [[ -n "$FILE_PATH" ]]; then
+            DIGEST="$(sha256sum "$FILE_PATH" | cut -d' ' -f1)"
+        fi
+        _need --digest "$DIGEST"; _valid_digest "$DIGEST" || die "attestation-store recipe needs a sha256 digest"
+        _run_recipe "VSA via github: collector (attestation store)" '--collector github:' 1
+        ran=1
+    fi
+
+    # Raw provenance via gh attestation verify (file build types).
+    if [[ "$DO_PROVENANCE" -eq 1 ]]; then
+        _need --file "$FILE_PATH"; [[ -f "$FILE_PATH" ]] || die "no such file: $FILE_PATH"
+        ARTIFACT_NAME="$(basename "$FILE_PATH")"
+        _valid_name "$ARTIFACT_NAME" || die "artifact filename has disallowed characters: $ARTIFACT_NAME"
+        _need --repo "$REPO";       _valid_repo "$REPO"       || die "bad --repo: $REPO"
+        _need --type "$BUILD_TYPE"; _valid_type "$BUILD_TYPE" || die "bad --type: $BUILD_TYPE"
+        # Bundle not staged for this recipe, so clear it for _run_recipe's stager.
+        BUNDLE_PATH=""
+        _run_recipe "raw provenance via gh attestation verify" 'gh attestation verify' 1
+        ran=1
+    fi
+
+    [[ "$ran" -eq 1 ]] || usage
+
+    log "summary: $PASS_COUNT passed, $FAIL_COUNT failed"
+    [[ "$FAIL_COUNT" -eq 0 ]] || exit 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/tools/verify_documented_recipes.sh
+++ b/tools/verify_documented_recipes.sh
@@ -89,15 +89,24 @@ _valid_image() { [[ "$1" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]]; }
 _valid_name()  { [[ "$1" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; }
 
 # --- doc extraction ------------------------------------------------------------
-# Emit every fenced ```bash block whose text contains the literal substring $1,
-# each terminated by NUL.
-_blocks_matching() {
+# Collect into the array named by $2 every fenced ```bash block whose text
+# contains the literal substring $1. Pure bash (no awk) so block boundaries don't
+# depend on the host awk's handling of NUL separators.
+_collect_blocks() {
     local sig="$1"
-    awk -v sig="$sig" '
-        $0 == "```bash" { inb = 1; blk = ""; next }
-        $0 == "```"     { if (inb && index(blk, sig)) printf "%s\0", blk; inb = 0; next }
-        inb             { blk = blk $0 "\n" }
-    ' "$DOC"
+    local -n _out="$2"
+    _out=()
+    local line blk="" inblk=0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        if [[ "$inblk" -eq 0 ]]; then
+            [[ "$line" == '```bash' ]] && { inblk=1; blk=""; }
+        elif [[ "$line" == '```' ]]; then
+            [[ "$blk" == *"$sig"* ]] && _out+=("$blk")
+            inblk=0
+        else
+            blk+="$line"$'\n'
+        fi
+    done < "$DOC"
 }
 
 # Print THE single template block matching signature $1; a count other than one
@@ -105,7 +114,7 @@ _blocks_matching() {
 _select_block() {
     local sig="$1"
     local -a matches=()
-    mapfile -d '' matches < <(_blocks_matching "$sig")
+    _collect_blocks "$sig" matches
     (( ${#matches[@]} == 1 )) \
         || die "expected exactly one doc block matching '$sig', found ${#matches[@]} — docs/verifying_artifacts.md drifted"
     printf '%s' "${matches[0]}"


### PR DESCRIPTION
claude: **Draft — step 1 of 2.** Builds the wrangle-side core of a "documented-recipe verifier". Step 2 (wiring it into wrangle-test's showcase) is the owner's, after review.

## What this does
`docs/verifying_artifacts.md` documents the exact raw `ampel`/`cosign`/`gh attestation` commands an *adopter* runs to verify wrangle-built artifacts. Nothing executes those recipes against live artifacts, so they can silently drift (today only the manual cut-release gate catches it). This adds a runner a showcase can call every heartbeat to prove the documented commands still verify.

## Anti-drift approach: **extract-and-run** (the brief's preferred option)
`tools/verify_documented_recipes.sh` does not reimplement the recipes. At run time it **extracts each fenced ` ```bash ` block from the doc**, substitutes the `<placeholders>` from flags, and executes the block verbatim. The checker therefore *cannot* diverge from the docs — drift is impossible, not merely detected.

I prototyped extraction first (as the brief asked). Of the three brittleness triggers, only "multiple commands per block" is hit (the two cosign blocks), and that's benign — the whole block is run. Prose sits *between* blocks, not inside; the one prose-y placeholder (`<resourceUri from the table above>`) is a single `<[^>]+>` match. So extract-and-run held; I did **not** fall back to the equivalence-guard.

Guards that give it the anti-drift property:
- Blocks are selected by a **literal content signature matching exactly one template block** — zero or many is a hard error (exit 2). The concrete worked examples (no `<...>`) are never selected.
- **Any `<...>` surviving substitution fails the run** — a new doc placeholder breaks the checker instead of running a half-filled command.
- Each block runs in a **private temp CWD** with **`set -euo pipefail` prepended** (the doc blocks carry none; without it the mid-block `jq -e` asserts and the `cosign download | jq` pipeline would fail *open*).

## Recipes covered
| Recipe | Doc section | Covered |
|---|---|---|
| (a) file VSA — `ampel verify … jsonl:` | Recommended: ampel | ✅ |
| (b) image VSA — `ampel verify … oci:` | Recommended: ampel | ✅ |
| by-digest — `ampel … github:` collector | By-digest fetch | ✅ (`--attestation-store`) |
| verifiedLevels read (`jq`) | What verifiedLevels carries | ✅ |
| (c) file — cosign + jq fallback | Without ampel | ✅ |
| (d) image — `cosign download attestation` | Without ampel | ✅ |
| (e) raw provenance — `gh attestation verify` | Verifying raw provenance | ✅ (`--provenance`) |

Deferred to the showcase (need live network/registry, can't be hermetic): the ecosystem-native `npm audit signatures` / PyPI PEP-740 checks are out of scope (not VSA/provenance recipes). Private-image pull auth is out of scope (doc calls it out).

## Two deviations from the literal brief — flagged per the draft's purpose

**1. Tool install uses `tools/go.mod` (`go install`), not `download_verify.sh` with a hardcoded checksum.** ampel v1.3.1 and cosign v3.0.6 are *already* pinned in `tools/go.mod`. A second download_verify pin of the same tools is exactly the duplicate-pin drift **DEP_MGMT.md §Drift** forbids ("a pin literal in more than one file must be single-sourced"); branch-1 / `go install` is the documented default for canonical Go tools, and #247 says ampel/cosign install via the go.mod manifest. So the composite installs them from go.mod (mirroring `test/setup_integration.sh`) — single source, Dependabot-covered, no checksum to drift. I did not add a download_verify install.

**2. The "passes on good / fails on tampered" fixture check is an integration test, not the hermetic unit test.** A keyless VSA verify needs Sigstore/Rekor/TUF; **CLAUDE.md** ("a test needing a real binary or network is an integration test") puts that out of the deterministic unit suite — which is why the existing `test/consumer/verify_consumer_vsa.bats` gates on `require_sigstore`. So:
- **Hermetic unit suite** (`actions/verify-showcase-recipes/*.bats`, runs in the PR `bats` job): the drift guard (every recipe extracts + fully substitutes against the real doc; duplicate/missing/new-placeholder fail closed) + stub-driven orchestration (exit-code plumbing, bounded retry, input validation). No network.
- **Integration** (`test/consumer/verify_documented_recipes.bats`, in `INTEGRATION_BATS` + the dogfood job): drives the script end-to-end against the captured npm fixture — good → `3 passed`, tampered byte → fail closed.

(Note: `tools/verify_documented_recipes.bats` would *not* be picked up by `make bats` — its glob is `tools/*/test.bats` — so the hermetic tests live under the action, which the brief allowed.)

## Retry note
Because a documented recipe is one fenced block, retry is at **block** granularity (coarser than the brief's "wrap only the Sigstore read"): the idempotent fetch is retried alongside the verify (harmless), and a genuine tamper burns the retries before failing (slower, still fail-closed). Direct consequence of extract-and-run.

## Interface
`--file/--bundle` (file class) · `--image/--digest` (image class) · `--provenance` · `--attestation-store` · `--resource-uri --repo --type` · `--non-strict` (or `WRANGLE_VSA_NON_STRICT=1`, mirroring the verify-vsa gate). Exit 0 = all verified, 1 = a recipe failed, 2 = usage/config/doc-drift. All inputs are allowlist-validated before substitution (they reach an executed block).

## Verification
- `shellcheck -x` clean on all new `.sh` and `.bats` (runner's exact flags). WSL001-007 conform by inspection (ast-grep unavailable in my sandbox; scripts match `verify_vsa.sh` preamble/`[[ ]]`/`printf` shape).
- New hermetic bats: **22/22 green**.
- `check_pin_ancestry` / `check_pin_freshness` / `check_catalog` all exit 0 — the `tools/` (non-catalog) + `actions/` additions do not trip freshness. No wrangle workflow references the new action, so no self-ref converge is needed.
- No live smoke run (no showcase artifact/registry access from here); the integration test exercises the real-tool path in CI's dogfood job.

## Unsure / for the owner
- The integration test uses the doc's remote policy locator (`git+…@v0.3.1#…`) against the v0.2.2-signed npm fixture; both resolve the same `-v1` contract, so it should PASS in the dogfood job exactly as `verify_consumer_vsa` does — worth confirming on first CI run.
- Non-strict applies two narrow post-extraction relaxations (strict policy → nonstrict policy; `@refs/tags/v[0-9.]+$` anchor → any ref), mirroring the verify-vsa gate. The drift guard asserts the *strict* verbatim form; non-strict is a tested transform on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)