### PR TITLE
claude: chore(catalog): bump tool-image digests (final pre-v0.4.0)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -126,7 +126,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         id: prep
         with:
           build-type: container
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -172,7 +172,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      uses: TomHennen/wrangle/build/actions/container@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -248,7 +248,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -287,7 +287,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -126,7 +126,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         id: prep
         with:
           build-type: container
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -172,7 +172,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      uses: TomHennen/wrangle/build/actions/container@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -248,7 +248,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -287,7 +287,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -163,7 +163,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         id: prep
         with:
           build-type: go
@@ -183,7 +183,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/checks@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/build@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         id: attest
         with:
           build-type: go
@@ -389,7 +389,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -415,7 +415,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -163,7 +163,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         id: prep
         with:
           build-type: go
@@ -183,7 +183,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/checks@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/build@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         id: attest
         with:
           build-type: go
@@ -389,7 +389,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -415,7 +415,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -151,7 +151,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         id: prep
         with:
           build-type: npm
@@ -171,7 +171,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/npm@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         id: attest
         with:
           build-type: npm
@@ -304,7 +304,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -331,7 +331,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -151,7 +151,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         id: prep
         with:
           build-type: npm
@@ -171,7 +171,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/npm@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         id: attest
         with:
           build-type: npm
@@ -304,7 +304,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -331,7 +331,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -128,7 +128,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         id: prep
         with:
           build-type: python
@@ -148,7 +148,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/python@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         id: attest
         with:
           build-type: python
@@ -290,7 +290,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -317,7 +317,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -128,7 +128,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         id: prep
         with:
           build-type: python
@@ -148,7 +148,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/python@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         id: attest
         with:
           build-type: python
@@ -290,7 +290,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -317,7 +317,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -193,7 +193,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+        uses: TomHennen/wrangle/build/actions/shell@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -193,7 +193,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+        uses: TomHennen/wrangle/build/actions/shell@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+        uses: TomHennen/wrangle/actions/scan@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+        uses: TomHennen/wrangle/actions/scan@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -111,7 +111,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      uses: TomHennen/wrangle/tools/scorecard@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -123,7 +123,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+      uses: TomHennen/wrangle/tools/dependency-review@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
 
     - name: Generate step summary
       if: always()

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -111,7 +111,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      uses: TomHennen/wrangle/tools/scorecard@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -123,7 +123,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+      uses: TomHennen/wrangle/tools/dependency-review@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -79,7 +79,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
+    - uses: TomHennen/wrangle/actions/verify@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -79,7 +79,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@01c2583606d707ac913e352e811efe638e538f22 # bot/catalog-autobump 2026-07-12
+    - uses: TomHennen/wrangle/actions/verify@117a4992c8d9a633cf33e9b6557a4d3711067cca # main 2026-07-12
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -3,28 +3,28 @@
   "tools": {
     "osv": {
       "kind": "scan",
-      "image": "ghcr.io/tomhennen/wrangle/osv@sha256:5315ed5330c33cd6174d62f320172813f17b5a30231cff61bd5df4505df7578f",
+      "image": "ghcr.io/tomhennen/wrangle/osv@sha256:64d14a631308809d78b4eb91de9c9c06e822977951af2f487d8827f6d761f2a3",
       "network": "egress"
     },
     "zizmor": {
       "kind": "scan",
-      "image": "ghcr.io/tomhennen/wrangle/zizmor@sha256:fd26ef48b19441acc58f5a9ab6a003ace2024284428a4f92c7c2e59744aea4d8",
+      "image": "ghcr.io/tomhennen/wrangle/zizmor@sha256:60bd9d1b0b6e5ae412185dd50562ea878aabc2b3f38d9d7920c4f8e9b5d705fd",
       "network": "egress",
       "secret": "github-token"
     },
     "wrangle-lint": {
       "kind": "scan",
-      "image": "ghcr.io/tomhennen/wrangle/wrangle-lint@sha256:095298e442622d91698a913ebac6f1b8906a0919edda41191abe035e70f2d8d6",
+      "image": "ghcr.io/tomhennen/wrangle/wrangle-lint@sha256:91ff9020a20021db3e9151016ca20b0e1d31125c3d67a56320524e2475f354bb",
       "network": "none"
     },
     "sbom": {
       "kind": "sbom",
-      "image": "ghcr.io/tomhennen/wrangle/syft@sha256:047f1791370d24e465ce8deccee0cef8717faaef573fb00f1cd89f53931d0bfe",
+      "image": "ghcr.io/tomhennen/wrangle/syft@sha256:77f42b49365d9b07dda520ee29ef3c6ff4f6487c0de2130e94e45bc857847b1b",
       "network": "none"
     },
     "attest-toolbox": {
       "kind": "attest",
-      "image": "ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:417dd8f91ca522d364cb94ec4a33c00fd1ee6eca8ceaba48ef0d02bbc0c4c7d5",
+      "image": "ghcr.io/tomhennen/wrangle/attest-toolbox@sha256:34ca21d10bed09a9817d23e4ede0fefbefc73ec66d02e882500c7cf98e5105bc",
       "network": "egress",
       "token": "sigstore"
     }


### PR DESCRIPTION
Catalog bump + pin converge. Hand-rolled because the bot lost a race — see below.

**Validation:** `check_pin_freshness` ✅ · `check_pin_ancestry` ✅ · `check_catalog_freshness` **exit 0** · `check_catalog_provenance_freshness` **exit 0**.

That takes `release_preflight` to a single remaining gate — the first-parent pin finalize, which is deliberately last.

## Why the bot couldn't do it (a race in #769, not a regression)

`bump-catalog` failed with the same "App cannot push workflow files" error #769 fixed — but for a **different reason**. The bot commits only `tools/catalog.json` (that part works). The problem is it branches from **the publish run's commit**, not from current `main`:

1. Publish triggered by #778 at `e62218d4`.
2. **#779 merged while it ran**, carrying pin-converge commits that changed `.github/workflows/**`.
3. The bot pushed a branch based on `e62218d4`, whose workflow files were now **older** than `main`'s — so GitHub saw the App modifying workflows and rejected the push.

Fix (follow-up, not this PR): the bot should branch from **current `origin/main`** and re-resolve digests there, rather than from the run's checkout SHA. It is a race with any concurrent merge that touches workflows — pin converges do, and they are common.

Also worth noting: this whole cycle was avoidable. The publish fired because #778 added `tools/cut_release.sh` — a release script that ships in **no image**. That is **#777** (the `tools/**` trigger is too broad), and it has now cost three needless rebuild+bump cycles today.

## ⚠️ Merge as a merge commit, not a squash
Carries 2 pin-converge commits.