### PR TITLE
claude: fix(osv): clear fresh scan findings — goldmark XSS bump + frozen-openpgp ignore

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -416,7 +416,7 @@ require (
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
-	github.com/yuin/goldmark v1.7.12 // indirect
+	github.com/yuin/goldmark v1.7.17 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	gitlab.com/gitlab-org/api/client-go v1.46.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1194,8 +1194,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.30/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/yuin/goldmark v1.7.12 h1:YwGP/rrea2/CnCtUHgjuolG/PnMxdQtPMO5PvaE2/nY=
-github.com/yuin/goldmark v1.7.12/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark v1.7.17 h1:p36OVWwRb246iHxA/U4p8OPEpOTESm4n+g+8t0EE5uA=
+github.com/yuin/goldmark v1.7.17/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9HTHs=
 github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=

--- a/tools/osv-scanner.toml
+++ b/tools/osv-scanner.toml
@@ -1,12 +1,12 @@
 # osv-scanner native config for manifests in this directory (tools/go.mod).
 # Discovered by the scanner itself — wrangle's scan adapter adds nothing.
-#
-# All advisories are in github.com/docker/docker v28.5.2+incompatible, pulled
-# in by osv-scanner's own module graph (`go mod why -m`: cmd/osv-scanner).
-# They are unfixable by version bump: the docker/docker module line was
-# re-namespaced and every version of the old path is flagged — the fix
-# exists only as github.com/moby/moby/v2, which osv-scanner upstream has not
-# migrated to. Remove these entries when an osv-scanner release imports
+# Every entry is an advisory with no version bump that clears it.
+
+# github.com/docker/docker v28.5.2+incompatible, pulled in by osv-scanner's own
+# module graph (`go mod why -m`: cmd/osv-scanner). Unfixable by bump: the
+# docker/docker module line was re-namespaced and every version of the old path
+# is flagged — the fix exists only as github.com/moby/moby/v2, which osv-scanner
+# upstream has not migrated to. Remove these when an osv-scanner release imports
 # moby/moby/v2.
 
 [[IgnoredVulns]]
@@ -28,3 +28,11 @@ reason = "docker/docker path has no patched version; fix is the moby/moby/v2 ren
 [[IgnoredVulns]]
 id = "GHSA-x744-4wpc-v9h2"
 reason = "docker/docker path has no patched version; fix is the moby/moby/v2 rename — waiting on osv-scanner upstream migration"
+
+# golang.org/x/crypto/openpgp, reached through wrangle-attest's PGP path (rekor
+# pki/pgp). Unfixable by bump: x/crypto froze openpgp as deprecated/unmaintained,
+# so no patched version exists.
+
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+reason = "x/crypto/openpgp is frozen and deprecated upstream — no patched version exists"

--- a/tools/osv-scanner.toml
+++ b/tools/osv-scanner.toml
@@ -1,6 +1,9 @@
 # osv-scanner native config for manifests in this directory (tools/go.mod).
 # Discovered by the scanner itself — wrangle's scan adapter adds nothing.
-# Every entry is an advisory with no version bump that clears it.
+# Every entry is an advisory with no version bump that clears it, so each is
+# suppressed with a justification. The shared `ignoreUntil` is a forced-revisit
+# tripwire: once that date passes the scan resurfaces every entry so the
+# decision to keep suppressing it is re-made, not inherited forever.
 
 # github.com/docker/docker v28.5.2+incompatible, pulled in by osv-scanner's own
 # module graph (`go mod why -m`: cmd/osv-scanner). Unfixable by bump: the
@@ -11,28 +14,35 @@
 
 [[IgnoredVulns]]
 id = "GHSA-rg2x-37c3-w2rh"
+ignoreUntil = 2026-10-11T00:00:00Z
 reason = "docker/docker path has no patched version; fix is the moby/moby/v2 rename — waiting on osv-scanner upstream migration"
 
 [[IgnoredVulns]]
 id = "GHSA-vp62-88p7-qqf5"
+ignoreUntil = 2026-10-11T00:00:00Z
 reason = "docker/docker path has no patched version; fix is the moby/moby/v2 rename — waiting on osv-scanner upstream migration"
 
 [[IgnoredVulns]]
 id = "GHSA-x86f-5xw2-fm2r"
+ignoreUntil = 2026-10-11T00:00:00Z
 reason = "docker/docker path has no patched version; fix is the moby/moby/v2 rename — waiting on osv-scanner upstream migration"
 
 [[IgnoredVulns]]
 id = "GHSA-pxq6-2prw-chj9"
+ignoreUntil = 2026-10-11T00:00:00Z
 reason = "docker/docker path has no patched version; fix is the moby/moby/v2 rename — waiting on osv-scanner upstream migration"
 
 [[IgnoredVulns]]
 id = "GHSA-x744-4wpc-v9h2"
+ignoreUntil = 2026-10-11T00:00:00Z
 reason = "docker/docker path has no patched version; fix is the moby/moby/v2 rename — waiting on osv-scanner upstream migration"
 
 # golang.org/x/crypto/openpgp, reached through wrangle-attest's PGP path (rekor
 # pki/pgp). Unfixable by bump: x/crypto froze openpgp as deprecated/unmaintained,
-# so no patched version exists.
+# so no patched version exists — the only real exit is dropping the PGP path,
+# which no advisory will ever signal, so the ignoreUntil revisit is what forces it.
 
 [[IgnoredVulns]]
 id = "GO-2026-5932"
+ignoreUntil = 2026-10-11T00:00:00Z
 reason = "x/crypto/openpgp is frozen and deprecated upstream — no patched version exists"

--- a/tools/osv-scanner.toml
+++ b/tools/osv-scanner.toml
@@ -1,48 +1,36 @@
 # osv-scanner native config for manifests in this directory (tools/go.mod).
 # Discovered by the scanner itself — wrangle's scan adapter adds nothing.
-# Every entry is an advisory with no version bump that clears it, so each is
-# suppressed with a justification. The shared `ignoreUntil` is a forced-revisit
-# tripwire: once that date passes the scan resurfaces every entry so the
-# decision to keep suppressing it is re-made, not inherited forever.
-
-# github.com/docker/docker v28.5.2+incompatible, pulled in by osv-scanner's own
-# module graph (`go mod why -m`: cmd/osv-scanner). Unfixable by bump: the
-# docker/docker module line was re-namespaced and every version of the old path
-# is flagged — the fix exists only as github.com/moby/moby/v2, which osv-scanner
-# upstream has not migrated to. Remove these when an osv-scanner release imports
-# moby/moby/v2.
+# Every entry is an advisory no version bump clears, and each `reason` carries
+# the full justification (the scanner prints it on every filtered finding). The
+# shared `ignoreUntil` is a forced-revisit tripwire: once it passes the scan
+# resurfaces every entry, so a suppression is re-decided, never inherited.
 
 [[IgnoredVulns]]
 id = "GHSA-rg2x-37c3-w2rh"
 ignoreUntil = 2026-10-11T00:00:00Z
-reason = "docker/docker path has no patched version; fix is the moby/moby/v2 rename — waiting on osv-scanner upstream migration"
+reason = "docker/docker (pulled in by osv-scanner's own module graph) has no patched version: the module line was re-namespaced and every version of the old path is flagged. The fix exists only as github.com/moby/moby/v2, which osv-scanner upstream has not migrated to — remove this entry when an osv-scanner release imports moby/moby/v2."
 
 [[IgnoredVulns]]
 id = "GHSA-vp62-88p7-qqf5"
 ignoreUntil = 2026-10-11T00:00:00Z
-reason = "docker/docker path has no patched version; fix is the moby/moby/v2 rename — waiting on osv-scanner upstream migration"
+reason = "docker/docker (pulled in by osv-scanner's own module graph) has no patched version: the module line was re-namespaced and every version of the old path is flagged. The fix exists only as github.com/moby/moby/v2, which osv-scanner upstream has not migrated to — remove this entry when an osv-scanner release imports moby/moby/v2."
 
 [[IgnoredVulns]]
 id = "GHSA-x86f-5xw2-fm2r"
 ignoreUntil = 2026-10-11T00:00:00Z
-reason = "docker/docker path has no patched version; fix is the moby/moby/v2 rename — waiting on osv-scanner upstream migration"
+reason = "docker/docker (pulled in by osv-scanner's own module graph) has no patched version: the module line was re-namespaced and every version of the old path is flagged. The fix exists only as github.com/moby/moby/v2, which osv-scanner upstream has not migrated to — remove this entry when an osv-scanner release imports moby/moby/v2."
 
 [[IgnoredVulns]]
 id = "GHSA-pxq6-2prw-chj9"
 ignoreUntil = 2026-10-11T00:00:00Z
-reason = "docker/docker path has no patched version; fix is the moby/moby/v2 rename — waiting on osv-scanner upstream migration"
+reason = "docker/docker (pulled in by osv-scanner's own module graph) has no patched version: the module line was re-namespaced and every version of the old path is flagged. The fix exists only as github.com/moby/moby/v2, which osv-scanner upstream has not migrated to — remove this entry when an osv-scanner release imports moby/moby/v2."
 
 [[IgnoredVulns]]
 id = "GHSA-x744-4wpc-v9h2"
 ignoreUntil = 2026-10-11T00:00:00Z
-reason = "docker/docker path has no patched version; fix is the moby/moby/v2 rename — waiting on osv-scanner upstream migration"
-
-# golang.org/x/crypto/openpgp, reached through wrangle-attest's PGP path (rekor
-# pki/pgp). Unfixable by bump: x/crypto froze openpgp as deprecated/unmaintained,
-# so no patched version exists — the only real exit is dropping the PGP path,
-# which no advisory will ever signal, so the ignoreUntil revisit is what forces it.
+reason = "docker/docker (pulled in by osv-scanner's own module graph) has no patched version: the module line was re-namespaced and every version of the old path is flagged. The fix exists only as github.com/moby/moby/v2, which osv-scanner upstream has not migrated to — remove this entry when an osv-scanner release imports moby/moby/v2."
 
 [[IgnoredVulns]]
 id = "GO-2026-5932"
 ignoreUntil = 2026-10-11T00:00:00Z
-reason = "x/crypto/openpgp is frozen and deprecated upstream — no patched version exists"
+reason = "x/crypto/openpgp, reached through wrangle-attest's PGP path (rekor pki/pgp), has no patched version: x/crypto froze openpgp as deprecated and unmaintained. The only exit is dropping the PGP path, which no advisory will ever signal — so the ignoreUntil revisit is what forces reconsideration."


### PR DESCRIPTION
## What

osv-scanner's database picked up two new advisories that fail the dogfood **scan** job on every branch (main included — its last scan predates the disclosures). Neither is introduced by any code change here; both are pre-existing deps of the tooling module surfaced by fresh advisories.

| Advisory | Package (`tools/go.mod`, indirect) | Fix |
|---|---|---|
| `CVE-2026-5160` / `GO-2026-5320` — XSS in `renderer/html` | `goldmark 1.7.12` | **Bump to 1.7.17** (patched upstream 2026-03-19; ~4 months old, past the 7-day adoption delay) |
| `GO-2026-5932` — openpgp deprecated/unmaintained | `x/crypto 0.53.0` | **No patched version** — x/crypto froze the openpgp package; add an `IgnoredVulns` entry |

### Why ignore `GO-2026-5932` rather than bump

There is no fixed version: the advisory states `golang.org/x/crypto/openpgp` is unmaintained and unsafe by design, and x/crypto has permanently frozen it. The package **is** reachable in our graph — through `wrangle-attest`'s PGP signing path (`rekor pki/pgp`) — so this is a genuine "no importable fix" case, matching the existing `docker/docker` no-fix suppressions in `tools/osv-scanner.toml`. The anti-staleness e2e test (`tools/osv/test.bats`) keeps the entry honest: it fails the moment a fix arrives and the advisory stops matching a live finding.

## Validation

- `osv-scanner scan -r .` on the fixed tree: **0 findings** in SARIF (goldmark advisory gone; `GO-2026-5932` filtered; no new CVE dragged in by the go.sum churn).
- `go mod verify` clean; goldmark stays `// indirect` at 1.7.17 (MVS max require).
- `GO-2026-5932` confirmed present in the raw scan's id/alias set, so the suppression-staleness test passes.

## Relationship to #744

#744's red `scan` check is this same repo-wide failure. #744 stays red until this lands on `main` and is pulled in via a merge — it is not fixed by #744 itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)