### PR TITLE
claude: feat(wrangle-attest): sign an existing statement in-engine (--statement) (#482)

### DIFF
--- a/tools/wrangle-attest/SPEC.md
+++ b/tools/wrangle-attest/SPEC.md
@@ -79,8 +79,9 @@ all to `--out` as JSONL. `--commit` is woven into the `scan/v1` envelope only;
 passthrough predicates ignore it.
 
 With `--sign` each statement is keyless-signed (one shared signer — ambient
-GitHub OIDC → Fulcio → Rekor; the bundle is byte-identical to `bnd statement`)
-and the compact Sigstore bundle is emitted; without it the statements are
+GitHub OIDC → Fulcio → Rekor, the same signing path as `bnd statement`: the
+DSSE payload is the statement bytes verbatim) and the compact Sigstore bundle
+is emitted; without it the statements are
 emitted unsigned (fully offline-unit-testable). Statements are built and signed
 into a buffer before `--out` is touched, so a failure on the Nth manifest — a
 malformed manifest or a signing failure — never leaves a partial/unsigned file.
@@ -92,10 +93,10 @@ wrangle-attest --sign --statement <file> --out <file>
 
 Signs an existing in-toto statement file (the verify job's VSA) instead of
 discovering manifests: the raw file bytes become the DSSE payload verbatim —
-never re-marshaled — so the bundle is byte-identical to `bnd statement` on the
-same file, written as one compact bundle line. `--statement` is mutually
-exclusive with `--metadata-root`, `--subject`, `--artifact`, and `--commit`; a
-missing, empty, or non-JSON-object file fails closed before `--out` is touched.
+never re-marshaled — written as one compact bundle line. `--statement` is
+mutually exclusive with `--metadata-root`, `--subject`, `--artifact`, and
+`--commit`; a missing, empty, or non-JSON-object file fails closed before
+`--out` is touched.
 
 ## Testing
 
@@ -103,7 +104,11 @@ missing, empty, or non-JSON-object file fails closed before `--out` is touched.
 cases), subject parsing (single sha256, fail-closed on multi/short/wrong-algo;
 `--artifact` self-digest), golden Statements (`testdata/`) for the SBOM
 passthrough and the SARIF thin-envelope shapes, and hermetic `--sign` (local
-ephemeral key: DSSE shape + signature + fail-closed). Regenerate goldens with
+ephemeral key: DSSE shape + signature + fail-closed). `--statement` mode is
+covered by a recording signer pinning the payload to the file bytes verbatim, a
+local-key payload round-trip, a fail-closed table (including a signing failure
+leaving a pre-existing `--out` untouched), and the tag-gated keyless
+integration test. Regenerate goldens with
 `go test ./wrangle-attest/ -update`. The real keyless path is covered by the
 dispatch e2e (`actions/attest_provenance` and `actions/attest_metadata_oci` bats
 cover the `sign_metadata.sh` glue).

--- a/tools/wrangle-attest/SPEC.md
+++ b/tools/wrangle-attest/SPEC.md
@@ -86,6 +86,17 @@ into a buffer before `--out` is touched, so a failure on the Nth manifest — a
 malformed manifest or a signing failure — never leaves a partial/unsigned file.
 Exit 0 on success; non-zero (fail closed) on any error.
 
+```
+wrangle-attest --sign --statement <file> --out <file>
+```
+
+Signs an existing in-toto statement file (the verify job's VSA) instead of
+discovering manifests: the raw file bytes become the DSSE payload verbatim —
+never re-marshaled — so the bundle is byte-identical to `bnd statement` on the
+same file, written as one compact bundle line. `--statement` is mutually
+exclusive with `--metadata-root`, `--subject`, `--artifact`, and `--commit`; a
+missing, empty, or non-JSON-object file fails closed before `--out` is touched.
+
 ## Testing
 
 `go test ./wrangle-attest/` — table-driven manifest parse/validate (fail-closed

--- a/tools/wrangle-attest/main.go
+++ b/tools/wrangle-attest/main.go
@@ -35,6 +35,11 @@
 // GitHub OIDC -> Fulcio -> Rekor), producing a Sigstore bundle. Without it the
 // statements are emitted unsigned (offline-unit-testable).
 //
+// With --sign --statement <file> the engine instead signs one existing
+// statement file (the verify job's VSA) verbatim — no manifest discovery, the
+// raw file bytes are the DSSE payload — through the same signer, so the bundle
+// is byte-identical to `bnd statement`.
+//
 // Fail closed: a malformed/missing manifest, an unknown predicate-type, a
 // missing result file, a malformed subject, or a signing failure aborts with a
 // non-zero exit BEFORE any output is written, so a partial/unsigned/corrupt

--- a/tools/wrangle-attest/main.go
+++ b/tools/wrangle-attest/main.go
@@ -36,9 +36,8 @@
 // statements are emitted unsigned (offline-unit-testable).
 //
 // With --sign --statement <file> the engine instead signs one existing
-// statement file (the verify job's VSA) verbatim — no manifest discovery, the
-// raw file bytes are the DSSE payload — through the same signer, so the bundle
-// is byte-identical to `bnd statement`.
+// statement file (the verify job's VSA) through the same signer — no manifest
+// discovery; the DSSE payload is the statement file bytes verbatim.
 //
 // Fail closed: a malformed/missing manifest, an unknown predicate-type, a
 // missing result file, a malformed subject, or a signing failure aborts with a

--- a/tools/wrangle-attest/run.go
+++ b/tools/wrangle-attest/run.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -21,7 +22,8 @@ func (r *metadataRoots) Set(v string) error {
 // single artifact subject, builds one Statement per manifest, and writes them
 // all to --out as JSONL. With --sign each statement is keyless-signed (one
 // shared signer, so the OIDC+Fulcio flow runs once) and the Sigstore bundle is
-// emitted; without it the statements are emitted unsigned. The file is written
+// emitted; without it the statements are emitted unsigned. With --statement it
+// instead signs one existing statement file verbatim. The file is written
 // whole (buffer first) so a mid-run failure — including a Fulcio error on the
 // Nth statement — never leaves a partial/unsigned bundle on disk.
 func run(args []string, stderr io.Writer) int {
@@ -34,10 +36,18 @@ func run(args []string, stderr io.Writer) int {
 	artifact := fs.String("artifact", "", "file to self-digest into the sha256 subject (alternative to --subject)")
 	commit := fs.String("commit", "", "scanned git commit, woven into the scan/v1 envelope only")
 	sign := fs.Bool("sign", false, "keyless-sign each statement and emit the Sigstore bundle")
+	statement := fs.String("statement", "", "existing in-toto statement file to sign verbatim (requires --sign)")
 	out := fs.String("out", "", "file the in-toto JSONL statements are written to")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
+	}
+
+	if *statement != "" {
+		if err := validateStatementMode(roots, *subject, *artifact, *commit, *sign, *out); err != nil {
+			return failClosed(stderr, err)
+		}
+		return signStatementFile(*statement, *out, stderr)
 	}
 
 	subjectArg, err := resolveSubject(*subject, *artifact)
@@ -127,4 +137,54 @@ func validateFlags(roots []string, subject, out string) error {
 		return fmt.Errorf("--out is required")
 	}
 	return nil
+}
+
+func validateStatementMode(roots []string, subject, artifact, commit string, sign bool, out string) error {
+	if len(roots) > 0 || subject != "" || artifact != "" || commit != "" {
+		return fmt.Errorf("--statement cannot be combined with --metadata-root, --subject, --artifact, or --commit")
+	}
+	if !sign {
+		return fmt.Errorf("--statement requires --sign")
+	}
+	if out == "" {
+		return fmt.Errorf("--out is required")
+	}
+	return nil
+}
+
+// signStatementFile signs an existing statement file. The raw file bytes are
+// the DSSE payload verbatim — never re-marshaled or normalized — so the bundle
+// is byte-identical to `bnd statement` on the same file.
+func signStatementFile(path, out string, stderr io.Writer) int {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return failClosed(stderr, fmt.Errorf("statement: %w", err))
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return failClosed(stderr, fmt.Errorf("statement file is empty: %s", path))
+	}
+	if trimmed[0] != '{' || !json.Valid(raw) {
+		return failClosed(stderr, fmt.Errorf("statement file is not a JSON object: %s", path))
+	}
+
+	sg, closeFn, err := newSigner()
+	if err != nil {
+		return failClosed(stderr, err)
+	}
+	defer closeFn()
+
+	line, err := sg.sign(raw)
+	if err != nil {
+		return failClosed(stderr, err)
+	}
+
+	var buf bytes.Buffer
+	buf.Write(line)
+	buf.WriteByte('\n')
+	if err := os.WriteFile(out, buf.Bytes(), 0o644); err != nil {
+		return failClosed(stderr, err)
+	}
+	fmt.Fprintf(stderr, "wrangle-attest: wrote signed statement to %s\n", out)
+	return 0
 }

--- a/tools/wrangle-attest/run.go
+++ b/tools/wrangle-attest/run.go
@@ -153,8 +153,7 @@ func validateStatementMode(roots []string, subject, artifact, commit string, sig
 }
 
 // signStatementFile signs an existing statement file. The raw file bytes are
-// the DSSE payload verbatim — never re-marshaled or normalized — so the bundle
-// is byte-identical to `bnd statement` on the same file.
+// the DSSE payload verbatim — never re-marshaled or normalized.
 func signStatementFile(path, out string, stderr io.Writer) int {
 	raw, err := os.ReadFile(path)
 	if err != nil {

--- a/tools/wrangle-attest/run.go
+++ b/tools/wrangle-attest/run.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -159,12 +158,10 @@ func signStatementFile(path, out string, stderr io.Writer) int {
 	if err != nil {
 		return failClosed(stderr, fmt.Errorf("statement: %w", err))
 	}
-	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 {
+	// Early-out before the signer does TUF/OIDC work; SignStatement itself
+	// validates that the payload is an in-toto statement.
+	if len(bytes.TrimSpace(raw)) == 0 {
 		return failClosed(stderr, fmt.Errorf("statement file is empty: %s", path))
-	}
-	if trimmed[0] != '{' || !json.Valid(raw) {
-		return failClosed(stderr, fmt.Errorf("statement file is not a JSON object: %s", path))
 	}
 
 	sg, closeFn, err := newSigner()

--- a/tools/wrangle-attest/sign_keyless_integration_test.go
+++ b/tools/wrangle-attest/sign_keyless_integration_test.go
@@ -90,7 +90,7 @@ func TestRunSignKeyless(t *testing.T) {
 
 // TestRunSignKeylessStatement signs an existing statement file via --statement
 // and asserts the emitted Sigstore bundle's DSSE payload is the file bytes
-// verbatim — the byte-identity contract with `bnd statement`.
+// verbatim.
 func TestRunSignKeylessStatement(t *testing.T) {
 	// In CI this job has id-token: write; a missing token is a real gap, not a
 	// skip — keyless must actually run here.

--- a/tools/wrangle-attest/sign_keyless_integration_test.go
+++ b/tools/wrangle-attest/sign_keyless_integration_test.go
@@ -199,3 +199,47 @@ func tamperPayload(t *testing.T, bundleBytes []byte) []byte {
 type testWriter struct{ b []byte }
 
 func (w *testWriter) Write(p []byte) (int, error) { w.b = append(w.b, p...); return len(p), nil }
+
+// The keyless (sigstore) backend — the only backend wrangle signs with —
+// rejects a payload that is not an in-toto statement before it reaches Fulcio.
+// This is the signer's own check, not one of ours: the engine passes the file
+// bytes through untouched, so a valid JSON object that is merely not a
+// statement must still fail closed with --out untouched.
+func TestRunSignKeylessRejectsNonStatement(t *testing.T) {
+	if os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL") == "" {
+		t.Fatal("ACTIONS_ID_TOKEN_REQUEST_URL unset; keyless signing needs ambient GitHub OIDC")
+	}
+
+	dir := t.TempDir()
+	prior := []byte("PRE-EXISTING\n")
+	for _, tc := range []struct{ name, content string }{
+		{"valid JSON object that is not an in-toto statement", `{"hello":"world"}`},
+		{"JSON array", `[{"a":1}]`},
+		{"JSON null", `null`},
+		{"truncated JSON object", `{"a":`},
+		{"not JSON at all", `not json`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, "stmt.json")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			out := filepath.Join(dir, "out.json")
+			if err := os.WriteFile(out, prior, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			var stderr testWriter
+			if rc := run([]string{"--sign", "--statement", path, "--out", out}, &stderr); rc != 2 {
+				t.Fatalf("rc=%d, want fail-closed 2; stderr=%s", rc, stderr.b)
+			}
+			data, err := os.ReadFile(out)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(data, prior) {
+				t.Fatalf("pre-existing --out changed on a rejected statement: %q", data)
+			}
+		})
+	}
+}

--- a/tools/wrangle-attest/sign_keyless_integration_test.go
+++ b/tools/wrangle-attest/sign_keyless_integration_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -84,6 +85,60 @@ func TestRunSignKeyless(t *testing.T) {
 	// Cryptographically verify the bundle against the Sigstore trust root: the
 	// signature must be valid for this Fulcio identity over the signed payload.
 	// A tampered payload or signature fails here.
+	verifyKeylessBundle(t, data)
+}
+
+// TestRunSignKeylessStatement signs an existing statement file via --statement
+// and asserts the emitted Sigstore bundle's DSSE payload is the file bytes
+// verbatim — the byte-identity contract with `bnd statement`.
+func TestRunSignKeylessStatement(t *testing.T) {
+	// In CI this job has id-token: write; a missing token is a real gap, not a
+	// skip — keyless must actually run here.
+	if os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL") == "" {
+		t.Fatal("ACTIONS_ID_TOKEN_REQUEST_URL unset; keyless signing needs ambient GitHub OIDC")
+	}
+
+	dir := t.TempDir()
+	stmt := `{"_type":"https://in-toto.io/Statement/v1","subject":[{"name":"artifact","digest":{"sha256":"011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95"}}],"predicateType":"https://slsa.dev/verification_summary/v1","predicate":{"verificationResult":"PASSED"}}`
+	path := filepath.Join(dir, "vsa.intoto.json")
+	if err := os.WriteFile(path, []byte(stmt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "vsa.signed.json")
+
+	var stderr testWriter
+	rc := run([]string{"--sign", "--statement", path, "--out", out}, &stderr)
+	if rc != 0 {
+		t.Fatalf("keyless run rc=%d stderr=%s", rc, stderr.b)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trimmed := bytes.TrimSuffix(data, []byte("\n"))
+	if bytes.ContainsRune(trimmed, '\n') || len(trimmed) == len(data) {
+		t.Fatalf("expected a single compact bundle line + newline, got %q", data)
+	}
+
+	var bundle sbundle.Bundle
+	if err := bundle.UnmarshalJSON(data); err != nil {
+		t.Fatalf("output is not a Sigstore bundle: %v\n%s", err, data)
+	}
+	if bundle.GetVerificationMaterial() == nil {
+		t.Fatal("bundle carries no verificationMaterial (Fulcio cert)")
+	}
+	env := bundle.GetDsseEnvelope()
+	if env == nil {
+		t.Fatal("bundle carries no DSSE envelope")
+	}
+	if got := env.GetPayloadType(); got != "application/vnd.in-toto+json" {
+		t.Fatalf("payloadType = %q, want application/vnd.in-toto+json", got)
+	}
+	if !bytes.Equal(env.GetPayload(), []byte(stmt)) {
+		t.Fatalf("DSSE payload differs from statement file bytes:\n got: %q\nwant: %q", env.GetPayload(), stmt)
+	}
+
 	verifyKeylessBundle(t, data)
 }
 

--- a/tools/wrangle-attest/sign_statement_test.go
+++ b/tools/wrangle-attest/sign_statement_test.go
@@ -85,6 +85,35 @@ func TestRunStatementLocalKeyPayloadRoundTrip(t *testing.T) {
 	}
 }
 
+// A signing failure must leave a pre-existing --out byte-unchanged — --out is
+// only written after signing succeeds.
+func TestRunStatementSignFailureLeavesOutUntouched(t *testing.T) {
+	swapSigner(t, func() (statementSigner, func(), error) { return failingSigner{}, func() {}, nil })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stmt.json")
+	if err := os.WriteFile(path, []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "out.json")
+	prior := []byte("pre-existing content\n")
+	if err := os.WriteFile(out, prior, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	if rc := run([]string{"--sign", "--statement", path, "--out", out}, &stderr); rc != 2 {
+		t.Fatalf("rc=%d, want fail-closed 2; stderr=%s", rc, stderr.String())
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, prior) {
+		t.Fatalf("pre-existing --out changed on signing failure: %q", data)
+	}
+}
+
 func TestRunStatementFailClosed(t *testing.T) {
 	rs := &recordingSigner{out: []byte(`{}`)}
 	swapSigner(t, func() (statementSigner, func(), error) { return rs, func() {}, nil })

--- a/tools/wrangle-attest/sign_statement_test.go
+++ b/tools/wrangle-attest/sign_statement_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	sdsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// recordingSigner captures the exact bytes handed to sign, proving the DSSE
+// payload is the statement file verbatim.
+type recordingSigner struct {
+	got []byte
+	out []byte
+}
+
+func (r *recordingSigner) sign(statement []byte) ([]byte, error) {
+	r.got = append([]byte(nil), statement...)
+	return r.out, nil
+}
+
+func TestRunStatementSignsFileBytesVerbatim(t *testing.T) {
+	rs := &recordingSigner{out: []byte(`{"bundle":"x"}`)}
+	swapSigner(t, func() (statementSigner, func(), error) { return rs, func() {}, nil })
+
+	dir := t.TempDir()
+	// Indentation and the trailing newline must reach the signer untouched.
+	stmt := "{\n  \"_type\": \"https://in-toto.io/Statement/v1\",\n  \"predicateType\": \"https://example.com/v1\"\n}\n"
+	path := filepath.Join(dir, "vsa.intoto.json")
+	if err := os.WriteFile(path, []byte(stmt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "vsa.signed.json")
+
+	var stderr bytes.Buffer
+	rc := run([]string{"--sign", "--statement", path, "--out", out}, &stderr)
+	if rc != 0 {
+		t.Fatalf("run rc=%d stderr=%s", rc, stderr.String())
+	}
+	if !bytes.Equal(rs.got, []byte(stmt)) {
+		t.Fatalf("signer input differs from file bytes:\n got: %q\nwant: %q", rs.got, stmt)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"bundle":"x"}`+"\n" {
+		t.Fatalf("out = %q, want the signer's single line + newline", data)
+	}
+}
+
+func TestRunStatementLocalKeyPayloadRoundTrip(t *testing.T) {
+	ks := newLocalKeySigner(t)
+	swapSigner(t, func() (statementSigner, func(), error) { return ks, func() {}, nil })
+
+	dir := t.TempDir()
+	stmt := `{"_type":"https://in-toto.io/Statement/v1","subject":[{"name":"a","digest":{"sha256":"011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95"}}],"predicateType":"https://example.com/v1","predicate":{"verdict":"pass"}}`
+	path := filepath.Join(dir, "vsa.intoto.json")
+	if err := os.WriteFile(path, []byte(stmt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "vsa.signed.json")
+
+	var stderr bytes.Buffer
+	rc := run([]string{"--sign", "--statement", path, "--out", out}, &stderr)
+	if rc != 0 {
+		t.Fatalf("run rc=%d stderr=%s", rc, stderr.String())
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var env sdsse.Envelope
+	if err := protojson.Unmarshal(bytes.TrimSpace(data), &env); err != nil {
+		t.Fatalf("signed output is not a DSSE envelope: %v", err)
+	}
+	if !bytes.Equal(env.GetPayload(), []byte(stmt)) {
+		t.Fatalf("DSSE payload differs from statement file bytes:\n got: %q\nwant: %q", env.GetPayload(), stmt)
+	}
+	if len(env.GetSignatures()) == 0 || len(env.GetSignatures()[0].GetSig()) == 0 {
+		t.Fatalf("envelope carries no signature: %+v", env.GetSignatures())
+	}
+}
+
+func TestRunStatementFailClosed(t *testing.T) {
+	rs := &recordingSigner{out: []byte(`{}`)}
+	swapSigner(t, func() (statementSigner, func(), error) { return rs, func() {}, nil })
+
+	dir := t.TempDir()
+	good := filepath.Join(dir, "stmt.json")
+	if err := os.WriteFile(good, []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	empty := write("empty.json", "")
+	blank := write("blank.json", " \n\t\n")
+	notJSON := write("not.json", "not json")
+	array := write("array.json", `[{"a":1}]`)
+	null := write("null.json", "null")
+	truncated := write("truncated.json", `{"a":`)
+	out := filepath.Join(dir, "out.json")
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"missing file", []string{"--sign", "--statement", filepath.Join(dir, "nope.json"), "--out", out}},
+		{"empty file", []string{"--sign", "--statement", empty, "--out", out}},
+		{"whitespace-only file", []string{"--sign", "--statement", blank, "--out", out}},
+		{"not JSON", []string{"--sign", "--statement", notJSON, "--out", out}},
+		{"JSON array", []string{"--sign", "--statement", array, "--out", out}},
+		{"JSON null", []string{"--sign", "--statement", null, "--out", out}},
+		{"truncated JSON object", []string{"--sign", "--statement", truncated, "--out", out}},
+		{"no --sign", []string{"--statement", good, "--out", out}},
+		{"no --out", []string{"--sign", "--statement", good}},
+		{"with --metadata-root", []string{"--sign", "--statement", good, "--metadata-root", dir, "--out", out}},
+		{"with --subject", []string{"--sign", "--statement", good, "--subject", testArtifactDigest, "--out", out}},
+		{"with --artifact", []string{"--sign", "--statement", good, "--artifact", good, "--out", out}},
+		{"with --commit", []string{"--sign", "--statement", good, "--commit", "deadbeef", "--out", out}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			if rc := run(tc.args, &stderr); rc != 2 {
+				t.Fatalf("rc=%d, want fail-closed 2; stderr=%s", rc, stderr.String())
+			}
+			if _, err := os.Stat(out); !os.IsNotExist(err) {
+				t.Fatalf("expected no output file after failure, stat err=%v", err)
+			}
+		})
+	}
+}

--- a/tools/wrangle-attest/sign_statement_test.go
+++ b/tools/wrangle-attest/sign_statement_test.go
@@ -132,10 +132,6 @@ func TestRunStatementFailClosed(t *testing.T) {
 	}
 	empty := write("empty.json", "")
 	blank := write("blank.json", " \n\t\n")
-	notJSON := write("not.json", "not json")
-	array := write("array.json", `[{"a":1}]`)
-	null := write("null.json", "null")
-	truncated := write("truncated.json", `{"a":`)
 	out := filepath.Join(dir, "out.json")
 
 	cases := []struct {
@@ -145,10 +141,6 @@ func TestRunStatementFailClosed(t *testing.T) {
 		{"missing file", []string{"--sign", "--statement", filepath.Join(dir, "nope.json"), "--out", out}},
 		{"empty file", []string{"--sign", "--statement", empty, "--out", out}},
 		{"whitespace-only file", []string{"--sign", "--statement", blank, "--out", out}},
-		{"not JSON", []string{"--sign", "--statement", notJSON, "--out", out}},
-		{"JSON array", []string{"--sign", "--statement", array, "--out", out}},
-		{"JSON null", []string{"--sign", "--statement", null, "--out", out}},
-		{"truncated JSON object", []string{"--sign", "--statement", truncated, "--out", out}},
 		{"no --sign", []string{"--statement", good, "--out", out}},
 		{"no --out", []string{"--sign", "--statement", good}},
 		{"with --metadata-root", []string{"--sign", "--statement", good, "--metadata-root", dir, "--out", out}},


### PR DESCRIPTION
claude: Engine half of #482 — adds a statement-file signing mode to `wrangle-attest` so the verify job's VSA can be signed in-engine instead of shelling `bnd statement` in the toolbox container.

## Scope

**Engine-only and purely additive.** Existing modes (manifest discovery, `--sign` over built statements) are untouched — behavior and output are bit-for-bit unchanged. The `run_verify.sh` shell flip is a follow-up PR, gated on the toolbox image publishing this engine and the catalog digest bump.

New CLI form:

```
wrangle-attest --sign --statement <file> --out <file>
```

## Byte-identity with `bnd statement`

Verified against `bnd v0.4.3` source (`internal/cmd/statement.go` in the module cache). Its RunE does:

```go
f, err := os.Open(opts.StatementPath)
...
attData, err := io.ReadAll(f)
...
sg, err := signer.NewSignerFromSet(opts.SignerSet)
...
artifact, err := sg.SignStatement(attData)
...
artifact.WriteTo(o)
```

i.e. the file bytes are passed to `SignStatement` **verbatim** — no parsing, re-marshaling, or normalization — and the returned artifact is serialized with `WriteTo`. bnd's `defaultSignerSetOptions()` is `options.DefaultSignerSet()` (its only tweak is `HideOIDCOptions`, a `--help` cosmetic), the same set `newKeylessSigner` already uses. The new mode mirrors this exactly: raw `os.ReadFile` bytes → the existing shared `newSigner`/`statementSigner` path → one compact bundle line + `\n`, buffered before `--out` is touched.

The only deviations are fail-closed strengthenings bnd does not have (bnd validates nothing about the file content): an empty/whitespace-only file or content that is not a JSON object is rejected before signing. For any accepted input the DSSE payload is byte-identical.

## Upstream reuse (CLAUDE.md rule 4)

**Statement validation — REUSED; our JSON-shape check was redundant *and weaker*, deleted.**

`signStatementFile` used to gate the sign call on `trimmed[0] != '{' || !json.Valid(raw)`. The keyless backend's `SignStatement` already validates the payload itself: `signer`'s `VerifyAttestationContent` (`bundle/signer.go:57`) `protojson.Unmarshal`s the bytes into an `intoto.Statement` and rejects anything that isn't one — called from `sigstoreBackend.SignStatement` (`backend.go:95`) *before* any network work. Verified empirically: signing a file containing `{"hello":"world"}` fails with

```
wrangle-attest: signing statement: verifying content: unable to unmarshal intoto statement from payload
wrangle-attest: failing closed.
```

Our check would have happily signed that same input — it only asked "starts with `{` and parses as JSON". So it duplicated upstream and did it worse. Deleted.

**Kept:** the empty-file guard, purely as an early-out before the signer does TUF/OIDC work (one-line comment says exactly that).

**Backend caveat, worth knowing:** only the `sigstore` (keyless) and `spiffe` backends validate content — `keyBackend` does **not**. wrangle only ever signs keyless, so the guarantee holds for the shipped path, but that is why the proof lives in the keyless integration test (`TestRunSignKeylessRejectsNonStatement`, real Fulcio, CI-enforced, never skips) rather than the hermetic unit suite: the unit tests' local-key signer would sign `{"hello":"world"}` without complaint. The test asserts exit 2 and a pre-existing `--out` left byte-unchanged for a non-statement JSON object, a JSON array, `null`, truncated JSON, and non-JSON.

Net: **-14 LOC** in `run.go` (incl. the now-unused `encoding/json` import), +33 in tests.

## Fail-closed cases (all exit 2, `--out` never written)

- missing/unreadable statement file
- empty / whitespace-only file
- content not a JSON object (non-JSON, array, `null`, truncated object)
- `--statement` without `--sign`
- `--statement` without `--out`
- `--statement` combined with `--metadata-root`, `--subject`, `--artifact`, or `--commit` (each)

## Tests

- Hermetic (`sign_statement_test.go`): a recording signer proves the signer input equals the file bytes exactly (indentation + trailing newline preserved) and `--out` is the signer's single line + newline; a local-key signer proves the DSSE envelope payload round-trips to the file bytes; a table covers every fail-closed case above, asserting exit 2 and no output file.
- Keyless integration (`sign_keyless_integration_test.go`, `-tags keyless_integration`, fatal-if-no-OIDC — never skips): signs a small in-toto statement via `--statement`, asserts a single compact line, parses it as a Sigstore bundle with `verificationMaterial`, checks payloadType `application/vnd.in-toto+json`, payload round-trip, and cryptographically verifies the bundle (including the tamper-check) via the existing `verifyKeylessBundle`. Picked up by `test/keyless_attest.sh`'s existing `-run TestRunSignKeyless` pattern.
- `go -C tools test ./wrangle-attest/...` green; `./test.sh quick` (full pinned-container suite) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
