### PR TITLE
claude: fix(ci): tool-binary cache misses on in-repo Go source changes

### DIFF
--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -146,15 +146,18 @@ jobs:
           go-version-file: ${{ inputs.go-tools-dir }}/go.mod
           cache-dependency-path: ${{ inputs.go-tools-dir }}/go.sum
 
-      # Restores prebuilt tool binaries on a go.sum-stable run so they aren't
+      # Restores prebuilt tool binaries on an input-stable run so they aren't
       # relinked; a hit skips the go.sum re-verify, so this is test/scan only
-      # and never gates a release (this workflow attests nothing).
+      # and never gates a release (this workflow attests nothing). Keyed on
+      # go.sum AND the in-repo Go tool sources, matching the setup script's
+      # rebuild stamp — wrangle-attest/wrangle-lint compile from the checkout,
+      # so a source-only change must miss the cache.
       - name: Cache setup-script tool binaries
         if: ${{ inputs.cache-setup-tools == 'enabled' && inputs.go-tools-dir != '' }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/.wrangle/bin
-          key: setup-tools-${{ runner.os }}-${{ hashFiles(format('{0}/go.sum', inputs.go-tools-dir)) }}
+          key: setup-tools-${{ runner.os }}-${{ hashFiles(format('{0}/go.sum', inputs.go-tools-dir), format('{0}/**/*.go', inputs.go-tools-dir)) }}
 
       # Cross-run cache of the docker images the setup-script registers in
       # $WRANGLE_IMAGE_CACHE_LIST (docker save/load): a hit loads the images

--- a/test/setup_integration.sh
+++ b/test/setup_integration.sh
@@ -32,16 +32,21 @@ done
 # database can't be disabled. go requires an absolute GOBIN, and env.sh's
 # local default for WRANGLE_BIN_DIR is CWD-relative.
 #
-# The stamp records the go.sum the binaries were built for: a warm bin dir
-# (a restored CI cache) with a matching stamp skips the rebuild, and a go.sum
-# change forces a fresh install so a stale cache can't serve mismatched tools.
+# The stamp records the build inputs — go.sum AND the in-repo tool sources
+# (wrangle-attest/wrangle-lint compile from tools/ itself, so a source-only
+# change leaves go.sum untouched): a warm bin dir (a restored CI cache) with a
+# matching stamp skips the rebuild, and any input change forces a fresh install
+# so a stale cache can't serve mismatched tools.
 TOOLS_STAMP="$WRANGLE_BIN_DIR/.go-tools.stamp"
-GOSUM_DIGEST="$(sha256sum "$REPO_ROOT/tools/go.sum" | cut -d' ' -f1)"
-if [[ -f "$TOOLS_STAMP" && "$(<"$TOOLS_STAMP")" == "$GOSUM_DIGEST" ]]; then
-    printf 'setup_integration: Go tools present for current go.sum, skipping install\n'
+TOOLS_DIGEST="$({
+    cat "$REPO_ROOT/tools/go.sum"
+    find "$REPO_ROOT/tools" -type f -name '*.go' -print0 | LC_ALL=C sort -z | xargs -0 cat
+} | sha256sum | cut -d' ' -f1)"
+if [[ -f "$TOOLS_STAMP" && "$(<"$TOOLS_STAMP")" == "$TOOLS_DIGEST" ]]; then
+    printf 'setup_integration: Go tools current for go.sum + tool sources, skipping install\n'
 else
     GOBIN="$(cd "$WRANGLE_BIN_DIR" && pwd)" go -C "$REPO_ROOT/tools" install tool
-    printf '%s\n' "$GOSUM_DIGEST" > "$TOOLS_STAMP"
+    printf '%s\n' "$TOOLS_DIGEST" > "$TOOLS_STAMP"
 fi
 
 # The lint-tool venvs the unit bats exercise (wrangle-shell-lint needs

--- a/test/test_setup_integration.bats
+++ b/test/test_setup_integration.bats
@@ -29,10 +29,17 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
-@test "setup_integration: guards the Go tool install with a go.sum-digest stamp" {
+@test "setup_integration: guards the Go tool install with a build-inputs stamp" {
     # A restored CI binary cache (build_shell.yml cache-setup-tools) must skip
-    # the rebuild: the install runs only when the stamp is absent or stale.
+    # the rebuild only when go.sum AND the in-repo tool sources are unchanged:
+    # wrangle-attest/wrangle-lint compile from the checkout, so a source-only
+    # change must invalidate the stamp or a stale binary serves the tests.
     run grep -F '.go-tools.stamp' "$SETUP"
+    [ "$status" -eq 0 ]
+    run grep -F "find \"\$REPO_ROOT/tools\" -type f -name '*.go'" "$SETUP"
+    [ "$status" -eq 0 ]
+    # The workflow cache key must invalidate on the same inputs as the stamp.
+    run grep -F "format('{0}/**/*.go', inputs.go-tools-dir)" "$REPO_ROOT/.github/workflows/build_shell.yml"
     [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
The `cache-setup-tools` binary cache (build_shell.yml) and the setup script's rebuild stamp are keyed on `tools/go.sum` alone — but `wrangle-attest` and `wrangle-lint` compile from the checkout's own `tools/` source, which changes without touching go.sum. A restored cache therefore keeps serving a stale binary to the integration bats indefinitely (until an unrelated go.sum bump).

Surfaced by #761: its real-engine flag-parity test failed against a cached `wrangle-attest` predating the `--statement` mode — the test did its job; the cache was unsound.

Fix: key both the `actions/cache` entry and the `.go-tools.stamp` on go.sum **plus** every `tools/**/*.go`, so either path rebuilds on a source-only change. The stamp fix alone would rebuild every run on a stale restore; the key fix makes a source change a clean cache miss + save.

Test: the stamp bats now pins the source-hash presence in both the script and the workflow key, so the two can't drift apart silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
