### PR TITLE
claude: feat(attest): wrangle-attest verify — exec ampel, dual-check the verdict (#484 spike, v0.5.0)

### DIFF
--- a/tools/wrangle-attest/SPEC.md
+++ b/tools/wrangle-attest/SPEC.md
@@ -165,15 +165,23 @@ env is scrubbed of `SIGSTORE_ID_TOKEN`, `ACTIONS_ID_TOKEN_REQUEST_*`, and
 signing material, and it resolves policy context keys from `AMPEL_<KEY>`.
 
 The verdict is dual-checked, because ampel's exit code alone is not a safe
-PASS signal (exit 1 covers both a FAILED verdict and every tool error; exit 0
-also covers SOFTFAIL and an empty-chain soft-pass): signing requires ampel
-exit 0 AND that `--results-path` parses as an in-toto VSA statement bound to
-exactly the requested single-sha256 subject with
+PASS signal: ampel exits 1 for a FAILED verdict *and* for every tool error
+(`cmd/ampel/main.go` exits 1 on any returned error;
+`internal/cmd/verify.go` `os.Exit(1)` only on `StatusFAIL`), so exit 0 does
+not prove a VSA was written, bound to this subject, or well-formed. Signing
+therefore requires ampel exit 0 AND that `--results-path` parses as an in-toto
+VSA statement bound to exactly the requested single-sha256 subject with
 `predicate.verificationResult` exactly `PASSED`. With `--fail=false` (warn
 mode) ampel runs with `--exit-code=false` and an explicitly `FAILED` VSA is
 still signed and delivered; any other verdict value fails closed in both
 modes. Exit 0 = verified, signed, delivered; 1 = FAILED verdict with
 `--fail=true` (nothing signed); 2 = anything else (nothing signed).
+
+A `SOFTFAIL` (a policy group with `enforce: OFF` — wrangle's own advisory
+`wrangle-release-pinned` tenet is one) is **not** distinguishable from a PASS
+here: ampel exits 0 and maps SOFTFAIL to `verificationResult: PASSED`
+(`pkg/attest/vsa.go` `resultStringToSLSAResult`). That is the intended policy
+semantics, unchanged from the shell, not a gap this check closes.
 
 ## Testing
 

--- a/tools/wrangle-attest/SPEC.md
+++ b/tools/wrangle-attest/SPEC.md
@@ -141,6 +141,40 @@ refuses the partially written `--bundle-dir` via the pre-existence check.
 `assemble` requires `--sign` and rejects `--subject`, `--artifact`,
 `--statement`, `--out`, and `--append`.
 
+```
+wrangle-attest verify (--subject sha256:<hex> | --artifact <file>) \
+    --policy <path-or-locator> --bundle <file> [--collector <c>]... \
+    [--context <kv>] [--attestation <file>] [--fail=<bool>] --out <file>
+```
+
+The verify job's orchestration: evaluate the policy over one subject by
+exec-ing the sibling `ampel` binary (both ship in the attest-toolbox image),
+then keyless-sign the VSA ampel emitted — the raw file bytes verbatim, the
+same signer path as `--statement` — and deliver it. `--bundle` is the
+attest-assembled per-artifact bundle: it is fed to the policy as ampel's
+`jsonl:` collector and, on success, appended with the identical signed line
+(same append semantics as `--append`: non-empty precheck before ampel runs,
+must not alias `--out`, a failed append removes the just-written `--out`).
+A file subject is self-digested to the single sha256 and passed as ampel's
+`--subject-hash`; a digest subject passes through as `--subject`. ampel's
+report (`--format=html`, stdout) passes through to stdout for the step
+summary; the exec is retried once for transient collector I/O, with the
+results file removed and the report buffer reset between attempts. The child
+env is scrubbed of `SIGSTORE_ID_TOKEN`, `ACTIONS_ID_TOKEN_REQUEST_*`, and
+`AMPEL_*` — ampel parses semi-trusted attestations and must never hold
+signing material, and it resolves policy context keys from `AMPEL_<KEY>`.
+
+The verdict is dual-checked, because ampel's exit code alone is not a safe
+PASS signal (exit 1 covers both a FAILED verdict and every tool error; exit 0
+also covers SOFTFAIL and an empty-chain soft-pass): signing requires ampel
+exit 0 AND that `--results-path` parses as an in-toto VSA statement bound to
+exactly the requested single-sha256 subject with
+`predicate.verificationResult` exactly `PASSED`. With `--fail=false` (warn
+mode) ampel runs with `--exit-code=false` and an explicitly `FAILED` VSA is
+still signed and delivered; any other verdict value fails closed in both
+modes. Exit 0 = verified, signed, delivered; 1 = FAILED verdict with
+`--fail=true` (nothing signed); 2 = anything else (nothing signed).
+
 ## Testing
 
 `go test ./wrangle-attest/` — table-driven manifest parse/validate (fail-closed
@@ -152,7 +186,10 @@ covered by a recording signer pinning the payload to the file bytes verbatim, a
 local-key payload round-trip, a fail-closed table (including a signing failure
 leaving a pre-existing `--out` untouched), and the tag-gated keyless
 integration test. `--append` and `assemble` are covered hermetically with fake
-signers (byte-exact bundle goldens, buffer-then-write fail-closed). Regenerate
+signers (byte-exact bundle goldens, buffer-then-write fail-closed). `verify`
+is covered with a scripted fake ampel + fake signer (the exit-code x VSA
+verdict matrix, env scrub, argv shape, retry); the real ampel CLI contract is
+pinned by the bats real-parser test and the dispatch e2e. Regenerate
 goldens with
 `go test ./wrangle-attest/ -update`. The real keyless path is covered by the
 dispatch e2e (`actions/attest_provenance` and `actions/attest_metadata_oci` bats

--- a/tools/wrangle-attest/main.go
+++ b/tools/wrangle-attest/main.go
@@ -41,6 +41,12 @@
 // also appends the identical signed line to an existing per-artifact bundle,
 // which must be non-empty (a VSA-only bundle is impossible).
 //
+// The verify subcommand is the verify job's orchestration: it execs the
+// sibling ampel binary to evaluate the policy over one subject, fails closed
+// unless ampel's exit code AND the VSA it emitted agree the verdict is
+// PASSED, then signs the VSA verbatim and appends the signed line to that
+// subject's per-artifact bundle.
+//
 // The assemble subcommand is the attest job's orchestration: it reads the
 // newline-separated subjects file, self-digests file subjects, signs every
 // discovered manifest per subject with one shared signer, and writes one

--- a/tools/wrangle-attest/run.go
+++ b/tools/wrangle-attest/run.go
@@ -32,6 +32,9 @@ func run(args []string, stderr io.Writer) int {
 	if len(args) > 0 && args[0] == "assemble" {
 		return runAssemble(args[1:], stderr)
 	}
+	if len(args) > 0 && args[0] == "verify" {
+		return runVerify(args[1:], os.Stdout, stderr)
+	}
 
 	fs := flag.NewFlagSet("wrangle-attest", flag.ContinueOnError)
 	fs.SetOutput(stderr)
@@ -190,6 +193,13 @@ func signStatementFile(path, out, appendTo string, stderr io.Writer) int {
 		}
 	}
 
+	return signAndDeliver(raw, out, appendTo, stderr)
+}
+
+// signAndDeliver keyless-signs raw statement bytes verbatim, writes the single
+// signed line to out, and (when appendTo is set) appends the identical line to
+// that bundle.
+func signAndDeliver(raw []byte, out, appendTo string, stderr io.Writer) int {
 	sg, closeFn, err := newSigner()
 	if err != nil {
 		return failClosed(stderr, err)
@@ -201,7 +211,7 @@ func signStatementFile(path, out, appendTo string, stderr io.Writer) int {
 		return failClosed(stderr, err)
 	}
 	if len(bytes.TrimSpace(line)) == 0 {
-		return failClosed(stderr, fmt.Errorf("signing produced no output for %s", path))
+		return failClosed(stderr, fmt.Errorf("signing produced no output"))
 	}
 
 	var buf bytes.Buffer

--- a/tools/wrangle-attest/verify.go
+++ b/tools/wrangle-attest/verify.go
@@ -258,12 +258,14 @@ func vsaVerdict(raw []byte) string {
 	return stmt.Predicate.VerificationResult
 }
 
-// validateVSA is the fail-closed half of the verdict protocol: ampel's exit
-// code alone is not a safe PASS signal (exit 0 also covers SOFTFAIL and other
-// non-FAIL statuses), so the emitted VSA must independently agree. The
-// statement must be a VSA bound to exactly the requested single-sha256
-// subject, and its verificationResult must be PASSED — or, with fail=false
-// (where a FAILED verdict is still signed and delivered), explicitly FAILED.
+// validateVSA is the fail-closed half of the verdict protocol: ampel exits
+// nonzero only on StatusFAIL, so exit 0 alone does not prove a VSA was written,
+// bound to this subject, or well-formed. The statement must be a VSA bound to
+// exactly the requested single-sha256 subject, and its verificationResult must
+// be PASSED — or, with fail=false (where a FAILED verdict is still signed and
+// delivered), explicitly FAILED. A SOFTFAIL (a policy group with enforce: OFF,
+// which wrangle's own advisory tenets use) is PASSED to ampel and to us alike;
+// it is not distinguishable here, by design.
 func validateVSA(raw []byte, subjectArg string, failMode bool) error {
 	var stmt vsaStatement
 	if err := json.Unmarshal(raw, &stmt); err != nil {

--- a/tools/wrangle-attest/verify.go
+++ b/tools/wrangle-attest/verify.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	intoto "github.com/in-toto/attestation/go/v1"
+)
+
+const vsaPredicateType = "https://slsa.dev/verification_summary/v1"
+
+// collectors accumulates repeated --collector flags.
+type collectors []string
+
+func (c *collectors) String() string { return fmt.Sprint([]string(*c)) }
+func (c *collectors) Set(v string) error {
+	*c = append(*c, v)
+	return nil
+}
+
+// verifyOpts is the parsed verify-subcommand invocation.
+type verifyOpts struct {
+	subject     string // digest-form subject as given (sha256:<hex>), or ""
+	artifact    string // file subject to self-digest, or ""
+	policy      string
+	bundle      string // per-artifact bundle: jsonl collector + append target
+	extra       collectors
+	context     string
+	attestation string
+	fail        bool
+	out         string
+}
+
+// runVerify implements the verify subcommand: evaluate the policy over one
+// subject by exec-ing the sibling ampel binary, fail closed unless ampel's
+// exit code AND the VSA it emitted agree on the verdict, then keyless-sign the
+// VSA verbatim, write the signed line to --out, and append it to --bundle.
+// ampel's report (stdout) passes through to stdout; everything the engine says
+// goes to stderr. Exit 0 = verified and delivered; 1 = the policy verdict is
+// FAILED (with --fail=true); 2 = any other failure, signing untouched.
+func runVerify(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("wrangle-attest verify", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	o := verifyOpts{}
+	fs.StringVar(&o.subject, "subject", "", "artifact subject digest sha256:<hex> the VSA binds to")
+	fs.StringVar(&o.artifact, "artifact", "", "file to self-digest into the sha256 subject (alternative to --subject)")
+	fs.StringVar(&o.policy, "policy", "", "ampel PolicySet path or locator")
+	fs.StringVar(&o.bundle, "bundle", "", "attest-assembled per-artifact bundle: fed to the policy as the jsonl collector and appended with the signed VSA")
+	fs.Var(&o.extra, "collector", "additional ampel collector (repeatable, e.g. the container's oci: referrers)")
+	fs.StringVar(&o.context, "context", "", "ampel policy context (KEY:VALUE, comma-separated)")
+	fs.StringVar(&o.attestation, "attestation", "", "explicit attestation file loaded in addition to the collectors")
+	fs.BoolVar(&o.fail, "fail", true, "when true a FAILED verdict exits 1 and nothing is signed; when false a FAILED VSA is still signed and delivered")
+	fs.StringVar(&o.out, "out", "", "file the single signed VSA line is written to")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() > 0 {
+		return failClosed(stderr, fmt.Errorf("verify: unexpected argument %q", fs.Arg(0)))
+	}
+
+	subjectArg, err := resolveSubject(o.subject, o.artifact)
+	if err != nil {
+		return failClosed(stderr, err)
+	}
+	if err := validateVerifyOpts(&o, subjectArg); err != nil {
+		return failClosed(stderr, err)
+	}
+
+	resultsDir, err := os.MkdirTemp("", "wrangle-verify")
+	if err != nil {
+		return failClosed(stderr, err)
+	}
+	defer os.RemoveAll(resultsDir)
+	resultsPath := filepath.Join(resultsDir, "vsa.intoto.json")
+
+	report, rc := runAmpel(ampelVerifyArgs(&o, subjectArg, resultsPath), resultsPath, stderr)
+	// The report reaches stdout (the step summary) whatever the verdict.
+	if _, err := stdout.Write(report); err != nil {
+		return failClosed(stderr, fmt.Errorf("writing report: %w", err))
+	}
+
+	raw, readErr := os.ReadFile(resultsPath)
+	if rc != 0 {
+		// ampel overloads exit 1 for both a FAILED verdict and a tool error;
+		// the emitted VSA (written on FAIL, absent on error) tells them apart.
+		if o.fail && readErr == nil && vsaVerdict(raw) == "FAILED" {
+			fmt.Fprintf(stderr, "wrangle-attest: policy verdict FAILED for %s\n", subjectArg)
+			return 1
+		}
+		return failClosed(stderr, fmt.Errorf("ampel verify failed (exit %d)", rc))
+	}
+	if readErr != nil {
+		return failClosed(stderr, fmt.Errorf("ampel exited 0 but wrote no VSA: %w", readErr))
+	}
+	if err := validateVSA(raw, subjectArg, o.fail); err != nil {
+		return failClosed(stderr, err)
+	}
+
+	return signAndDeliver(raw, o.out, o.bundle, stderr)
+}
+
+// validateVerifyOpts fail-closes everything checkable before ampel runs: the
+// required flags, the subject shape, and the append target (must exist
+// non-empty — a VSA-only bundle is impossible — and must not alias --out).
+func validateVerifyOpts(o *verifyOpts, subjectArg string) error {
+	switch {
+	case o.policy == "":
+		return fmt.Errorf("--policy is required")
+	case o.bundle == "":
+		return fmt.Errorf("--bundle is required")
+	case o.out == "":
+		return fmt.Errorf("--out is required")
+	case subjectArg == "":
+		return fmt.Errorf("--subject or --artifact is required")
+	}
+	if !sha256DigestRe.MatchString(subjectArg) {
+		return fmt.Errorf("subject %q must be sha256:<64-hex>", subjectArg)
+	}
+	if filepath.Clean(o.bundle) == filepath.Clean(o.out) {
+		return fmt.Errorf("--out must not be the same file as --bundle")
+	}
+	info, err := os.Stat(o.bundle)
+	if err != nil {
+		return fmt.Errorf("bundle: %w", err)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("bundle %s is empty", o.bundle)
+	}
+	return nil
+}
+
+// ampelVerifyArgs builds the ampel argv. A digest-form --subject passes
+// through; a file subject was self-digested, and the precomputed hash goes
+// via --subject-hash so the VSA subject stays single-sha256 (ampel's own file
+// hasher would bind sha256+sha512, which the attestation store rejects).
+func ampelVerifyArgs(o *verifyOpts, digest, resultsPath string) []string {
+	args := []string{"verify"}
+	if o.subject != "" {
+		args = append(args, "--subject="+o.subject)
+	} else {
+		args = append(args, "--subject-hash="+digest)
+	}
+	args = append(args, "--collector=jsonl:"+o.bundle)
+	for _, c := range o.extra {
+		args = append(args, "--collector="+c)
+	}
+	args = append(args,
+		"--policy="+o.policy,
+		"--exit-code="+strconv.FormatBool(o.fail),
+		"--attest-results",
+		"--attest-format=vsa",
+		"--results-path="+resultsPath)
+	if o.context != "" {
+		args = append(args, "--context", o.context)
+	}
+	if o.attestation != "" {
+		args = append(args, "--attestation", o.attestation)
+	}
+	return append(args, "--format=html")
+}
+
+// runAmpel execs the sibling ampel binary, retrying once so a transient
+// collector/locator fetch can't block a release. Each attempt starts from a
+// removed results file and a fresh report buffer, so only the surviving
+// attempt's VSA and report are ever evaluated or emitted.
+func runAmpel(argv []string, resultsPath string, stderr io.Writer) ([]byte, int) {
+	var report bytes.Buffer
+	for attempt := 0; ; attempt++ {
+		report.Reset()
+		if err := os.Remove(resultsPath); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(stderr, "wrangle-attest: removing stale results: %v\n", err)
+			return report.Bytes(), 2
+		}
+		cmd := exec.Command("ampel", argv...)
+		cmd.Stdout = &report
+		cmd.Stderr = stderr
+		cmd.Env = ampelEnv(os.Environ())
+		err := cmd.Run()
+		if err == nil {
+			return report.Bytes(), 0
+		}
+		rc := 2
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			rc = exitErr.ExitCode()
+		} else {
+			fmt.Fprintf(stderr, "wrangle-attest: exec ampel: %v\n", err)
+		}
+		if attempt > 0 {
+			return report.Bytes(), rc
+		}
+		fmt.Fprintf(stderr, "wrangle-attest: ampel failed (exit %d); retrying once for transient I/O\n", rc)
+		time.Sleep(retryDelay())
+	}
+}
+
+// retryDelay honors WRANGLE_RETRY_DELAY (seconds) like lib/retry.sh; tests
+// set it to 0.
+func retryDelay() time.Duration {
+	if v := os.Getenv("WRANGLE_RETRY_DELAY"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return 5 * time.Second
+}
+
+// ampelEnv strips the signing token (and the mint-anything request vars) from
+// the child env: ampel parses semi-trusted attestations and policy and must
+// never hold signing material. AMPEL_* is dropped too — ampel resolves policy
+// context keys from AMPEL_<KEY> env vars, so a stray variable could steer the
+// verdict.
+func ampelEnv(env []string) []string {
+	kept := make([]string, 0, len(env))
+	for _, kv := range env {
+		name, _, _ := strings.Cut(kv, "=")
+		switch {
+		case name == "SIGSTORE_ID_TOKEN",
+			strings.HasPrefix(name, "ACTIONS_ID_TOKEN_REQUEST_"),
+			strings.HasPrefix(name, "AMPEL_"):
+			continue
+		}
+		kept = append(kept, kv)
+	}
+	return kept
+}
+
+// vsaStatement is the slice of the emitted VSA the verdict protocol reads.
+type vsaStatement struct {
+	Type          string `json:"_type"`
+	PredicateType string `json:"predicateType"`
+	Subject       []struct {
+		Digest map[string]string `json:"digest"`
+	} `json:"subject"`
+	Predicate struct {
+		VerificationResult string `json:"verificationResult"`
+	} `json:"predicate"`
+}
+
+// vsaVerdict extracts predicate.verificationResult, or "" if raw is not a VSA.
+func vsaVerdict(raw []byte) string {
+	var stmt vsaStatement
+	if err := json.Unmarshal(raw, &stmt); err != nil {
+		return ""
+	}
+	return stmt.Predicate.VerificationResult
+}
+
+// validateVSA is the fail-closed half of the verdict protocol: ampel's exit
+// code alone is not a safe PASS signal (exit 0 also covers SOFTFAIL and other
+// non-FAIL statuses), so the emitted VSA must independently agree. The
+// statement must be a VSA bound to exactly the requested single-sha256
+// subject, and its verificationResult must be PASSED — or, with fail=false
+// (where a FAILED verdict is still signed and delivered), explicitly FAILED.
+func validateVSA(raw []byte, subjectArg string, failMode bool) error {
+	var stmt vsaStatement
+	if err := json.Unmarshal(raw, &stmt); err != nil {
+		return fmt.Errorf("VSA is not valid JSON: %w", err)
+	}
+	if stmt.Type != intoto.StatementTypeUri {
+		return fmt.Errorf("VSA _type is %q, want %q", stmt.Type, intoto.StatementTypeUri)
+	}
+	if stmt.PredicateType != vsaPredicateType {
+		return fmt.Errorf("VSA predicateType is %q, want %q", stmt.PredicateType, vsaPredicateType)
+	}
+	wantHex := strings.TrimPrefix(subjectArg, "sha256:")
+	if len(stmt.Subject) != 1 || len(stmt.Subject[0].Digest) != 1 ||
+		stmt.Subject[0].Digest["sha256"] != wantHex {
+		return fmt.Errorf("VSA subject is not the single sha256 digest %s", subjectArg)
+	}
+	switch v := stmt.Predicate.VerificationResult; {
+	case v == "PASSED":
+		return nil
+	case v == "FAILED" && !failMode:
+		return nil
+	default:
+		return fmt.Errorf("VSA verificationResult is %q but ampel exited 0 — refusing to sign", v)
+	}
+}

--- a/tools/wrangle-attest/verify_test.go
+++ b/tools/wrangle-attest/verify_test.go
@@ -1,0 +1,456 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The verdict/exit-code matrix must be deterministic and offline, so these
+// tests exec a scripted fake ampel; the real CLI contract (flag names, VSA
+// shape) is pinned by the bats real-parser test and the dispatch e2e.
+// installFakeAmpel writes an executable `ampel` script into its own dir and
+// prepends it to PATH.
+func installFakeAmpel(t *testing.T, script string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ampel")
+	if err := os.WriteFile(path, []byte("#!/bin/bash\n"+script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("WRANGLE_RETRY_DELAY", "0")
+	return dir
+}
+
+// fakeVSA renders the minimal VSA statement ampel emits at --results-path.
+func fakeVSA(digestHex, verdict string) string {
+	return fmt.Sprintf(`{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [{"digest": {"sha256": "%s"}}],
+  "predicateType": "https://slsa.dev/verification_summary/v1",
+  "predicate": {"verificationResult": "%s"}
+}`, digestHex, verdict)
+}
+
+// ampelWritingVSA scripts a fake ampel that writes the given VSA body to
+// --results-path, prints a report line, and exits rc.
+func ampelWritingVSA(vsa string, rc int) string {
+	return fmt.Sprintf(`out=""
+for a in "$@"; do case "$a" in --results-path=*) out="${a#--results-path=}";; esac; done
+if [[ -n "$out" ]]; then cat > "$out" <<'VSA'
+%s
+VSA
+fi
+printf '<report>ampel says hi</report>\n'
+exit %d
+`, vsa, rc)
+}
+
+// stageBundle creates a non-empty append target and returns (bundle, out).
+func stageBundle(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "a.tgz.intoto.jsonl")
+	if err := os.WriteFile(bundle, []byte(`{"provenance":1}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return bundle, filepath.Join(dir, "vsa.signed.jsonl")
+}
+
+func verifyArgs(bundle, out string, extra ...string) []string {
+	args := []string{
+		"--subject", testArtifactDigest,
+		"--policy", "/policies/p.hjson",
+		"--bundle", bundle,
+		"--out", out,
+	}
+	return append(args, extra...)
+}
+
+const testDigestHex = "011b95c8e47c538646a2c01df5373fe703381cd415c847357b3d563563eb1d95"
+
+func TestVerifyPassSignsAndAppends(t *testing.T) {
+	installFakeAmpel(t, ampelWritingVSA(fakeVSA(testDigestHex, "PASSED"), 0))
+	rs := &recordingSigner{out: []byte(`{"bundle":"signed-vsa"}`)}
+	swapSigner(t, func() (statementSigner, func(), error) { return rs, func() {}, nil })
+	bundle, out := stageBundle(t)
+
+	var stdout, stderr bytes.Buffer
+	rc := runVerify(verifyArgs(bundle, out), &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+	// The DSSE payload is the emitted VSA verbatim.
+	if !strings.Contains(string(rs.got), `"verificationResult": "PASSED"`) {
+		t.Fatalf("signer input is not the VSA: %q", rs.got)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"bundle":"signed-vsa"}`+"\n" {
+		t.Fatalf("out = %q", data)
+	}
+	b, err := os.ReadFile(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != `{"provenance":1}`+"\n"+`{"bundle":"signed-vsa"}`+"\n" {
+		t.Fatalf("bundle = %q", b)
+	}
+	if !strings.Contains(stdout.String(), "<report>ampel says hi</report>") {
+		t.Fatalf("report missing from stdout: %q", stdout.String())
+	}
+}
+
+func TestVerifyFailedVerdictExits1WithoutSigning(t *testing.T) {
+	// fail=true: ampel exits 1 and the emitted VSA says FAILED — the verdict
+	// path, distinct from a tool error.
+	installFakeAmpel(t, ampelWritingVSA(fakeVSA(testDigestHex, "FAILED"), 1))
+	rs := &recordingSigner{out: []byte(`{}`)}
+	swapSigner(t, func() (statementSigner, func(), error) { return rs, func() {}, nil })
+	bundle, out := stageBundle(t)
+	before, _ := os.ReadFile(bundle)
+
+	var stdout, stderr bytes.Buffer
+	rc := runVerify(verifyArgs(bundle, out), &stdout, &stderr)
+	if rc != 1 {
+		t.Fatalf("rc=%d, want 1; stderr=%s", rc, stderr.String())
+	}
+	if rs.got != nil {
+		t.Fatal("signer must not run on a FAILED verdict")
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatal("out must not be written on a FAILED verdict")
+	}
+	after, _ := os.ReadFile(bundle)
+	if !bytes.Equal(before, after) {
+		t.Fatal("bundle must be untouched on a FAILED verdict")
+	}
+	if !strings.Contains(stderr.String(), "policy verdict FAILED") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	// The report still reaches the step summary on a failed verdict.
+	if !strings.Contains(stdout.String(), "<report>") {
+		t.Fatalf("report missing from stdout: %q", stdout.String())
+	}
+}
+
+func TestVerifyFailFalseSignsFailedVerdict(t *testing.T) {
+	// fail=false: ampel exits 0 on a FAILED verdict and the FAILED VSA is
+	// still signed and delivered (warn mode).
+	installFakeAmpel(t, ampelWritingVSA(fakeVSA(testDigestHex, "FAILED"), 0))
+	rs := &recordingSigner{out: []byte(`{"warn":"vsa"}`)}
+	swapSigner(t, func() (statementSigner, func(), error) { return rs, func() {}, nil })
+	bundle, out := stageBundle(t)
+
+	var stdout, stderr bytes.Buffer
+	rc := runVerify(verifyArgs(bundle, out, "--fail=false"), &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+	if !strings.Contains(string(rs.got), `"FAILED"`) {
+		t.Fatalf("signer input: %q", rs.got)
+	}
+}
+
+func TestVerifyExitZeroButFailedVSAFailsClosed(t *testing.T) {
+	// THE fail-open guard: a hypothetical ampel that exits 0 while its own VSA
+	// says FAILED (e.g. --exit-code mishandled) must never be signed.
+	installFakeAmpel(t, ampelWritingVSA(fakeVSA(testDigestHex, "FAILED"), 0))
+	rs := &recordingSigner{out: []byte(`{}`)}
+	swapSigner(t, func() (statementSigner, func(), error) { return rs, func() {}, nil })
+	bundle, out := stageBundle(t)
+
+	var stdout, stderr bytes.Buffer
+	rc := runVerify(verifyArgs(bundle, out), &stdout, &stderr)
+	if rc != 2 {
+		t.Fatalf("rc=%d, want 2", rc)
+	}
+	if rs.got != nil {
+		t.Fatal("signer must not run when exit code and VSA disagree")
+	}
+	if !strings.Contains(stderr.String(), "refusing to sign") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestVerifyVSAFailClosedTable(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		vsa  string
+	}{
+		{"empty verdict (ampel --pid edge)", fakeVSA(testDigestHex, "")},
+		{"SOFTFAIL leaks through verbatim", fakeVSA(testDigestHex, "SOFTFAIL")},
+		{"wrong subject digest", fakeVSA(strings.Repeat("ab", 32), "PASSED")},
+		{"multi-digest subject", `{"_type":"https://in-toto.io/Statement/v1","subject":[{"digest":{"sha256":"` + testDigestHex + `","sha512":"aa"}}],"predicateType":"https://slsa.dev/verification_summary/v1","predicate":{"verificationResult":"PASSED"}}`},
+		{"two subjects", `{"_type":"https://in-toto.io/Statement/v1","subject":[{"digest":{"sha256":"` + testDigestHex + `"}},{"digest":{"sha256":"` + testDigestHex + `"}}],"predicateType":"https://slsa.dev/verification_summary/v1","predicate":{"verificationResult":"PASSED"}}`},
+		{"wrong predicateType", `{"_type":"https://in-toto.io/Statement/v1","subject":[{"digest":{"sha256":"` + testDigestHex + `"}}],"predicateType":"https://example.com/other","predicate":{"verificationResult":"PASSED"}}`},
+		{"wrong _type", `{"_type":"https://example.com/Statement","subject":[{"digest":{"sha256":"` + testDigestHex + `"}}],"predicateType":"https://slsa.dev/verification_summary/v1","predicate":{"verificationResult":"PASSED"}}`},
+		{"not JSON", `not json at all`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			installFakeAmpel(t, ampelWritingVSA(tc.vsa, 0))
+			rs := &recordingSigner{out: []byte(`{}`)}
+			swapSigner(t, func() (statementSigner, func(), error) { return rs, func() {}, nil })
+			bundle, out := stageBundle(t)
+
+			var stdout, stderr bytes.Buffer
+			// fail=false too: even warn mode never signs a malformed VSA.
+			rc := runVerify(verifyArgs(bundle, out, "--fail=false"), &stdout, &stderr)
+			if rc != 2 {
+				t.Fatalf("rc=%d, want 2; stderr=%s", rc, stderr.String())
+			}
+			if rs.got != nil {
+				t.Fatal("signer must not run on an invalid VSA")
+			}
+		})
+	}
+}
+
+func TestVerifyExitZeroWithoutVSAFailsClosed(t *testing.T) {
+	installFakeAmpel(t, "printf 'report\\n'\nexit 0\n")
+	rs := &recordingSigner{out: []byte(`{}`)}
+	swapSigner(t, func() (statementSigner, func(), error) { return rs, func() {}, nil })
+	bundle, out := stageBundle(t)
+
+	var stdout, stderr bytes.Buffer
+	rc := runVerify(verifyArgs(bundle, out), &stdout, &stderr)
+	if rc != 2 {
+		t.Fatalf("rc=%d, want 2", rc)
+	}
+	if !strings.Contains(stderr.String(), "wrote no VSA") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestVerifyToolErrorExits2(t *testing.T) {
+	// Exit 1 with no VSA is a tool error, not a verdict; both retry attempts run.
+	counter := filepath.Join(t.TempDir(), "count")
+	installFakeAmpel(t, fmt.Sprintf("echo x >> %q\nprintf 'boom\\n' >&2\nexit 1\n", counter))
+	bundle, out := stageBundle(t)
+
+	var stdout, stderr bytes.Buffer
+	rc := runVerify(verifyArgs(bundle, out), &stdout, &stderr)
+	if rc != 2 {
+		t.Fatalf("rc=%d, want 2", rc)
+	}
+	if !strings.Contains(stderr.String(), "ampel verify failed (exit 1)") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	data, _ := os.ReadFile(counter)
+	if got := strings.Count(string(data), "x"); got != 2 {
+		t.Fatalf("ampel ran %d times, want 2 (one retry)", got)
+	}
+}
+
+func TestVerifyRetryRecoversAndEmitsOneReport(t *testing.T) {
+	// First attempt fails (transient), second passes; only the surviving
+	// attempt's report and VSA are used.
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "first-attempt")
+	script := fmt.Sprintf(`if [[ ! -e %q ]]; then touch %q; printf 'flaky report\n'; exit 1; fi
+%s`, marker, marker, ampelWritingVSA(fakeVSA(testDigestHex, "PASSED"), 0))
+	installFakeAmpel(t, script)
+	rs := &recordingSigner{out: []byte(`{"ok":1}`)}
+	swapSigner(t, func() (statementSigner, func(), error) { return rs, func() {}, nil })
+	bundle, out := stageBundle(t)
+
+	var stdout, stderr bytes.Buffer
+	rc := runVerify(verifyArgs(bundle, out), &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "flaky report") {
+		t.Fatalf("failed attempt's report leaked: %q", stdout.String())
+	}
+	if got := strings.Count(stdout.String(), "<report>"); got != 1 {
+		t.Fatalf("want exactly one report, got %d", got)
+	}
+	if !strings.Contains(stderr.String(), "retrying once") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestVerifyScrubsSigningTokenFromAmpelEnv(t *testing.T) {
+	// ampel parses semi-trusted attestations in the same container as the
+	// signing token; the child env must never carry it.
+	dir := t.TempDir()
+	envDump := filepath.Join(dir, "env")
+	installFakeAmpel(t, fmt.Sprintf(`env > %q
+%s`, envDump, ampelWritingVSA(fakeVSA(testDigestHex, "PASSED"), 0)))
+	rs := &recordingSigner{out: []byte(`{}`)}
+	swapSigner(t, func() (statementSigner, func(), error) { return rs, func() {}, nil })
+	t.Setenv("SIGSTORE_ID_TOKEN", "SECRET-SIGNING-JWT")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "SECRET-REQUEST-BEARER")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://oidc.example")
+	t.Setenv("AMPEL_SOURCEREPO", "https://github.com/evil/repo")
+	t.Setenv("GITHUB_TOKEN", "registry-token")
+	bundle, out := stageBundle(t)
+
+	var stdout, stderr bytes.Buffer
+	rc := runVerify(verifyArgs(bundle, out), &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+	env, err := os.ReadFile(envDump)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, banned := range []string{"SIGSTORE_ID_TOKEN", "ACTIONS_ID_TOKEN_REQUEST", "AMPEL_"} {
+		if strings.Contains(string(env), banned) {
+			t.Fatalf("%s leaked into ampel's env", banned)
+		}
+	}
+	// The oci: collector's registry auth must survive the scrub.
+	if !strings.Contains(string(env), "GITHUB_TOKEN=registry-token") {
+		t.Fatal("GITHUB_TOKEN missing from ampel's env")
+	}
+}
+
+func TestVerifyAmpelArgVector(t *testing.T) {
+	dir := t.TempDir()
+	argDump := filepath.Join(dir, "args")
+	installFakeAmpel(t, fmt.Sprintf(`printf '%%s\n' "$@" > %q
+%s`, argDump, ampelWritingVSA(fakeVSA(testDigestHex, "PASSED"), 0)))
+	rs := &recordingSigner{out: []byte(`{}`)}
+	swapSigner(t, func() (statementSigner, func(), error) { return rs, func() {}, nil })
+	bundle, out := stageBundle(t)
+
+	var stdout, stderr bytes.Buffer
+	rc := runVerify(verifyArgs(bundle, out,
+		"--collector", "oci:ghcr.io/o/r@sha256:aa",
+		"--context", "sourceRepo:https://github.com/o/r",
+		"--attestation", "extra.intoto.json",
+	), &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+	got, err := os.ReadFile(argDump)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(got)), "\n")
+	want := []string{
+		"verify",
+		"--subject=" + testArtifactDigest,
+		"--collector=jsonl:" + bundle,
+		"--collector=oci:ghcr.io/o/r@sha256:aa",
+		"--policy=/policies/p.hjson",
+		"--exit-code=true",
+		"--attest-results",
+		"--attest-format=vsa",
+		// [8] is --results-path=<engine temp>, asserted by prefix below.
+		"--context", "sourceRepo:https://github.com/o/r",
+		"--attestation", "extra.intoto.json",
+		"--format=html",
+	}
+	if len(lines) != len(want)+1 {
+		t.Fatalf("argv = %q", lines)
+	}
+	for i, w := range want {
+		g := lines[i]
+		if i >= 8 {
+			g = lines[i+1]
+		}
+		if g != w {
+			t.Fatalf("argv[%d] = %q, want %q (full: %q)", i, g, w, lines)
+		}
+	}
+	if !strings.HasPrefix(lines[8], "--results-path=") {
+		t.Fatalf("argv[8] = %q, want --results-path=…", lines[8])
+	}
+}
+
+func TestVerifyArtifactSubjectSelfDigestsToSubjectHash(t *testing.T) {
+	dir := t.TempDir()
+	blob := filepath.Join(dir, "app.tgz")
+	if err := os.WriteFile(blob, []byte("CONTENT\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256([]byte("CONTENT\n"))
+	wantHex := hex.EncodeToString(sum[:])
+
+	argDump := filepath.Join(dir, "args")
+	installFakeAmpel(t, fmt.Sprintf(`printf '%%s\n' "$@" > %q
+%s`, argDump, ampelWritingVSA(fakeVSA(wantHex, "PASSED"), 0)))
+	rs := &recordingSigner{out: []byte(`{}`)}
+	swapSigner(t, func() (statementSigner, func(), error) { return rs, func() {}, nil })
+	bundle, out := stageBundle(t)
+
+	var stdout, stderr bytes.Buffer
+	rc := runVerify([]string{
+		"--artifact", blob,
+		"--policy", "/p.hjson",
+		"--bundle", bundle,
+		"--out", out,
+	}, &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+	got, err := os.ReadFile(argDump)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "--subject-hash=sha256:"+wantHex+"\n") {
+		t.Fatalf("argv = %q, want --subject-hash=sha256:%s", got, wantHex)
+	}
+	if strings.Contains(string(got), "--subject=") {
+		t.Fatalf("file subject must not use --subject: %q", got)
+	}
+}
+
+func TestVerifyFlagFailClosedTable(t *testing.T) {
+	bundle, out := stageBundle(t)
+	empty := filepath.Join(t.TempDir(), "empty.jsonl")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"missing policy", []string{"--subject", testArtifactDigest, "--bundle", bundle, "--out", out}},
+		{"missing bundle", []string{"--subject", testArtifactDigest, "--policy", "p", "--out", out}},
+		{"missing out", []string{"--subject", testArtifactDigest, "--policy", "p", "--bundle", bundle}},
+		{"missing subject", []string{"--policy", "p", "--bundle", bundle, "--out", out}},
+		{"subject and artifact", []string{"--subject", testArtifactDigest, "--artifact", "f", "--policy", "p", "--bundle", bundle, "--out", out}},
+		{"non-sha256 subject", []string{"--subject", "sha512:abcd", "--policy", "p", "--bundle", bundle, "--out", out}},
+		{"short digest", []string{"--subject", "sha256:abcd", "--policy", "p", "--bundle", bundle, "--out", out}},
+		{"missing artifact file", []string{"--artifact", "/nonexistent.tgz", "--policy", "p", "--bundle", bundle, "--out", out}},
+		{"out aliases bundle", []string{"--subject", testArtifactDigest, "--policy", "p", "--bundle", bundle, "--out", bundle}},
+		{"missing bundle file", []string{"--subject", testArtifactDigest, "--policy", "p", "--bundle", "/nonexistent.jsonl", "--out", out}},
+		{"empty bundle file", []string{"--subject", testArtifactDigest, "--policy", "p", "--bundle", empty, "--out", out}},
+		{"positional arg", []string{"stray", "--subject", testArtifactDigest, "--policy", "p", "--bundle", bundle, "--out", out}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Any ampel invocation would be a bug: these all fail pre-exec.
+			installFakeAmpel(t, "echo SHOULD-NOT-RUN >&2; exit 97\n")
+			var stdout, stderr bytes.Buffer
+			rc := runVerify(tc.args, &stdout, &stderr)
+			if rc != 2 {
+				t.Fatalf("rc=%d, want 2; stderr=%s", rc, stderr.String())
+			}
+			if strings.Contains(stderr.String(), "SHOULD-NOT-RUN") {
+				t.Fatal("ampel ran despite invalid flags")
+			}
+		})
+	}
+}
+
+func TestRunDispatchesVerify(t *testing.T) {
+	var stderr bytes.Buffer
+	rc := run([]string{"verify"}, &stderr)
+	if rc != 2 {
+		t.Fatalf("rc=%d, want 2", rc)
+	}
+	if !strings.Contains(stderr.String(), "required") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}

--- a/tools/wrangle-attest/verify_test.go
+++ b/tools/wrangle-attest/verify_test.go
@@ -186,8 +186,11 @@ func TestVerifyVSAFailClosedTable(t *testing.T) {
 		name string
 		vsa  string
 	}{
-		{"empty verdict (ampel --pid edge)", fakeVSA(testDigestHex, "")},
-		{"SOFTFAIL leaks through verbatim", fakeVSA(testDigestHex, "SOFTFAIL")},
+		// ampel maps an unknown status to "" (pkg/attest/vsa.go
+		// resultStringToSLSAResult); any value that is not PASSED/FAILED is
+		// refused rather than guessed at.
+		{"empty verdict", fakeVSA(testDigestHex, "")},
+		{"unknown verdict value", fakeVSA(testDigestHex, "SOFTFAIL")},
 		{"wrong subject digest", fakeVSA(strings.Repeat("ab", 32), "PASSED")},
 		{"multi-digest subject", `{"_type":"https://in-toto.io/Statement/v1","subject":[{"digest":{"sha256":"` + testDigestHex + `","sha512":"aa"}}],"predicateType":"https://slsa.dev/verification_summary/v1","predicate":{"verificationResult":"PASSED"}}`},
 		{"two subjects", `{"_type":"https://in-toto.io/Statement/v1","subject":[{"digest":{"sha256":"` + testDigestHex + `"}},{"digest":{"sha256":"` + testDigestHex + `"}}],"predicateType":"https://slsa.dev/verification_summary/v1","predicate":{"verificationResult":"PASSED"}}`},


### PR DESCRIPTION
Spike of #484 with a deliberately different design than the issue proposes: **exec the `ampel` CLI as an in-container sibling** instead of importing ampel's Go packages. Stage 1 of 2 — engine only, no shell or image change.

**DRAFT, targeting v0.5.0.** #484 is deferred out of v0.4.0; nothing here needs to land now. This PR exists so v0.5.0 starts from evidence rather than from scratch. The verdict write-up is on #484.

## Why exec, not import

#484 was deferred over three blockers, all caused by the library plan: ampel's HTML report has no public API, `pkg/attest` churned VSA semantics in a patch release, and pulling the CEL evaluator + plugins into the signing engine needed a security design pass. Exec-ing the CLI dodges all three: the CLI is ampel's stable contract, the HTML report is just ampel's stdout passed through, and the engine consumes the emitted VSA as opaque bytes (it parses only `_type`/`predicateType`/`subject`/`predicate.verificationResult` — the churny VSA internals never enter our code). `ampel` and `wrangle-attest` already ship in the same `attest-toolbox` image, so the exec needs no new dispatch.

## The verdict protocol (the load-bearing part)

Verified by reading ampel v1.3.1 source directly (module cache), not from docs:

- **`ampel verify` exits 1 for BOTH a FAILED verdict and every tool error.** `cmd/ampel/main.go` does `os.Exit(1)` on any returned error; `internal/cmd/verify.go:542,579` does `os.Exit(1)` only when `results.GetStatus() == papi.StatusFAIL && opts.SetExitCode`. The exit code alone therefore **cannot** distinguish "policy failed" from "ampel broke".
- **The VSA is machine-readable and is the disambiguator.** `--attest-results --attest-format=vsa --results-path=F` calls `attester.AttestToFile(...)` (verify.go:527) *before* the exit-code check, so F is written on PASS **and** on FAIL, but **not** on a tool error (which returns early). It is an in-toto VSA statement with `predicate.verificationResult`.
- **Exit code and VSA cannot disagree** — both derive from the same in-memory `results` object.
- `--exit-code` is a bool, **default true** (verify.go:174).

So the engine **dual-checks**: signing requires ampel exit 0 AND an emitted VSA that parses as in-toto, binds exactly the requested single-sha256 subject, and says `verificationResult: "PASSED"`. **There is no text-scraping anywhere** — the verdict is read from a JSON field, not from the report.

### One honest limitation (corrected mid-spike)

`pkg/attest/vsa.go` `resultStringToSLSAResult` maps **both `StatusPASS` and `StatusSOFTFAIL` to `"PASSED"`**, and ampel exits nonzero only on `StatusFAIL`. So a **SOFTFAIL is indistinguishable from a PASS** by exit code *and* by VSA. This is not a hole this design opens — it is intended ampel + wrangle semantics: wrangle's own `wrangle-release-pinned` tenet is an `enforce: OFF` advisory group whose policy comment already says *"a branch/SHA build SOFTFAILs here and still emits a PASSED VSA"*. Identical in today's shell. I initially claimed the dual-check caught SOFTFAIL; that was wrong, and the SPEC and the test case are corrected in this PR rather than left overstating the guarantee.

What the dual-check *does* catch (none of which the current shell catches): an absent VSA, an unparseable VSA, a wrong-subject VSA, a wrong-predicateType VSA, an empty verdict, and a FAILED verdict that somehow exited 0.

The engine also strips `SIGSTORE_ID_TOKEN`, `ACTIONS_ID_TOKEN_REQUEST_*`, and `AMPEL_*` from ampel's child env. The `AMPEL_*` scrub is load-bearing in principle — `--context-env` defaults **true** (verify.go:154) and `pkg/context/env.go` reads policy context from `AMPEL_<KEY>` vars, so a stray var could steer a verdict — though the container boundary already blocks host env today, making it defense-in-depth.

## Upstream reuse (CLAUDE.md rule 4)

- **ampel CLI** over `pkg/verifier`: the import path is exactly what #484 deferred (unstable post-1.0 Go API, no report API); the CLI contract above is verified at v1.3.1, our pinned build.
- **`carabiner-dev/signer`** signs the VSA bytes verbatim through the existing `--statement` path (shared `signAndDeliver`); it retries Fulcio/Rekor/TSA itself, so the engine adds no signing retry.
- **`carabiner-dev/hasher`** self-digests file subjects via the existing `subjects.go`.
- The one retry the engine does add wraps only the side-effect-free ampel exec (transient collector/locator I/O), with the results file removed between attempts.

## Empirically verified

Ran the real engine + real ampel v1.3.1 against the checked-in consumer fixtures (`test/consumer/fixtures/npm-vsa.intoto.jsonl` + blob) and the shipped `wrangle-vsa-consumer-v1.hjson` policy: ampel exec'd as a sibling, the HTML report (🟢 PASS) passed through stdout, `validateVSA` accepted real ampel's VSA shape (subject digest + verdict), and signing failed closed at the OIDC step exactly as designed (no ambient token locally).

## Tests

Hermetic Go tests with a scripted fake ampel (the exit-code × VSA verdict matrix must be deterministic offline; the real CLI contract is pinned by the stacked PR's real-binary bats test and the dispatch e2e) + the existing fake-signer seam: the fail-open guard (ampel exit 0 + FAILED VSA → exit 2, nothing signed), SOFTFAIL/empty-verdict/subject-mismatch/multi-digest/wrong-predicateType rejection, warn mode, retry semantics, env scrub, and the exact ampel argv.

Part of #484. Stacked flip: #<flip-pr>. Relationship to #761: that PR flips only the VSA signing (`bnd statement` → `--statement`); this ladder supersedes it if the exec-ampel design is accepted — sequencing is the owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
