### PR TITLE
claude: docs: verification example -> the curated v0.4.0 release (recipe re-verified)

### DIFF
--- a/docs/verifying_artifacts.md
+++ b/docs/verifying_artifacts.md
@@ -48,35 +48,35 @@ digest (see below). Adopters can suppress the attach with the verify action's
 wrangle creates the Release for the tag automatically if none exists; pre-create
 one yourself only for custom notes or a draft — see the per-language build READMEs.
 
-### A real example (the curated v0.3.1 Go release)
+### A real example (the curated v0.4.0 Go release)
 
 The [`wrangle-test`](https://github.com/TomHennen/wrangle-test) showcase
-publishes a curated Go release — built with wrangle pinned at the `v0.3.1`
-release tag — that you can verify yourself. Its `v0.3.1` tag includes, for the
+publishes a curated Go release — built with wrangle pinned at the `v0.4.0`
+release tag — that you can verify yourself. Its `v0.4.0` tag includes, for the
 Go build:
 
-- `wrangle-test-fixture-go_0.3.1_linux_amd64.tar.gz` — the archive
-- `wrangle-test-fixture-go_0.3.1_linux_amd64.tar.gz.intoto.jsonl` — its bundle (provenance + VSA)
+- `wrangle-test-fixture-go_0.4.0_linux_amd64.tar.gz` — the archive
+- `wrangle-test-fixture-go_0.4.0_linux_amd64.tar.gz.intoto.jsonl` — its bundle (provenance + VSA)
 - `go-metadata-go.zip` — the [unified metadata](metadata_layout.md) (SBOM + scan results)
 - `checksums.txt` — goreleaser's archive checksums
 
 Download the archive and its bundle:
 
 ```bash
-base=https://github.com/TomHennen/wrangle-test/releases/download/v0.3.1
-curl -sSLO "$base/wrangle-test-fixture-go_0.3.1_linux_amd64.tar.gz"
-curl -sSLO "$base/wrangle-test-fixture-go_0.3.1_linux_amd64.tar.gz.intoto.jsonl"
+base=https://github.com/TomHennen/wrangle-test/releases/download/v0.4.0
+curl -sSLO "$base/wrangle-test-fixture-go_0.4.0_linux_amd64.tar.gz"
+curl -sSLO "$base/wrangle-test-fixture-go_0.4.0_linux_amd64.tar.gz.intoto.jsonl"
 ```
 
-Built at the `v0.3.1` tag, its VSA carries a `@refs/tags/v0.3.1` signer
+Built at the `v0.4.0` tag, its VSA carries a `@refs/tags/v0.4.0` signer
 identity, so the strict `wrangle-vsa-consumer-v1` policy verifies it — the same
 command you run against your own tag-built releases:
 
 ```bash
-ampel verify --subject wrangle-test-fixture-go_0.3.1_linux_amd64.tar.gz \
+ampel verify --subject wrangle-test-fixture-go_0.4.0_linux_amd64.tar.gz \
   --policy git+https://github.com/TomHennen/wrangle@v0.4.0#policies/wrangle-vsa-consumer-v1.hjson \
-  --collector jsonl:wrangle-test-fixture-go_0.3.1_linux_amd64.tar.gz.intoto.jsonl \
-  --context expectedResourceUri:pkg:golang/github.com/tomhennen/wrangle-test/go@v0.3.1 \
+  --collector jsonl:wrangle-test-fixture-go_0.4.0_linux_amd64.tar.gz.intoto.jsonl \
+  --context expectedResourceUri:pkg:golang/github.com/tomhennen/wrangle-test/go@v0.4.0 \
   --context sourceRepo:https://github.com/TomHennen/wrangle-test
 ```
 


### PR DESCRIPTION
Closes the last release follow-up: **cut-release Phase 4, gate 3** — *"Re-run the consumer download-and-verify recipe against a real release artifact this cycle. Commands drift — never assert an untested command."*

## Why this waited until after the tag

The worked example cites a **real published artifact** an adopter can download and verify today. A v0.4.0 curated release didn't exist until the tag was cut and `showcase-curated` built one — so bumping it earlier would have documented a URL that 404s. #776 deliberately left it at v0.3.1 for exactly this reason.

wrangle-test is now tagged `v0.4.0`, and its curated showcase built a Go release **using wrangle v0.4.0 itself**, pinned at the release tag so the VSA signer ref is `@refs/tags/v0.4.0`.

## Verified, not asserted

I ran the documented commands **verbatim** against the real artifact:

```
vsa-passed  ● PASS   VSA PASSED for the expected resource at SLSA Build L3
                     verifiedLevels: SLSA_BUILD_LEVEL_3, WRANGLE_HAS_SBOM,
                                     WRANGLE_VULN_SCANNED, WRANGLE_WORKFLOWS_LINTED,
                                     WRANGLE_LINTED, WRANGLE_RELEASE_PINNED
ampel exit: 0
```

The whole chain, on the real thing: **v0.4.0 builds a release → an adopter's consumer policy verifies it.** `WRANGLE_RELEASE_PINNED` appears only because the build was pinned at a release tag, which is the property the example is there to demonstrate.

(I also verified the *previous* recipe against the real v0.3.1 artifact before the cut — it passed — so the commands themselves were known-good; this bumps them to the current release.)

## Changes
`docs/verifying_artifacts.md` only: artifact URLs, filenames, tag references, and the `expectedResourceUri` context → v0.4.0. Zero `v0.3.1` references remain. `test_pin_consistency.bats` green.