### PR TITLE
claude: release: finalize the self-ref pins (v0.4.0, take 2)

### DIFF
--- a/.github/workflows/build_and_publish_container.yml
+++ b/.github/workflows/build_and_publish_container.yml
@@ -126,7 +126,7 @@ jobs:
       scan: ${{ steps.prep.outputs.scan }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         id: prep
         with:
           build-type: container
@@ -146,7 +146,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -172,7 +172,7 @@ jobs:
     # TODO: replace with $/build/actions/container when GitHub ships $/ syntax (#136)
     - name: "build and publish"
       id: build
-      uses: TomHennen/wrangle/build/actions/container@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      uses: TomHennen/wrangle/build/actions/container@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
       with:
         path: ${{ inputs.path }}
         dockerfile: ${{ inputs.dockerfile }}
@@ -248,7 +248,7 @@ jobs:
       # image's bundle the verify job appends the VSA to. cosign is built from
       # tools/go.mod here.
       # TODO: replace with $/actions/attest_metadata_oci when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_metadata_oci@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_metadata_oci@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         with:
           shortname: ${{ needs.prep.outputs.shortname }}
           subject-digest: ${{ needs.build.outputs.digest }}
@@ -287,7 +287,7 @@ jobs:
 
       # oci-target pushes the VSA referrer; the dist download is skipped (the image is the artifact).
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         with:
           build-type: container
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_go.yml
+++ b/.github/workflows/build_and_publish_go.yml
@@ -163,7 +163,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         id: prep
         with:
           build-type: go
@@ -183,7 +183,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -215,7 +215,7 @@ jobs:
       # TODO: replace with $/build/actions/go/checks when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge — bump-self-refs follow-up
       # repoints to the squashed merge SHA after this lands.
-      - uses: TomHennen/wrangle/build/actions/go/checks@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/checks@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         id: checks
         with:
           path: ${{ inputs.path }}
@@ -278,7 +278,7 @@ jobs:
 
       # TODO: replace with $/build/actions/go/build when GitHub ships $/ syntax (#136)
       # Self-pinned to PR HEAD until merge.
-      - uses: TomHennen/wrangle/build/actions/go/build@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/go/build@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         id: release
         with:
           path: ${{ inputs.path }}
@@ -368,7 +368,7 @@ jobs:
       # writes non-artifact bookkeeping into dist/ that is not released. This is
       # the same canonical subject set the VSA binds to.
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         id: attest
         with:
           build-type: go
@@ -389,7 +389,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -415,7 +415,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         with:
           build-type: go
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_npm.yml
+++ b/.github/workflows/build_and_publish_npm.yml
@@ -151,7 +151,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         id: prep
         with:
           build-type: npm
@@ -171,7 +171,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/npm when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/npm@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/npm@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -282,7 +282,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         id: attest
         with:
           build-type: npm
@@ -304,7 +304,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -331,7 +331,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         with:
           build-type: npm
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_and_publish_python.yml
+++ b/.github/workflows/build_and_publish_python.yml
@@ -128,7 +128,7 @@ jobs:
       metadata-pre: ${{ steps.prep.outputs.metadata-pre }}
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         id: prep
         with:
           build-type: python
@@ -148,7 +148,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -180,7 +180,7 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       # TODO: replace with $/build/actions/python when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/build/actions/python@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/build/actions/python@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         id: build
         with:
           path: ${{ inputs.path }}
@@ -268,7 +268,7 @@ jobs:
       bundles-artifact-name: ${{ steps.attest.outputs.bundles-artifact-name }}
     steps:
       # TODO: replace with $/actions/attest_provenance when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/attest_provenance@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/attest_provenance@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         id: attest
         with:
           build-type: python
@@ -290,7 +290,7 @@ jobs:
       attestations: write   # post each VSA to the GitHub attestation store
     steps:
       # TODO: replace with $/actions/verify_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/verify_release@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/verify_release@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}
@@ -317,7 +317,7 @@ jobs:
       contents: write   # create the release if absent and upload the asset set
     steps:
       # TODO: replace with $/actions/publish_release when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/publish_release@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/publish_release@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         with:
           build-type: python
           shortname: ${{ needs.prep.outputs.shortname }}

--- a/.github/workflows/build_shell.yml
+++ b/.github/workflows/build_shell.yml
@@ -101,7 +101,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
 
   # Source scan. A load-bearing (:fail) finding fails the run alongside
   # the shell build/test (there is no artifact to gate publishing of).
@@ -114,7 +114,7 @@ jobs:
       security-events: write
     steps:
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/scan@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/scan@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         if: ${{ inputs.scan-tools != '' }}
         with:
           checkout: "true"
@@ -193,7 +193,7 @@ jobs:
         # bats-jobs input — the main-pinned version would ignore it and run
         # bats serially, so the dogfood run wouldn't exercise the fan-out.
         # Bump to main post-merge via tools/bump_action_pins.sh.
-        uses: TomHennen/wrangle/build/actions/shell@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+        uses: TomHennen/wrangle/build/actions/shell@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         with:
           scan-path: ${{ inputs.scan-path }}
           bats-path: ${{ inputs.bats-path }}

--- a/.github/workflows/check_source_change.yml
+++ b/.github/workflows/check_source_change.yml
@@ -18,7 +18,7 @@ jobs:
     permissions: {}    # guard reads env only — no workspace, no API, no secrets
     steps:
       # TODO: replace with $/actions/prep when GitHub ships $/ syntax (#136)
-      - uses: TomHennen/wrangle/actions/prep@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      - uses: TomHennen/wrangle/actions/prep@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
 
   check-change:
     needs: [prep]
@@ -36,7 +36,7 @@ jobs:
       # empty and the name is just "scan".
       # TODO: replace with $/actions/scan when GitHub ships $/ syntax (#136)
       - name: Source scan
-        uses: TomHennen/wrangle/actions/scan@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+        uses: TomHennen/wrangle/actions/scan@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
         with:
           checkout: "true"
           tools: ${{ inputs.tools }}

--- a/actions/scan/action.yml
+++ b/actions/scan/action.yml
@@ -111,7 +111,7 @@ runs:
     # TODO: replace with $/tools/scorecard when $/ syntax ships (#136, #137)
     - name: Scorecard
       if: always() && contains(inputs.tools, 'scorecard') && github.event_name != 'pull_request'
-      uses: TomHennen/wrangle/tools/scorecard@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      uses: TomHennen/wrangle/tools/scorecard@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
 
     # Dependency Review is PR-only — the upstream action requires
     # github.event.pull_request.base.sha / head.sha to compute the diff.
@@ -123,7 +123,7 @@ runs:
     # The wrapper's inline defaults (fail-on-severity: high) still apply.
     - name: Dependency Review
       if: always() && contains(inputs.tools, 'dependency-review') && github.event_name == 'pull_request'
-      uses: TomHennen/wrangle/tools/dependency-review@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+      uses: TomHennen/wrangle/tools/dependency-review@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
 
     - name: Generate step summary
       if: always()

--- a/actions/verify_release/action.yml
+++ b/actions/verify_release/action.yml
@@ -79,7 +79,7 @@ runs:
         path: ${{ steps.names.outputs.metadata-dir }}/
 
     # TODO: replace with $/actions/verify when GitHub ships $/ syntax (#136)
-    - uses: TomHennen/wrangle/actions/verify@e029656803f53a67502f050a926acaf82a92eaf7 # main 2026-07-12
+    - uses: TomHennen/wrangle/actions/verify@1e88d4034aff3d73081638882800ab42bfe399bd # main 2026-07-12
       with:
         dist-files: ${{ inputs.dist-files }}
         subjects: ${{ inputs.subjects }}


### PR DESCRIPTION
**The last commit before the v0.4.0 tag.** After this, `release_preflight` is 6/6.

All 15 declared self-ref pins rolled onto `1e88d403`, labelled `# main`:

```
check_pin_main_history: all 15 pins on origin/main first-parent history, labeled # main
check_pin_freshness:    all 18 resolve to HEAD content
check_pin_ancestry:     all 18 reachable from HEAD
```

## Why a second finalize

The first one (#785) was undone by the catalog cycle that followed it — merging a catalog bump converges the pins onto branch commits again, which is exactly why the finalize must be **last**.

That cycle existed because of my error: #785 accidentally shipped `tools/finalize_pins.sh` (I checked it out of #784's branch to *use* it, then `git add -A` swept it in). `check_catalog_provenance_freshness` caught it — the pinned images were no longer built from current source. #784 then replaced the file with the fixed version, which forced the rebuild + bump, which undid the finalize.

## This one is terminal

It touches **8 files, all pin lines** — nothing under `tools/` or `lib/`, so it cannot trigger the image publish (#777) and re-stale the catalog. Verified before committing, rather than after.

Produced by `tools/finalize_pins.sh` (now on `main`), not by hand.

## ⚠️ Merge as a merge commit, not a squash