### PR TITLE
claude: fix(pins): label pins from origin/main, not a stale local branch (#592)

### DIFF
--- a/test/test_bump_action_pins.bats
+++ b/test/test_bump_action_pins.bats
@@ -314,6 +314,34 @@ EOF
     grep -qF "# main 2099-12-31" .github/workflows/a.yml
 }
 
+@test "bump_action_pins: labels as 'main' via origin/main when the local main is stale" {
+    # The footgun: a throwaway worktree's local `main` lags the remote, so a
+    # target already merged upstream misses the local ancestry test and gets the
+    # cleanup branch's name. Preferring origin/main labels it correctly.
+    git checkout -q -b main 2>/dev/null || git checkout -q main
+    local stale_local; stale_local="$(git rev-parse HEAD)"
+    # A bare "remote" whose main carries a commit the local main doesn't have.
+    local remote="$TEST_DIR/remote.git"
+    git init -q --bare "$remote"
+    git remote add origin "$remote"
+    git commit --allow-empty -q -m "merged upstream"
+    target_sha="$(git rev-parse HEAD)"
+    git push -q origin main
+    # Rewind the local main behind the remote to simulate the stale worktree.
+    git reset -q --hard "$stale_local"
+    git fetch -q origin
+    git checkout -q -b cleanup-branch
+    cat > .github/workflows/a.yml <<EOF
+jobs:
+  build:
+    uses: TomHennen/wrangle/build/actions/python@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+    unset WRANGLE_PINS_BRANCH
+    run "$SCRIPT" "$target_sha"
+    [[ "$status" -eq 0 ]]
+    grep -qF "# main 2099-12-31" .github/workflows/a.yml
+}
+
 @test "bump_action_pins: labels as current branch when target SHA is NOT on main" {
     # Setup: main with one commit, feature branch with an additional commit.
     # Run the script targeting the feature-branch-only commit.

--- a/tools/bump_action_pins.sh
+++ b/tools/bump_action_pins.sh
@@ -30,10 +30,12 @@
 #   WRANGLE_PINS_REPO   — repo prefix to match (default: TomHennen/wrangle)
 #   WRANGLE_PINS_BRANCH — branch label to write into the comment.
 #                         Default detection (in order):
-#                           1. If target_sha is reachable from `main` (i.e.,
-#                              already merged), use `main`. This makes
-#                              post-merge cleanup runs label correctly even
-#                              when the cleanup happens on a temporary branch.
+#                           1. If target_sha is reachable from the default
+#                              branch (i.e. already merged), use its name. The
+#                              remote-tracking ref (`origin/main`) is preferred
+#                              over the local branch, which a throwaway worktree
+#                              often lacks or leaves stale, so a post-merge
+#                              cleanup run on a temporary branch labels correctly.
 #                           2. Else use the current branch
 #                              (`git symbolic-ref --short HEAD`).
 #                           3. Else (detached HEAD) fall back to "main".
@@ -76,9 +78,20 @@ if [[ ! "$target_sha" =~ ^[0-9a-f]{40}$ ]]; then
 fi
 
 default_branch="${WRANGLE_PINS_DEFAULT_BRANCH:-main}"
+# Prefer the remote-tracking ref: a throwaway worktree's local default branch is
+# often stale or absent, so a target already merged to origin would otherwise
+# miss the ancestry test and get mislabeled with the current branch's name.
+default_branch_ref=""
+for cand in "origin/$default_branch" "$default_branch"; do
+    if git -C "$REPO_ROOT" rev-parse --verify --quiet "$cand^{commit}" >/dev/null; then
+        default_branch_ref="$cand"
+        break
+    fi
+done
 if [[ -n "${WRANGLE_PINS_BRANCH:-}" ]]; then
     branch_label="$WRANGLE_PINS_BRANCH"
-elif git -C "$REPO_ROOT" merge-base --is-ancestor "$target_sha" "$default_branch" >/dev/null 2>&1; then
+elif [[ -n "$default_branch_ref" ]] \
+    && git -C "$REPO_ROOT" merge-base --is-ancestor "$target_sha" "$default_branch_ref" >/dev/null 2>&1; then
     # Target is already on the default branch — e.g., the operator branched
     # off main to refresh pins after a merge. Label as the default branch
     # rather than the cleanup branch's name, which would be misleading.


### PR DESCRIPTION
## What

`bump_action_pins.sh` picked the `# <label>` comment by testing the target SHA against the **local** `main` ref. In a throwaway worktree that ref is often stale or absent, so a SHA already merged to origin failed the ancestry test and the pin got labelled with the *current branch's* name.

That's why `main` carries pins like:

```
uses: TomHennen/wrangle/actions/prep@aecba7dd… # priv-immutable-597-407 2026-07-06
```

Fix: resolve the default branch via `origin/main` **before** the local branch, so a main-reachable target is labelled `# main` no matter which branch the bump runs from.

## Scope

This is **part 2 of #592 only**, split out of #743 so it can land on its own — it's a pure bug fix with no workflow or process change. The first-parent pin **guard** (part 1) is being reworked separately: rather than gating every PR (which would force a finalize PR after ~half of all PRs and red-line `main` in between), it becomes a **release-time** check, which is where #592 actually bit during v0.3.0 prep.

Does not close #592 — the guard half is still open.

## Validation

- `test/test_bump_action_pins.bats`: 29/29 pass, including the new **"labels as 'main' via origin/main when the local main is stale"** covering exactly this footgun.
- shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)