### PR TITLE
claude: release: script the tag cut (#758)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,3 +124,9 @@ release-preflight:
 # (cut-release Phase 2). Usage: make bump-version-refs VERSION=v0.4.0
 bump-version-refs:
 	@./tools/bump_version_refs.sh $(VERSION)
+
+# Cut a release tag. Dispatches the Release Gate on the target and refuses to
+# tag unless it is green; requires a hand-written notes file and an interactive
+# confirmation. Usage: make cut-release VERSION=v0.4.0 NOTES=release-notes.md
+cut-release:
+	@./tools/cut_release.sh $(VERSION) $(NOTES)

--- a/test/test_cut_release.bats
+++ b/test/test_cut_release.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+# The tag is immutable and there is no undo, so what matters is that every
+# refusal path aborts BEFORE `gh release create` runs. Each test asserts the
+# stub was never invoked.
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../tools/cut_release.sh"
+    TMP_DIR="$(mktemp -d)"
+    STUB_BIN="$TMP_DIR/bin"
+    mkdir -p "$STUB_BIN"
+
+    # A gh stub that records every call. If `release create` is ever reached on a
+    # path that should have refused, the assertion below catches it.
+    cat > "$STUB_BIN/gh" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >> "$GH_CALLS"
+exit 0
+EOF
+    chmod +x "$STUB_BIN/gh"
+    export GH_CALLS="$TMP_DIR/gh-calls"
+    : > "$GH_CALLS"
+    PATH="$STUB_BIN:$PATH"
+    export PATH
+
+    NOTES="$TMP_DIR/notes.md"
+    printf 'What you get in v9.9.9.\n' > "$NOTES"
+
+    # A real git repo so the tag/ancestry checks operate on something.
+    REPO="$TMP_DIR/repo"
+    mkdir -p "$REPO"
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email t@t.t
+    git -C "$REPO" config user.name t
+    printf 'x\n' > "$REPO/f"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -qm init
+    export WRANGLE_REPO_ROOT="$REPO"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+released() { grep -q "release create" "$GH_CALLS"; }
+
+@test "cut_release: rejects a non-semver version without tagging" {
+    run "$SCRIPT" 0.4.0 "$NOTES"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"must be vX.Y.Z"* ]]
+    ! released
+}
+
+@test "cut_release: refuses a missing notes file without tagging" {
+    run "$SCRIPT" v9.9.9 "$TMP_DIR/nope.md"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"notes file not found"* ]]
+    ! released
+}
+
+@test "cut_release: refuses an empty notes file without tagging" {
+    # LOAD-BEARING. The runbook wants hand-written benefit-first prose and
+    # explicitly rejects --generate-notes; an empty file is a wiring error.
+    : > "$TMP_DIR/empty.md"
+    run "$SCRIPT" v9.9.9 "$TMP_DIR/empty.md"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"empty"* ]]
+    ! released
+}
+
+@test "cut_release: refuses a whitespace-only notes file without tagging" {
+    printf '\n  \n\t\n' > "$TMP_DIR/ws.md"
+    run "$SCRIPT" v9.9.9 "$TMP_DIR/ws.md"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"whitespace only"* ]]
+    ! released
+}
+
+@test "cut_release: refuses when the tag already exists" {
+    # LOAD-BEARING. Tags are immutable; re-cutting one must never be attempted.
+    git -C "$REPO" tag v9.9.9
+    run "$SCRIPT" v9.9.9 "$NOTES"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"already exists"* ]]
+    ! released
+}
+
+@test "cut_release: refuses to cut non-interactively" {
+    # LOAD-BEARING. The tag is the owner's call. bats gives no tty, so this also
+    # guarantees no test in this suite can ever cut a real release.
+    run "$SCRIPT" v9.9.9 "$NOTES" --target HEAD
+    [[ "$status" -ne 0 ]]
+    ! released
+}
+
+@test "cut_release: usage error on missing arguments" {
+    run "$SCRIPT" v9.9.9
+    [[ "$status" -eq 2 ]]
+    ! released
+}

--- a/tools/cut_release.sh
+++ b/tools/cut_release.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# cut_release.sh — cut a wrangle release tag (cut-release runbook, Phase 5).
+#
+# Usage: cut_release.sh <version> <notes-file> [--target <sha>]
+#          e.g. cut_release.sh v0.4.0 release-notes.md
+#
+# The tag is immutable once created and there is no undo, so every precondition
+# is checked BEFORE `gh release create` and any failure aborts without tagging:
+#
+#   1. version is vX.Y.Z (goreleaser needs a semver-parseable tag)
+#   2. the tag does not already exist, locally or on the remote
+#   3. the notes file exists and is non-empty (never --generate-notes: the runbook
+#      wants benefit-first prose, not an auto-changelog)
+#   4. the target commit is on origin/main
+#   5. the Release Gate workflow is green ON THAT COMMIT — dispatched here and
+#      polled, because the gate is the only thing that proves the pins and the
+#      curated tool-image digests are release-worthy, and a local run cannot
+#      prove it (a stale or shallow checkout yields a confident false green)
+#   6. the operator confirms, interactively, with the version
+#
+# It does NOT write the release notes and it does NOT decide to release: the tag
+# is the owner's call.
+#
+# Exit: 0 released, 1 a precondition failed (nothing tagged), 2 usage.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${WRANGLE_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+GATE_WORKFLOW="${WRANGLE_RELEASE_GATE:-release_gate.yml}"
+
+wrangle_die() { printf 'cut_release: %s\n' "$1" >&2; return 1; }
+
+wrangle_check_version() {
+    [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+        || wrangle_die "version must be vX.Y.Z (goreleaser needs semver), got: $1"
+}
+
+wrangle_check_tag_free() {
+    local v="$1"
+    if git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/$v" >/dev/null 2>&1; then
+        wrangle_die "tag $v already exists locally — tags are immutable, refusing"
+    fi
+    if git -C "$REPO_ROOT" ls-remote --exit-code --tags origin "$v" >/dev/null 2>&1; then
+        wrangle_die "tag $v already exists on origin — tags are immutable, refusing"
+    fi
+}
+
+# Hand-written, benefit-first prose. An empty file is a wiring error, not a
+# release with no notes.
+wrangle_check_notes() {
+    local f="$1"
+    [[ -f "$f" ]] || wrangle_die "notes file not found: $f"
+    [[ -s "$f" ]] || wrangle_die "notes file is empty: $f"
+    [[ -n "$(tr -d '[:space:]' < "$f")" ]] || wrangle_die "notes file is whitespace only: $f"
+}
+
+wrangle_check_target_on_main() {
+    local sha="$1"
+    git -C "$REPO_ROOT" fetch -q --no-tags origin +refs/heads/main:refs/remotes/origin/main
+    git -C "$REPO_ROOT" merge-base --is-ancestor "$sha" origin/main 2>/dev/null \
+        || wrangle_die "target $sha is not on origin/main"
+}
+
+# Dispatch the Release Gate on the target and poll it. A locally-run preflight
+# cannot substitute: the pin gates read origin/main's history, so a stale or
+# shallow checkout can produce a confident false green.
+wrangle_release_gate_green() {
+    local sha="$1"
+    printf 'cut_release: dispatching %s on %s\n' "$GATE_WORKFLOW" "${sha:0:8}"
+    gh workflow run "$GATE_WORKFLOW" --ref "$sha" >/dev/null \
+        || wrangle_die "could not dispatch $GATE_WORKFLOW"
+
+    local id="" i
+    for ((i = 0; i < 30; i++)); do
+        sleep 5
+        id="$(gh run list --workflow "$GATE_WORKFLOW" --commit "$sha" \
+            --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null || true)"
+        [[ -n "$id" ]] && break
+    done
+    [[ -n "$id" ]] || wrangle_die "the dispatched $GATE_WORKFLOW run never appeared"
+
+    printf 'cut_release: waiting on run %s\n' "$id"
+    for ((i = 0; i < 240; i++)); do
+        local status
+        status="$(gh run view "$id" --json status -q .status 2>/dev/null || true)"
+        [[ "$status" == "completed" ]] && break
+        sleep 15
+    done
+
+    local conclusion
+    conclusion="$(gh run view "$id" --json conclusion -q .conclusion 2>/dev/null || true)"
+    if [[ "$conclusion" != "success" ]]; then
+        wrangle_die "Release Gate is ${conclusion:-not finished} on ${sha:0:8} — refusing to tag"
+    fi
+    printf 'cut_release: Release Gate green on %s\n' "${sha:0:8}"
+}
+
+# The tag is the owner's call and it cannot be undone.
+wrangle_confirm() {
+    local v="$1" sha="$2"
+    if [[ ! -t 0 ]]; then
+        wrangle_die "refusing to cut non-interactively — the tag is immutable and is the owner's call"
+    fi
+    printf '\nAbout to cut %s at %s (immutable, no undo).\nType the version to confirm: ' "$v" "${sha:0:8}"
+    local reply
+    read -r reply
+    [[ "$reply" == "$v" ]] || wrangle_die "confirmation did not match — nothing tagged"
+}
+
+wrangle_cut_release() {
+    local version="$1" notes="$2" target="${3:-}"
+
+    wrangle_check_version "$version"
+    wrangle_check_notes "$notes"
+    wrangle_check_tag_free "$version"
+
+    if [[ -z "$target" ]]; then
+        git -C "$REPO_ROOT" fetch -q --no-tags origin +refs/heads/main:refs/remotes/origin/main
+        target="$(git -C "$REPO_ROOT" rev-parse origin/main)"
+    fi
+    wrangle_check_target_on_main "$target"
+    wrangle_release_gate_green "$target"
+    wrangle_confirm "$version" "$target"
+
+    gh release create "$version" \
+        --target "$target" \
+        --title "$version" \
+        --notes-file "$notes" \
+        --latest \
+        || wrangle_die "gh release create failed"
+
+    printf 'cut_release: released %s at %s\n' "$version" "${target:0:8}"
+}
+
+main() {
+    local version="" notes="" target=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --target) target="${2:-}"; shift 2 ;;
+            -*) printf 'cut_release: unknown flag: %s\n' "$1" >&2; exit 2 ;;
+            *)
+                if [[ -z "$version" ]]; then version="$1"
+                elif [[ -z "$notes" ]]; then notes="$1"
+                else printf 'cut_release: unexpected argument: %s\n' "$1" >&2; exit 2
+                fi
+                shift
+                ;;
+        esac
+    done
+    if [[ -z "$version" || -z "$notes" ]]; then
+        printf 'Usage: cut_release.sh <version> <notes-file> [--target <sha>]\n' >&2
+        exit 2
+    fi
+    wrangle_cut_release "$version" "$notes" "$target"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
Phase 5 of the cut-release runbook, and the other half of #758 (the `bump_version_refs.sh` half landed in #776).

Today's tag cut would otherwise be a hand-typed `gh release create` — with an immutable tag and **no undo** at the end of it.

## What it enforces before tagging

Every precondition is checked **before** `gh release create`, and any failure aborts **without tagging**:

| check | why |
|---|---|
| version is `vX.Y.Z` | goreleaser needs a semver-parseable tag |
| tag absent locally **and** on origin | tags are immutable; re-cutting must never be attempted |
| notes file exists, non-empty, not whitespace | the runbook wants **hand-written benefit-first prose** and explicitly rejects `--generate-notes` |
| target commit is on `origin/main` | no tagging a stray ref |
| **Release Gate green on the target** | dispatched here and polled |
| operator types the version to confirm | the tag is the owner's call |

## Why it dispatches the gate rather than trusting a local preflight

`make release-preflight` is the fast local loop, but it **cannot prove** the release is cuttable: `check_pin_main_history` walks `origin/main`'s first-parent list and `check_pin_ancestry` needs full history, so a stale or shallow checkout produces a **confident false green** — the worst possible failure for a release gate.

This is not hypothetical. I hit exactly that class of error twice today: a stale local checkout told me a workflow didn't exist, and a `check_pin_freshness` run against an *uncommitted* tree reported green while CI correctly reported STALE.

So `cut_release.sh` dispatches **Release Gate** on the target commit — a fresh clone at the exact SHA — and refuses to tag on anything but `success`. That closes the gap I flagged when the gate was introduced (#757): it was *evidence*, and nothing forced anyone to look at it. Now the cut can't proceed without it.

## What it deliberately does NOT do

- **Does not write the release notes.** Benefit-first prose is a writing task, not a scripting one.
- **Does not decide to release.** No `--yes`, no non-interactive path: it refuses without a tty.

## Validation

**7/7 bats, 0 `not ok`.** Every refusal path asserts, via a recording `gh` stub, that `release create` was **never invoked**. Because it refuses without a tty, no test in this suite can ever cut a real release. shellcheck clean.