### PR TITLE
claude: narrow the image-publish trigger to real Dockerfile inputs (#777)

### DIFF
--- a/.github/workflows/local_publish_images.yml
+++ b/.github/workflows/local_publish_images.yml
@@ -1,22 +1,35 @@
 name: publish tool images
 
 # Build, publish, and attest wrangle's containerized tool images. One matrix
-# entry per tool — enroll a new tool by adding a line. The trigger is
-# deliberately broad (any tools/ or lib/ change) so we over-build rather than
-# miss a build: a tool image's build context is the repo root (the Dockerfile
-# builds from tools/go.mod and bundles adapter glue from lib/). See
+# entry per tool — enroll a new tool by adding a line. See
 # docs/tool_container_design.md.
 
 on:
   workflow_dispatch:
   push:
     branches: [main]
+    # Every path any image Dockerfile reads from the build context (the repo
+    # root). A missed rebuild ships a stale image while CI stays green, so the
+    # set is over-broad by design and test/test_publish_trigger_coverage.bats
+    # fails if a Dockerfile grows an input this list does not match.
     paths:
-      - tools/**
+      - tools/*/Dockerfile
+      - tools/*/adapter.sh
+      - tools/*/install.sh
+      - tools/*/render_md.sh
+      - tools/*/requirements.txt
+      - tools/go.mod
+      - tools/go.sum
+      - tools/wrangle-attest/**
+      - tools/wrangle-lint/**
+      # Any Go source a first-party binary could compile in, wherever it lands
+      # (`**` does not stand in for zero directories here, so both forms).
+      - tools/*.go
+      - "tools/**/*.go"
       - lib/**
-      # A catalog-only push is a digest bump, not a source change: excluding it
-      # keeps the auto-bump below from looping. Must stay after `tools/**` —
-      # last matching pattern wins, so reordering silently reopens the loop.
+      # A catalog-only push is a digest bump, not a source change: triggering on
+      # it would loop the auto-bump below. No pattern above matches it; this is
+      # the backstop if one ever does.
       - "!tools/catalog.json"
 
 permissions: {}

--- a/docs/tool_container_design.md
+++ b/docs/tool_container_design.md
@@ -485,14 +485,15 @@ release does not rebuild or re-tag tool images.**
   catalog is inside every self-ref pin's freshness scope, so the bump PR **arrives red on
   `check_pin_freshness` by design**: whoever picks it up runs `make converge-action-pins`, pushes the
   convergence commits to the bump branch, and lands it as a merge commit (never a squash — see
-  [e2e_testing.md](e2e_testing.md)). The publish trigger is
-  a path glob that matches `tools/catalog.json`, so a catalog-only digest change would re-trigger a rebuild;
-  the trigger excludes `tools/catalog.json`, which is what keeps the bump from looping.
+  [e2e_testing.md](e2e_testing.md)). The trigger excludes `tools/catalog.json`, which is what keeps the
+  bump from looping: a catalog-only digest change would otherwise re-trigger a rebuild.
 - **Release tag** — precondition: the catalog is fresh. `check_catalog_freshness.sh` proves the shipped
   half — no digest is behind its published `:latest` (adoption lag); `check_catalog_provenance_freshness.sh`
   proves the stronger half — every digest is the image built from the current tool source, read from each
-  image's signed provenance over a coarse `tools/`+`lib/` diff-set (it over-flags a harmless rebuild
-  rather than miss a stale image). Both are blocking release gates that fail closed on a backend error
+  image's signed provenance and diffed over the same build-input path set the publish workflow triggers on
+  (`test/test_publish_trigger_coverage.bats` derives that set from the Dockerfiles and holds the two in
+  agreement, so a flagged image is always one a push to main already rebuilt). Both are blocking release
+  gates that fail closed on a backend error
   (exit 2 = precondition unverified); source-freshness also runs as a **weekly advisory**, and is **not**
   a per-signing-run blocker (that would false-block signing during the normal bump window). Then tag. No
   image is built or re-tagged at release time.

--- a/test/check_publish_trigger.py
+++ b/test/check_publish_trigger.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Assert the image-publish trigger covers every Dockerfile build input.
+
+`.github/workflows/local_publish_images.yml` rebuilds the curated tool images on
+a narrow `paths:` filter. A path that feeds an image but is missing from that
+filter is a silent supply-chain failure: the image goes stale while CI stays
+green. This derives the true input set from the workflow's own matrix — each
+image's Dockerfile, every path it COPYs from the build context (the repo root),
+expanded to files — and fails if any of them is not matched by the filter.
+
+Over-triggering is safe, so the check is one-directional: the filter may match
+more than the Dockerfiles read, never less.
+
+--check-gate holds the release gate to the same set. Its stale-image diff-set
+(PROVENANCE_DIFF_PATHS in tools/check_catalog_provenance_freshness.sh) must
+cover every build input — or it calls an image fresh while its source moved —
+and must stay within the trigger, or it reds the release with a staleness no
+push to main can rebuild away.
+
+Usage:
+  check_publish_trigger.py [--workflow F] [--repo-root D]   coverage check
+  check_publish_trigger.py --check-gate [--gate-script F]   gate/trigger agreement
+  check_publish_trigger.py --list-inputs                    print the input set
+  check_publish_trigger.py --match PATH...                  print MATCH/NO-MATCH
+
+Exit: 0 covered, 1 uncovered input found, 2 tool/usage error (fail closed).
+"""
+
+import json
+import os
+import re
+import shlex
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("check_publish_trigger: PyYAML not available for this python3.\n")
+    raise SystemExit(2)
+
+WORKFLOW = ".github/workflows/local_publish_images.yml"
+DOCKERFILE_EXPR = "${{ matrix.path }}/Dockerfile"
+BUILDER_WORKFLOW = "build_and_publish_container.yml"
+GATE_SCRIPT = "tools/check_catalog_provenance_freshness.sh"
+GATE_ARRAY = "PROVENANCE_DIFF_PATHS"
+PRUNED_DIRS = {".git", ".claude", ".beads", ".wrangle"}
+
+
+def fail(msg):
+    sys.stderr.write("check_publish_trigger: %s\n" % msg)
+    raise SystemExit(2)
+
+
+def load_workflow(path):
+    with open(path, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    if not isinstance(doc, dict):
+        fail("%s is not a workflow mapping" % path)
+    # PyYAML resolves the bare `on:` key to the boolean True (YAML 1.1).
+    triggers = doc.get("on", doc.get(True))
+    if not isinstance(triggers, dict):
+        fail("%s has no `on:` mapping" % path)
+    return doc, triggers
+
+
+def trigger_patterns(triggers):
+    push = triggers.get("push")
+    if not isinstance(push, dict) or not isinstance(push.get("paths"), list):
+        fail("%s has no on.push.paths list" % WORKFLOW)
+    patterns = push["paths"]
+    if not all(isinstance(p, str) for p in patterns):
+        fail("on.push.paths must be a list of strings")
+    return patterns
+
+
+def image_dockerfiles(doc):
+    """The Dockerfile of every image this workflow builds, from every job."""
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        fail("no jobs")
+    paths = []
+    for name, job in jobs.items():
+        if not isinstance(job, dict) or BUILDER_WORKFLOW not in str(job.get("uses", "")):
+            continue
+        dockerfile = job.get("with", {}).get("dockerfile")
+        if dockerfile != DOCKERFILE_EXPR:
+            fail(
+                "%s.with.dockerfile is %r, not %r — this check derives each "
+                "image's Dockerfile from the matrix path and cannot follow "
+                "another form" % (name, dockerfile, DOCKERFILE_EXPR)
+            )
+        include = job.get("strategy", {}).get("matrix", {}).get("include")
+        if not isinstance(include, list) or not include:
+            fail("%s builds images but has no matrix include list" % name)
+        for entry in include:
+            if not isinstance(entry, dict) or "path" not in entry:
+                fail("matrix entry without a `path`: %r" % (entry,))
+            paths.append("%s/Dockerfile" % entry["path"].rstrip("/"))
+    if not paths:
+        fail("no job builds an image via %s" % BUILDER_WORKFLOW)
+    return paths
+
+
+def copy_sources(dockerfile, repo_root):
+    """Build-context sources COPY/ADDed by dockerfile (stage sources excluded)."""
+    with open(os.path.join(repo_root, dockerfile), encoding="utf-8") as fh:
+        raw = fh.read()
+    logical = re.sub(r"\\\n", " ", raw)
+    sources = []
+    for line in logical.splitlines():
+        line = line.strip()
+        for mount in re.findall(r"--mount=(\S+)", line):
+            fields = dict(
+                field.split("=", 1) for field in mount.split(",") if "=" in field
+            )
+            # A bind mount with no `from=` reads the build context — the whole of
+            # it when it names no source — with no COPY to derive an input from.
+            if fields.get("type", "bind") == "bind" and "from" not in fields:
+                fail("%s bind-mounts the build context, which this check cannot "
+                     "expand into an input set: %s" % (dockerfile, line))
+        # An ONBUILD COPY runs in a child build, where the context is not this
+        # repo — treat it as unmodellable rather than derive a set that ignores it.
+        if re.match(r"(?i)^onbuild\s", line):
+            fail("%s uses ONBUILD, whose build context this check cannot "
+                 "derive: %s" % (dockerfile, line))
+        if not re.match(r"(?i)^(copy|add)\s", line):
+            continue
+        body = line.split(None, 1)[1].strip()
+        if body.startswith("["):
+            try:
+                tokens = json.loads(body)
+            except ValueError:
+                fail("cannot parse JSON-form instruction in %s: %s" % (dockerfile, line))
+        else:
+            tokens = shlex.split(body)
+        if any(t.startswith("--from=") for t in tokens):
+            continue  # copies from an earlier stage, not from the build context
+        operands = [t for t in tokens if not t.startswith("--")]
+        if len(operands) < 2:
+            fail("cannot parse instruction in %s: %s" % (dockerfile, line))
+        sources.extend(operands[:-1])
+    return sources
+
+
+def expand(source, dockerfile, repo_root):
+    """A context source (file or directory) as the set of repo files it reads."""
+    if re.search(r"[*?\[]", source):
+        fail("wildcard context source %r in %s is not supported" % (source, dockerfile))
+    rel = os.path.normpath(source)
+    abs_path = os.path.join(repo_root, rel)
+    if os.path.isfile(abs_path):
+        return {rel}
+    if os.path.isdir(abs_path):
+        files = set()
+        for dirpath, _, filenames in os.walk(abs_path):
+            for name in filenames:
+                files.add(os.path.relpath(os.path.join(dirpath, name), repo_root))
+        return files
+    fail("%s COPYs %r, which is not in the repo" % (dockerfile, source))
+
+
+def pattern_to_regex(pattern):
+    """A GitHub paths pattern as a regex: `*` stops at `/`, `**` does not."""
+    out = []
+    i = 0
+    while i < len(pattern):
+        char = pattern[i]
+        if char == "*":
+            if pattern.startswith("**", i):
+                out.append(".*")
+                i += 2
+            else:
+                out.append("[^/]*")
+                i += 1
+        elif char == "?":
+            out.append("[^/]")
+            i += 1
+        elif char in "[]+!":
+            fail("unsupported glob character %r in pattern %r" % (char, pattern))
+        else:
+            out.append(re.escape(char))
+            i += 1
+    return re.compile("^%s$" % "".join(out))
+
+
+def matches(path, patterns):
+    """GitHub paths semantics: `!` negates, and the last matching pattern wins."""
+    included = False
+    for pattern in patterns:
+        negated = pattern.startswith("!")
+        if pattern_to_regex(pattern.lstrip("!")).match(path):
+            included = not negated
+    return included
+
+
+def gate_pathspecs(repo_root, gate_script):
+    """The git pathspecs the release gate diffs to decide an image is stale."""
+    with open(os.path.join(repo_root, gate_script), encoding="utf-8") as fh:
+        body = fh.read()
+    found = re.search(r"^%s=\((.*?)\)$" % GATE_ARRAY, body, re.MULTILINE | re.DOTALL)
+    if not found:
+        fail("no %s array in %s" % (GATE_ARRAY, gate_script))
+    specs = shlex.split(found.group(1), comments=True)
+    if not specs:
+        fail("%s in %s is empty" % (GATE_ARRAY, gate_script))
+    return specs
+
+
+def git_pattern_to_regex(pattern):
+    """A git `:(glob)` pathspec as a regex: unlike GitHub's, `**` matches zero
+    path components, so `tools/**/*.go` covers `tools/x.go`."""
+    out = []
+    segments = pattern.split("/")
+    for i, segment in enumerate(segments):
+        last = i == len(segments) - 1
+        if segment == "**":
+            out.append(".*" if last else "(?:[^/]*/)*")
+            continue
+        if "**" in segment:
+            fail("`**` must be its own path component in %r" % pattern)
+        out.append(pattern_to_regex(segment).pattern[1:-1])
+        if not last:
+            out.append("/")
+    return re.compile("^%s$" % "".join(out))
+
+
+def gate_matcher(spec):
+    """A git pathspec as (excluded, regex). Only the magic the gate uses."""
+    magic = []
+    path = spec
+    found = re.match(r"^:\(([^)]*)\)(.*)$", spec)
+    if found:
+        magic = found.group(1).split(",")
+        path = found.group(2)
+    elif spec.startswith(":"):
+        fail("unsupported pathspec magic in %r" % spec)
+    unknown = set(magic) - {"glob", "exclude"}
+    if unknown:
+        fail("unsupported pathspec magic %s in %r" % (sorted(unknown), spec))
+    if "glob" in magic:
+        regex = git_pattern_to_regex(path)
+    else:
+        # A literal pathspec matches the path itself and, for a directory,
+        # everything beneath it.
+        escaped = re.escape(path.rstrip("/"))
+        regex = re.compile("^%s(/.*)?$" % escaped)
+    return "exclude" in magic, regex
+
+
+def gate_files(repo_root, gate_script, repo_files):
+    """The repo files the release gate's diff-set covers."""
+    matchers = [gate_matcher(spec) for spec in gate_pathspecs(repo_root, gate_script)]
+    included = set()
+    for path in repo_files:
+        if any(regex.match(path) for excluded, regex in matchers if not excluded) and not any(
+            regex.match(path) for excluded, regex in matchers if excluded
+        ):
+            included.add(path)
+    return included
+
+
+def repo_files(repo_root):
+    files = set()
+    for dirpath, dirnames, filenames in os.walk(repo_root):
+        dirnames[:] = [d for d in dirnames if d not in PRUNED_DIRS]
+        for name in filenames:
+            files.add(os.path.relpath(os.path.join(dirpath, name), repo_root))
+    return files
+
+
+def build_inputs(doc, repo_root):
+    """Every repo file every image's Dockerfile reads, keyed by Dockerfile."""
+    inputs = {}
+    for dockerfile in image_dockerfiles(doc):
+        files = {dockerfile}
+        for source in copy_sources(dockerfile, repo_root):
+            files |= expand(source, dockerfile, repo_root)
+        inputs[dockerfile] = files
+    return inputs
+
+
+def report(header, items):
+    sys.stderr.write("check_publish_trigger: %s\n" % header)
+    for item in items:
+        sys.stderr.write("  %s\n" % item)
+    return 1
+
+
+def check_gate(doc, repo_root, gate_script, patterns):
+    covered = gate_files(repo_root, gate_script, repo_files(repo_root))
+    inputs = build_inputs(doc, repo_root)
+
+    missing = sorted(
+        "%s (read by %s)" % (path, dockerfile)
+        for dockerfile, files in inputs.items()
+        for path in files
+        if path not in covered
+    )
+    if missing:
+        return report(
+            "these image build inputs are not in %s's %s — the release gate would "
+            "call the image fresh with its source changed:" % (gate_script, GATE_ARRAY),
+            missing,
+        )
+
+    stranded = sorted(path for path in covered if not matches(path, patterns))
+    if stranded:
+        return report(
+            "%s's %s covers paths the publish trigger ignores — a change to one "
+            "reds the release gate with no rebuild able to clear it:"
+            % (gate_script, GATE_ARRAY),
+            stranded,
+        )
+    print("release gate diff-set agrees with the trigger over %d paths" % len(covered))
+    return 0
+
+
+def main(argv):
+    repo_root = os.getcwd()
+    workflow = None
+    gate_script = GATE_SCRIPT
+    match_paths = []
+    list_inputs = False
+    gate = False
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--repo-root":
+            repo_root = argv[i + 1]
+            i += 2
+        elif arg == "--workflow":
+            workflow = argv[i + 1]
+            i += 2
+        elif arg == "--gate-script":
+            gate_script = argv[i + 1]
+            i += 2
+        elif arg == "--check-gate":
+            gate = True
+            i += 1
+        elif arg == "--list-inputs":
+            list_inputs = True
+            i += 1
+        elif arg == "--match":
+            match_paths = argv[i + 1:]
+            break
+        else:
+            fail("unknown argument %r" % arg)
+    doc, triggers = load_workflow(os.path.join(repo_root, workflow or WORKFLOW))
+    patterns = trigger_patterns(triggers)
+
+    if match_paths:
+        for path in match_paths:
+            print("%s %s" % ("MATCH" if matches(path, patterns) else "NO-MATCH", path))
+        return 0
+
+    if gate:
+        return check_gate(doc, repo_root, gate_script, patterns)
+
+    inputs = build_inputs(doc, repo_root)
+
+    if list_inputs:
+        for path in sorted(set().union(*inputs.values())):
+            print(path)
+        return 0
+
+    uncovered = []
+    checked = 0
+    for dockerfile, files in sorted(inputs.items()):
+        for path in sorted(files):
+            checked += 1
+            if not matches(path, patterns):
+                uncovered.append("%s (read by %s)" % (path, dockerfile))
+
+    if uncovered:
+        return report(
+            "these image build inputs are not matched by on.push.paths — a change "
+            "to one would ship a stale image:",
+            uncovered,
+        )
+    print("checked %d build inputs across %d images" % (checked, len(inputs)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/test/test_publish_trigger_coverage.bats
+++ b/test/test_publish_trigger_coverage.bats
@@ -1,0 +1,263 @@
+#!/usr/bin/env bats
+
+# Meta-test: the publish trigger and the Dockerfiles must agree.
+#
+# `publish tool images` rebuilds the curated tool images on a narrow `paths:`
+# filter. If a Dockerfile grows an input the filter does not match, the image
+# silently goes stale on the next change to it while CI stays green — the
+# supply-chain failure wrangle exists to prevent. test/check_publish_trigger.py
+# derives the real input set from each Dockerfile and fails if the filter misses
+# one, so a new COPY cannot be landed without extending the trigger.
+#
+# The reverse direction (the filter matching more than the Dockerfiles read) is
+# safe and deliberately allowed — see the canary test for the floor it must not
+# fall back through.
+
+load "lib/bats_helpers"
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    CHECK="$REPO_ROOT/test/check_publish_trigger.py"
+
+    # PyYAML lives in the managed venv the test image builds; fall back to a
+    # system python3 that has it (local dev). Same resolution as
+    # tools/wrangle-workflow-lint/lint.sh.
+    if [[ -x /opt/wrangle-workflow-lint/bin/python3 ]]; then
+        PYTHON=/opt/wrangle-workflow-lint/bin/python3
+    elif command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' 2>/dev/null; then
+        PYTHON=python3
+    else
+        skip_or_fail "no python3 with PyYAML on PATH"
+    fi
+    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/publish-trigger-XXXXXX")"
+}
+
+teardown() {
+    [[ -n "${TMP_DIR:-}" ]] && rm -rf "$TMP_DIR"
+}
+
+@test "publish-trigger: every Dockerfile build input is matched by the trigger" {
+    run "$PYTHON" "$CHECK" --repo-root "$REPO_ROOT"
+    [ "$status" -eq 0 ]
+    # Guard against a vacuous pass: all five curated images, each contributing
+    # inputs. A parse that silently found nothing would still "cover" the set.
+    [[ "$output" == *"across 5 images"* ]]
+    local checked="${output#checked }"
+    [[ "${checked%% *}" -ge 5 ]]
+}
+
+@test "publish-trigger: the check fails when the trigger misses a build input" {
+    # The check's own red path: the same matrix against a filter that omits
+    # everything under tools/ must be rejected.
+    cat > "$TMP_DIR/incomplete.yml" <<'YAML'
+on:
+  push:
+    paths:
+      - lib/**
+jobs:
+  publish:
+    uses: ./.github/workflows/build_and_publish_container.yml
+    strategy:
+      matrix:
+        include:
+          - path: tools/osv
+    with:
+      dockerfile: ${{ matrix.path }}/Dockerfile
+YAML
+    run "$PYTHON" "$CHECK" --repo-root "$REPO_ROOT" --workflow "$TMP_DIR/incomplete.yml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tools/osv/Dockerfile"* ]]
+    [[ "$output" == *"tools/osv/adapter.sh"* ]]
+}
+
+# A stand-in publish workflow building $TMP_DIR/tools/faketool, whose Dockerfile
+# is the given body. Its trigger matches everything under tools/, so only a build
+# input the check cannot see at all can keep it green.
+fake_image() {
+    mkdir -p "$TMP_DIR/tools/faketool"
+    cat > "$TMP_DIR/tools/faketool/Dockerfile"
+    cat > "$TMP_DIR/fake.yml" <<'YAML'
+on:
+  push:
+    paths:
+      - tools/**
+jobs:
+  publish:
+    uses: ./.github/workflows/build_and_publish_container.yml
+    strategy:
+      matrix:
+        include:
+          - path: tools/faketool
+    with:
+      dockerfile: ${{ matrix.path }}/Dockerfile
+YAML
+    printf '%s' "$TMP_DIR/fake.yml"
+}
+
+@test "publish-trigger: a Dockerfile that bind-mounts the context fails the check" {
+    # A bind mount reads the build context with no COPY to derive an input set
+    # from, so the check refuses it rather than reporting a coverage it can't see.
+    local workflow
+    workflow="$(fake_image <<'DOCKERFILE'
+FROM scratch
+RUN --mount=type=bind,source=tools,target=/src true
+DOCKERFILE
+)"
+    run "$PYTHON" "$CHECK" --repo-root "$TMP_DIR" --workflow "$workflow"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"bind-mounts the build context"* ]]
+}
+
+@test "publish-trigger: a stage mount does not mask a context bind mount on the same line" {
+    local workflow
+    workflow="$(fake_image <<'DOCKERFILE'
+FROM scratch AS build
+FROM scratch
+RUN --mount=type=cache,target=/c --mount=type=bind,from=build,source=/out,target=/s --mount=type=bind,source=lib,target=/l true
+DOCKERFILE
+)"
+    run "$PYTHON" "$CHECK" --repo-root "$TMP_DIR" --workflow "$workflow"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"bind-mounts the build context"* ]]
+}
+
+@test "publish-trigger: an ONBUILD copy fails the check" {
+    local workflow
+    workflow="$(fake_image <<'DOCKERFILE'
+FROM scratch
+ONBUILD COPY tools/catalog.json /catalog.json
+DOCKERFILE
+)"
+    run "$PYTHON" "$CHECK" --repo-root "$TMP_DIR" --workflow "$workflow"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ONBUILD"* ]]
+}
+
+@test "publish-trigger: an image built outside the publish job is still checked" {
+    # Enrolling an image is documented as a matrix line, but a second job calling
+    # the image builder must not slip past the check.
+    mkdir -p "$TMP_DIR/tools/faketool"
+    printf 'FROM scratch\nCOPY tools/catalog.json /catalog.json\n' \
+        > "$TMP_DIR/tools/faketool/Dockerfile"
+    printf '{}\n' > "$TMP_DIR/tools/catalog.json"
+    cat > "$TMP_DIR/second.yml" <<'YAML'
+on:
+  push:
+    paths:
+      - lib/**
+jobs:
+  publish-more:
+    uses: ./.github/workflows/build_and_publish_container.yml
+    strategy:
+      matrix:
+        include:
+          - path: tools/faketool
+    with:
+      dockerfile: ${{ matrix.path }}/Dockerfile
+YAML
+    run "$PYTHON" "$CHECK" --repo-root "$TMP_DIR" --workflow "$TMP_DIR/second.yml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tools/catalog.json"* ]]
+}
+
+@test "publish-trigger: the gate's ** covers a path at the root of its tree" {
+    # git's :(glob) ** stands in for zero directories where GitHub's does not, so
+    # a tools/*.go the gate diffs must still be one the trigger rebuilds.
+    mkdir -p "$TMP_DIR/tools/faketool"
+    printf 'FROM scratch\nCOPY tools/faketool/adapter.sh /adapter.sh\n' \
+        > "$TMP_DIR/tools/faketool/Dockerfile"
+    printf '#!/bin/bash\n' > "$TMP_DIR/tools/faketool/adapter.sh"
+    printf 'package main\n' > "$TMP_DIR/tools/toplevel.go"
+    cat > "$TMP_DIR/rootgo.yml" <<'YAML'
+on:
+  push:
+    paths:
+      - tools/*/Dockerfile
+      - tools/*/adapter.sh
+      - "tools/**/*.go"
+jobs:
+  publish:
+    uses: ./.github/workflows/build_and_publish_container.yml
+    strategy:
+      matrix:
+        include:
+          - path: tools/faketool
+    with:
+      dockerfile: ${{ matrix.path }}/Dockerfile
+YAML
+    local gate
+    gate="$(gate_script_with "':(glob)tools/*/Dockerfile'" "':(glob)tools/*/adapter.sh'" \
+        "':(glob)tools/**/*.go'")"
+    run "$PYTHON" "$CHECK" --repo-root "$TMP_DIR" --workflow "$TMP_DIR/rootgo.yml" \
+        --check-gate --gate-script "$gate"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tools/toplevel.go"* ]]
+}
+
+@test "publish-trigger: dev scripts and the catalog do not trigger a rebuild" {
+    # The floor the narrowing must not fall back through: files in no image's
+    # build context. A catalog-only push is a digest bump — matching it would
+    # loop the post-publish auto-bump.
+    run "$PYTHON" "$CHECK" --repo-root "$REPO_ROOT" --match \
+        tools/catalog.json \
+        tools/cut_release.sh \
+        tools/open_catalog_bump_pr.sh \
+        tools/bump_version_refs.sh \
+        tools/check_catalog.sh \
+        tools/gen_policies/gen.sh \
+        tools/dependency-review/action.yml \
+        tools/scorecard/action.yml
+    [ "$status" -eq 0 ]
+    while IFS= read -r line; do
+        [[ "$line" == NO-MATCH* ]] || { printf 'unexpectedly triggers a rebuild: %s\n' "$line" >&2; return 1; }
+    done <<< "$output"
+}
+
+# A stand-in release gate whose stale-image diff-set is the given pathspecs.
+gate_script_with() {
+    printf 'PROVENANCE_DIFF_PATHS=(\n' > "$TMP_DIR/gate.sh"
+    printf '    %s\n' "$@" >> "$TMP_DIR/gate.sh"
+    printf ')\n' >> "$TMP_DIR/gate.sh"
+    printf '%s' "$TMP_DIR/gate.sh"
+}
+
+@test "publish-trigger: the release gate's stale-image diff-set agrees with the trigger" {
+    run "$PYTHON" "$CHECK" --repo-root "$REPO_ROOT" --check-gate
+    [ "$status" -eq 0 ]
+}
+
+@test "publish-trigger: the check fails when the release gate misses a build input" {
+    # A build input the gate does not diff is an image it calls fresh with its
+    # source changed under it.
+    local gate
+    gate="$(gate_script_with "':(glob)tools/*/Dockerfile'")"
+    run "$PYTHON" "$CHECK" --repo-root "$REPO_ROOT" --check-gate --gate-script "$gate"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"lib/sarif_adapter_exit.sh"* ]]
+}
+
+@test "publish-trigger: the check fails when the release gate flags what the trigger ignores" {
+    # The other direction: a path the gate diffs but the trigger ignores reds the
+    # release gate with no rebuild able to clear it.
+    local gate
+    gate="$(gate_script_with tools lib)"
+    run "$PYTHON" "$CHECK" --repo-root "$REPO_ROOT" --check-gate --gate-script "$gate"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tools/cut_release.sh"* ]]
+}
+
+@test "publish-trigger: an image's own inputs do trigger a rebuild" {
+    # The opposite floor — the matcher is not vacuously rejecting everything.
+    run "$PYTHON" "$CHECK" --repo-root "$REPO_ROOT" --match \
+        tools/osv/Dockerfile \
+        tools/osv/adapter.sh \
+        tools/syft/install.sh \
+        tools/zizmor/requirements.txt \
+        tools/wrangle-lint/main.go \
+        tools/wrangle-attest/sign.go \
+        tools/go.mod \
+        tools/go.sum \
+        lib/sarif_adapter_exit.sh
+    [ "$status" -eq 0 ]
+    [[ "$output" != *NO-MATCH* ]]
+}

--- a/tools/attest-toolbox/Dockerfile
+++ b/tools/attest-toolbox/Dockerfile
@@ -15,7 +15,8 @@
 # Build context is the repo root (the build needs tools/go.mod + go.sum).
 FROM golang:1.26.4@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5 AS build
 WORKDIR /src
-COPY tools/ ./tools/
+COPY tools/go.mod tools/go.sum ./tools/
+COPY tools/wrangle-attest/ ./tools/wrangle-attest/
 ENV CGO_ENABLED=0
 RUN cd tools \
  && go build -trimpath -o /out/ampel github.com/carabiner-dev/ampel/cmd/ampel \

--- a/tools/check_catalog_provenance_freshness.sh
+++ b/tools/check_catalog_provenance_freshness.sh
@@ -25,9 +25,25 @@ PROVENANCE_PREDICATE_TYPE='https://slsa.dev/provenance/v1'
 COMMIT_RE='^[0-9a-f]{40}$'
 # A build commit is trusted only from a resolvedDependency on wrangle's own repo.
 WRANGLE_SOURCE_URI_PREFIX='git+https://github.com/tomhennen/wrangle@'
-# Whole tools/ so a binary built from a sibling package counts; minus the catalog
-# file, so a digest bump can't flag its own image stale.
-PROVENANCE_DIFF_PATHS=(tools lib ':(exclude)tools/catalog.json')
+# Every path an image Dockerfile reads from the build context — the set
+# local_publish_images.yml rebuilds on, so anything flagged stale here is
+# something a push to main already rebuilt (test/test_publish_trigger_coverage.bats
+# keeps the two in agreement). Minus the catalog, so a digest bump can't flag its
+# own image stale.
+PROVENANCE_DIFF_PATHS=(
+    ':(glob)tools/*/Dockerfile'
+    ':(glob)tools/*/adapter.sh'
+    ':(glob)tools/*/install.sh'
+    ':(glob)tools/*/render_md.sh'
+    ':(glob)tools/*/requirements.txt'
+    tools/go.mod
+    tools/go.sum
+    tools/wrangle-attest
+    tools/wrangle-lint
+    ':(glob)tools/**/*.go'
+    lib
+    ':(exclude)tools/catalog.json'
+)
 
 # provenance_build_commit <image> — print the single wrangle build commit from
 # <image>'s signed provenance. Returns 2 on a read failure, 1 if no single

--- a/tools/osv/Dockerfile
+++ b/tools/osv/Dockerfile
@@ -6,7 +6,7 @@
 # Build context is the repo root (the build needs tools/go.mod + lib/).
 FROM golang:1.26.4@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5 AS build
 WORKDIR /src
-COPY tools/ ./tools/
+COPY tools/go.mod tools/go.sum ./tools/
 RUN cd tools && CGO_ENABLED=0 go build -trimpath \
       -o /out/osv-scanner github.com/google/osv-scanner/v2/cmd/osv-scanner
 

--- a/tools/wrangle-lint/Dockerfile
+++ b/tools/wrangle-lint/Dockerfile
@@ -6,7 +6,8 @@
 # Build context is the repo root (the build needs tools/go.mod + tools/wrangle-lint + lib/).
 FROM golang:1.26.4@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5 AS build
 WORKDIR /src
-COPY tools/ ./tools/
+COPY tools/go.mod tools/go.sum ./tools/
+COPY tools/wrangle-lint/ ./tools/wrangle-lint/
 RUN cd tools && CGO_ENABLED=0 go build -trimpath \
       -o /out/wrangle-lint github.com/TomHennen/wrangle/tools/wrangle-lint
 


### PR DESCRIPTION
Fixes #777.

## The bug

`publish tool images` triggered on all of `tools/**`, but most files there feed no image. A dev script landing (`open_catalog_bump_pr.sh`, `bump_version_refs.sh`, …) rebuilt all 5 images; the builds are not bit-reproducible, so unchanged content still minted new digests → catalog stale → bump PR → pin convergence → merge commit. It fired four needless times cutting v0.4.0.

## Derivation (from the Dockerfiles, not intuition)

Build context is the repo root. Context reads per image, after this PR:

| image | reads from the context |
|---|---|
| `osv` | `tools/go.mod`, `tools/go.sum`, `tools/osv/adapter.sh`, `tools/osv/render_md.sh`, `lib/sanitize.sh`, `lib/sarif_adapter_exit.sh` |
| `wrangle-lint` | `tools/go.mod`, `tools/go.sum`, `tools/wrangle-lint/` (whole dir), `lib/sarif_adapter_exit.sh` |
| `attest-toolbox` | `tools/go.mod`, `tools/go.sum`, `tools/wrangle-attest/` (whole dir) |
| `zizmor` | `tools/zizmor/requirements.txt`, `tools/zizmor/adapter.sh`, `lib/sarif_adapter_exit.sh` |
| `syft` | `tools/syft/install.sh`, `tools/syft/adapter.sh`, `lib/download_verify.sh` |

Plus each image's own `Dockerfile` (which carries the base-image digest pins).

The three Go images previously did `COPY tools/ ./tools/` — the whole directory, dev scripts and all — which is *why* the trigger had to be `tools/**`. They now copy only `go.mod`/`go.sum` plus the first-party package dir they compile (whole dir, so a future `//go:embed` target is covered). External tools (osv-scanner, ampel, bnd, cosign) build from the module graph alone — verified by a real build of all three images. **A cross-package import added later is now a hard build failure, not a silently stale image.**

## The trigger

```yaml
paths:
  - tools/*/Dockerfile
  - tools/*/adapter.sh
  - tools/*/install.sh
  - tools/*/render_md.sh
  - tools/*/requirements.txt
  - tools/go.mod
  - tools/go.sum
  - tools/wrangle-attest/**
  - tools/wrangle-lint/**
  - tools/*.go             # any Go source a first-party binary could compile in
  - "tools/**/*.go"
  - lib/**
  - "!tools/catalog.json"  # kept: a catalog-only push is a digest bump, not a source change
```

## The enforcement (the part that matters)

`test/check_publish_trigger.py` reads every job that calls `build_and_publish_container.yml`, parses each image's Dockerfile, expands every context `COPY`/`ADD` source to files, and fails if any is not matched by `on.push.paths` — GitHub's glob semantics (`*` stops at `/`, last match wins, `!` negates). A Dockerfile cannot grow an input without the trigger growing with it. What it cannot model, it refuses (exit 2): a bind-mounted build context, `ONBUILD`, wildcard sources, a `dockerfile:` that isn't the matrix path.

**The release gate had to move too.** `check_catalog_provenance_freshness.sh` diffed a coarse `tools`+`lib` set to decide an image is stale. Narrowing only the trigger would have made that *worse*: a dev-script push would no longer rebuild, yet would still red the gate — with nothing able to clear it. Its `PROVENANCE_DIFF_PATHS` is now the same set, and `--check-gate` holds the two in agreement in both directions (gate ⊇ Dockerfile inputs, so it cannot call a moved image fresh; gate ⊆ trigger, so it cannot red the release with a staleness no push can rebuild away). The two globs are different dialects — git's `:(glob) **` matches zero directories, GitHub's does not — and the checker models each separately.

`test/test_publish_trigger_coverage.bats` (12 tests) pins all of it, including every red path: each was verified to actually fail by injecting the corresponding disagreement.

## Adversarial review

An independent reviewer with one brief — *find a change to a real build input this trigger would MISS* — found no live under-trigger, but four ways the enforcement failed open: a bind mount masked by a stage mount on the same line, a second publishing job, the git-vs-GitHub `**` dialect gap, and `ONBUILD`. All four are fixed, each with a test (see the comment below). Those fixes postdate the review and rest on my own tests.

## Candor

- **This PR self-triggers.** It edits three Dockerfiles (real image inputs), so merging fires one rebuild + catalog-bump cycle. That one is correct, and the last of its kind for a change like this.
- **Known gap, pre-existing:** image content also depends on `build_and_publish_container.yml` (buildx flags, labels). Neither the old nor the new trigger watches it, and the coverage test cannot derive it from a Dockerfile. Say the word and I'll add it to `paths:` — the cost is a rebuild cycle on any edit to that workflow.
- `tools/osv-scanner.toml` is not an image input (no Dockerfile copies it; it is read from the scanned source tree at run time).
- `build_shell.yml`'s tool-image cache key still uses the coarse `hashFiles('tools/**', 'lib/**', ...)`. Left alone deliberately: a coarse cache key only costs a cache miss, never staleness.
- Verified: all three narrowed images build; the 4 `test/image/` contract suites pass (14/14); the osv image was run against a fixture and writes `output.sarif` under the adapter contract.

`./test.sh quick`: 1438 ok, 0 not ok (11 skips, all pre-existing integration-tool skips). All 12 new tests run no-skip in the CI `test` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
