### PR TITLE
claude: chore(catalog): bump all 5 tool image digests (unblocks the #485 shell flips)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -126,7 +126,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         id: prep
         with:
           build-type: container
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -172,7 +172,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      uses: TomHennen/wrangle/build/actions/container@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -248,7 +248,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -287,7 +287,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -126,7 +126,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         id: prep
         with:
           build-type: container
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -172,7 +172,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      uses: TomHennen/wrangle/build/actions/container@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -248,7 +248,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -287,7 +287,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -163,7 +163,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         id: prep
         with:
           build-type: go
@@ -183,7 +183,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/checks@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/build@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         id: attest
         with:
           build-type: go
@@ -389,7 +389,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -415,7 +415,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -163,7 +163,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         id: prep
         with:
           build-type: go
@@ -183,7 +183,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/checks@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/build@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         id: attest
         with:
           build-type: go
@@ -389,7 +389,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -415,7 +415,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -151,7 +151,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         id: prep
         with:
           build-type: npm
@@ -171,7 +171,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/npm@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         id: attest
         with:
           build-type: npm
@@ -304,7 +304,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -331,7 +331,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -151,7 +151,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         id: prep
         with:
           build-type: npm
@@ -171,7 +171,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/npm@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         id: attest
         with:
           build-type: npm
@@ -304,7 +304,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -331,7 +331,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -128,7 +128,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         id: prep
         with:
           build-type: python
@@ -148,7 +148,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/python@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         id: attest
         with:
           build-type: python
@@ -290,7 +290,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -317,7 +317,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -128,7 +128,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         id: prep
         with:
           build-type: python
@@ -148,7 +148,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/python@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         id: attest
         with:
           build-type: python
@@ -290,7 +290,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -317,7 +317,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -193,7 +193,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+        uses: TomHennen/wrangle/build/actions/shell@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -193,7 +193,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+        uses: TomHennen/wrangle/build/actions/shell@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+        uses: TomHennen/wrangle/actions/scan@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+        uses: TomHennen/wrangle/actions/scan@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -111,7 +111,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      uses: TomHennen/wrangle/tools/scorecard@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -123,7 +123,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+      uses: TomHennen/wrangle/tools/dependency-review@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -111,7 +111,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      uses: TomHennen/wrangle/tools/scorecard@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -123,7 +123,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+      uses: TomHennen/wrangle/tools/dependency-review@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -79,7 +79,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@9bb62911a9b199e4bdaadac05417cae1af9f1567 # main 2026-07-12
+    - uses: TomHennen/wrangle/actions/verify@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -79,7 +79,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@fa813d380e5a99074aba058cf5d604fa25604df1 # main 2026-07-12
+    - uses: TomHennen/wrangle/actions/verify@e6ece464416283ff8b4d1f277804e7885968930c # main 2026-07-12
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -3,28 +3,28 @@
   "tools": {
     "osv": {
       "kind": "scan",
-      "image": "ghcr.io/tomhennen/wrangle/osv@sha256:c6316e86f7dcdcf7ba08e84b40807e837f920c71bf1b0622bf4bae4e2167eeb4",
+      "image": "ghcr.io/tomhennen/wrangle/osv@sha256:bb68cb612783ea237ac7b59bb32c5603723af21ac8b93c933ad38c5bce9ba012",
       "network": "egress"
     },
     "zizmor": {
       "kind": "scan",
-      "image": "ghcr.io/tomhennen/wrangle/zizmor@sha256:5c4c93346ed8880d4923af84260926ccb9501f00146d62ee00e8d07b98d940d9",
+      "image": "ghcr.io/tomhennen/wrangle/zizmor@sha256:48368d848705a27e32511983991fd73841ad7651c687a82549039c3f0f744373",
       "network": "egress",
       "secret": "github-token"
     },
     "wrangle-lint": {
       "kind": "scan",
-      "image": "ghcr.io/tomhennen/wrangle/wrangle-lint@sha256:f168f1d3cfebc145c555e3556c55fdb82c90b5ebeb51586d0f634231bcdeadbd",
+      "image": "ghcr.io/tomhennen/wrangle/wrangle-lint@sha256:a70a783ba5cd3077cb1017c3cf965ea62cbf6a2f0b15c5566c71c1aacb71ea01",
       "network": "none"
     },
     "sbom": {
       "kind": "sbom",
-      "image": "ghcr.io/tomhennen/wrangle/syft@sha256:2b94574c8895299a99ad9159af23315257b1841db9a6483764621e0bcae876f4",
+      "image": "ghcr.io/tomhennen/wrangle/syft@sha256:2f96460af2e69b75282ec864bb866d793c2b002207f9fcd469b39e5b858befb5",
       "network": "none"
     },
     "attest-toolbox": {
       "kind": "attest",
-      "image": "ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:7aed5ac0d202f235dc61656db24e17a34b728f5d1ef3618a1ea61479e6765151",
+      "image": "ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:72380ec7c52d6850688b6e7a1c5d0e440ccf1edb84479e63d99ada238d6903c7",
       "network": "egress",
       "token": "sigstore"
     }


### PR DESCRIPTION
## What

Bumps all five curated tool-image digests to the images just published from `main`.

The one that matters: **`attest-toolbox`** is now built from #763, so it is the first image to carry the `wrangle-attest` **`assemble`** subcommand and **`--statement` / `--append`**. I verified this by extracting the binary from the published image rather than trusting the build:

```
"SLSA provenance bundle copied verbatim into every per-artifact bundle"    ← --provenance
"raw cosign attestation-download output, filtered to the SLSA provenance"  ← --provenance-referrers
"directory the per-artifact <artifact>.intoto.jsonl bundles are written to" ← --bundle-dir
"file to self-digest into the sha256 subject (alternative to --subject)"
```

| tool | new digest |
|---|---|
| attest-toolbox | `sha256:72380ec7…` |
| osv | `sha256:bb68cb61…` |
| zizmor | `sha256:48368d84…` |
| wrangle-lint | `sha256:a70a783b…` |
| sbom (syft) | `sha256:2f96460a…` |

## Why this is a hand-rolled PR

The post-publish auto-bump (`bump-catalog`) is structurally broken — **#767**, failing 13/13 runs. Bumping `catalog.json` stales the self-ref pins, so the bot runs `converge_action_pins.sh`, which rewrites `.github/workflows/*.yml`, and `GITHUB_TOKEN` **cannot push workflow files** (the `workflows` scope cannot be granted via `permissions:`). It dies at `git push`, so `gh pr create` never runs. #769 fixes it by making the bot commit `tools/catalog.json` only.

This PR is exactly what the bot could not push: the digest bump **plus** the 2 pin-converge commits.

## Unblocks

The shell flips (#766, #761) fail today with `flag provided but not defined: -statement` because the catalog pins an attest-toolbox image built *before* those flags existed. Once this lands, they rebase onto it and the `dispatch` e2e finally exercises the engine for real.

## Validation

- `check_pin_freshness` — all 18 pins resolve to HEAD content ✅
- `check_pin_ancestry` — all 18 reachable ✅
- `check_catalog_freshness` — **exit 0, in sync** (was exit 1; this also clears the weekly freshness cron failures, which were true positives caused by #767)

## ⚠️ Merge as a merge commit, not a squash
Carries 2 pin-converge commits — squashing re-orphans the intermediate pins and turns `main` red.