### PR TITLE
claude: release: v0.4.0 release notes (draft — please edit)

### DIFF
--- a/release-notes-v0.4.0.md
+++ b/release-notes-v0.4.0.md
@@ -1,0 +1,36 @@
+## wrangle v0.4.0
+
+Private repos and immutable releases can now complete a release — two places wrangle previously couldn't finish at all. Shell builds are roughly **2× faster**. Pin the reusable workflows at `@v0.4.0`.
+
+**Breaking:** the `go-cache` input is gone — remove it from your workflow calls, or they'll fail with an unknown-input error. It cached nothing once the scan tools moved to containers.
+
+### Your private repo can release now
+
+The release path used to die on a private repo: `attest` failed, `verify` never ran, nothing was published, and there was no way to turn it off.
+
+Set **`attest-and-verify: disabled`** and you get a normal release — built, tested, scanned, same gates — published **unattested** and marked as such. The default (`enabled`) is unchanged on public repos; on a private one wrangle now **fails fast in the first job** with a message telling you what to do, instead of dying mid-build on a raw API error.
+
+It isn't automatic because attestation genuinely can't work there, for two different reasons:
+
+- **Private personal repo** — GitHub's attestation store **doesn't support it**. It would simply fail.
+- **Private org repo** — wrangle signs keyless to public-good Sigstore, so the certificate lands in the **public Rekor transparency log**, permanently leaking the repo's identity and build timing.
+
+Full private-repo attestation is tracked in [#600](https://github.com/TomHennen/wrangle/issues/600).
+
+### Immutable releases work
+
+wrangle used to publish the release, *then* upload the signed bundles — which a frozen release rejects. It now creates a **draft**, attaches everything, and publishes as the last step. Nothing to configure.
+
+### Faster builds
+
+The shell build dropped from **~6 minutes to ~2m50s** (warm) — tool images are pre-built concurrently into a layer cache, and the test-harness setup no longer rebuilds per test. Want more: set **`bats-jobs: <n>`** to run test files concurrently (default `1`; raise it only if your suite shares no cross-file state).
+
+### Coming from v0.3.0?
+
+v0.3.1 was quiet, so you also get: **scan and SBOM tools running as digest-pinned OCI images that wrangle verifies before running** (fails closed if an image doesn't verify), and **bring-your-own SBOM tool** via `.wrangle/tools.json` + `sbom-tool: <name>`, sandboxed and attested like the built-ins.
+
+### Check the evidence yourself
+
+Every artifact carries a signed attestation you can verify with `gh attestation verify`, `cosign`, or `ampel`; the curated tool images carry their own SLSA-L3 provenance. Recipe: [docs/verifying_artifacts.md](https://github.com/TomHennen/wrangle/blob/v0.4.0/docs/verifying_artifacts.md). Your VSAs now name **wrangle** as the verifier, not the underlying policy engine.
+
+Signing is also more reliable: wrangle used to open a fresh Sigstore session per artifact (a six-artifact release meant six OIDC/TUF/certificate handshakes, any of which could fail transiently). It now does one per job.


### PR DESCRIPTION
The release notes, as a reviewable file. `cut_release.sh` reads it via `--notes-file`, so **this file is literally what ships** — edit it here and the cut picks it up.

Benefit-first, second person, matching the v0.3.1 voice. No `--generate-notes` (the runbook rejects an auto-changelog).

## Calls I made — please sanity-check these

1. **Led with private repos + immutable releases.** Those took adopters from *"can't release at all"* to *"can"*. The wrangle-attest engine work is a reliability win, so it's one line under "Check the evidence yourself" rather than a section — adopters don't see it.

2. **Included a "Coming from v0.3.0?" section**, since you said v0.3.1 went unadvertised. Anyone jumping from v0.3.0 would otherwise miss the verified tool containers and BYO-SBOM entirely.

3. **The private-repo section is the longest**, deliberately. "Why can't you just do it for me" is the obvious reader question, and the two reasons are genuinely different: a **private personal repo** is *unsupported by GitHub's attestation store* (it would simply fail), while a **private org repo** would *leak identity and build timing to the public Rekor log*. Earlier drafts of mine wrongly framed this as privacy-only.

4. **Left out** `tools.lock` (#264) and the `WRANGLE_RELEASE_PINNED` marker (#424) — both read as internal plumbing. Say the word and I'll add them.

5. **Perf numbers** are from #714/#715/#716: shell build ~6min → **~2m50s** warm, plus the opt-in `bats-jobs` input.

## Note
The file is committed so it's reviewable and so the cut has a stable input. If you'd rather it not live in the repo, I'll delete it in a follow-up right after the tag.