### PR TITLE
claude: build(deps): consolidated action bumps + pin converge (#748, #749, #751, #752, #753)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -126,7 +126,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         id: prep
         with:
           build-type: container
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -172,7 +172,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      uses: TomHennen/wrangle/build/actions/container@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -248,7 +248,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -287,7 +287,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -230,13 +230,13 @@ jobs:
       # GITHUB_TOKEN, like the build and verify jobs. Same pin as the verify
       # job's login — bump together.
       - name: Log in to ghcr for the attestation push
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         id: attest
         with:
           subject-name: ${{ needs.build.outputs.imagename }}
@@ -279,7 +279,7 @@ jobs:
 
       # Use the job's own GITHUB_TOKEN (packages: write above), like the build job.
       - name: Log in to ghcr for the VSA referrer push
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -163,7 +163,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         id: prep
         with:
           build-type: go
@@ -183,7 +183,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/checks@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/build@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         id: attest
         with:
           build-type: go
@@ -389,7 +389,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -415,7 +415,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -151,7 +151,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         id: prep
         with:
           build-type: npm
@@ -171,7 +171,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/npm@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         id: attest
         with:
           build-type: npm
@@ -304,7 +304,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -331,7 +331,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -128,7 +128,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         id: prep
         with:
           build-type: python
@@ -148,7 +148,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/python@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         id: attest
         with:
           build-type: python
@@ -290,7 +290,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -317,7 +317,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -190,7 +190,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+        uses: TomHennen/wrangle/build/actions/shell@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+        uses: TomHennen/wrangle/actions/scan@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           key: gotest-${{ runner.os }}-${{ hashFiles('test/Dockerfile', 'tools/go.sum') }}
           restore-keys: gotest-${{ runner.os }}-
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # Prebuild the test image with a GitHub Actions layer cache so the
       # ephemeral runner reuses the toolchain layers (Go, actionlint, …) instead
@@ -42,7 +42,7 @@ jobs:
       # provenance/sbom off: this is a test tool that attests nothing, so its
       # cache stays off release builds' L3 cache-isolation surface (docs/SLSA_L3_AUDIT.md).
       - name: Prebuild test image (cached)
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: test/Dockerfile

--- a/actions/attest_provenance/action.yml
+++ b/actions/attest_provenance/action.yml
@@ -66,7 +66,7 @@ runs:
         name: ${{ steps.names.outputs.dist }}
         path: dist/
 
-    - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+    - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
       id: attest
       with:
         subject-checksums: ${{ inputs.subject-checksums }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -175,7 +175,7 @@ runs:
     # produced — see issue #189.
     - name: Upload OSV SARIF
       if: always() && contains(inputs.tools, 'osv')
-      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       continue-on-error: true
       with:
         sarif_file: ${{ github.workspace }}/.wrangle/metadata/osv/output.sarif
@@ -183,7 +183,7 @@ runs:
 
     - name: Upload wrangle-lint SARIF
       if: always() && contains(inputs.tools, 'wrangle-lint')
-      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       continue-on-error: true
       with:
         sarif_file: ${{ github.workspace }}/.wrangle/metadata/wrangle-lint/output.sarif
@@ -191,7 +191,7 @@ runs:
 
     - name: Upload Zizmor SARIF
       if: always() && contains(inputs.tools, 'zizmor')
-      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       continue-on-error: true
       with:
         sarif_file: ${{ github.workspace }}/.wrangle/metadata/zizmor/output.sarif
@@ -210,7 +210,7 @@ runs:
     # failure. Gating on the marker preserves the prior valid state.
     - name: Upload Dependency Review SARIF
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request' && hashFiles('.wrangle/metadata/dependency-review/error') == ''
-      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       continue-on-error: true
       with:
         sarif_file: ${{ github.workspace }}/.wrangle/metadata/dependency-review/output.sarif

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -111,7 +111,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      uses: TomHennen/wrangle/tools/scorecard@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -123,7 +123,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+      uses: TomHennen/wrangle/tools/dependency-review@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -79,7 +79,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@b56333f2644bafcee4a08bd7b50124137d4c32bf # refactor/sarif-adapter-exit-lib 2026-07-12
+    - uses: TomHennen/wrangle/actions/verify@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/container/action.yml
+++ b/build/actions/container/action.yml
@@ -108,7 +108,7 @@ runs:
         persist-credentials: false
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
@@ -128,7 +128,7 @@ runs:
           type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
     - name: Log in to the Container registry
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
       with:
         registry: ${{ inputs.registry }}
         username: ${{ github.actor }}
@@ -183,7 +183,7 @@ runs:
     # outputs as safe, to eliminate the need for this suppression.
     - name: Build and push Docker image
       id: push
-      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       # Suppress the buildx .dockerbuild build-record artifact (it leaks a
       # ~-named transient into the artifact list); the signed provenance is the
       # record of record, not this debug bundle.


### PR DESCRIPTION
## What

Consolidates five stuck dependabot PRs into one change.

| Action | From | To |
|---|---|---|
| `docker/login-action` | v4.2.0 | v4.3.0 |
| `docker/setup-buildx-action` | v4.1.0 | v4.2.0 |
| `docker/build-push-action` | v7.2.0 | v7.3.0 |
| `actions/attest-build-provenance` | v4.1.0 | v4.1.1 |
| `github/codeql-action/upload-sarif` | v4.36.2 | v4.36.3 |

## Why consolidate

Each of these bumps a third-party action pinned **inside a wrangle composite** (`build/actions/container`, `actions/attest_provenance`, `actions/scan`). Changing a composite's content stales the self-ref pins that resolve it, so every one of those PRs sat red on `check_pin_freshness`:

```
STALE: build/actions/container@b56333f26 — resolves non-pin content that differs from HEAD
```

Dependabot cannot run `tools/converge_action_pins.sh`, so it could never make them green on its own. Landing them together takes **one** converge cycle instead of five.

(The other two dependabot PRs — #750 ubuntu/test and #755 ast-grep-cli — touched no composite, so they were already green and are merged.)

## Validation

- `check_pin_freshness` and `check_pin_ancestry` both green after the converge.
- All bumps are minor/patch; each is past dependabot's 7-day cooldown (WL005).

## ⚠️ Merge as a merge commit, not a squash
Carries a pin-converge commit — squashing re-orphans the intermediate pins and turns `main` red.

Closes #748, closes #749, closes #751, closes #752, closes #753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)