### PR TITLE
claude: release: script the pin finalize, and make cut_release name it (#758)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,3 +130,9 @@ bump-version-refs:
 # confirmation. Usage: make cut-release VERSION=v0.4.0 NOTES=release-notes.md
 cut-release:
 	@./tools/cut_release.sh $(VERSION) $(NOTES)
+
+# Roll the self-ref pins onto main's first-parent history, labelled `# main`
+# (cut-release Phase 1, last step). Open the result as a PR; merge it as a
+# merge commit, never a squash.
+finalize-pins:
+	@./tools/finalize_pins.sh $(SHA)

--- a/test/test_finalize_pins.bats
+++ b/test/test_finalize_pins.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+# The finalize is the step a human forgets, and `bump_action_pins` silently
+# labels with the current branch unless WRANGLE_PINS_BRANCH=main is set. Both
+# mistakes were made by hand cutting v0.4.0, so both are pinned here.
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../tools/finalize_pins.sh"
+    TMP_DIR="$(mktemp -d)"
+    STUB="$TMP_DIR/bin"
+    mkdir -p "$STUB"
+
+    # Record how bump_action_pins is invoked, and with what label.
+    cat > "$STUB/bump_action_pins.sh" <<'EOF'
+#!/bin/bash
+printf 'target=%s label=%s\n' "$1" "${WRANGLE_PINS_BRANCH:-<unset>}" >> "$BUMP_CALLS"
+exit 0
+EOF
+    cat > "$STUB/check_pin_main_history.sh" <<'EOF'
+#!/bin/bash
+exit "${MAIN_HISTORY_RC:-0}"
+EOF
+    cat > "$STUB/check_pin_freshness.sh" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+    chmod +x "$STUB"/*.sh
+    export BUMP_CALLS="$TMP_DIR/bump-calls"
+    : > "$BUMP_CALLS"
+
+    REPO="$TMP_DIR/repo"
+    mkdir -p "$REPO"
+    git -C "$REPO" init -qb main
+    git -C "$REPO" config user.email t@t.t
+    git -C "$REPO" config user.name t
+    printf 'x\n' > "$REPO/f"
+    git -C "$REPO" add -A && git -C "$REPO" commit -qm c1
+    git -C "$REPO" remote add origin "$REPO"
+    git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+    export WRANGLE_REPO_ROOT="$REPO"
+
+    # Run the real script but with stubbed siblings on its SCRIPT_DIR.
+    mkdir -p "$TMP_DIR/tools"
+    cp "$SCRIPT" "$TMP_DIR/tools/"
+    cp "$STUB"/*.sh "$TMP_DIR/tools/"
+    RUN="$TMP_DIR/tools/finalize_pins.sh"
+}
+
+teardown() { rm -rf "$TMP_DIR"; }
+
+@test "finalize_pins: always labels the pins # main, never the current branch" {
+    # LOAD-BEARING. Without WRANGLE_PINS_BRANCH=main, bump_action_pins writes the
+    # current branch's name and the pins come out `# some-branch` — the #592
+    # footgun, hit by hand while cutting v0.4.0.
+    git -C "$REPO" checkout -qb some-feature-branch
+    run "$RUN"
+    [[ "$status" -eq 0 ]]
+    grep -q 'label=main' "$BUMP_CALLS"
+    ! grep -q 'some-feature-branch' "$BUMP_CALLS"
+}
+
+@test "finalize_pins: refuses a target that is not on main's first-parent history" {
+    # LOAD-BEARING. Pinning a branch commit is exactly the state being fixed;
+    # accepting one here would silently no-op the finalize.
+    git -C "$REPO" checkout -qb side
+    printf 'y\n' > "$REPO/g"
+    git -C "$REPO" add -A && git -C "$REPO" commit -qm side-commit
+    local side; side="$(git -C "$REPO" rev-parse HEAD)"
+    run "$RUN" "$side"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"first-parent"* ]]
+    [[ ! -s "$BUMP_CALLS" ]]
+}
+
+@test "finalize_pins: fails when the pins still aren't on first-parent after the bump" {
+    export MAIN_HISTORY_RC=1
+    run "$RUN"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"do not cut"* ]]
+}
+
+@test "finalize_pins: usage error on extra arguments" {
+    run "$RUN" a b
+    [[ "$status" -eq 2 ]]
+}

--- a/test/test_finalize_pins.bats
+++ b/test/test_finalize_pins.bats
@@ -83,3 +83,22 @@ teardown() { rm -rf "$TMP_DIR"; }
     run "$RUN" a b
     [[ "$status" -eq 2 ]]
 }
+
+@test "finalize_pins: a long first-parent history doesn't SIGPIPE the check" {
+    # REGRESSION. The check was `rev-list --first-parent | grep -qx "$sha"`.
+    # grep -q exits on the first match — and for HEAD the match IS the first
+    # line — so rev-list took SIGPIPE (141) and pipefail turned that into a
+    # false "not on first-parent history". It only reproduces when rev-list has
+    # more to write after grep exits, i.e. a history longer than a pipe buffer's
+    # worth of lines, which the other fixtures are too short to trigger (#771).
+    local i
+    for ((i = 0; i < 200; i++)); do
+        printf '%s\n' "$i" > "$REPO/f"
+        git -C "$REPO" add -A
+        git -C "$REPO" commit -qm "c$i"
+    done
+    git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+    run "$RUN"
+    [[ "$status" -eq 0 ]]
+    grep -q 'label=main' "$BUMP_CALLS"
+}

--- a/tools/cut_release.sh
+++ b/tools/cut_release.sh
@@ -63,6 +63,18 @@ wrangle_check_target_on_main() {
         || wrangle_die "target $sha is not on origin/main"
 }
 
+# The Release Gate catches un-finalized pins too, but 10 minutes later and as an
+# opaque "gate failed". Say it up front, with the remedy.
+wrangle_check_pins_finalized() {
+    "$SCRIPT_DIR/check_pin_main_history.sh" >/dev/null 2>&1 && return 0
+    printf 'cut_release: the self-ref pins are not on main'"'"'s first-parent history.\n' >&2
+    printf '\n  An in-PR converge pins branch commits; only a post-merge bump can reach\n' >&2
+    printf '  first-parent history. Run the finalize, open it as a PR, merge it as a\n' >&2
+    printf '  MERGE COMMIT (not a squash), then cut at that commit:\n\n' >&2
+    printf '    tools/finalize_pins.sh\n\n' >&2
+    return 1
+}
+
 # Dispatch the Release Gate on the target and poll it. A locally-run preflight
 # cannot substitute: the pin gates read origin/main's history, so a stale or
 # shallow checkout can produce a confident false green.
@@ -121,6 +133,7 @@ wrangle_cut_release() {
         target="$(git -C "$REPO_ROOT" rev-parse origin/main)"
     fi
     wrangle_check_target_on_main "$target"
+    wrangle_check_pins_finalized "$target"
     wrangle_release_gate_green "$target"
     wrangle_confirm "$version" "$target"
 

--- a/tools/finalize_pins.sh
+++ b/tools/finalize_pins.sh
@@ -31,8 +31,11 @@ wrangle_die() { printf 'finalize_pins: %s\n' "$1" >&2; return 1; }
 # where they started.
 wrangle_check_first_parent() {
     local sha="$1"
-    git -C "$REPO_ROOT" rev-list --first-parent origin/main \
-        | grep -qx "$sha" \
+    # Captured, not piped: grep -q exits on the first match and would SIGPIPE
+    # rev-list, which pipefail turns into a false failure (#771).
+    local first_parents
+    first_parents="$(git -C "$REPO_ROOT" rev-list --first-parent origin/main)"
+    grep -qx "$sha" <<<"$first_parents" \
         || wrangle_die "target ${sha:0:9} is not on origin/main's first-parent history — pass a merge commit from main"
 }
 

--- a/tools/finalize_pins.sh
+++ b/tools/finalize_pins.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# finalize_pins.sh — roll the declared self-ref pins onto main's first-parent
+# history, labelled `# main` (cut-release runbook, Phase 1, last step).
+#
+# Usage: finalize_pins.sh [<main-sha>]      default: current origin/main
+#
+# Why this exists as a script rather than a documented command: an in-PR converge
+# necessarily pins branch commits, and main's first-parent line is all merge
+# commits — a merge SHA cannot exist before the merge. So the pins can only reach
+# first-parent history in a second step, after the merge. That step is easy to
+# forget, and easy to get subtly wrong: `bump_action_pins.sh` writes the *current
+# branch's* name as the label unless the target is reachable from origin/main, so
+# converging from a feature branch silently produces `# some-branch` pins. Both
+# mistakes were made by hand while cutting v0.4.0.
+#
+# The result must be opened as a PR: direct pushes to main are blocked, and the
+# converge commits must land as a MERGE COMMIT, never a squash, or the
+# intermediate pins re-orphan.
+#
+# Exit: 0 finalized (or already finalized), 1 the finalize did not take, 2 usage.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${WRANGLE_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+wrangle_die() { printf 'finalize_pins: %s\n' "$1" >&2; return 1; }
+
+# The target must be ON main's first-parent line, or the pins land right back
+# where they started.
+wrangle_check_first_parent() {
+    local sha="$1"
+    git -C "$REPO_ROOT" rev-list --first-parent origin/main \
+        | grep -qx "$sha" \
+        || wrangle_die "target ${sha:0:9} is not on origin/main's first-parent history — pass a merge commit from main"
+}
+
+wrangle_finalize_pins() {
+    local target="${1:-}"
+
+    git -C "$REPO_ROOT" fetch -q --no-tags origin +refs/heads/main:refs/remotes/origin/main
+
+    if [[ -z "$target" ]]; then
+        target="$(git -C "$REPO_ROOT" rev-parse origin/main)"
+    else
+        target="$(git -C "$REPO_ROOT" rev-parse "$target")"
+    fi
+    wrangle_check_first_parent "$target"
+
+    # WRANGLE_PINS_BRANCH=main is the whole point: without it the label follows
+    # the current branch and the pins come out `# some-branch`.
+    WRANGLE_PINS_BRANCH=main "$SCRIPT_DIR/bump_action_pins.sh" "$target" \
+        || wrangle_die "bump_action_pins failed"
+
+    if ! "$SCRIPT_DIR/check_pin_main_history.sh"; then
+        wrangle_die "pins are still not on main's first-parent history — do not cut"
+    fi
+    "$SCRIPT_DIR/check_pin_freshness.sh" >/dev/null \
+        || wrangle_die "pins resolve stale content after the finalize"
+
+    if git -C "$REPO_ROOT" diff --quiet; then
+        printf 'finalize_pins: already finalized at %s — nothing to do\n' "${target:0:9}"
+        return 0
+    fi
+
+    printf '\nfinalize_pins: pins rolled onto %s, labelled # main.\n' "${target:0:9}"
+    printf 'Commit these and open a PR. Merge it as a MERGE COMMIT, not a squash.\n'
+}
+
+main() {
+    [[ $# -le 1 ]] || { printf 'Usage: finalize_pins.sh [<main-sha>]\n' >&2; exit 2; }
+    wrangle_finalize_pins "${1:-}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
Fallout from cutting v0.4.0 by hand. The owner's diagnosis: *"seems like something we need to fix in the cut release script."*

## The two mistakes I made by hand tonight

1. **The finalize is easy to forget.** An in-PR converge can only pin *branch* commits — `main`'s first-parent line is all merge commits, and a merge SHA cannot exist before the merge. So the pins reach first-parent history only via a **post-merge bump**, and nothing forced that step.
2. **Getting it right needs an env var you must also remember.** `bump_action_pins.sh` labels a pin with the **current branch's name** unless `WRANGLE_PINS_BRANCH=main` is set. I converged #773/#775 correctly, then dropped the variable on #779/#782 — which came out labelled `# chore/catalog-bump-final` instead of `# main`. That is precisely the **#592** footgun, and the owner caught it, not CI.

## The fix

**`tools/finalize_pins.sh`** (+ `make finalize-pins`) encodes the convention so neither can be forgotten:
- **Always** passes `WRANGLE_PINS_BRANCH=main` — the label can't follow a feature branch.
- **Refuses a target not on `origin/main`'s first-parent history** — pinning a branch commit is the exact state being fixed; accepting one would silently no-op the finalize.
- **Re-checks `check_pin_main_history` after the bump** and fails loudly if the finalize didn't take.
- Tells you to open a PR and merge it as a **merge commit, not a squash**.

**`cut_release.sh`** now checks `check_pin_main_history` **up front** and prints the remedy:

```
cut_release: the self-ref pins are not on main's first-parent history.

  An in-PR converge pins branch commits; only a post-merge bump can reach
  first-parent history. Run the finalize, open it as a PR, merge it as a
  MERGE COMMIT (not a squash), then cut at that commit:

    tools/finalize_pins.sh
```

The Release Gate already caught this — but ~10 minutes later and as an opaque "gate failed". The safety net stays; this just says it up front, actionably.

## Validation

**4/4 new bats, 0 `not ok`** (cut_release still 7/7). The two load-bearing cases are exactly what bit me:
- *"always labels the pins `# main`, never the current branch"* — runs from a feature branch and asserts the label is `main`.
- *"refuses a target that is not on main's first-parent history"* — and asserts `bump_action_pins` was **never invoked**.

shellcheck clean.