### PR TITLE
claude: make the catalog auto-bump PR catalog-only (fixes #767)

### DIFF
--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -478,7 +478,14 @@ release does not rebuild or re-tag tool images.**
   rebuilds (wrangle's own `ghcr.io/tomhennen/wrangle/*`) are **exempt from the 7-day community-vetting
   cooldown** — that delay exists to let the community vet *third-party* updates for supply-chain attacks,
   which a rebuild of wrangle's own reviewed source is not — so the bump merges on CI/review latency and
-  keeps the catalog current. One source PR + one bump PR — not a manual double-bump. The publish trigger is
+  keeps the catalog current. One source PR + one bump PR — not a manual double-bump.
+
+  The bot's commit carries `tools/catalog.json` and nothing else, because `GITHUB_TOKEN` cannot push
+  `.github/workflows/**` (that needs the `workflows` scope, which no `permissions:` block grants). The
+  catalog is inside every self-ref pin's freshness scope, so the bump PR **arrives red on
+  `check_pin_freshness` by design**: whoever picks it up runs `make converge-action-pins`, pushes the
+  convergence commits to the bump branch, and lands it as a merge commit (never a squash — see
+  [e2e_testing.md](e2e_testing.md)). The publish trigger is
   a path glob that matches `tools/catalog.json`, so a catalog-only digest change would re-trigger a rebuild;
   the trigger excludes `tools/catalog.json`, which is what keeps the bump from looping.
 - **Release tag** — precondition: the catalog is fresh. `check_catalog_freshness.sh` proves the shipped

--- a/test/test_open_catalog_bump_pr.bats
+++ b/test/test_open_catalog_bump_pr.bats
@@ -9,7 +9,6 @@
 setup() {
     TOOLS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/tools"
     SCRIPT="$TOOLS_DIR/open_catalog_bump_pr.sh"
-    FRESHNESS="$TOOLS_DIR/check_pin_freshness.sh"
     BIN_DIR="$BATS_TEST_TMPDIR/bin"
     WORK="$BATS_TEST_TMPDIR/work"
     REMOTE="$BATS_TEST_TMPDIR/remote.git"
@@ -29,10 +28,8 @@ setup() {
     git -C "$WORK" config user.name t
     git -C "$WORK" config user.email t@example.com
     git -C "$WORK" config commit.gpgsign false
-    # The repo must carry a converged self-ref pin: open_catalog_bump_pr.sh now
-    # converges the pins after the catalog commit, and converge errors on a repo
-    # with no pins at all. A workflow pins a verify action at the sha where its
-    # tree first appears, so the chain is fresh until the catalog moves.
+    # The fixture carries a self-ref pin in a workflow so the catalog-only
+    # assertion is meaningful: a converging script would rewrite that file.
     mkdir -p "$WORK/tools" "$WORK/actions/verify" "$WORK/.github/workflows" "$WORK/lib"
     printf '{"tools":{}}\n' > "$WORK/tools/catalog.json"
     printf 'name: verify\n' > "$WORK/actions/verify/action.yml"
@@ -86,19 +83,16 @@ SHIM
     grep -q -- '--head bot/catalog-autobump' "$GH_LOG"
 }
 
-@test "open_catalog_bump_pr: converges the pins so the bump branch passes freshness" {
-    # The catalog commit stales the consuming pin (freshness folds catalog into
-    # scope); the script must converge so the PR is not born red.
+@test "open_catalog_bump_pr: the bump commit carries the catalog and nothing else" {
+    # A commit touching .github/workflows/** is exactly what GITHUB_TOKEN's absent
+    # `workflows` scope rejects at push time, so the bump must stay catalog-only.
     printf '{"tools":{"osv":{"image":"x@sha256:new"}}}\n' > "$WORK/tools/catalog.json"
     run "$SCRIPT"
     [ "$status" -eq 0 ]
-    # The pushed branch resolves current content: freshness passes on its HEAD.
-    git -C "$WORK" checkout -q bot/catalog-autobump
-    run bash -c "cd '$WORK' && '$FRESHNESS'"
-    [ "$status" -eq 0 ]
-    # Catalog commit + at least one convergence commit landed on the branch.
     run git -C "$WORK" rev-list --count main..bot/catalog-autobump
-    [ "$output" -ge 2 ]
+    [ "$output" -eq 1 ]
+    run git -C "$WORK" diff --name-only main bot/catalog-autobump
+    [ "$output" = "tools/catalog.json" ]
 }
 
 @test "open_catalog_bump_pr: an already-open PR is refreshed, not recreated" {

--- a/tools/open_catalog_bump_pr.sh
+++ b/tools/open_catalog_bump_pr.sh
@@ -6,16 +6,16 @@ set -f
 #
 # Runs after bump_catalog_to_latest.sh in the post-publish workflow: it takes the
 # already-modified tools/catalog.json in the working tree, commits it to a
-# dedicated bot branch, converges the self-ref pins onto that commit, and opens a
-# PR (or force-updates the existing one, so a rolling publish keeps a single PR
-# rather than piling up). No-op when the catalog is unchanged. First-party
-# rebuilds are cooldown-exempt (§11), so the PR is meant to be reviewed and merged
-# on CI/review latency, not held for the 7-day community-vetting delay. Uses git +
-# the gh CLI with the ambient GITHUB_TOKEN.
+# dedicated bot branch, and opens a PR (or force-updates the existing one, so a
+# rolling publish keeps a single PR rather than piling up). No-op when the catalog
+# is unchanged. First-party rebuilds are cooldown-exempt (§11), so the PR is meant
+# to be reviewed and merged on CI/review latency, not held for the 7-day
+# community-vetting delay. Uses git + the gh CLI with the ambient GITHUB_TOKEN.
 #
-# The convergence step is required: check_pin_freshness folds tools/catalog.json
-# into every pin's scope, so a catalog-only commit stales the consumers until the
-# pins are re-bumped onto it.
+# The commit carries tools/catalog.json and nothing else: GITHUB_TOKEN cannot push
+# .github/workflows/** (that needs the `workflows` scope, which no `permissions:`
+# block can grant), so pin convergence — which rewrites those files — is a human
+# step on the PR (`make converge-action-pins`) rather than part of this script.
 #
 # Setup requirement: the repository must have "Allow GitHub Actions to create and
 # approve pull requests" enabled, or `gh pr create` with GITHUB_TOKEN fails.
@@ -28,8 +28,6 @@ BASE="${WRANGLE_AUTOBUMP_BASE:-main}"
 CATALOG_REL="tools/catalog.json"
 BOT_NAME="github-actions[bot]"
 BOT_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 pr_title() {
     printf 'chore(catalog): bump curated tool-image digests to :latest'
@@ -51,11 +49,14 @@ CI/review latency to keep the catalog current.
 Adopter-override entries (a foreign namespace) are never touched here; those
 pins stay adopter-owned.
 
-**Merge as a merge commit, not a squash.** Beyond the catalog bump this PR carries
-self-ref pin-convergence commits (one per nesting level); squashing re-orphans the
-intermediate pins. The `# <branch>` pin labels are relabelled `# main` at release.
+**Before merging, converge the pins.** This PR bumps `tools/catalog.json` only, so
+`check_pin_freshness` is red by design: the catalog is in every self-ref pin's
+scope, and a bot cannot push the `.github/workflows/**` edits a convergence makes.
+Check the digests out, run `make converge-action-pins`, and push the resulting
+commits to this branch — then merge it as a **merge commit, not a squash**, or the
+intermediate pins re-orphan.
 
-Refs #619, #596.
+Refs #619, #596, #767.
 BODY
 }
 
@@ -102,18 +103,10 @@ main() {
     fi
     : "${WRANGLE_AUTOBUMP_GH_REPO:?set WRANGLE_AUTOBUMP_GH_REPO (owner/repo)}"
 
-    # Set the bot identity at repo scope: the catalog commit and every
-    # converge_action_pins.sh pin commit (which commits with no inline identity)
-    # both need it, and the CI checkout configures none.
-    git config user.name "$BOT_NAME"
-    git config user.email "$BOT_EMAIL"
-
     git switch -C "$BRANCH" >/dev/null 2>&1 || { printf 'open_catalog_bump_pr: could not create branch %s\n' "$BRANCH" >&2; return 2; }
     git add "$CATALOG_REL"
-    git commit -m "$(pr_title)" >/dev/null || { printf 'open_catalog_bump_pr: commit failed\n' >&2; return 2; }
-    # The catalog commit stales every pin (freshness folds tools/catalog.json into
-    # each pin's scope); converge re-bumps them onto it so the PR passes freshness.
-    "$SCRIPT_DIR/converge_action_pins.sh" || { printf 'open_catalog_bump_pr: pin convergence failed\n' >&2; return 2; }
+    git -c "user.name=$BOT_NAME" -c "user.email=$BOT_EMAIL" \
+        commit -m "$(pr_title)" >/dev/null || { printf 'open_catalog_bump_pr: commit failed\n' >&2; return 2; }
     push_branch || { printf 'open_catalog_bump_pr: push failed\n' >&2; return 2; }
     open_or_update_pr || { printf 'open_catalog_bump_pr: gh pr open failed\n' >&2; return 2; }
 }


### PR DESCRIPTION
## Why

`publish tool images` → `bump-catalog` has failed on **every run** (13/13 in the last 30 days), and it fires on every `tools/**` / `lib/**` push to main. It is the single largest source of failure-notification email to the owner.

`open_catalog_bump_pr.sh` ran `converge_action_pins.sh` after the catalog commit. Convergence rewrites `.github/workflows/*.yml`, and `GITHUB_TOKEN` cannot push those — the `workflows` scope is not grantable through a `permissions:` block:

```
! [remote rejected] bot/catalog-autobump (refusing to allow a GitHub App to create or
  update workflow `.github/workflows/build_and_publish_container.yml` without `workflows` permission)
```

## What

Option 1 from #767. The bot commits `tools/catalog.json` and nothing else, so the push succeeds and the PR opens.

`tools/catalog.json` stays inside the self-ref pin freshness scope — removing it (option 3) would let a digest bump not propagate to the pins, so the dogfood/showcase would silently run the old catalog. Option 2 (a `workflows`-scoped bot token) is a privilege escalation and is not proposed.

Consequence, and it is deliberate: **the bump PR arrives red on `check_pin_freshness`.** Whoever picks it up runs `make converge-action-pins`, pushes the convergence commits, and lands it as a merge commit. The PR body the bot writes now says exactly that, and §11 of the design doc records it.

The new bats asserts the commit is catalog-only — it fails against the converging script and passes against this one (verified both ways).

## Notes

- No pins staled by this PR (freshness scope is the pinned action trees + `tools/catalog.json` + `lib/`), so **no converge needed; this can squash-merge normally.**
- `./test.sh quick` green: 0 `not ok`.

### Owner action still needed

1. **Confirm "Allow GitHub Actions to create and approve pull requests" is enabled** (Settings → Actions → General). Every failure so far died at `git push`, so `gh pr create` has *never* actually run — if that setting is off, the job will still fail at PR-create. I can't read the setting with my token.
2. **One manual catch-up bump** clears the accumulated drift that is currently (correctly) failing the two weekly freshness crons: `tools/bump_catalog_to_latest.sh` + `make converge-action-pins`, landed as a merge commit.

Fixes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)