### PR TITLE
claude: release: bump adopter-facing version refs to v0.4.0

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -126,7 +126,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         id: prep
         with:
           build-type: container
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -172,7 +172,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      uses: TomHennen/wrangle/build/actions/container@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -248,7 +248,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -287,7 +287,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -163,7 +163,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         id: prep
         with:
           build-type: go
@@ -183,7 +183,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/checks@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/build@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         id: attest
         with:
           build-type: go
@@ -389,7 +389,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -415,7 +415,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -151,7 +151,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         id: prep
         with:
           build-type: npm
@@ -171,7 +171,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/npm@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         id: attest
         with:
           build-type: npm
@@ -304,7 +304,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -331,7 +331,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -128,7 +128,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         id: prep
         with:
           build-type: python
@@ -148,7 +148,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/python@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         id: attest
         with:
           build-type: python
@@ -290,7 +290,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -317,7 +317,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -193,7 +193,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+        uses: TomHennen/wrangle/build/actions/shell@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+        uses: TomHennen/wrangle/actions/scan@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test lint shellcheck shellstyle workflowstyle gotest bats zizmor integration bump-action-pins converge-action-pins check-catalog check-catalog-freshness check-catalog-provenance-freshness bump-catalog-digest bump-catalog-to-latest release-preflight
+.PHONY: bump-version-refs all test lint shellcheck shellstyle workflowstyle gotest bats zizmor integration bump-action-pins converge-action-pins check-catalog check-catalog-freshness check-catalog-provenance-freshness bump-catalog-digest bump-catalog-to-latest release-preflight
 
 # bash, not the default sh: the integration recipe sources lib/env.sh,
 # whose `set -o pipefail` dash doesn't reliably support.
@@ -119,3 +119,8 @@ bump-catalog-to-latest:
 # immutable, so this runs before `gh release create`, not after.
 release-preflight:
 	@./tools/release_preflight.sh
+
+# Retarget every adopter-facing wrangle release ref at a new version tag
+# (cut-release Phase 2). Usage: make bump-version-refs VERSION=v0.4.0
+bump-version-refs:
+	@./tools/bump_version_refs.sh $(VERSION)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
 ```

--- a/actions/scan/README.md
+++ b/actions/scan/README.md
@@ -23,7 +23,7 @@ jobs:
       actions: read
       contents: read
       security-events: write   # SARIF upload to the Security tab
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
 ```
 
 Findings appear in the Security tab; the run's step summary shows an overview.
@@ -49,7 +49,7 @@ The May 2026 Mini Shai-Hulud compromise of TanStack/router is the canonical exam
 The `tools` input is a space-separated list. Default: `"osv zizmor scorecard:info dependency-review wrangle-lint"`. Suffix with `:info` to make a tool's findings non-blocking.
 
 ```yaml
-uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
 with:
   tools: "osv zizmor"   # skip Scorecard and dependency-review
 ```

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -111,7 +111,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      uses: TomHennen/wrangle/tools/scorecard@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -123,7 +123,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+      uses: TomHennen/wrangle/tools/dependency-review@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
 
     - name: Generate step summary
       if: always()

--- a/actions/verify-vsa/README.md
+++ b/actions/verify-vsa/README.md
@@ -19,7 +19,7 @@ Drop it into your publish job between `download-artifact` and the publish step:
     path: dist/
 
 # Pin by release tag; a SHA-pinned build's VSA fails this gate (see below).
-- uses: TomHennen/wrangle/actions/verify-vsa@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+- uses: TomHennen/wrangle/actions/verify-vsa@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
   with:
     path: dist/
     resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -79,7 +79,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@b6c85d2be08cd9e7df08910d733627764506aab1 # bot/catalog-autobump 2026-07-12
+    - uses: TomHennen/wrangle/actions/verify@3bf023336089e358baaebb99ea9353b818c0ad12 # release/v0.4.0-adopter-refs 2026-07-12
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/build/actions/container/README.md
+++ b/build/actions/container/README.md
@@ -35,7 +35,7 @@ Consumers verify the image with one command — ampel fetches the VSA straight f
 
 ```bash
 ampel verify --subject sha256:<digest> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.3.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.4.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector oci:<imagename>@sha256:<digest> \
   --context expectedResourceUri:<imagename>@sha256:<digest> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/build/actions/go/README.md
+++ b/build/actions/go/README.md
@@ -19,7 +19,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
 ```
@@ -77,7 +77,7 @@ Downstream users verify a release archive with one command. Download the archive
 
 ```bash
 ampel verify --subject <archive> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.3.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.4.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector jsonl:<archive>.intoto.jsonl \
   --context expectedResourceUri:pkg:golang/<module-path>@<version> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/build/actions/npm/README.md
+++ b/build/actions/npm/README.md
@@ -17,7 +17,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       release-events: tag-only   # only tag pushes publish
@@ -58,7 +58,7 @@ Publishing happens in your workflow, so two things there are load-bearing — bo
 2. **Verify before you publish** — run wrangle's [`verify-vsa`](../../../actions/verify-vsa/README.md) action between `download-artifact` and `npm publish`, piping the build's `resource-uri` output, so the exact bytes leaving the runner are the bytes that passed wrangle's policy:
 
    ```yaml
-   - uses: TomHennen/wrangle/actions/verify-vsa@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+   - uses: TomHennen/wrangle/actions/verify-vsa@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
      with:
        path: dist/
        resource-uri: ${{ needs.build.outputs.resource-uri }}
@@ -83,7 +83,7 @@ Downstream users verify the released tarball with one command. Download the tarb
 
 ```bash
 ampel verify --subject <tarball> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.3.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.4.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector jsonl:<tarball>.intoto.jsonl \
   --context expectedResourceUri:pkg:npm/<name>@<version> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/build/actions/python/README.md
+++ b/build/actions/python/README.md
@@ -17,7 +17,7 @@ jobs:
       attestations: write     # GitHub-issued SLSA provenance
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       release-events: tag-only   # only tag pushes publish
@@ -58,7 +58,7 @@ Publishing happens in your workflow, so two things there are load-bearing — bo
 2. **Verify before you publish** — run wrangle's [`verify-vsa`](../../../actions/verify-vsa/README.md) action between `download-artifact` and the publish step, piping the build's `resource-uri` output, so the exact bytes leaving the runner are the bytes that passed wrangle's policy:
 
    ```yaml
-   - uses: TomHennen/wrangle/actions/verify-vsa@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+   - uses: TomHennen/wrangle/actions/verify-vsa@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
      with:
        path: dist/
        resource-uri: ${{ needs.build.outputs.resource-uri }}
@@ -79,7 +79,7 @@ Downstream users verify a dist file with one command. Download the wheel (or sdi
 
 ```bash
 ampel verify --subject <dist-file> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.3.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.4.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector jsonl:<dist-file>.intoto.jsonl \
   --context expectedResourceUri:pkg:pypi/<name>@<version> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/build/actions/shell/README.md
+++ b/build/actions/shell/README.md
@@ -13,7 +13,7 @@ jobs:
       contents: read
       actions: read           # source scan
       security-events: write  # scan findings -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
 ```
 
 PRs, pushes, and manual dispatches all run the same checks — there's no release step to gate.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -18,7 +18,7 @@ Pin by release **tag** (`@vX.Y.Z`), with an inline zizmor exception on that one
 line:
 
 ```yaml
-uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
 ```
 
 wrangle's release tags are

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -782,7 +782,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
 ```
 
 This is the entire file an adopter needs. No secrets, no configuration, no dependencies to manage.

--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -74,7 +74,7 @@ command you run against your own tag-built releases:
 
 ```bash
 ampel verify --subject wrangle-test-fixture-go_0.3.1_linux_amd64.tar.gz \
-  --policy git+https://github.com/TomHennen/wrangle@v0.3.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.4.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector jsonl:wrangle-test-fixture-go_0.3.1_linux_amd64.tar.gz.intoto.jsonl \
   --context expectedResourceUri:pkg:golang/github.com/tomhennen/wrangle-test/go@v0.3.1 \
   --context sourceRepo:https://github.com/TomHennen/wrangle-test
@@ -96,7 +96,7 @@ bundle and self-selects the VSA matching `--subject`:
 
 ```bash
 ampel verify --subject <artifact> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.3.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.4.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector jsonl:<artifact>.intoto.jsonl \
   --context expectedResourceUri:<resourceUri from the table above> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>
@@ -107,7 +107,7 @@ download step:
 
 ```bash
 ampel verify --subject sha256:<digest> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.3.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.4.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector oci:<imagename>@sha256:<digest> \
   --context expectedResourceUri:<imagename>@sha256:<digest> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>
@@ -126,7 +126,7 @@ build type, including a container image by its OCI digest:
 
 ```bash
 ampel verify --subject sha256:<digest> \
-  --policy git+https://github.com/TomHennen/wrangle@v0.3.1#policies/wrangle-vsa-consumer-v1.hjson \
+  --policy git+https://github.com/TomHennen/wrangle@v0.4.0#policies/wrangle-vsa-consumer-v1.hjson \
   --collector github:<your-org>/<your-repo> \
   --context expectedResourceUri:<resourceUri from the table above> \
   --context sourceRepo:https://github.com/<your-org>/<your-repo>

--- a/gh_workflow_examples/build_and_publish_containers.yml
+++ b/gh_workflow_examples/build_and_publish_containers.yml
@@ -24,7 +24,7 @@ jobs:
       attestations: write  # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_container.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: PATH/TO/FOLDER/WITH/Dockerfile
       imagename: ghcr.io/${{ github.repository }}/YOUR_IMAGE_NAME

--- a/gh_workflow_examples/build_go.yml
+++ b/gh_workflow_examples/build_go.yml
@@ -37,7 +37,7 @@ jobs:
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_go.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       # release-events: tag-only         # default; uncomment + change to "non-pull-request" or "main-and-tags" for early failure detection on non-tag events

--- a/gh_workflow_examples/build_npm.yml
+++ b/gh_workflow_examples/build_npm.yml
@@ -52,7 +52,7 @@ jobs:
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_npm.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       release-events: tag-only          # only tag pushes publish (recommended default)
@@ -96,7 +96,7 @@ jobs:
 
       # Verify the downloaded tarball against wrangle's signed VSA — the
       # full policy verdict — before any bytes leave this runner.
-      - uses: TomHennen/wrangle/actions/verify-vsa@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+      - uses: TomHennen/wrangle/actions/verify-vsa@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
         with:
           path: dist/
           resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/gh_workflow_examples/build_python.yml
+++ b/gh_workflow_examples/build_python.yml
@@ -49,7 +49,7 @@ jobs:
       attestations: write   # wrangle's attest job writes GitHub-issued SLSA provenance
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_and_publish_python.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
     with:
       path: "."
       release-events: tag-only          # only tag pushes publish (recommended default)
@@ -74,7 +74,7 @@ jobs:
 
       # Verify the downloaded dist against wrangle's signed VSA — the
       # full policy verdict — before any bytes leave this runner.
-      - uses: TomHennen/wrangle/actions/verify-vsa@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+      - uses: TomHennen/wrangle/actions/verify-vsa@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
         with:
           path: dist/
           resource-uri: ${{ needs.build.outputs.resource-uri }}

--- a/gh_workflow_examples/build_shell.yml
+++ b/gh_workflow_examples/build_shell.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       actions: read  # source scan: Scorecard reads the Actions API
       security-events: write  # source-scan SARIF -> Security tab
-    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/build_shell.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable
     # with:
     #   scan-path: "."       # optional: subdirectory to scan (default: repo root)
     #   bats-path: ""        # optional: path to bats tests (default: auto-detect)

--- a/gh_workflow_examples/check_source_change.yml
+++ b/gh_workflow_examples/check_source_change.yml
@@ -14,4 +14,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.3.1 # zizmor: ignore[unpinned-uses] - immutable
+    uses: TomHennen/wrangle/.github/workflows/check_source_change.yml@v0.4.0 # zizmor: ignore[unpinned-uses] - immutable

--- a/test/test_bump_version_refs.bats
+++ b/test/test_bump_version_refs.bats
@@ -49,7 +49,9 @@ seed_tree() {
 
 @test "bump_version_refs: fails closed when refs already disagree on a version" {
     seed_tree v0.3.1
-    printf 'uses: TomHennen/wrangle/actions/scan@v0.2.0\n' > "$TMP_DIR/gh_workflow_examples/stale.yml"
+    # Version interpolated, never a literal pin: test_pin_consistency.bats greps
+    # the whole repo, so a literal here would read as a real adopter pin.
+    printf 'uses: TomHennen/wrangle/actions/scan@%s\n' v0.2.0 > "$TMP_DIR/gh_workflow_examples/stale.yml"
     run "$SCRIPT" v0.4.0
     [[ "$status" -eq 1 ]]
     [[ "$output" == *"disagree on a version"* ]]

--- a/test/test_bump_version_refs.bats
+++ b/test/test_bump_version_refs.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../tools/bump_version_refs.sh"
+    TMP_DIR="$(mktemp -d)"
+    export WRANGLE_REPO_ROOT="$TMP_DIR"
+    mkdir -p "$TMP_DIR/gh_workflow_examples" "$TMP_DIR/build/actions/go" "$TMP_DIR/docs"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+seed_tree() {
+    local v="${1:-v0.3.1}"
+    printf 'jobs:\n  build:\n    uses: TomHennen/wrangle/.github/workflows/build_go.yml@%s # zizmor: ignore\n' "$v" \
+        > "$TMP_DIR/gh_workflow_examples/build_go.yml"
+    printf 'Verify:\n\n```\nampel verify \\\n  --policy git+https://github.com/TomHennen/wrangle@%s#policies/wrangle-vsa-consumer-v1.hjson \\\n```\n' "$v" \
+        > "$TMP_DIR/build/actions/go/README.md"
+}
+
+@test "bump_version_refs: rewrites uses: pins and policy locators together" {
+    seed_tree v0.3.1
+    run "$SCRIPT" v0.4.0
+    [[ "$status" -eq 0 ]]
+    grep -q 'build_go.yml@v0.4.0' "$TMP_DIR/gh_workflow_examples/build_go.yml"
+    grep -q 'wrangle@v0.4.0#policies/' "$TMP_DIR/build/actions/go/README.md"
+    ! grep -rq 'v0\.3\.1' "$TMP_DIR"
+}
+
+@test "bump_version_refs: leaves the wrangle-test curated-release example alone" {
+    # LOAD-BEARING. The worked example cites a real published artifact; the new
+    # release's does not exist until the tag is cut, so rewriting it 404s the docs.
+    seed_tree v0.3.1
+    printf 'base=https://github.com/TomHennen/wrangle-test/releases/download/v0.3.1\n' \
+        > "$TMP_DIR/docs/verifying_artifacts.md"
+    run "$SCRIPT" v0.4.0
+    [[ "$status" -eq 0 ]]
+    grep -q 'wrangle-test/releases/download/v0.3.1' "$TMP_DIR/docs/verifying_artifacts.md"
+}
+
+@test "bump_version_refs: never touches a third-party action pinned at the same version" {
+    seed_tree v0.3.1
+    printf 'steps:\n  - uses: actions/checkout@v0.3.1\n' > "$TMP_DIR/gh_workflow_examples/other.yml"
+    run "$SCRIPT" v0.4.0
+    [[ "$status" -eq 0 ]]
+    grep -q 'actions/checkout@v0.3.1' "$TMP_DIR/gh_workflow_examples/other.yml"
+}
+
+@test "bump_version_refs: fails closed when refs already disagree on a version" {
+    seed_tree v0.3.1
+    printf 'uses: TomHennen/wrangle/actions/scan@v0.2.0\n' > "$TMP_DIR/gh_workflow_examples/stale.yml"
+    run "$SCRIPT" v0.4.0
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"disagree on a version"* ]]
+    # Nothing rewritten — a partial bump is the exact drift being guarded against.
+    grep -q '@v0.3.1' "$TMP_DIR/gh_workflow_examples/build_go.yml"
+}
+
+@test "bump_version_refs: rejects a malformed version" {
+    seed_tree v0.3.1
+    run "$SCRIPT" 0.4.0
+    [[ "$status" -eq 2 ]]
+    grep -q '@v0.3.1' "$TMP_DIR/gh_workflow_examples/build_go.yml"
+}
+
+@test "bump_version_refs: no-ops when already at the target version" {
+    seed_tree v0.4.0
+    run "$SCRIPT" v0.4.0
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"already at v0.4.0"* ]]
+}

--- a/test/test_pin_consistency.bats
+++ b/test/test_pin_consistency.bats
@@ -11,8 +11,9 @@
 # wrangle's release tags are immutable, so a tag pin is safe; the inline zizmor
 # ignore keeps an adopter's own `unpinned-uses` from firing on the wrangle line.
 # A SHA pin (`@<40-hex> # vX.Y.Z`) is also accepted. Excluded: wrangle's internal
-# self-references (`# main YYYY-MM-DD`), the `git+https://...@vX` policy locators
-# (no `uses:`), and test fixtures.
+# self-references (`# main YYYY-MM-DD`) and the `git+https://...@vX` policy
+# locators (no `uses:`). NOT excluded: test fixtures — the grep is repo-wide, so
+# a fixture must interpolate its version rather than embed a literal pin.
 
 setup() {
     REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"

--- a/tools/bump_version_refs.sh
+++ b/tools/bump_version_refs.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -euo pipefail
+set -f  # values reach globs/case; disable pathname expansion
+
+# bump_version_refs.sh — retarget every adopter-facing wrangle release ref at a
+# new version tag (cut-release runbook, Phase 2).
+#
+# Usage: bump_version_refs.sh <new-version>      e.g. bump_version_refs.sh v0.4.0
+#
+# Two ref shapes are adopter-facing, and both must move together or a copy-paste
+# hands adopters a stale wrangle with no signal (test/test_pin_consistency.bats
+# is the fail-closed guard):
+#
+#   uses: <org>/wrangle/<path>@vX.Y.Z                          reusable workflows + actions
+#   git+https://github.com/<org>/wrangle@vX.Y.Z#policies/...   ampel policy locators
+#
+# The current version is discovered from the refs themselves rather than passed
+# in: they must already agree on exactly one version (the same invariant the
+# oracle enforces), so a divergent tree fails closed here instead of being half
+# rewritten.
+#
+# Deliberately NOT rewritten: docs/verifying_artifacts.md's worked example, which
+# cites a real published wrangle-test curated release. Neither pattern matches it
+# (it is a releases/download URL, not a uses: pin or a policy locator), and the
+# new release's artifact does not exist until the tag is cut.
+#
+# Exit: 0 rewritten, 1 nothing to do or the tree disagrees on a version, 2 usage.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${WRANGLE_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+USES_RE='uses: [A-Za-z0-9_.-]+/wrangle/[^@[:space:]]+@v[0-9]+\.[0-9]+\.[0-9]+'
+POLICY_RE='github\.com/[A-Za-z0-9_.-]+/wrangle@v[0-9]+\.[0-9]+\.[0-9]+#policies'
+
+# Every adopter-facing ref in the tree, as bare version tags.
+wrangle_current_versions() {
+    grep -rhoIE "$USES_RE|$POLICY_RE" \
+        --include='*.yml' --include='*.yaml' --include='*.md' \
+        --exclude-dir=.git --exclude-dir=.claude \
+        "$REPO_ROOT" 2>/dev/null \
+        | grep -oE '@v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^@//' | sort -u
+}
+
+wrangle_files_with_refs() {
+    grep -rlIE "$USES_RE|$POLICY_RE" \
+        --include='*.yml' --include='*.yaml' --include='*.md' \
+        --exclude-dir=.git --exclude-dir=.claude \
+        "$REPO_ROOT" 2>/dev/null | sort
+}
+
+# Rewrite both ref shapes in one file. Anchored on the wrangle path so a
+# third-party action pinned at the same version is never touched.
+wrangle_rewrite_file() {
+    local file="$1" from="$2" to="$3"
+    sed -i -E \
+        -e "s|(uses: [A-Za-z0-9_.-]+/wrangle/[^@[:space:]]+)@${from}([[:space:]]\|\$)|\1@${to}\2|g" \
+        -e "s|(github\.com/[A-Za-z0-9_.-]+/wrangle)@${from}(#policies)|\1@${to}\2|g" \
+        "$file"
+}
+
+wrangle_bump_version_refs() {
+    local new="$1"
+
+    if [[ ! "$new" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        printf 'bump_version_refs: version must be vX.Y.Z, got: %s\n' "$new" >&2
+        return 2
+    fi
+
+    local -a versions
+    mapfile -t versions < <(wrangle_current_versions)
+
+    if [[ "${#versions[@]}" -eq 0 ]]; then
+        printf 'bump_version_refs: no adopter-facing wrangle refs found under %s\n' "$REPO_ROOT" >&2
+        return 1
+    fi
+    if [[ "${#versions[@]}" -gt 1 ]]; then
+        printf 'bump_version_refs: refs disagree on a version — fix the divergence first:\n' >&2
+        printf '  %s\n' "${versions[@]}" >&2
+        return 1
+    fi
+
+    local old="${versions[0]}"
+    if [[ "$old" == "$new" ]]; then
+        printf 'bump_version_refs: already at %s — nothing to do\n' "$new"
+        return 1
+    fi
+
+    local -a files
+    mapfile -t files < <(wrangle_files_with_refs)
+    local f
+    for f in "${files[@]}"; do
+        wrangle_rewrite_file "$f" "$old" "$new"
+    done
+
+    # Fail closed if anything still names the old version: a partial rewrite is
+    # exactly the drift the oracle exists to catch.
+    local -a left
+    mapfile -t left < <(wrangle_current_versions)
+    if [[ "${#left[@]}" -ne 1 || "${left[0]}" != "$new" ]]; then
+        printf 'bump_version_refs: rewrite incomplete, tree still names: %s\n' "${left[*]}" >&2
+        return 1
+    fi
+
+    printf 'bump_version_refs: %s -> %s across %d file(s)\n' "$old" "$new" "${#files[@]}"
+    printf '  %s\n' "${files[@]#"$REPO_ROOT"/}"
+    printf '\nverifying_artifacts.md'\''s worked example still cites the published %s\n' "$old"
+    printf 'curated release; update it with the Phase 4 recipe re-verification.\n'
+}
+
+main() {
+    if [[ $# -ne 1 ]]; then
+        printf 'Usage: bump_version_refs.sh <new-version>   e.g. v0.4.0\n' >&2
+        exit 2
+    fi
+    wrangle_bump_version_refs "$1"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
Release prep, **Phase 2** of the cut-release runbook. Independent of the #485 spike — these files are outside the self-ref pin scope, so later merges won't undo it.

## What changed

| | count |
|---|---|
| `uses: TomHennen/wrangle/<path>@v0.3.1` → `@v0.4.0` | **20** |
| ampel policy locators `git+…/wrangle@v0.3.1#policies/…` → `@v0.4.0` | **8** |

Across the example workflows, the per-build-type and action READMEs, the top-level README, `docs/FAQ.md`, and `docs/SPEC.md` — 17 files. The surface was discovered by grep, not hand-maintained (the runbook is explicit that copies drift).

## Deliberately NOT bumped

`docs/verifying_artifacts.md`'s **worked example** stays at `v0.3.1`:

```
base=https://github.com/TomHennen/wrangle-test/releases/download/v0.3.1
```

That is a **real, published wrangle-test curated release** an adopter can download and verify today. A `v0.4.0` curated release does not exist until the tag is cut and the showcase builds it — bumping now would document a URL that 404s.

It gets updated as part of **Phase 4 gate 3** (re-verify the download+verify recipes against the actual release artifact), which must happen against the real thing anyway.

## Validation

- **`test/test_pin_consistency.bats` green** — the fail-closed oracle for this exact class of drift ("a release that bumps some pins but not all hands adopters a stale wrangle on copy-paste, with no signal").
- Sweep confirms **20 `uses:` pins at `@v0.4.0`, 0 at any other version**; **8 policy locators at `@v0.4.0`**.
- Full bats suite: **0 `not ok`** (397 ok).
- `check_pin_freshness` / `check_pin_ancestry` unaffected — docs and examples are outside the pin-resolution scope.

## Note
Merging this makes `main` reference a `v0.4.0` tag that does not exist yet. That is the runbook's intended order (Phase 2 precedes Phase 5); the refs resolve the moment the tag is cut at this commit or later.