### PR TITLE
claude: fix the pipefail SIGPIPE races that redden main with exit 141

### DIFF
--- a/test/setup_integration.sh
+++ b/test/setup_integration.sh
@@ -98,8 +98,16 @@ if [[ -n "${GITHUB_PATH:-}" ]]; then
     printf '%s\n' "$WRANGLE_BIN_DIR" >> "$GITHUB_PATH"
 fi
 
+# Capture, then slice: `cmd | head -1` exits the reader early, and under pipefail
+# a tool still writing its banner takes SIGPIPE and fails the script with 141.
+first_line() {
+    local out
+    out="$("$@" 2>&1)"
+    printf '%s\n' "${out%%$'\n'*}"
+}
+
 printf 'setup_integration: installed tool versions:\n'
-osv-scanner --version | head -1
-ampel version | head -1
+first_line osv-scanner --version
+first_line ampel version
 cosign version 2>&1 | grep GitVersion
-zizmor --version | head -1
+first_line zizmor --version

--- a/test/test_self_ref_pin_paths.bats
+++ b/test/test_self_ref_pin_paths.bats
@@ -18,10 +18,12 @@ setup() {
     source "$LIB"
     mapfile -t paths < <(wrangle_self_ref_pin_paths)
     [ "${#paths[@]}" -gt 0 ]
-    printf '%s\n' "${paths[@]}" | grep -qx '.github/workflows'
-    printf '%s\n' "${paths[@]}" | grep -qx 'actions'
-    printf '%s\n' "${paths[@]}" | grep -qx 'build'
-    printf '%s\n' "${paths[@]}" | grep -qx 'tools'
+    # Space-delimited containment, not `printf | grep -q`: grep exits on the match
+    # while printf is still writing, and under pipefail that SIGPIPE is a 141.
+    local want
+    for want in '.github/workflows' 'actions' 'build' 'tools'; do
+        [[ " ${paths[*]} " == *" $want "* ]]
+    done
 }
 
 @test "self_ref_pin_paths: both pin tools source it rather than hardcoding paths" {


### PR DESCRIPTION
## Why

The `main`-branch run of 2026-07-12 failed in **two** workflows with exit **141** — SIGPIPE, not a real test failure:

| Workflow | Where | Run |
|---|---|---|
| Build Shell | `test/setup_integration.sh` version banner (`ampel version \| head -1`) | 29197537246 |
| Test | `test_self_ref_pin_paths.bats` — `not ok 317 … failed with status 141` | 29197537153 |

Both are the same bug. `cmd | head -1` and `printf | grep -q` let the reader exit as soon as it has what it needs; if the writer is still writing, it takes SIGPIPE, and under `set -o pipefail` the pipeline returns 141 and `set -e` kills the run. It is a timing race, so it fails intermittently — which is what makes it email-spammy rather than obviously broken.

Reproduced directly:

```
$ chatty | head -1     # under set -euo pipefail
rc=141
$ first_line chatty
rc=0
```

## What

- `setup_integration.sh`: capture-then-slice (`first_line`) instead of `| head -1`. The `cosign version 2>&1 | grep GitVersion` line is left alone — `grep` without `-q` reads to EOF, so it cannot SIGPIPE the writer.
- `test_self_ref_pin_paths.bats`: space-delimited containment instead of `printf | grep -qx`. The paths contain no spaces, so this stays an exact match.

## Scope

There are ~30 other latent `printf | grep -q` sites in the test suite with the same shape. I fixed only the two that actually fired rather than sweeping the repo; a `wrangle-shell-lint` rule for the pattern is the right mechanical fix — filed as #771.

For the record, the other two recent `main` failures were **not** this bug and are not addressed here (both already resolved on main): Build Shell 2026-07-11 was a real `not ok 711 sign_metadata` (fixed by the in-flight attest work), and Test 2026-07-03 was a transient `proxy.golang.org` stream error.

`./test.sh quick` green: 0 `not ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
