### PR TITLE
claude: fix(cut_release): dispatch the Release Gate on a branch, not a sha

### DIFF
--- a/test/test_cut_release.bats
+++ b/test/test_cut_release.bats
@@ -5,7 +5,7 @@
 # stub was never invoked.
 
 setup() {
-    SCRIPT="$BATS_TEST_DIRNAME/../tools/cut_release.sh"
+    REAL_SCRIPT="$BATS_TEST_DIRNAME/../tools/cut_release.sh"
     TMP_DIR="$(mktemp -d)"
     STUB_BIN="$TMP_DIR/bin"
     mkdir -p "$STUB_BIN"
@@ -23,18 +23,32 @@ EOF
     PATH="$STUB_BIN:$PATH"
     export PATH
 
+    # cut_release calls its SCRIPT_DIR siblings; stub them so the tests exercise
+    # cut_release's own logic, not the real pin checks against a fixture repo.
+    mkdir -p "$TMP_DIR/tools"
+    cp "$REAL_SCRIPT" "$TMP_DIR/tools/"
+    for sib in check_pin_main_history.sh check_pin_freshness.sh; do
+        printf '#!/bin/bash\nexit 0\n' > "$TMP_DIR/tools/$sib"
+        chmod +x "$TMP_DIR/tools/$sib"
+    done
+    SCRIPT="$TMP_DIR/tools/cut_release.sh"
+
     NOTES="$TMP_DIR/notes.md"
     printf 'What you get in v9.9.9.\n' > "$NOTES"
 
     # A real git repo so the tag/ancestry checks operate on something.
     REPO="$TMP_DIR/repo"
     mkdir -p "$REPO"
-    git -C "$REPO" init -q
+    git -C "$REPO" init -qb main
     git -C "$REPO" config user.email t@t.t
     git -C "$REPO" config user.name t
     printf 'x\n' > "$REPO/f"
     git -C "$REPO" add -A
     git -C "$REPO" commit -qm init
+    # A real remote so the script's `git fetch origin` works — without it the
+    # fetch fails and every guard "passes" for the wrong reason.
+    git -C "$REPO" remote add origin "$REPO"
+    git -C "$REPO" update-ref refs/remotes/origin/main HEAD
     export WRANGLE_REPO_ROOT="$REPO"
 }
 
@@ -96,5 +110,24 @@ released() { grep -q "release create" "$GH_CALLS"; }
 @test "cut_release: usage error on missing arguments" {
     run "$SCRIPT" v9.9.9
     [[ "$status" -eq 2 ]]
+    ! released
+}
+
+@test "cut_release: refuses a target that is not the release branch's HEAD" {
+    # REGRESSION. workflow_dispatch takes a branch/tag ref, never a raw sha
+    # (`--ref <sha>` is a 422), so the gate can only be dispatched on a branch.
+    # If the target isn't that branch's HEAD, the gate would verify a different
+    # commit than the one being tagged. Found the hard way: cut_release.sh
+    # dispatched `--ref "$target"` and died mid-cut of v0.4.0.
+    local ancestor; ancestor="$(git -C "$REPO" rev-parse HEAD)"
+    printf 'z\n' > "$REPO/f2"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -qm newer
+    git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+    # ancestor IS on origin/main, but is not its HEAD — so it passes the
+    # ancestry check and must be caught by the branch-HEAD guard.
+    run "$SCRIPT" v9.9.9 "$NOTES" --target "$ancestor"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"HEAD"* ]]
     ! released
 }

--- a/test/test_finalize_pins.bats
+++ b/test/test_finalize_pins.bats
@@ -91,11 +91,11 @@ teardown() { rm -rf "$TMP_DIR"; }
     # false "not on first-parent history". It only reproduces when rev-list has
     # more to write after grep exits, i.e. a history longer than a pipe buffer's
     # worth of lines, which the other fixtures are too short to trigger (#771).
+    # Empty commits: the check only walks first-parent shas, so no tree churn is
+    # needed — and 200 working-tree writes under parallel bats corrupted the repo.
     local i
     for ((i = 0; i < 200; i++)); do
-        printf '%s\n' "$i" > "$REPO/f"
-        git -C "$REPO" add -A
-        git -C "$REPO" commit -qm "c$i"
+        git -C "$REPO" commit -q --allow-empty -m "c$i"
     done
     git -C "$REPO" update-ref refs/remotes/origin/main HEAD
     run "$RUN"

--- a/tools/cut_release.sh
+++ b/tools/cut_release.sh
@@ -75,13 +75,25 @@ wrangle_check_pins_finalized() {
     return 1
 }
 
-# Dispatch the Release Gate on the target and poll it. A locally-run preflight
-# cannot substitute: the pin gates read origin/main's history, so a stale or
-# shallow checkout can produce a confident false green.
+# Dispatch the Release Gate and poll it. A locally-run preflight cannot
+# substitute: the pin gates read origin/main's history, so a stale or shallow
+# checkout can produce a confident false green.
+#
+# workflow_dispatch takes a BRANCH or TAG ref, never a raw sha (`--ref <sha>` is
+# a 422). So dispatch the branch and then assert the run that came back actually
+# ran on the target — otherwise a merge racing the dispatch would green-light a
+# commit that is not the one being tagged.
 wrangle_release_gate_green() {
     local sha="$1"
-    printf 'cut_release: dispatching %s on %s\n' "$GATE_WORKFLOW" "${sha:0:8}"
-    gh workflow run "$GATE_WORKFLOW" --ref "$sha" >/dev/null \
+    local branch="${WRANGLE_RELEASE_BRANCH:-main}"
+
+    local head
+    head="$(git -C "$REPO_ROOT" rev-parse "origin/$branch")"
+    [[ "$head" == "$sha" ]] || wrangle_die \
+        "target ${sha:0:8} is not origin/$branch's HEAD (${head:0:8}) — the gate can only be dispatched on a branch, so it would verify the wrong commit"
+
+    printf 'cut_release: dispatching %s on %s (%s)\n' "$GATE_WORKFLOW" "$branch" "${sha:0:8}"
+    gh workflow run "$GATE_WORKFLOW" --ref "$branch" >/dev/null \
         || wrangle_die "could not dispatch $GATE_WORKFLOW"
 
     local id="" i


### PR DESCRIPTION
`cut_release.sh` would have died at the one step that matters. Found while cutting v0.4.0 — the tag was cut with the runbook's `gh release create` instead.

## The bug

```
$ gh workflow run release_gate.yml --ref ee6a1a73852105eb4ab8e49f2cb723bbebadb704
HTTP 422: No ref found for: ee6a1a73...
```

`workflow_dispatch` accepts a **branch or tag ref, never a raw commit sha**. `cut_release.sh` dispatched `--ref "$target"` (a sha), so the gate could never run — the script would abort right where it was supposed to prove the release was cuttable. Verified empirically: `--ref <sha>` 422s, `--ref main` and `--ref v0.4.0` both work.

## The fix

Dispatch the **branch**, and **refuse when the target is not that branch's HEAD** — otherwise the gate would verify a different commit than the one being tagged, which is a worse failure than not running at all.

The poll already did the right thing (`gh run list --commit "$sha"`), so the run it accepts is guaranteed to be on the target. Only the dispatch ref was wrong.

## The tests were lying, which is the more useful finding

The new guard's test "passed" for **three different wrong reasons** before it tested anything:

1. It hit an **earlier** guard — `wrangle_check_pins_finalized` ran the *real* `check_pin_main_history.sh` against a fixture repo, and failed there.
2. Then `git fetch origin` failed — the fixture had **no remote**.
3. Then `couldn't find remote ref refs/heads/main` — `git init` defaulted to `master`, so the fixture had **no `main` branch**.

Each time the script exited non-zero, so `[[ "$status" -ne 0 ]]` was satisfied and the test looked green. Fixed the harness: stub the SCRIPT_DIR siblings, give the fixture a real remote and a `main` branch, and assert on the guard's actual message.

Mutation-checked: remove the guard and the test no longer fails fast — the script sails through to the gate-polling loop, which is exactly the behavior the guard exists to prevent.

**8/8 bats, 0 `not ok`.** shellcheck clean.

## Note
This touches `tools/`, so it will trigger the image publish and a catalog-bump cycle (#777).