### PR TITLE
claude: release: finalize the self-ref pins onto main's first-parent history

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -126,7 +126,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         id: prep
         with:
           build-type: container
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -172,7 +172,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      uses: TomHennen/wrangle/build/actions/container@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -248,7 +248,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -287,7 +287,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -163,7 +163,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         id: prep
         with:
           build-type: go
@@ -183,7 +183,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/checks@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/build@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         id: attest
         with:
           build-type: go
@@ -389,7 +389,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -415,7 +415,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -151,7 +151,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         id: prep
         with:
           build-type: npm
@@ -171,7 +171,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/npm@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         id: attest
         with:
           build-type: npm
@@ -304,7 +304,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -331,7 +331,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -128,7 +128,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         id: prep
         with:
           build-type: python
@@ -148,7 +148,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/python@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         id: attest
         with:
           build-type: python
@@ -290,7 +290,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -317,7 +317,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -193,7 +193,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+        uses: TomHennen/wrangle/build/actions/shell@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+        uses: TomHennen/wrangle/actions/scan@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -111,7 +111,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      uses: TomHennen/wrangle/tools/scorecard@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -123,7 +123,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+      uses: TomHennen/wrangle/tools/dependency-review@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -79,7 +79,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@6ec39d26040aaeb1cd9d87b0e8fc0ca4332d7b73 # main 2026-07-12
+    - uses: TomHennen/wrangle/actions/verify@33dd4b43d0b0ae5e18d39f3ab9a7ba26312882ff # main 2026-07-12
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}

--- a/tools/finalize_pins.sh
+++ b/tools/finalize_pins.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -euo pipefail
+set -f
+
+# finalize_pins.sh — roll the declared self-ref pins onto main's first-parent
+# history, labelled `# main` (cut-release runbook, Phase 1, last step).
+#
+# Usage: finalize_pins.sh [<main-sha>]      default: current origin/main
+#
+# Why this exists as a script rather than a documented command: an in-PR converge
+# necessarily pins branch commits, and main's first-parent line is all merge
+# commits — a merge SHA cannot exist before the merge. So the pins can only reach
+# first-parent history in a second step, after the merge. That step is easy to
+# forget, and easy to get subtly wrong: `bump_action_pins.sh` writes the *current
+# branch's* name as the label unless the target is reachable from origin/main, so
+# converging from a feature branch silently produces `# some-branch` pins. Both
+# mistakes were made by hand while cutting v0.4.0.
+#
+# The result must be opened as a PR: direct pushes to main are blocked, and the
+# converge commits must land as a MERGE COMMIT, never a squash, or the
+# intermediate pins re-orphan.
+#
+# Exit: 0 finalized (or already finalized), 1 the finalize did not take, 2 usage.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${WRANGLE_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+wrangle_die() { printf 'finalize_pins: %s\n' "$1" >&2; return 1; }
+
+# The target must be ON main's first-parent line, or the pins land right back
+# where they started.
+wrangle_check_first_parent() {
+    local sha="$1"
+    git -C "$REPO_ROOT" rev-list --first-parent origin/main \
+        | grep -qx "$sha" \
+        || wrangle_die "target ${sha:0:9} is not on origin/main's first-parent history — pass a merge commit from main"
+}
+
+wrangle_finalize_pins() {
+    local target="${1:-}"
+
+    git -C "$REPO_ROOT" fetch -q --no-tags origin +refs/heads/main:refs/remotes/origin/main
+
+    if [[ -z "$target" ]]; then
+        target="$(git -C "$REPO_ROOT" rev-parse origin/main)"
+    else
+        target="$(git -C "$REPO_ROOT" rev-parse "$target")"
+    fi
+    wrangle_check_first_parent "$target"
+
+    # WRANGLE_PINS_BRANCH=main is the whole point: without it the label follows
+    # the current branch and the pins come out `# some-branch`.
+    WRANGLE_PINS_BRANCH=main "$SCRIPT_DIR/bump_action_pins.sh" "$target" \
+        || wrangle_die "bump_action_pins failed"
+
+    if ! "$SCRIPT_DIR/check_pin_main_history.sh"; then
+        wrangle_die "pins are still not on main's first-parent history — do not cut"
+    fi
+    "$SCRIPT_DIR/check_pin_freshness.sh" >/dev/null \
+        || wrangle_die "pins resolve stale content after the finalize"
+
+    if git -C "$REPO_ROOT" diff --quiet; then
+        printf 'finalize_pins: already finalized at %s — nothing to do\n' "${target:0:9}"
+        return 0
+    fi
+
+    printf '\nfinalize_pins: pins rolled onto %s, labelled # main.\n' "${target:0:9}"
+    printf 'Commit these and open a PR. Merge it as a MERGE COMMIT, not a squash.\n'
+}
+
+main() {
+    [[ $# -le 1 ]] || { printf 'Usage: finalize_pins.sh [<main-sha>]\n' >&2; exit 2; }
+    wrangle_finalize_pins "${1:-}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
**The last gate before the v0.4.0 tag.** After this, `release_preflight` is 6/6.

## What this is

An in-PR converge can only pin **branch** commits — `main`'s first-parent line is all merge commits, and a merge SHA cannot exist before the merge. So the pins reach first-parent history only via a **post-merge bump**. This is that bump.

All 15 declared self-ref pins rolled onto `33dd4b43`, labelled `# main`:

```
check_pin_main_history: all 15 wrangle self-ref pin(s) on origin/main first-parent history, labeled # main
check_pin_freshness:    all 18 resolve to HEAD content
check_pin_ancestry:     all 18 reachable from HEAD
```

## Why it matters

Without it, a release ships pins that resolve to **non-main history** — code that was never on `main`'s first-parent line. Both `check_pin_ancestry` and `check_pin_freshness` stay green in that state (the pins are reachable and byte-fresh), which is precisely why #592 went undetected through v0.3.0 prep. `check_pin_main_history` is the check that catches it, and it is a **release gate**, so `cut_release.sh` will refuse to tag until this lands.

## It touches no `tools/` file

So it will **not** trigger the image publish (#777) and re-stale the catalog. The finalize is genuinely terminal — nothing after it moves `main` before the tag.

## Produced by the script from #784

Not by hand. Running it is what surfaced a **SIGPIPE-under-`pipefail` bug** in that very script (`rev-list --first-parent | grep -q` → `grep -q` exits on the first match → `rev-list` gets SIGPIPE → `pipefail` reports failure), fixed and regression-tested there.

## ⚠️ Merge as a merge commit, not a squash